### PR TITLE
Fix probing underflow after local copy failure

### DIFF
--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1774,7 +1774,10 @@ impl Worker {
             && job.entry.size > 0
         {
             match self.try_copy_local(idx, &job) {
-                Ok(true) => return Ok(()),
+                Ok(true) => {
+                    self.sched.ranges_ready(idx, vec![]);
+                    return Ok(());
+                }
                 Ok(false) => {} // not offloadable — fall through to streaming
                 Err(e) => {
                     self.sched.ranges_ready(idx, vec![]);
@@ -1962,6 +1965,7 @@ impl Worker {
 
     /// Attempt an in-kernel same-host copy. Ok(true) = done; Ok(false) =
     /// kernel can't offload, caller should stream; Err = real failure.
+    /// The caller owns scheduler probing bookkeeping for every terminal result.
     fn try_copy_local(&mut self, idx: usize, job: &FileJob) -> Result<bool> {
         // If a partial exists, prefer the streaming path so its hash-based
         // resume reuses the bytes already on disk; copy_file_range would
@@ -2003,7 +2007,6 @@ impl Worker {
                 );
                 self.progress.add_bytes(job.entry.size);
                 job.done.store(job.entry.size, Relaxed);
-                self.sched.ranges_ready(idx, vec![]);
                 self.finish_file(idx)?;
                 Ok(true)
             }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -996,6 +996,24 @@ fn dir_vs_file_destination_collision_rejected() {
 }
 
 #[test]
+fn file_over_nonempty_destination_directory_reports_error_without_panicking() {
+    let t = Tmp::new();
+    write(&t.path("src/foo"), b"source");
+    write(&t.path("dest/foo/keep"), b"keep");
+
+    let out = pcp(&["-j", "1", "--no-resume", &t.s("src/foo"), &t.s("dest")]);
+
+    assert_eq!(out.status.code(), Some(23));
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("destination") && err.contains("is a directory"),
+        "{err}"
+    );
+    assert!(!err.contains("panicked"), "{err}");
+    assert_eq!(read(&t.path("dest/foo/keep")), b"keep");
+}
+
+#[test]
 fn verify_only_detects_symlink_difference() {
     let t = Tmp::new();
     fs::create_dir_all(t.path("s")).unwrap();


### PR DESCRIPTION
## Summary

- keep scheduler probing bookkeeping owned by the local-copy caller
- avoid decrementing probing twice when finalization fails
- add a regression test for copying a file over a non-empty destination directory

The regression runs with -j1 and --no-resume, confirming the failure and fix are independent of journaling.

## Testing

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets