### PR TITLE
Add secure syq distribution and updates

### DIFF
--- a/.env.release
+++ b/.env.release
@@ -1,0 +1,10 @@
+#/-------------------[DOTENV_PUBLIC_KEY]--------------------/
+#/            public-key encryption for .env files          /
+#/       [how it works](https://dotenvx.com/encryption)     /
+#/----------------------------------------------------------/
+DOTENV_PUBLIC_KEY_RELEASE="0249481bd0ff1f3140fbf51a892bade47727acf6e783ad0ac2cc3a208c6e644a8e"
+
+# .env.release
+SYQ_RELEASE_PUBLIC_KEY="encrypted:BGNVQQia/kOJgYe6KfcIDubIt1qvUxtkfUvbSKi7eHnBrRIdgd+rZAZxNqZvA6kur6Uwju+LdST1M4Brkry7gLBc3pSspSB71UcQ1nbbUyuJJfZcyy4KX6dn/P+Uwddvkeuef/vjBKQGYUKlSTpAsJ19fBgBquM+4IAzUVjwN2YZvHHVxN5YTBCuxTbV"
+SYQ_RELEASE_SIGNING_KEY_PEM_B64="encrypted:BIFeH+mp5q4/riu0ny1Al81HJm1HmI4cOmJIusuWHuwMiTOmpqElwfzRgnaKdWpW6YhDdnbB7kfOKuhILcljCKj197Myd7P7H5Pje6tE1xnOakrjGKLeh7+yddpSeiYSiNarjGMC5+STTwnC2JG29jwUlMR2h0fkmw1tQ/5wfhKV49mzLs+O6KPsKPxU8qTv4tyR0C6TLZxAnwhvwK//f4/Fqde4ofZrsxsOOd9EScGFJ/r9j1Kt+PnYzrV/WfwXxuJJjYipBKu/GA4LAoqRzva/cSLNn1HV7fKoySlK9pb2/Vyc76TQ+TBXFbpY2KNHswF2FelwzVHXA9pP2Sakx2I="
+HOMEBREW_TAP_DEPLOY_KEY="encrypted:BIZEGlnPV7msvjFqMosCkMW+YXk9uTvgBFsJi77bQ7L80Ot4Hx8jkcKmHBvZcCSGjuMxeDJI/TsbtwoVzRq6iFp50jtPOh9V2bwdh4qFzotZBRuTmWFDl8pknlhnpCGiPcnpp4CcHBaHEamWB/fmY0GGo1RjgVCrvcQ6qQJj6NjNcrgntduZW1oq93qL+oVMZ8mClEJyqIVfHZNrDc4D6DfK2Dk2X8KpNA4fYnYO0JXqrXw9q84UeI8UnFFQhZ0Ljt7796+5Y1LF1RfsaQXfQYhn+T3TXhVBoSENrcoR4mINIi7vny4kvcvBlO9jeTZdWA+cBpqRbUrIqCrmASkXGYjkSuPpivcYGmEvuU8sHQeSoasAH0ksOFAU/PCTufJN0FFM11BA2Edv9kUGb9ieKkj3IW2YoHFI6L6g/SsDejL41uEVnL/gcAE0iyzAq/z3e8Bvim78nWTiYMa054gm+Ea2Mc3dnW4pHt/FiHyfrGedp/FsoE8KfozMNn7DJJlWLB+Y1e2TzU+BE6zl+xknw66lYgAx71yaRM7Pxe3Ie/S5UxQSb9bHDoOuDQdMWlDGVxJb5i5HTYdpwqLlgB3ilOTPbRi2vI7eNBxlr29HL7/e4O/U/HOXhShAYWZtDpLtQAqBzUy8M/xxVbj43e5sobWnmvy9qjhwuW6r"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - run: rustup component add rustfmt clippy
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --locked --all-targets --all-features -- -D warnings
+      - run: cargo test --locked --all-targets
+      - run: scripts/test-installer.sh
+      - run: scripts/test-release-tools.sh
+      - run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-homebrew-formula.sh
+
+  macos:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - run: cargo check --locked --all-targets
+      - run: scripts/test-installer.sh
+      - run: scripts/test-homebrew-formula.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
       - run: cargo test --locked --all-targets
       - run: scripts/test-installer.sh
       - run: scripts/test-release-tools.sh
-      - run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-homebrew-formula.sh
+      - run: scripts/test-secret-tools.sh
+      - run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-homebrew-formula.sh scripts/test-secret-tools.sh
 
   macos:
     runs-on: macos-14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,71 +1,225 @@
-# Build stripped release binaries for Linux and macOS on x86-64 and ARM64,
-# and attach raw, gzip-compressed, and SHA-256 assets to a GitHub Release.
-#
-# Trigger: push a tag like v0.1.0  (git tag v0.1.0 && git push origin v0.1.0)
-# or run manually from the Actions tab (workflow_dispatch).
+# Build all supported targets, assemble one complete signed release, attest its
+# contents, publish it draft-first, then update the project-owned Homebrew tap.
 name: release
+
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch:
 
 permissions:
-  contents: write   # needed to create the Release and upload assets
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
+  verify-tag:
+    name: verify signed release tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release tooling
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Require a verified annotated tag for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          scripts/verify-release-tag.sh \
+            "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_SHA" master
+
   build:
+    name: build (${{ matrix.name }})
+    needs: verify-tag
     strategy:
+      fail-fast: true
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            name: pcp-linux-x86_64            # static, runs on any glibc-or-not Linux
+            name: syq-linux-x86_64
             flags: "-C target-feature=+crt-static"
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            name: pcp-linux-aarch64           # static, native GitHub ARM64 runner
+            name: syq-linux-aarch64
             flags: "-C target-feature=+crt-static"
-          - os: macos-14                       # Apple Silicon runner
+          - os: macos-14
             target: aarch64-apple-darwin
-            name: pcp-macos-arm64
-          - os: macos-15-intel                 # Intel runner
+            name: syq-macos-arm64
+            flags: ""
+          - os: macos-15-intel
             target: x86_64-apple-darwin
-            name: pcp-macos-x86_64
+            name: syq-macos-x86_64
+            flags: ""
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Check out the verified tag
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          targets: ${{ matrix.target }}
-      - name: Check tag matches package version
-        if: startsWith(github.ref, 'refs/tags/')
+          persist-credentials: false
+      - name: Validate release inputs
+        env:
+          SYQ_RELEASE_PUBLIC_KEY: ${{ vars.SYQ_RELEASE_PUBLIC_KEY }}
+        shell: bash
         run: |
+          set -euo pipefail
+          test -n "$SYQ_RELEASE_PUBLIC_KEY" || {
+            echo 'Set the SYQ_RELEASE_PUBLIC_KEY repository variable before releasing.' >&2
+            exit 1
+          }
+          test "$(printf '%s' "$SYQ_RELEASE_PUBLIC_KEY" | openssl base64 -d -A | wc -c | tr -d ' ')" -eq 32 || {
+            echo 'SYQ_RELEASE_PUBLIC_KEY must be one base64-encoded 32-byte Ed25519 key.' >&2
+            exit 1
+          }
           version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
           test "$GITHUB_REF_NAME" = "v$version"
-      - name: Build
+          rustup target add '${{ matrix.target }}'
+          test "$(rustc --version | awk '{print $2}')" = "$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)"
+      - name: Build locked release binary
         env:
           RUSTFLAGS: ${{ matrix.flags }}
-        run: cargo build --release --target ${{ matrix.target }}
-      - name: Stage binary
+          SYQ_RELEASE_PUBLIC_KEY: ${{ vars.SYQ_RELEASE_PUBLIC_KEY }}
+        run: cargo build --locked --release --bin syq --target '${{ matrix.target }}'
+      - name: Stage raw and compressed binaries
+        shell: bash
         run: |
-          mkdir -p dist
-          cp target/${{ matrix.target }}/release/pcp dist/${{ matrix.name }}
-          gzip -9 -n -c dist/${{ matrix.name }} > dist/${{ matrix.name }}.gz
-          shasum -a 256 dist/${{ matrix.name }}.gz | awk '{print $1}' > dist/${{ matrix.name }}.gz.sha256
-      - uses: actions/upload-artifact@v4
+          set -euo pipefail
+          mkdir dist
+          cp 'target/${{ matrix.target }}/release/syq' 'dist/${{ matrix.name }}'
+          chmod 755 'dist/${{ matrix.name }}'
+          gzip -9 -n -c 'dist/${{ matrix.name }}' > 'dist/${{ matrix.name }}.gz'
+          test -s 'dist/${{ matrix.name }}'
+          test -s 'dist/${{ matrix.name }}.gz'
+      - name: Upload build output
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.name }}
           path: dist/*
+          if-no-files-found: error
+          retention-days: 1
 
   release:
+    name: verify, attest, and publish
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
-      - uses: actions/download-artifact@v4
-        with: { path: dist, merge-multiple: true }
-      - name: Publish release
-        uses: softprops/action-gh-release@v2
+      - name: Check out release tooling
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          files: dist/*
-          fail_on_unmatched_files: true
+          persist-credentials: false
+      - name: Download every target
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Build and validate release metadata
+        run: scripts/package-release.sh "$GITHUB_REF_NAME" dist
+      - name: Sign release manifest and verify the configured key
+        env:
+          SYQ_RELEASE_PUBLIC_KEY: ${{ vars.SYQ_RELEASE_PUBLIC_KEY }}
+          SYQ_RELEASE_SIGNING_KEY_PEM_B64: ${{ secrets.SYQ_RELEASE_SIGNING_KEY_PEM_B64 }}
+        run: |
+          scripts/sign-release-manifest.sh \
+            dist/syq-release-manifest.json dist/syq-release-manifest.json.sig
+      - name: Verify final release inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="$RUNNER_TEMP/expected-assets"
+          for asset in syq-linux-x86_64 syq-linux-aarch64 syq-macos-arm64 syq-macos-x86_64; do
+            printf '%s\n' "$asset" "$asset.sha256" "$asset.gz" "$asset.gz.sha256"
+          done > "$expected"
+          printf '%s\n' install.sh syq-release-manifest.json syq-release-manifest.json.sig syq.rb >> "$expected"
+          sort -o "$expected" "$expected"
+          find dist -mindepth 1 -maxdepth 1 -printf '%f\n' | sort > "$RUNNER_TEMP/actual-assets"
+          diff -u "$expected" "$RUNNER_TEMP/actual-assets"
+          ruby -c dist/syq.rb
+          scripts/test-installer.sh
+      - name: Refuse a divergent published release
+        id: release_state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! gh release view "$GITHUB_REF_NAME" --json isDraft > "$RUNNER_TEMP/release-state" 2>/dev/null; then
+            echo 'published=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          draft=$(jq -r .isDraft "$RUNNER_TEMP/release-state")
+          test "$draft" = false || {
+            echo "Draft $GITHUB_REF_NAME already exists; inspect and remove it before retrying." >&2
+            exit 1
+          }
+          scripts/verify-release-assets.sh "$GITHUB_REF_NAME" dist
+          echo 'published=true' >> "$GITHUB_OUTPUT"
+      - name: Attest all release files
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: dist/*
+      - name: Create, verify, and publish a new immutable release
+        if: steps.release_state.outputs.published != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" --draft --verify-tag \
+            --title "syq ${GITHUB_REF_NAME#v}" --generate-notes
+          gh release upload "$GITHUB_REF_NAME" dist/*
+          scripts/verify-release-assets.sh "$GITHUB_REF_NAME" dist
+          gh release edit "$GITHUB_REF_NAME" --draft=false
+      - name: Carry the verified published formula to the tap job
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: homebrew-formula
+          path: dist/syq.rb
+          if-no-files-found: error
+          retention-days: 1
+
+  homebrew:
+    name: update Homebrew tap
+    needs: release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    steps:
+      - name: Check out project-owned tap
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: greaber/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+      - name: Download generated formula
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: homebrew-formula
+          path: formula
+      - name: Commit formula update
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p tap/Formula
+          cp formula/syq.rb tap/Formula/syq.rb
+          cd tap
+          git diff --check
+          git add Formula/syq.rb
+          git diff --cached --quiet && {
+            echo 'The tap already contains this exact formula version.'
+            exit 0
+          }
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m "syq ${GITHUB_REF_NAME#v}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: greaber/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
           path: tap
       - name: Download generated formula
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.claude/*
 !/.claude/settings.json
 /.worktrees/
+/.env.keys
 
 # Agent working notes / handoff plans (not committed).
 /current-plans

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 
 # Agent working notes / handoff plans (not committed).
 /current-plans
+
+.*.pcp-transfer-session.json
+.*.syq-transfer-session.json
+.pcp-transfer-session.json
+.syq-transfer-session.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,24 @@ outlive its premise and steer later work in the wrong direction.
   temporary directories. Treat `syq --rm`, remote destinations, bootstrap
   installation, and operations on real user data as potentially destructive.
 
+## Release secrets
+
+Once provisioned, `.env.release` is the committed dotenvx-encrypted source of
+truth for release credentials. `.env.keys` is its gitignored decryption
+authority and must remain on developer-controlled machines and in protected
+backup storage. Never upload `.env.keys` or a `DOTENV_PRIVATE_KEY_*` value to
+GitHub, CI, the Homebrew tap, or a runtime system.
+
+CI consumes only the two individual environment secrets it needs. A maintainer
+materializes those values locally with `scripts/sync-github-secrets.sh`; the
+script has a fixed inventory and refuses to target anything except
+`github.com/greaber/syq`. Do not change that boundary to let CI decrypt
+`.env.release`, and do not add a general dotenvx key to GitHub secrets.
+
+Use dotenvx 2.21.0 for this inventory. Initialize it once with
+`scripts/init-release-secrets.sh`, and run the sync without `--execute` before
+every actual update. See `RELEASING.md` for provisioning, backup, and rotation.
+
 ## Verification
 
 Run checks proportionate to the change. The normal Rust checks are:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ outlive its premise and steer later work in the wrong direction.
   task-related stash, and no commits that still need integration. An ancestry
   result such as `git branch --merged` says nothing about uncommitted files.
 
-## Working on PCP
+## Working on syq
 
 - `README.md` is the user-facing contract; the code is authoritative for
   everything else. `RESUME-DESIGN.md` covers the resume feature's design.
@@ -84,7 +84,7 @@ outlive its premise and steer later work in the wrong direction.
 - Copy failures must be visible. Do not make an incomplete or truncated result
   look successful.
 - Exercise copy, resume, verification, and removal behavior in disposable
-  temporary directories. Treat `pcp --rm`, remote destinations, bootstrap
+  temporary directories. Treat `syq --rm`, remote destinations, bootstrap
   installation, and operations on real user data as potentially destructive.
 
 ## Verification

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,10 +124,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -199,7 +220,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -224,12 +245,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -315,6 +351,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,10 +450,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "generic-array"
@@ -523,6 +646,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,24 +668,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "pcp"
-version = "0.1.0"
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "aes-gcm",
- "anyhow",
- "base64",
- "clap",
- "getrandom 0.2.17",
- "ignore",
- "jwalk",
- "libc",
- "postcard",
- "serde",
- "serde_bytes",
- "serde_json",
- "shell-words",
- "xxhash-rust",
- "zstd",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -736,7 +858,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -753,6 +875,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,12 +898,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -793,6 +951,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
@@ -800,6 +969,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syq"
+version = "0.1.0"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "base64",
+ "clap",
+ "ed25519-dalek",
+ "flate2",
+ "getrandom 0.2.17",
+ "ignore",
+ "jwalk",
+ "libc",
+ "postcard",
+ "semver",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2",
+ "shell-words",
+ "xxhash-rust",
+ "zstd",
 ]
 
 [[package]]
@@ -829,7 +1023,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -911,6 +1105,12 @@ name = "xxhash-rust"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,22 @@
 [package]
-name = "pcp"
+name = "syq"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.94"
 description = "Parallel copy with an rsync-shaped interface"
 license = "MIT"
-repository = "https://github.com/greaber/pcp"
+repository = "https://github.com/greaber/syq"
+readme = "README.md"
+keywords = ["copy", "rsync", "ssh", "parallel", "transfer"]
+categories = ["command-line-utilities", "filesystem"]
+include = [
+    "/src/**",
+    "/tests/**",
+    "/Cargo.toml",
+    "/Cargo.lock",
+    "/README.md",
+    "/LICENSE",
+]
 
 [dependencies]
 anyhow = "1"
@@ -22,6 +34,10 @@ aes-gcm = "0.10"
 getrandom = "0.2"
 serde_json = "1"
 base64 = "0.22"
+ed25519-dalek = "2"
+flate2 = "1"
+semver = "1"
+sha2 = "0.10"
 
 [profile.release]
 opt-level = 3

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Grant Reaber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# pcp
+# syq
 
-`pcp` is a parallel file copier with an rsync-shaped command line. It scans
+`syq` is a parallel file copier with an rsync-shaped command line. It scans
 source and destination, works out what differs, and moves the data over
 **N independent connections at once** — encrypted TCP by default, authenticated
 over ssh, falling back to ssh's own channels when a direct port can't be
@@ -15,28 +15,74 @@ a copy is complete.
 
 ## Install
 
+The standalone installer needs no `sudo` and installs the matching Linux or
+macOS binary in `~/.local/bin`:
+
 ```sh
-cargo build --release          # binary at target/release/pcp
-cargo install --path .         # or: put it on your PATH
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/greaber/syq/releases/latest/download/install.sh | sh
 ```
 
-The remote side runs `pcp --server`, but it does not need to be installed or
-configured first. pcp uses an exact versioned helper under
-`~/.cache/pcp/helpers/`. On first use of a version it detects the remote
+To inspect it first, download the same URL without piping it to `sh`. Every
+release also has an immutable versioned installer, for example
+`https://github.com/greaber/syq/releases/download/v0.1.0/install.sh`. To choose
+another directory, download the script and run `sh install.sh --bin-dir DIR`
+(or pipe it to `sh -s -- --bin-dir DIR`). The script detects the target,
+verifies the archive's embedded SHA-256 and size, runs the temporary binary to
+check its version and protocol identity, and then replaces `syq` atomically.
+Even with `--bin-dir`, either `HOME` or `XDG_CONFIG_HOME` must be set so every
+successful standalone installation can record its managed-install receipt.
+
+Homebrew is also supported through the project-owned tap:
+
+```sh
+brew install greaber/tap/syq
+```
+
+Or build from source with the pinned Rust toolchain:
+
+```sh
+cargo build --release          # binary at target/release/syq
+cargo install --locked --path . # or: put it on your PATH
+```
+
+Standalone installs check the signed release manifest at most once a day after
+a successful interactive command. They only print an update notice by default:
+`syq --self-update` performs the update, and `syq --enable-auto-update` opts in
+to installing a signed update after a successful interactive command. Use
+`syq --disable-auto-update` to opt out again. The install receipt lives at
+`$XDG_CONFIG_HOME/syq/install.json` (normally `~/.config/syq/install.json`) and
+must name the running executable, so a Homebrew or source build never replaces
+itself. Update Homebrew installs with `brew upgrade syq`.
+
+Release binaries are published for Linux x86-64/ARM64 and macOS Apple
+Silicon/Intel. Terminal downloads and Homebrew normally do not attach macOS's
+quarantine attribute, which is why command-line tools installed this way do not
+usually produce Gatekeeper prompts. A binary downloaded through a browser may;
+browser-oriented distribution would need Apple Developer ID signing and
+notarization in addition to this terminal-first path.
+
+The remote side runs `syq --server`, but it does not need to be installed or
+configured first. syq uses an exact versioned helper under
+`~/.cache/syq/helpers/`. On first use of a version it detects the remote
 platform, downloads the matching compressed binary from that version's GitHub
-release, verifies its SHA-256 checksum, and installs it atomically. Later runs
-execute that exact path without an extra probe connection. Linux x86-64 and
-ARM64 and macOS Apple Silicon and Intel are published.
+release, verifies its SHA-256 against the separately signed release manifest,
+and installs it atomically. Later runs execute that exact path without an extra
+probe connection.
 
-If the remote cannot reach GitHub, pcp uploads its current executable when the
-local and remote platforms match. For a different-platform host without
-outbound access, install a compatible binary yourself and pass
-`--pcp-path /path/to/pcp`. `--no-bootstrap` disables managed helpers and
-requires `pcp` on the non-interactive remote `PATH`.
+If the release cannot be downloaded, syq uploads its current executable when
+the local and remote platforms match. Source builds do not embed the official
+release key unless `SYQ_RELEASE_PUBLIC_KEY` was supplied at compile time, so
+they take this upload path; use an official build for automatic cross-platform
+bootstrap. For a different-platform host without a trusted release download,
+install a compatible binary yourself and pass `--syq-path /path/to/syq`.
+`--no-bootstrap` disables managed helpers and requires `syq` on the
+non-interactive remote `PATH`.
 
-The remote download uses `curl` or `wget`, `gzip`, and one of `sha256sum`,
-`shasum`, or `openssl`. Version directories coexist and the helper cache can be
-removed at any time; pcp recreates the helper it needs on the next connection.
+The local client verifies the Ed25519-signed manifest and passes its trusted
+hash to the remote install script. The remote uses `curl` or `wget`, `gzip`, and
+one of `sha256sum`, `shasum`, or `openssl`. Version directories coexist and the
+helper cache can be removed at any time; syq recreates the helper it needs on
+the next connection.
 
 - **macOS (Apple Silicon / Intel):** build natively on the Mac with
   `cargo build --release` (needs the Xcode command-line tools, `xcode-select
@@ -52,36 +98,38 @@ removed at any time; pcp recreates the helper it needs on the next connection.
 ## Usage
 
 ```
-pcp [OPTIONS] SRC... DEST
-pcp [OPTIONS] [USER@]HOST:SRC... DEST
-pcp [OPTIONS] SRC... [USER@]HOST:DEST
+syq [OPTIONS] SRC... DEST
+syq [OPTIONS] [USER@]HOST:SRC... DEST
+syq [OPTIONS] SRC... [USER@]HOST:DEST
 ```
 
 ```sh
-pcp -avz project/ server:backup/project/      # push
-pcp -avz server:data/ ./data/                 # pull
-pcp -a /mnt/nfs/tree /local/tree              # local → local (parallel scan and copy)
-pcp -a hostA:big/ hostB:big/                  # remote → remote: runs on hostA, data goes A → B directly
-pcp -a --relay hostA:big/ hostB:big/          # ...or relay through this machine if A can't reach B
-pcp -avz -j 16 bigdir server:dest             # 16 parallel connections
-pcp -a --bwlimit 50M src server:dst            # cap all connections at 50 MiB/s total
-pcp -a -e 'ssh -p 2222 -i ~/.ssh/other' src host:dst
-pcp -a --dry-run -v src host:dst              # show what would be copied
-pcp -ac src host:dst                          # skip the quick check; compare blocks, repair differences
-pcp -a --verify-only src host:dst             # compare only; transfer nothing
-pcp -a src newhost:dst                        # the matching remote helper is automatic
-pcp -a --checkpoint ./copy.state src host:dst # retain completed-file state if this run fails
+syq -avz project/ server:backup/project/      # push
+syq -avz server:data/ ./data/                 # pull
+syq -a /mnt/nfs/tree /local/tree              # local → local (parallel scan and copy)
+syq -a hostA:big/ hostB:big/                  # remote → remote: runs on hostA, data goes A → B directly
+syq -a --relay hostA:big/ hostB:big/          # ...or relay through this machine if A can't reach B
+syq -avz -j 16 bigdir server:dest             # 16 parallel connections
+syq -a --bwlimit 50M src server:dst            # cap all connections at 50 MiB/s total
+syq -a -e 'ssh -p 2222 -i ~/.ssh/other' src host:dst
+syq -a --dry-run -v src host:dst              # show what would be copied
+syq -ac src host:dst                          # skip the quick check; compare blocks, repair differences
+syq -a --verify-only src host:dst             # compare only; transfer nothing
+syq -a src newhost:dst                        # the matching remote helper is automatic
+syq -a --checkpoint ./copy.state src host:dst # retain completed-file state if this run fails
 ```
 
 ### Options
 
 | Option | Meaning |
 |---|---|
+| `--self-update` | Install the newest signed release (standalone installer builds only) |
+| `--enable-auto-update` / `--disable-auto-update` | Opt in/out of signed updates after successful interactive commands |
 | `-a`, `--archive` | Same as `-rlptgoD` |
 | `-r` `-l` `-p` `-t` `-g` `-o` `-D` | Recursive; symlinks as symlinks; perms; mtimes; group; owner; devices and specials |
 | `-v` | List files as they complete (also new dirs, symlinks) |
 | `-q` | Errors only |
-| `-z`, `--compress` | zstd-compress data in transit (inside pcp's protocol, not `ssh -C`) |
+| `-z`, `--compress` | zstd-compress data in transit (inside syq's protocol, not `ssh -C`) |
 | `-n`, `--dry-run` | Scan and report; change nothing |
 | `-j N`, `--connections N` | Parallel data connections (default: auto-tuned, see below) |
 | `--bwlimit RATE` | Limit aggregate file-data throughput (bare rate is KiB/s; `0` disables) |
@@ -89,8 +137,8 @@ pcp -a --checkpoint ./copy.state src host:dst # retain completed-file state if t
 | `--min-split SIZE` | Don't split an in-flight file with less than this left (default 32M) |
 | `--progress` / `--no-progress` | Progress meter (default on when stderr is a terminal) |
 | `-P` | Turns on `--progress` (the `--partial` half is always on; see below) |
-| `--partial` | No-op for rsync compatibility (pcp always keeps partial files) |
-| `--numeric-ids` | No-op for rsync compatibility (pcp always uses numeric uid/gid) |
+| `--partial` | No-op for rsync compatibility (syq always keeps partial files) |
+| `--numeric-ids` | No-op for rsync compatibility (syq always uses numeric uid/gid) |
 | `--progress-json` | One JSON line per second on stderr |
 | `--stats` | Summary counts at the end |
 | `-c`, `--checksum` | Compare every file block by block instead of size+mtime; repair mismatches |
@@ -99,8 +147,8 @@ pcp -a --checkpoint ./copy.state src host:dst # retain completed-file state if t
 | `--fsync` | fsync each file and its parent dir around the rename (survives a crash; slower) |
 | `--checkpoint FILE` | Save completed-file state for an accelerated retry; retained on failure, removed on success |
 | `-e CMD`, `--rsh CMD` | Remote shell command (default `ssh`) |
-| `--pcp-path PATH` | Use this exact remote `pcp` instead of the managed helper |
-| `--no-bootstrap` | Require `pcp` on the remote `PATH`; do not install a managed helper |
+| `--syq-path PATH` | Use this exact remote `syq` instead of the managed helper |
+| `--no-bootstrap` | Require `syq` on the remote `PATH`; do not install a managed helper |
 | `--no-tcp` | Send data over the ssh connection instead of separate TCP sockets |
 | `--tcp-plain` | TCP data connections without encryption (trusted networks only) |
 | `--tcp-ports LO-HI` | Port range the remote listens on for TCP data (default 47600-47699) |
@@ -115,25 +163,25 @@ pcp -a --checkpoint ./copy.state src host:dst # retain completed-file state if t
 `--bwlimit` is one approximate limit shared by every `-j` worker, not a
 per-connection limit. As in rsync, a bare rate is KiB/s, suffixes such as `K`,
 `M`, `G`, and `MiB` use powers of 1024, a final `+1` or `-1` adjusts the scaled
-value by one byte, and `0` means unlimited. PCP counts uncompressed file bytes;
+value by one byte, and `0` means unlimited. SYQ counts uncompressed file bytes;
 protocol overhead is not counted, and `-z` may make the actual network rate
 lower. Scanning, hashing, and metadata operations are not limited.
 
 ### Remote-to-remote
 
-`pcp hostA:src hostB:dst` starts the orchestrator *on hostA* over `ssh -A`
+`syq hostA:src hostB:dst` starts the orchestrator *on hostA* over `ssh -A`
 (agent forwarding), which then pushes to hostB with N connections, so data
 flows A → B directly. Matching helpers are installed automatically on both
 hosts. HostA must be able to ssh to hostB (with your forwarded agent, or its
 own keys). Progress and `-v` output are streamed back. If hostA can't reach
 hostB, `--relay` keeps the orchestrator here and routes every byte A → you → B
 — always works, at half the bandwidth.
-`pcp hostA:src hostA:dst` (same host and user on both ends) simply runs a
+`syq hostA:src hostA:dst` (same host and user on both ends) simply runs a
 local copy on hostA.
 
 Add `--detach` to let a remote-to-remote transfer outlive the ssh session that
-launched it: pcp starts it on hostA, returns, and writes progress to a log on
-hostA. Reattach with `pcp --follow hostA:LOG` to stream that progress.
+launched it: syq starts it on hostA, returns, and writes progress to a log on
+hostA. Reattach with `syq --follow hostA:LOG` to stream that progress.
 An explicit `--checkpoint` path belongs to the machine running the
 orchestrator: normally the invoking machine, but hostA for a direct or detached
 remote-to-remote copy (`--relay` keeps it local).
@@ -142,9 +190,9 @@ remote-to-remote copy (`--relay` keeps it local).
 
 Identical to rsync:
 
-- `pcp -a src dest` copies the directory itself → `dest/src`. `dest` is
+- `syq -a src dest` copies the directory itself → `dest/src`. `dest` is
   created if missing.
-- `pcp -a src/ dest` copies the *contents* of `src` into `dest`. `src/.` and
+- `syq -a src/ dest` copies the *contents* of `src` into `dest`. `src/.` and
   `.` behave the same way.
 - A single file source goes to `dest/file` if `dest` is an existing directory,
   otherwise `dest` is the new filename.
@@ -152,8 +200,8 @@ Identical to rsync:
 - A destination that is a symlink to a directory is that directory (the link
   is kept, with or without a trailing slash); a symlink to anything else is
   replaced like a file.
-- pcp's own bookkeeping is never payload (as rsync excludes its
-  `--partial-dir`): a source entry named `.name.pcp-partial` is silently left
+- syq's own bookkeeping is never payload (as rsync excludes its
+  `--partial-dir`): a source entry named `.name.syq-partial` is silently left
   out. Everything else is copied.
 - `host:path` is relative to the remote home; `host:/abs` and `host:~/x` work.
   A colon before the first slash means remote; `./x:y` is local. All sources
@@ -170,7 +218,7 @@ by the local umask and existing files keep their mode. Without `-t`, every
 file is transferred every time (the quick check needs mtimes).
 
 Directory mtimes are set last, deepest first, so writing children doesn't
-disturb them. A directory pcp must write into but can't (no owner write bit)
+disturb them. A directory syq must write into but can't (no owner write bit)
 is opened up for the duration and gets its own mode back at the end — or the
 source's mode with `-p`.
 
@@ -185,9 +233,9 @@ onto a largest-first queue; when a worker runs dry it steals the back half of
 the remaining range of whichever file has the most left, so the tail of a
 transfer stays parallel without pre-deciding chunk counts.
 
-On the receiving side each file is written into `.name.pcp-partial` in its
+On the receiving side each file is written into `.name.syq-partial` in its
 directory (preallocated with `fallocate`, written with `pwrite` from several
-processes), given its metadata, and `rename`d over the target. By default pcp
+processes), given its metadata, and `rename`d over the target. By default syq
 does not `fsync` each file (the rename still orders correctly, and per-file
 fsync is costly on NFS); pass `--fsync` to force each file durable before the
 rename for crash safety.
@@ -210,7 +258,7 @@ levels.
 **Within a file.** There is no per-file state file — the partial *is* the state:
 
 - Files whose size and mtime already match are skipped (the rsync quick check).
-- If a range-transfer `.name.pcp-partial` exists, both sides hash it and the
+- If a range-transfer `.name.syq-partial` exists, both sides hash it and the
   source in `--block-size` blocks and only the mismatching blocks are sent.
   Pipelined small files are rewritten wholesale on retry instead of paying an
   extra partial-file probe.
@@ -220,7 +268,7 @@ levels.
 
 This block-level skip catches appends and in-place modifications (VM images,
 databases, logs). It does **not** catch a byte inserted near the start of a
-file, which rsync's rolling checksum would — for pcp's intended use (fresh
+file, which rsync's rolling checksum would — for syq's intended use (fresh
 uploads and downloads) that trade was made deliberately.
 
 **Across the whole job.** Ordinary copies keep no transfer history. Every
@@ -231,34 +279,34 @@ For a tree so large or failure-prone that repeatedly reaching the unfinished
 frontier is itself expensive, opt in explicitly:
 
 ```sh
-pcp -a --checkpoint ./copy.state huge-tree/ host:huge-tree/
+syq -a --checkpoint ./copy.state huge-tree/ host:huge-tree/
 # after an interruption, run the identical command again
 ```
 
 The mode-0600 JSONL checkpoint identifies the canonical source, destination,
-and copy semantics. It records regular files only after PCP established that
+and copy semantics. It records regular files only after SYQ established that
 the destination was complete and, for transferred files, rechecked the source.
 On retry, a record whose source fingerprint still matches (size, nanosecond
 mtime, and requested mode/owner/group metadata) skips that destination lookup.
 Everything else follows the normal quick check, partial hashing, and transfer
 path. Unfinished individual files are never checkpoint-complete; their actual
-`.pcp-partial` contents remain the resume state.
+`.syq-partial` contents remain the resume state.
 
 The checkpoint is flushed about once a second, retained after interruption or
 failure, and removed after a clean copy. Losing its last buffered records only
-causes repeated work. If the destination root disappeared, PCP resets the
+causes repeated work. If the destination root disappeared, SYQ resets the
 checkpoint. `-n` may read an existing checkpoint to preview a retry but never
 creates or changes one. `-c` and `--verify-only` conflict with `--checkpoint`
 because they explicitly require destination inspection. One checkpoint file
 may be used by only one running copy at a time.
 
-A checkpoint is an explicit trust decision: PCP does not inspect a destination
+A checkpoint is an explicit trust decision: SYQ does not inspect a destination
 file covered by a matching record. If another process deleted, replaced, or
 modified that destination after it was recorded, a checkpointed retry will not
 notice. Do not use a checkpoint when the destination may be independently
-modified; omit the option and PCP remains history-independent.
+modified; omit the option and SYQ remains history-independent.
 
-Like rsync, ordinary PCP runs do not coordinate with each other. Concurrent
+Like rsync, ordinary SYQ runs do not coordinate with each other. Concurrent
 copies into one tree produce the union of their files, and one whole-file
 rename wins for any path both write.
 
@@ -291,7 +339,7 @@ the re-stat catches the common case, `--verify-only` afterwards catches the
 rest.
 
 Compared with rsync: ordinary writes use the same temporary-file plus atomic
-rename model; `--inplace` explicitly gives that up. PCP's deterministic partial
+rename model; `--inplace` explicitly gives that up. SYQ's deterministic partial
 also remains reusable without publishing it under the final name. The
 change-during-transfer check is the same idea; deletes and hardlinks aren't
 implemented, so there is no ordering question for them.
@@ -302,18 +350,18 @@ implemented, so there is no ordering question for them.
   syntax) instead.
 - `--delete`, `--link-dest`, `-u`/`--update`, `--files-from`.
 - Hardlinks (`-H`), ACLs and xattrs (`-A`/`-X`).
-- rsync daemon mode / `rsync://`. pcp speaks its own protocol; it cannot talk
+- rsync daemon mode / `rsync://`. syq speaks its own protocol; it cannot talk
   to an rsync server.
 - Rolling-checksum delta transfer (see Resume above).
-- Preserving existing partial files from `rsync --partial`; only pcp's own
-  `.name.pcp-partial` files are recognised.
+- Preserving existing partial files from `rsync --partial`; only syq's own
+  `.name.syq-partial` files are recognised.
 
 ## When parallelism helps
 
 - **ssh CPU**: one ssh process tops out at a few hundred MB/s of cipher/MAC
   work. N processes scale roughly linearly. Multiplexed channels over one
   connection wouldn't help — same TCP stream, same single encrypting process —
-  so pcp passes `-o ControlMaster=no -o ControlPath=none` for its connections
+  so syq passes `-o ControlMaster=no -o ControlPath=none` for its connections
   on purpose.
 - **WAN**: several TCP flows beat one against per-flow window and loss limits.
 - **High-latency filesystems** (NFS, FUSE, object-backed): many small files
@@ -324,7 +372,7 @@ implemented, so there is no ordering question for them.
 
 ## How many connections (`-j`)
 
-Without `-j`, pcp tunes the number of workers while a copy runs instead of
+Without `-j`, syq tunes the number of workers while a copy runs instead of
 guessing (`--rm` keeps a fixed 8, or 32 locally: removal is metadata-bound
 and short). It starts with 8 over the network (32 when both ends are
 local: threads are free, connections are not) and measures: progress (bytes,
@@ -362,13 +410,13 @@ a shared link.
 
 ssh caps every stream at a few hundred MB/s of cipher CPU, and its 2 MB
 per-channel flow-control window caps a stream at roughly `2 MB / RTT` on long
-links (≈7 MB/s at 265 ms). So by default (unless `--no-tcp`) pcp keeps ssh for
+links (≈7 MB/s at 265 ms). So by default (unless `--no-tcp`) syq keeps ssh for
 authentication and control only and moves the data over separate TCP
 connections: the remote opens a listener on a port from `--tcp-ports` (default
 47600-47699), and the data connections are plain TCP sockets carrying
 AES-256-GCM records keyed by a secret exchanged over the ssh session
 (`--tcp-plain` skips the encryption on trusted networks; `--no-tcp` sends data over the ssh connection instead). If the port can't be
-reached — a firewall, typically — pcp says so once and falls back to ssh data
+reached — a firewall, typically — syq says so once and falls back to ssh data
 connections, so the default is always safe.
 
 The remote advertises every address it has (the one your ssh session arrived
@@ -377,7 +425,7 @@ adds the name it reached ssh through — the only address that works for a
 host behind NAT or port forwarding — ahead of the overlay ones, tries them
 all, and prefers the best that answers. If none answers it says so and uses
 ssh (silenced by `-q`). When several NICs of
-comparable speed are reachable (e.g. an 8-rail RoCE fabric), pcp spreads its
+comparable speed are reachable (e.g. an 8-rail RoCE fabric), syq spreads its
 data connections across all of them (multipath) — it keeps only paths within
 2x of the fastest, so it never drags a fast transfer down by mixing in a slow
 link. Single-homed hosts and laptops use the one best path, unchanged. With ufw:
@@ -387,7 +435,7 @@ sudo ufw allow from 10.2.201.0/24 to any port 47600:47699 proto tcp   # LAN peer
 sudo ufw allow from 203.0.113.5   to any port 47600:47699 proto tcp   # a specific client
 ```
 
-Remote→remote (`pcp hostA:src hostB:dst`) works the same way: the
+Remote→remote (`syq hostA:src hostB:dst`) works the same way: the
 orchestrator on hostA connects to hostB's listener.
 
 ## Defaults chosen for network filesystems
@@ -399,18 +447,18 @@ final-named files. `--inplace` is the explicit space/safety tradeoff.
 
 ## Ignoring paths (`-i`, `--ignore-from`)
 
-pcp has one filter mechanism instead of rsync's include/exclude/filter rules:
+syq has one filter mechanism instead of rsync's include/exclude/filter rules:
 every `-i PATTERN` is a line of a virtual `.gitignore` anchored at each source
 root, and `--ignore-from FILE` splices in the lines of a file. Patterns from
 both are applied in command-line order with gitignore semantics (last match
 wins, `!` re-includes), so anything you'd write in a `.gitignore` works here:
 
 ```sh
-pcp -a -i node_modules -i .git src/ host:dst/   # a name matches at any depth
-pcp -a -i '*.o' -i /build src/ host:dst/         # glob; leading / anchors to the root
-pcp -a -i 'logs/*' -i '!logs/keep/' src/ dst/    # everything in logs/ except keep/
-pcp -a --ignore-from .gitignore -i '!dist/' repo/ host:repo/
-pcp -a -i '*' -i '!*/' -i '!*.jpg' photos/ bak/  # copy only *.jpg
+syq -a -i node_modules -i .git src/ host:dst/   # a name matches at any depth
+syq -a -i '*.o' -i /build src/ host:dst/         # glob; leading / anchors to the root
+syq -a -i 'logs/*' -i '!logs/keep/' src/ dst/    # everything in logs/ except keep/
+syq -a --ignore-from .gitignore -i '!dist/' repo/ host:repo/
+syq -a -i '*' -i '!*/' -i '!*.jpg' photos/ bak/  # copy only *.jpg
 ```
 
 Rules of thumb (they're git's): `foo` matches a file or directory named `foo`
@@ -430,17 +478,17 @@ nothing to act on. Ignore the siblings instead (`logs/*`, which does not cross
 
 ## Parallel removal (`--rm`)
 
-`pcp --rm [-j N] [-n] [-v] PATH...` removes trees the way pcp copies them:
+`syq --rm [-j N] [-n] [-v] PATH...` removes trees the way syq copies them:
 a parallel scan, files unlinked in batches across N workers, directories
 removed deepest-first with each level in parallel. Symlinks are removed, not
 followed. Remote paths (`host:path`) work. It refuses `/`, `.` and `~`. On
 NFS, where every unlink is a round trip, `-j32` removed 20,000 files in 2.5 s
-versus 9.7 s for `rm -rf`; on a local SSD `rm -rf` is already fast and pcp is
+versus 9.7 s for `rm -rf`; on a local SSD `rm -rf` is already fast and syq is
 no faster.
 
 ## Same-machine copies (copy_file_range)
 
-When source and destination are on the same machine, pcp copies each file with
+When source and destination are on the same machine, syq copies each file with
 `copy_file_range(2)` instead of streaming bytes through userspace: the kernel
 does a reflink or a straight in-kernel copy, and on NFS 4.2 the *server* copies
 the file internally (no client round trip). Measured: a single 8 GB file
@@ -453,7 +501,7 @@ exception described above.
 
 ## NFS
 
-Local↔NFS copies are a local→local pcp run (`pcp -a -j16 /raid/x /mnt/nfs/x`)
+Local↔NFS copies are a local→local syq run (`syq -a -j16 /raid/x /mnt/nfs/x`)
 and benefit from the same parallelism: measured on a 20 Gbit NFSv4.2 mount,
 reads of one 4 GB file 858 MiB/s with `-j8` vs ~400 MB/s for `cp`; 20,000
 small files written in 28 s vs 72 s for `cp -r`. Writes of a *single* file
@@ -465,7 +513,7 @@ fix for that.
 
 ## Performance notes
 
-- pcp asks ssh for `aes128-gcm@openssh.com` first (falling back to the usual
+- syq asks ssh for `aes128-gcm@openssh.com` first (falling back to the usual
   ciphers). On x86 with AES-NI that is noticeably faster per stream than
   OpenSSH's default chacha20-poly1305.
 - Each connection costs one ssh handshake (~0.3 s on a LAN, several seconds
@@ -473,8 +521,8 @@ fix for that.
   (everything waits on them; only then do data connections start), up to 32
   at a time, and if the
   server sheds one — sshd's `MaxStartups` (default 10) randomly rejects
-  sessions beyond 10 being set up at once — pcp halves that number for the
-  rest of the run and retries. On a server set up for pcp (`MaxStartups
+  sessions beyond 10 being set up at once — syq halves that number for the
+  rest of the run and retries. On a server set up for syq (`MaxStartups
   100`, see `scripts/server-setup.sh`) 32 sessions come up in one round.
   Auto-tuning starts at 8 and only opens more once they have been shown to
   pay.
@@ -482,11 +530,11 @@ fix for that.
   through your machine; over a slow link that dominates setup time. Keys on the
   source host avoid it.
 - Measured on two 160-core hosts on a 20 Gbit LAN: a single ssh stream tops out
-  around 450–550 MB/s; `pcp -j8` into tmpfs reached ~1.2–1.3 GiB/s (the raw
+  around 450–550 MB/s; `syq -j8` into tmpfs reached ~1.2–1.3 GiB/s (the raw
   multi-stream ssh ceiling), while writes to the destination's ext4 NVMe capped
   everything, rsync included, at ~600 MB/s. Check the disk before blaming the
   network.
-- `PCP_DEBUG=1` prints connect times and where each worker and each remote
+- `SYQ_DEBUG=1` prints connect times and where each worker and each remote
   server spent its time (blocked on reads, pipe writes, acks; waiting, handling).
 
 ## Exit codes
@@ -495,4 +543,4 @@ fix for that.
 |---|---|
 | 0 | Everything copied and verified |
 | 23 | Finished, but some files failed (unreadable source, `DIFFERS`, changed during transfer …) — errors are on stderr |
-| 1 | Fatal: bad arguments, couldn't connect, remote `pcp` missing, connection lost |
+| 1 | Fatal: bad arguments, couldn't connect, remote `syq` missing, connection lost |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,23 +21,24 @@ releases setting so published assets and tags cannot be changed afterward.
    `v*` tags to release maintainers. GitHub's ruleset signature rule applies to
    commits, not annotated tag-object signatures; the release workflow checks
    the latter explicitly through GitHub's tag verification API.
-4. Give a fine-grained token write access only to the contents of
-   `greaber/homebrew-tap`. It does not need access to the syq repository. This
-   token and the release signing key enter the encrypted inventory described
-   below; do not paste either value into GitHub directly.
+4. The encrypted inventory initializer generates a dedicated SSH deploy key
+   for `greaber/homebrew-tap`. The sync installs its public half on that
+   repository with write access and places only its private half in the
+   protected `release` environment. It has no access to the syq repository or
+   to any other repository in the account.
 
 ## Encrypted release inventory
 
 The committed `.env.release` file is the canonical release-credential
 inventory. It contains ciphertext for `SYQ_RELEASE_SIGNING_KEY_PEM_B64` and
-`HOMEBREW_TAP_TOKEN`, plus the corresponding public
+`HOMEBREW_TAP_DEPLOY_KEY`, plus the corresponding public
 `SYQ_RELEASE_PUBLIC_KEY`. Its decryption authority lives only in the
 gitignored `.env.keys`. Forks receive the ciphertext but neither the
 decryption key nor official publishing authority.
 
 Install the pinned maintainer tool, then initialize the inventory on an
-encrypted developer machine. The initializer prompts without echoing for the
-fine-grained Homebrew token and generates the Ed25519 signing key locally:
+encrypted developer machine. The initializer generates independent Ed25519
+keys for manifest signing and Homebrew tap access; it needs no secret input:
 
 ```sh
 npm install --global @dotenvx/dotenvx@2.21.0
@@ -60,23 +61,19 @@ gh secret list --repo greaber/syq --env release
 gh variable list --repo greaber/syq
 ```
 
-The sync sends the individual private key and tap token to environment secrets;
-it sends the public key to the repository variable used by every official
+The sync sends the two individual private keys to environment secrets, installs
+the Homebrew key's public half as a write-enabled deploy key on the tap, and
+sends the release public key to the repository variable used by every official
 build. It never sends `.env.keys`, any `DOTENV_PRIVATE_KEY_*` value, or an
-undeclared entry from the encrypted file. It also derives the public key from
-the private key and refuses to update GitHub if they differ.
+undeclared entry from the encrypted file. It derives both public keys locally
+and refuses a mismatched release signing pair or tap deploy key.
 
-To rotate the Homebrew token, update the canonical ciphertext and rerun the
-same dry-run/execute sequence:
-
-```sh
-read -r -s -p 'New Homebrew tap token: ' token; printf '\n'
-dotenvx set HOMEBREW_TAP_TOKEN "$token" -f .env.release --no-native
-unset token
-git add .env.release && git commit -m 'Rotate Homebrew tap token'
-scripts/sync-github-secrets.sh
-scripts/sync-github-secrets.sh --execute
-```
+The Homebrew deploy key is already restricted to one repository and should not
+need routine rotation. If it is exposed, replace its ciphertext with a newly
+generated Ed25519 private key, remove the deploy key titled `syq release
+workflow` from the tap, commit `.env.release`, and rerun the dry-run/execute
+sync. The sync will install the new public half before updating the protected
+environment secret.
 
 Do not rotate the release signing key casually: installed clients trust it, so
 a planned rotation first needs a release that trusts both old and new keys.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,115 @@
+# Releasing syq
+
+Releases are deliberately fail-closed: all four binaries, a matching signing
+key, a protected release environment, and the Homebrew tap must be configured
+before a tag can publish anything. The workflow uses a draft until every file
+is uploaded and checked, then publishes it once. Enable GitHub's immutable
+releases setting so published assets and tags cannot be changed afterward.
+
+## One-time repository setup
+
+1. Rename the existing GitHub repository to `greaber/syq` and make it public;
+   do not delete and recreate it. GitHub redirects old repository web and Git
+   URLs after a rename. Create a public `greaber/homebrew-tap` repository; the
+   formula will be written to `Formula/syq.rb` there.
+2. Create a GitHub Actions environment named `release`. Add required reviewers
+   and restrict deployments to release tags. Keep the default workflow token
+   read-only; the workflow grants write permissions only to its release job.
+3. Enable immutable releases, artifact attestations, branch protection for
+   `master`, required `ci` checks, dependency review/Dependabot, secret
+   scanning, and a ruleset that restricts creation, update, and deletion of
+   `v*` tags to release maintainers. GitHub's ruleset signature rule applies to
+   commits, not annotated tag-object signatures; the release workflow checks
+   the latter explicitly through GitHub's tag verification API.
+4. Give a fine-grained token write access only to the contents of
+   `greaber/homebrew-tap`. Store it as the `HOMEBREW_TAP_TOKEN` secret in the
+   `release` environment. It does not need access to the syq repository.
+
+Create the Ed25519 release key offline on an encrypted machine and retain a
+protected backup:
+
+```sh
+umask 077
+openssl genpkey -algorithm ED25519 -out syq-release-signing.pem
+public_key=$(openssl pkey -in syq-release-signing.pem -pubout -outform DER | tail -c 32 | base64 | tr -d '\n')
+gh variable set SYQ_RELEASE_PUBLIC_KEY --body "$public_key"
+base64 < syq-release-signing.pem | tr -d '\n' | gh secret set SYQ_RELEASE_SIGNING_KEY_PEM_B64 --env release
+```
+
+`SYQ_RELEASE_PUBLIC_KEY` is a repository variable because every official target
+embeds it. The private-key value is an environment secret available only after
+release approval. CI derives the public key from the private key and refuses to
+publish if they differ. Do not rotate this key casually: installed clients
+trust it, so a planned rotation first needs a release that trusts both old and
+new keys.
+
+## Rename cutover with active worktrees
+
+Treat the code rename and the GitHub repository rename as one coordinated
+cutover, after functional branches that still use `pcp` have merged:
+
+1. Merge ready in-progress feature branches into `master` while the code still
+   uses the old name. Rebase this distribution branch onto that result and land
+   its mechanical `pcp`-to-`syq` rename once.
+2. Immediately rename `greaber/pcp` to `greaber/syq` in GitHub settings, as the
+   second half of the same cutover. Do not later create another `greaber/pcp`,
+   because that disables GitHub's old-URL redirect.
+3. From the primary checkout, run
+   `git remote set-url origin https://github.com/greaber/syq.git`. The remote
+   configuration is shared by all linked worktrees, so do this only once.
+4. Rebase any feature branch that must remain open onto the renamed `master`.
+   It then resolves the naming change once, rather than making every worktree
+   carry an independent partial rename.
+
+The local `/home/grant/repos/pcp` directory name is cosmetic. Do not move it
+while linked worktrees exist, because Git records their paths. If changing the
+directory name matters, remove completed linked worktrees first and make a
+fresh clone at `/home/grant/repos/syq`; otherwise leaving the directory named
+`pcp` has no user-visible effect.
+
+## Cutting a release
+
+1. Update the package version in `Cargo.toml`, run `cargo check` to refresh
+   `Cargo.lock`, then run the normal locked checks to validate it. Update
+   release notes and merge through the protected branch. Change the protocol
+   version in `src/proto.rs` only for a wire-incompatible release.
+2. Create and push a signed annotated tag matching the package version. Its
+   signing key and email must be configured on your GitHub account so GitHub
+   reports the tag-object signature as verified:
+
+   ```sh
+   git tag -s v0.1.0 -m 'syq 0.1.0'
+   git push origin v0.1.0
+   ```
+
+3. Approve the protected `release` environment. The workflow first verifies
+   that the annotated tag's signature is valid and that it directly targets
+   the workflow commit, and that this commit is reachable from protected
+   `master`. It then builds static GNU Linux x86-64/ARM64 binaries and native
+   macOS Apple Silicon/Intel binaries, signs the manifest, verifies the exact
+   asset inventory, creates provenance attestations, uploads a draft, checks
+   every uploaded byte, publishes it, and finally updates the tap.
+4. Verify one or more downloaded artifacts and exercise both install paths:
+
+   ```sh
+   gh attestation verify syq-linux-x86_64 --repo greaber/syq
+   curl --proto '=https' --tlsv1.2 -LsSf https://github.com/greaber/syq/releases/latest/download/install.sh -o install.sh
+   less install.sh
+   sh install.sh --bin-dir "$(mktemp -d)"
+   brew install greaber/tap/syq
+   ```
+
+If a job stops after creating a draft, inspect that draft rather than
+overwriting it. The workflow refuses to reuse drafts. It may safely be rerun
+after a fully published release: it downloads every published asset and
+requires byte-for-byte equality with the rebuilt release before forwarding the
+formula to the tap job.
+
+## macOS signing
+
+The supported install paths use terminal download tools or Homebrew, which
+normally do not set `com.apple.quarantine`; unsigned command-line binaries
+therefore do not normally trigger the warning seen for browser downloads. The
+current workflow does not hold an Apple Developer credential. If syq later
+offers browser downloads as a primary path, add Developer ID signing and Apple
+notarization in the macOS build jobs before advertising that path.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,26 +22,64 @@ releases setting so published assets and tags cannot be changed afterward.
    commits, not annotated tag-object signatures; the release workflow checks
    the latter explicitly through GitHub's tag verification API.
 4. Give a fine-grained token write access only to the contents of
-   `greaber/homebrew-tap`. Store it as the `HOMEBREW_TAP_TOKEN` secret in the
-   `release` environment. It does not need access to the syq repository.
+   `greaber/homebrew-tap`. It does not need access to the syq repository. This
+   token and the release signing key enter the encrypted inventory described
+   below; do not paste either value into GitHub directly.
 
-Create the Ed25519 release key offline on an encrypted machine and retain a
-protected backup:
+## Encrypted release inventory
+
+The committed `.env.release` file is the canonical release-credential
+inventory. It contains ciphertext for `SYQ_RELEASE_SIGNING_KEY_PEM_B64` and
+`HOMEBREW_TAP_TOKEN`, plus the corresponding public
+`SYQ_RELEASE_PUBLIC_KEY`. Its decryption authority lives only in the
+gitignored `.env.keys`. Forks receive the ciphertext but neither the
+decryption key nor official publishing authority.
+
+Install the pinned maintainer tool, then initialize the inventory on an
+encrypted developer machine. The initializer prompts without echoing for the
+fine-grained Homebrew token and generates the Ed25519 signing key locally:
 
 ```sh
-umask 077
-openssl genpkey -algorithm ED25519 -out syq-release-signing.pem
-public_key=$(openssl pkey -in syq-release-signing.pem -pubout -outform DER | tail -c 32 | base64 | tr -d '\n')
-gh variable set SYQ_RELEASE_PUBLIC_KEY --body "$public_key"
-base64 < syq-release-signing.pem | tr -d '\n' | gh secret set SYQ_RELEASE_SIGNING_KEY_PEM_B64 --env release
+npm install --global @dotenvx/dotenvx@2.21.0
+scripts/init-release-secrets.sh
+git add .env.release
+git commit -m 'Add encrypted release credential inventory'
 ```
 
-`SYQ_RELEASE_PUBLIC_KEY` is a repository variable because every official target
-embeds it. The private-key value is an environment secret available only after
-release approval. CI derives the public key from the private key and refuses to
-publish if they differ. Do not rotate this key casually: installed clients
-trust it, so a planned rotation first needs a release that trusts both old and
-new keys.
+Back up `.env.keys` immediately in protected storage. Do not commit it, upload
+it to GitHub, or use it in CI. Losing every copy prevents future releases from
+using the signing identity embedded in installed clients.
+
+After the repository has been renamed and the protected `release` environment
+exists, preview and then synchronize the allowlisted values:
+
+```sh
+scripts/sync-github-secrets.sh
+scripts/sync-github-secrets.sh --execute
+gh secret list --repo greaber/syq --env release
+gh variable list --repo greaber/syq
+```
+
+The sync sends the individual private key and tap token to environment secrets;
+it sends the public key to the repository variable used by every official
+build. It never sends `.env.keys`, any `DOTENV_PRIVATE_KEY_*` value, or an
+undeclared entry from the encrypted file. It also derives the public key from
+the private key and refuses to update GitHub if they differ.
+
+To rotate the Homebrew token, update the canonical ciphertext and rerun the
+same dry-run/execute sequence:
+
+```sh
+read -r -s -p 'New Homebrew tap token: ' token; printf '\n'
+dotenvx set HOMEBREW_TAP_TOKEN "$token" -f .env.release --no-native
+unset token
+git add .env.release && git commit -m 'Rotate Homebrew tap token'
+scripts/sync-github-secrets.sh
+scripts/sync-github-secrets.sh --execute
+```
+
+Do not rotate the release signing key casually: installed clients trust it, so
+a planned rotation first needs a release that trusts both old and new keys.
 
 ## Rename cutover with active worktrees
 

--- a/RESUME-DESIGN.md
+++ b/RESUME-DESIGN.md
@@ -1,10 +1,10 @@
-# PCP resume and checkpoint design
+# SYQ resume and checkpoint design
 
 **Status:** implemented. README.md is the user-facing contract.
 
 ## Goals
 
-PCP needs to recover efficiently at two different scales:
+SYQ needs to recover efficiently at two different scales:
 
 1. An interrupted large file should reuse bytes already present at the
    destination.
@@ -13,21 +13,21 @@ PCP needs to recover efficiently at two different scales:
    prohibitively expensive.
 
 Ordinary invocations must not leave a persistent history or make their result
-depend on hidden state from earlier PCP commands. The second optimization is
+depend on hidden state from earlier SYQ commands. The second optimization is
 therefore opt-in through `--checkpoint FILE`.
 
 ## Atomic publication and per-file resume
 
 Unless `--inplace` was explicit, every regular file is written to the
-deterministic destination-side name `.<name>.pcp-partial`, given its final
+deterministic destination-side name `.<name>.syq-partial`, given its final
 metadata, and atomically renamed over the requested pathname. Small files are
 still pipelined as whole-file protocol requests, but the receiver stages and
-renames each one before acknowledging it. PCP does not `fsync` by default;
+renames each one before acknowledging it. SYQ does not `fsync` by default;
 `--fsync` separately requests crash durability for the file and directory.
 
 If a range transfer is interrupted, the partial itself is the per-file state.
 A normal rerun finds it, hashes it and the current source at fixed
-`--block-size` offsets, and transmits only mismatching blocks. PCP never needs a
+`--block-size` offsets, and transmits only mismatching blocks. SYQ never needs a
 local record to trust those bytes. A stale partial is content-safe because
 every reused block is compared with the current source. Pipelined small files
 are cheap enough to overwrite wholesale on retry; they avoid the extra partial
@@ -81,7 +81,7 @@ Malformed or crash-torn records are ignored.
 
 ## Using and retiring a checkpoint
 
-The source is scanned on every attempt. For each regular file, PCP first claims
+The source is scanned on every attempt. For each regular file, SYQ first claims
 its destination mapping (so checkpoint skipping cannot hide source collisions),
 then looks up its destination-relative path. A matching source fingerprint is
 counted complete without a destination stat. A missing or mismatching record
@@ -91,7 +91,7 @@ transfer path.
 The checkpoint is retained after interruption or any copy error. After a clean
 copy it is closed and removed: completed jobs do not become hidden history. If
 the destination root no longer exists at startup, an old checkpoint is reset
-because none of its destination claims can still be valid. PCP validates that
+because none of its destination claims can still be valid. SYQ validates that
 the user-selected path contains this job's checkpoint before resetting it; it
 never silently replaces an unrelated file. A dry run may read state to preview
 the corresponding retry but does not create, append, reset, or remove it.
@@ -105,7 +105,7 @@ inspection.
 A checkpoint record is a historical assertion. A matching record intentionally
 wins over current destination reality: if another process deletes, replaces,
 or modifies that destination path between attempts, the retry skips it. This is
-why checkpointing is opt-in and why ordinary PCP runs keep no automatic
+why checkpointing is opt-in and why ordinary SYQ runs keep no automatic
 journal.
 
 The source fingerprint detects ordinary source changes between attempts but is
@@ -135,7 +135,7 @@ prevent the job from reaching new work.
 ## Removed automatic state
 
 An earlier implementation kept a job-keyed journal under
-`$XDG_STATE_HOME/pcp` for every copy and placed a session marker in the
+`$XDG_STATE_HOME/syq` for every copy and placed a session marker in the
 destination. That made ordinary results depend on invisible history, consumed
 coordinator storage without an explicit request, required a writable state
 directory, and introduced marker lifecycle and concurrency semantics unlike

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.94.1"
+profile = "minimal"

--- a/scripts/generate-homebrew-formula.sh
+++ b/scripts/generate-homebrew-formula.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Generate the formula published to greaber/homebrew-tap from the same hashes
+# and immutable assets used by the standalone installer.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 MANIFEST OUTPUT" >&2
+  exit 2
+fi
+manifest=$1
+output=$2
+command -v jq >/dev/null || { echo "generate-homebrew-formula needs jq" >&2; exit 1; }
+
+version=$(jq -er '.version' "$manifest")
+tag=$(jq -er '.tag' "$manifest")
+repository=$(jq -er '.repository' "$manifest")
+test "$repository" = 'https://github.com/greaber/syq' || { echo "unexpected repository" >&2; exit 1; }
+
+asset() { jq -er --arg target "$1" '.artifacts[$target].binary.name' "$manifest"; }
+hash() { jq -er --arg target "$1" '.artifacts[$target].binary.sha256' "$manifest"; }
+
+linux_x86_asset=$(asset linux-x86_64)
+linux_x86_hash=$(hash linux-x86_64)
+linux_arm_asset=$(asset linux-aarch64)
+linux_arm_hash=$(hash linux-aarch64)
+mac_x86_asset=$(asset macos-x86_64)
+mac_x86_hash=$(hash macos-x86_64)
+mac_arm_asset=$(asset macos-arm64)
+mac_arm_hash=$(hash macos-arm64)
+
+cat > "$output" <<EOF
+class Syq < Formula
+  desc "Parallel copy with an rsync-shaped interface"
+  homepage "$repository"
+  version "$version"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "$repository/releases/download/$tag/$mac_arm_asset", using: :nounzip
+      sha256 "$mac_arm_hash"
+    else
+      url "$repository/releases/download/$tag/$mac_x86_asset", using: :nounzip
+      sha256 "$mac_x86_hash"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "$repository/releases/download/$tag/$linux_arm_asset", using: :nounzip
+      sha256 "$linux_arm_hash"
+    else
+      url "$repository/releases/download/$tag/$linux_x86_asset", using: :nounzip
+      sha256 "$linux_x86_hash"
+    end
+  end
+
+  def install
+    bin.install Dir["syq-*"].first => "syq"
+  end
+
+  test do
+    assert_match "syq #{version}", shell_output("#{bin}/syq --version")
+  end
+end
+EOF

--- a/scripts/generate-installer.sh
+++ b/scripts/generate-installer.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Generate a version-pinned installer whose trusted hashes come from the signed
+# release manifest. The generated script needs only POSIX sh at install time.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 MANIFEST OUTPUT" >&2
+  exit 2
+fi
+manifest=$1
+output=$2
+command -v jq >/dev/null || { echo "generate-installer needs jq" >&2; exit 1; }
+
+version=$(jq -er '.version' "$manifest")
+tag=$(jq -er '.tag' "$manifest")
+helper_id=$(jq -er '.helper_id' "$manifest")
+repository=$(jq -er '.repository' "$manifest")
+test "$repository" = 'https://github.com/greaber/syq' || { echo "unexpected repository" >&2; exit 1; }
+
+for target in linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64; do
+  jq -e --arg target "$target" '
+    .artifacts[$target].archive
+    | (.name | test("^[A-Za-z0-9._-]+$"))
+      and (.sha256 | test("^[0-9a-f]{64}$"))
+      and (.size | type == "number" and . > 0)
+  ' "$manifest" >/dev/null || { echo "invalid archive metadata for $target" >&2; exit 1; }
+done
+
+{
+  cat <<EOF
+#!/bin/sh
+# Generated for syq $version. Inspect this script before running it; the exact
+# version remains at $repository/releases/download/$tag/install.sh.
+set -eu
+
+version='$version'
+tag='$tag'
+helper_id='$helper_id'
+base_url=\${SYQ_INSTALL_BASE_URL:-'$repository/releases/download/$tag'}
+bin_dir=\${HOME:+\$HOME/.local/bin}
+
+usage() {
+  cat <<USAGE
+Install syq $version without sudo.
+
+Usage: install.sh [--bin-dir DIR]
+
+The default is \$HOME/.local/bin. The installer detects this host, downloads
+the pinned release archive, checks its embedded SHA-256 and size, verifies the
+binary's version and helper identity, then replaces the destination atomically.
+USAGE
+}
+
+while [ \$# -gt 0 ]; do
+  case \$1 in
+    --bin-dir)
+      [ \$# -ge 2 ] || { echo 'install.sh: --bin-dir needs a value' >&2; exit 2; }
+      bin_dir=\$2
+      shift 2
+      ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "install.sh: unknown option: \$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+[ -n "\${bin_dir:-}" ] || { echo 'install.sh: HOME is not set; pass --bin-dir DIR' >&2; exit 1; }
+[ -n "\${XDG_CONFIG_HOME:-}" ] || [ -n "\${HOME:-}" ] || {
+  echo 'install.sh: HOME and XDG_CONFIG_HOME are not set; cannot record a managed installation' >&2
+  exit 1
+}
+if [ -n "\${XDG_CONFIG_HOME:-}" ]; then
+  receipt_dir=\$XDG_CONFIG_HOME/syq
+else
+  receipt_dir=\$HOME/.config/syq
+fi
+mkdir -p "\$receipt_dir" || {
+  echo "install.sh: cannot prepare install receipt directory: \$receipt_dir" >&2
+  exit 1
+}
+receipt_probe=\$(mktemp "\$receipt_dir/.syq-install-preflight.XXXXXXXX") || {
+  echo "install.sh: install receipt directory is not writable: \$receipt_dir" >&2
+  exit 1
+}
+rm -f "\$receipt_probe"
+
+case "\$(uname -s):\$(uname -m)" in
+EOF
+  for target in linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64; do
+    archive=$(jq -r --arg target "$target" '.artifacts[$target].archive.name' "$manifest")
+    hash=$(jq -r --arg target "$target" '.artifacts[$target].archive.sha256' "$manifest")
+    size=$(jq -r --arg target "$target" '.artifacts[$target].archive.size' "$manifest")
+    case "$target" in
+      linux-x86_64) pattern='Linux:x86_64' ;;
+      linux-aarch64) pattern='Linux:aarch64|Linux:arm64' ;;
+      macos-arm64) pattern='Darwin:arm64|Darwin:aarch64' ;;
+      macos-x86_64) pattern='Darwin:x86_64' ;;
+    esac
+    printf '%s) archive=%s; expected_sha=%s; expected_size=%s ;;\n' \
+      "$pattern" "'$archive'" "'$hash'" "'$size'"
+  done
+  cat <<'EOF'
+*) echo "install.sh: unsupported platform: $(uname -s) $(uname -m)" >&2; exit 1 ;;
+esac
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-install.XXXXXXXX")
+install_tmp=
+cleanup() {
+  rm -rf "$work"
+  [ -z "$install_tmp" ] || rm -f "$install_tmp"
+}
+trap cleanup EXIT HUP INT TERM
+download="$work/$archive"
+program="$work/syq"
+
+fetch() {
+  if command -v curl >/dev/null 2>&1; then
+    curl --fail --silent --show-error --location --retry 2 --connect-timeout 10 \
+      --proto '=https' --proto-redir '=https' --output "$2" "$1"
+  elif command -v wget >/dev/null 2>&1; then
+    wget --quiet --https-only --timeout=10 --tries=3 -O "$2" "$1"
+  else
+    echo 'install.sh: downloading syq requires curl or wget' >&2
+    return 1
+  fi
+}
+
+fetch "$base_url/$archive" "$download"
+actual_size=$(wc -c < "$download" | tr -d '[:space:]')
+[ "$actual_size" = "$expected_size" ] || {
+  echo "install.sh: downloaded archive has size $actual_size, expected $expected_size" >&2
+  exit 1
+}
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_sha=$(sha256sum "$download" | sed 's/[[:space:]].*$//')
+elif command -v shasum >/dev/null 2>&1; then
+  actual_sha=$(shasum -a 256 "$download" | sed 's/[[:space:]].*$//')
+elif command -v openssl >/dev/null 2>&1; then
+  actual_sha=$(openssl dgst -sha256 "$download" | sed 's/^.*= //')
+else
+  echo 'install.sh: verification requires sha256sum, shasum, or openssl' >&2
+  exit 1
+fi
+[ "$actual_sha" = "$expected_sha" ] || {
+  echo 'install.sh: downloaded archive failed SHA-256 verification' >&2
+  exit 1
+}
+
+gzip -dc "$download" > "$program"
+chmod 755 "$program"
+got=$("$program" --version 2>/dev/null) || {
+  echo 'install.sh: downloaded syq cannot run on this host' >&2
+  exit 1
+}
+[ "$got" = "syq $version" ] || {
+  echo "install.sh: downloaded binary reports an unexpected version: $got" >&2
+  exit 1
+}
+got_id=$("$program" --remote-helper-id 2>/dev/null) || {
+  echo 'install.sh: downloaded syq has no helper identity' >&2
+  exit 1
+}
+[ "$got_id" = "$helper_id" ] || {
+  echo "install.sh: downloaded binary reports an unexpected identity: $got_id" >&2
+  exit 1
+}
+
+mkdir -p "$bin_dir"
+[ ! -d "$bin_dir/syq" ] || {
+  echo "install.sh: destination is a directory: $bin_dir/syq" >&2
+  exit 1
+}
+install_tmp=$(mktemp "$bin_dir/.syq-install.XXXXXXXX")
+cp "$program" "$install_tmp"
+chmod 755 "$install_tmp"
+mv -f "$install_tmp" "$bin_dir/syq"
+install_tmp=
+"$bin_dir/syq" --register-standalone-install
+trap - EXIT HUP INT TERM
+cleanup
+
+echo "installed syq $version at $bin_dir/syq"
+case ":$PATH:" in
+  *":$bin_dir:"*) ;;
+  *) echo "add $bin_dir to PATH, for example: export PATH=\"$bin_dir:\$PATH\"" ;;
+esac
+EOF
+} > "$output"
+chmod 755 "$output"
+sh -n "$output"

--- a/scripts/init-release-secrets.sh
+++ b/scripts/init-release-secrets.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Create syq's encrypted release inventory without exposing its durable signing
+# key or Homebrew credential to GitHub. Run once, then commit only .env.release.
+set -euo pipefail
+
+DOTENVX_VERSION=2.21.0
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+ENV_FILE="$ROOT_DIR/.env.release"
+KEYS_FILE="$ROOT_DIR/.env.keys"
+DOTENVX_BIN=${DOTENVX_BIN:-dotenvx}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+if [ "$#" -ne 0 ]; then
+  die "usage: $0"
+fi
+
+if [[ "$DOTENVX_BIN" == */* ]]; then
+  [ -x "$DOTENVX_BIN" ] || die "dotenvx is not executable: $DOTENVX_BIN"
+else
+  command -v "$DOTENVX_BIN" >/dev/null || die "dotenvx $DOTENVX_VERSION is required"
+fi
+command -v openssl >/dev/null || die "openssl is required"
+[ "$("$DOTENVX_BIN" --version)" = "$DOTENVX_VERSION" ] \
+  || die "dotenvx $DOTENVX_VERSION is required"
+
+[ ! -e "$ENV_FILE" ] || die "$ENV_FILE already exists; refusing to replace the release inventory"
+[ ! -e "$KEYS_FILE" ] || die "$KEYS_FILE already exists; refusing to replace its decryption authority"
+
+if [ -t 0 ]; then
+  printf 'Fine-grained greaber/homebrew-tap token: ' >&2
+  IFS= read -r -s homebrew_token
+  printf '\n' >&2
+else
+  IFS= read -r homebrew_token || die "expected the Homebrew tap token on standard input"
+fi
+[ -n "$homebrew_token" ] || die "the Homebrew tap token must not be empty"
+
+umask 077
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-init-release.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+
+private_key="$work/signing.pem"
+staged_env="$work/.env.release"
+staged_keys="$work/.env.keys"
+
+openssl genpkey -algorithm ED25519 -out "$private_key"
+signing_key_b64=$(openssl base64 -A -in "$private_key")
+public_key=$(openssl pkey -in "$private_key" -pubout -outform DER \
+  | tail -c 32 | openssl base64 -A)
+
+dotenvx_set() {
+  "$DOTENVX_BIN" set "$1" "$2" -f "$staged_env" -fk "$staged_keys" \
+    --no-native >/dev/null
+}
+
+dotenvx_get() {
+  "$DOTENVX_BIN" get "$1" -f "$staged_env" -fk "$staged_keys" \
+    --strict --overload --no-native
+}
+
+dotenvx_set SYQ_RELEASE_PUBLIC_KEY "$public_key"
+dotenvx_set SYQ_RELEASE_SIGNING_KEY_PEM_B64 "$signing_key_b64"
+dotenvx_set HOMEBREW_TAP_TOKEN "$homebrew_token"
+
+[ "$(dotenvx_get SYQ_RELEASE_PUBLIC_KEY)" = "$public_key" ] \
+  || die "failed to verify the encrypted public key"
+[ "$(dotenvx_get SYQ_RELEASE_SIGNING_KEY_PEM_B64)" = "$signing_key_b64" ] \
+  || die "failed to verify the encrypted signing key"
+[ "$(dotenvx_get HOMEBREW_TAP_TOKEN)" = "$homebrew_token" ] \
+  || die "failed to verify the encrypted Homebrew token"
+
+chmod 600 "$staged_keys"
+chmod 644 "$staged_env"
+mv "$staged_keys" "$KEYS_FILE"
+mv "$staged_env" "$ENV_FILE"
+
+unset homebrew_token signing_key_b64
+printf '%s\n' \
+  "Created $ENV_FILE and local $KEYS_FILE." \
+  "Back up .env.keys in protected storage, then commit only .env.release."

--- a/scripts/init-release-secrets.sh
+++ b/scripts/init-release-secrets.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Create syq's encrypted release inventory without exposing its durable signing
-# key or Homebrew credential to GitHub. Run once, then commit only .env.release.
+# or Homebrew deploy keys to GitHub. Run once, then commit only .env.release.
 set -euo pipefail
 
 DOTENVX_VERSION=2.21.0
@@ -24,20 +24,12 @@ else
   command -v "$DOTENVX_BIN" >/dev/null || die "dotenvx $DOTENVX_VERSION is required"
 fi
 command -v openssl >/dev/null || die "openssl is required"
+command -v ssh-keygen >/dev/null || die "ssh-keygen is required"
 [ "$("$DOTENVX_BIN" --version)" = "$DOTENVX_VERSION" ] \
   || die "dotenvx $DOTENVX_VERSION is required"
 
 [ ! -e "$ENV_FILE" ] || die "$ENV_FILE already exists; refusing to replace the release inventory"
 [ ! -e "$KEYS_FILE" ] || die "$KEYS_FILE already exists; refusing to replace its decryption authority"
-
-if [ -t 0 ]; then
-  printf 'Fine-grained greaber/homebrew-tap token: ' >&2
-  IFS= read -r -s homebrew_token
-  printf '\n' >&2
-else
-  IFS= read -r homebrew_token || die "expected the Homebrew tap token on standard input"
-fi
-[ -n "$homebrew_token" ] || die "the Homebrew tap token must not be empty"
 
 umask 077
 work=$(mktemp -d "${TMPDIR:-/tmp}/syq-init-release.XXXXXXXX")
@@ -45,13 +37,16 @@ cleanup() { rm -rf "$work"; }
 trap cleanup EXIT HUP INT TERM
 
 private_key="$work/signing.pem"
+homebrew_key="$work/homebrew-tap"
 staged_env="$work/.env.release"
 staged_keys="$work/.env.keys"
 
 openssl genpkey -algorithm ED25519 -out "$private_key"
+ssh-keygen -q -t ed25519 -N '' -C 'syq release workflow' -f "$homebrew_key"
 signing_key_b64=$(openssl base64 -A -in "$private_key")
 public_key=$(openssl pkey -in "$private_key" -pubout -outform DER \
   | tail -c 32 | openssl base64 -A)
+homebrew_deploy_key=$(<"$homebrew_key")
 
 dotenvx_set() {
   "$DOTENVX_BIN" set "$1" "$2" -f "$staged_env" -fk "$staged_keys" \
@@ -65,21 +60,21 @@ dotenvx_get() {
 
 dotenvx_set SYQ_RELEASE_PUBLIC_KEY "$public_key"
 dotenvx_set SYQ_RELEASE_SIGNING_KEY_PEM_B64 "$signing_key_b64"
-dotenvx_set HOMEBREW_TAP_TOKEN "$homebrew_token"
+dotenvx_set HOMEBREW_TAP_DEPLOY_KEY "$homebrew_deploy_key"
 
 [ "$(dotenvx_get SYQ_RELEASE_PUBLIC_KEY)" = "$public_key" ] \
   || die "failed to verify the encrypted public key"
 [ "$(dotenvx_get SYQ_RELEASE_SIGNING_KEY_PEM_B64)" = "$signing_key_b64" ] \
   || die "failed to verify the encrypted signing key"
-[ "$(dotenvx_get HOMEBREW_TAP_TOKEN)" = "$homebrew_token" ] \
-  || die "failed to verify the encrypted Homebrew token"
+[ "$(dotenvx_get HOMEBREW_TAP_DEPLOY_KEY)" = "$homebrew_deploy_key" ] \
+  || die "failed to verify the encrypted Homebrew deploy key"
 
 chmod 600 "$staged_keys"
 chmod 644 "$staged_env"
 mv "$staged_keys" "$KEYS_FILE"
 mv "$staged_env" "$ENV_FILE"
 
-unset homebrew_token signing_key_b64
+unset homebrew_deploy_key signing_key_b64
 printf '%s\n' \
   "Created $ENV_FILE and local $KEYS_FILE." \
   "Back up .env.keys in protected storage, then commit only .env.release."

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Validate a complete four-target build and create deterministic release
+# metadata, checksums, the standalone installer, and the Homebrew formula.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 vVERSION DIST_DIR" >&2
+  exit 2
+fi
+
+tag=$1
+dist=$2
+case "$tag" in
+  v[0-9]*.[0-9]*.[0-9]*) ;;
+  *) echo "invalid release tag: $tag" >&2; exit 2 ;;
+esac
+version=${tag#v}
+test -d "$dist" || { echo "missing distribution directory: $dist" >&2; exit 1; }
+command -v jq >/dev/null || { echo "package-release needs jq" >&2; exit 1; }
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_dir=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+package_version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$repo_dir/Cargo.toml" | head -1)
+test "$version" = "$package_version" || {
+  echo "tag $tag does not match Cargo.toml version $package_version" >&2
+  exit 1
+}
+protocol=$(sed -n 's/^pub const VERSION: u32 = \([0-9][0-9]*\);/\1/p' "$repo_dir/src/proto.rs")
+test -n "$protocol" || { echo "could not read protocol version" >&2; exit 1; }
+
+targets=(linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64)
+assets=(syq-linux-x86_64 syq-linux-aarch64 syq-macos-arm64 syq-macos-x86_64)
+artifacts='{}'
+
+for index in "${!targets[@]}"; do
+  target=${targets[$index]}
+  asset=${assets[$index]}
+  binary="$dist/$asset"
+  archive="$binary.gz"
+  if [ ! -f "$binary" ] || [ -L "$binary" ]; then
+    echo "missing regular asset: $binary" >&2
+    exit 1
+  fi
+  if [ ! -f "$archive" ] || [ -L "$archive" ]; then
+    echo "missing regular asset: $archive" >&2
+    exit 1
+  fi
+
+  binary_hash=$(sha256sum "$binary" | awk '{print $1}')
+  archive_hash=$(sha256sum "$archive" | awk '{print $1}')
+  binary_size=$(stat -c '%s' "$binary")
+  archive_size=$(stat -c '%s' "$archive")
+  printf '%s  %s\n' "$binary_hash" "$asset" > "$binary.sha256"
+  printf '%s  %s\n' "$archive_hash" "$asset.gz" > "$archive.sha256"
+
+  entry=$(jq -cn \
+    --arg binary_name "$asset" --arg binary_sha "$binary_hash" --argjson binary_size "$binary_size" \
+    --arg archive_name "$asset.gz" --arg archive_sha "$archive_hash" --argjson archive_size "$archive_size" \
+    '{binary:{name:$binary_name,sha256:$binary_sha,size:$binary_size},archive:{name:$archive_name,sha256:$archive_sha,size:$archive_size}}')
+  artifacts=$(jq -cn --argjson all "$artifacts" --arg target "$target" --argjson entry "$entry" '$all + {($target):$entry}')
+done
+
+manifest_core=$(mktemp)
+jq -n --sort-keys \
+  --arg repository 'https://github.com/greaber/syq' \
+  --arg version "$version" \
+  --arg tag "$tag" \
+  --arg helper_id "$tag-p$protocol" \
+  --argjson artifacts "$artifacts" \
+  '{schema:1,repository:$repository,version:$version,tag:$tag,helper_id:$helper_id,artifacts:$artifacts}' \
+  > "$manifest_core"
+
+"$script_dir/generate-installer.sh" "$manifest_core" "$dist/install.sh"
+"$script_dir/generate-homebrew-formula.sh" "$manifest_core" "$dist/syq.rb"
+installer_hash=$(sha256sum "$dist/install.sh" | awk '{print $1}')
+installer_size=$(stat -c '%s' "$dist/install.sh")
+formula_hash=$(sha256sum "$dist/syq.rb" | awk '{print $1}')
+formula_size=$(stat -c '%s' "$dist/syq.rb")
+jq --sort-keys \
+  --arg installer_sha "$installer_hash" --argjson installer_size "$installer_size" \
+  --arg formula_sha "$formula_hash" --argjson formula_size "$formula_size" \
+  '. + {
+    installer:{name:"install.sh",sha256:$installer_sha,size:$installer_size},
+    homebrew_formula:{name:"syq.rb",sha256:$formula_sha,size:$formula_size}
+  }' "$manifest_core" > "$dist/syq-release-manifest.json"
+rm -f "$manifest_core"
+
+# Anything unexpected here indicates a partial or contaminated release job.
+expected=$(mktemp)
+actual=$(mktemp)
+trap 'rm -f "$expected" "$actual"' EXIT
+for asset in "${assets[@]}"; do
+  printf '%s\n' "$asset" "$asset.sha256" "$asset.gz" "$asset.gz.sha256"
+done | sort > "$expected"
+printf '%s\n' install.sh syq-release-manifest.json syq.rb >> "$expected"
+sort -o "$expected" "$expected"
+find "$dist" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort > "$actual"
+diff -u "$expected" "$actual" || {
+  echo "release directory contains missing or unexpected files" >&2
+  exit 1
+}

--- a/scripts/server-setup.sh
+++ b/scripts/server-setup.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# server-setup.sh — one idempotent script for everything pcp/RoCE needs on a
+# server-setup.sh — one idempotent script for everything syq/RoCE needs on a
 # Japanese GPU host. Run as root; rerun any time (it only changes what differs).
 #
 #   sudo ./server-setup.sh plan      # print exactly what `apply` would change here
 #   sudo ./server-setup.sh apply     # do everything below
 #   sudo ./server-setup.sh status    # show what is / isn't in place (no changes)
-#   sudo ./server-setup.sh install-pcp # install the pcp binary system-wide (/usr/local/bin)
+#   sudo ./server-setup.sh install-syq # install the syq binary system-wide (/usr/local/bin)
 #   sudo ./server-setup.sh roce-clean# remove only the RoCE bits this script added (keep the rest)
 #
 # There is intentionally no blanket "undo": these settings (BBR, buffers,
@@ -14,11 +14,11 @@
 #
 # What `apply` does (each step is skipped when already done):
 #   1. TCP tuning for long-RTT transfers: 64 MB socket buffers, BBR, fq.
-#      -> /etc/sysctl.d/90-pcp-net.conf, /etc/modules-load.d/pcp-bbr.conf
+#      -> /etc/sysctl.d/90-syq-net.conf, /etc/modules-load.d/syq-bbr.conf
 #   2. sshd MaxStartups 100:30:200 so many parallel ssh sessions aren't dropped.
 #      -> the MaxStartups line in /etc/ssh/sshd_config itself (uncommented /
 #         replaced in place, added if absent) + sshd reload
-#   3. ufw: allow pcp's TCP data ports (47600-47699) from the cluster LAN, from
+#   3. ufw: allow syq's TCP data ports (47600-47699) from the cluster LAN, from
 #      each cluster host's public IP, and from the listed client machines.
 #   4. RoCE: bring the ConnectX ports up; if any have link, give each an
 #      address 192.168.<100+N>.<host octet>/24 with MTU 9000 via
@@ -27,7 +27,7 @@
 #      `netplan apply`, which would re-touch bond0). Ports without a cable are
 #      left alone, so this is a no-op on hosts that aren't wired yet.
 #
-# Everything this script writes carries a "pcp-setup" marker. Nothing here
+# Everything this script writes carries a "syq-setup" marker. Nothing here
 # touches bond0, NFS mounts, or the provider's RoCE fabric.
 
 set -euo pipefail
@@ -36,16 +36,16 @@ set -euo pipefail
 CLUSTER_LAN=10.2.201.0/24
 CLUSTER_PUBLIC=(157.66.255.44 157.66.255.45 157.66.255.46 157.66.255.59)   # j3 j2 j4 j5
 CLIENTS=(116.202.146.123)                                                 # grant's Hetzner box
-PCP_PORTS=47600:47699
+SYQ_PORTS=47600:47699
 ROCE_SUBNET_BASE=100
-MARK=pcp-setup
+MARK=syq-setup
 
-ETC=${PCP_SETUP_ETC:-/etc}           # overridable for testing only
-SYSCTL_FILE=$ETC/sysctl.d/90-pcp-net.conf
+ETC=${SYQ_SETUP_ETC:-/etc}           # overridable for testing only
+SYSCTL_FILE=$ETC/sysctl.d/90-syq-net.conf
 OLD_SYSCTL_FILE=$ETC/sysctl.d/99-net.conf
-MODULES_FILE=$ETC/modules-load.d/pcp-bbr.conf
+MODULES_FILE=$ETC/modules-load.d/syq-bbr.conf
 SSHD_CONFIG=$ETC/ssh/sshd_config
-OLD_SSHD_FILE=$ETC/ssh/sshd_config.d/60-pcp.conf   # from an earlier version of this script
+OLD_SSHD_FILE=$ETC/ssh/sshd_config.d/60-syq.conf   # from an earlier version of this script
 NETPLAN_FILE=$ETC/netplan/60-roce.yaml
 
 die() { echo "error: $*" >&2; exit 1; }
@@ -60,7 +60,7 @@ write_file() { if [ "$DRY" = 1 ]; then echo "    would write: $1"; sed 's/^/    
 # ---- 1. sysctl -----------------------------------------------------------------
 sysctl_wanted() {
   cat <<EOF
-# $MARK: TCP tuning for pcp / long-RTT transfers
+# $MARK: TCP tuning for syq / long-RTT transfers
 net.core.rmem_max = 67108864
 net.core.wmem_max = 67108864
 net.ipv4.tcp_rmem = 4096 131072 67108864
@@ -128,21 +128,21 @@ ufw_active() {
   grep -q "Status: active" <<<"$UFW_STATUS"
 }
 # `ufw status verbose` always prints the direction ("ALLOW IN"); plain status doesn't.
-ufw_has() { grep -qE "^$PCP_PORTS/tcp +ALLOW IN +$1( |$)" <<<"$UFW_STATUS"; }
+ufw_has() { grep -qE "^$SYQ_PORTS/tcp +ALLOW IN +$1( |$)" <<<"$UFW_STATUS"; }
 ufw_has_iface() { grep -qE "^Anywhere on $1 +ALLOW IN" <<<"$UFW_STATUS"; }
 ufw_status() {
   if ! ufw_active; then say "ufw: inactive (nothing to do)"; return 0; fi
   local ok=0 missing=""
   for s in $(ufw_sources); do ufw_has "$s" || missing="$missing $s"; done
-  say "ufw: pcp ports $PCP_PORTS/tcp ${missing:+missing from:$missing}${missing:-allowed from all listed sources}"
+  say "ufw: syq ports $SYQ_PORTS/tcp ${missing:+missing from:$missing}${missing:-allowed from all listed sources}"
   [ -z "$missing" ]
 }
 ufw_apply() {
   if ! ufw_active; then say "ufw: inactive, skipping"; return; fi
   for s in $(ufw_sources); do
     if ufw_has "$s"; then continue; fi
-    run ufw allow from "$s" to any port "$PCP_PORTS" proto tcp comment "$MARK pcp data" >/dev/null
-    say "ufw: allowed $PCP_PORTS/tcp from $s"
+    run ufw allow from "$s" to any port "$SYQ_PORTS" proto tcp comment "$MARK syq data" >/dev/null
+    say "ufw: allowed $SYQ_PORTS/tcp from $s"
   done
   say "ufw: done"
 }
@@ -250,26 +250,26 @@ roce_clean() {
   say "roce: removed $removed of our 192.168.10x addresses (provider addresses left intact)"
 }
 
-# ---- install pcp system-wide ------------------------------------------------
-PCP_SRC=/mnt/nfs/grant/pcp.bin        # staged static binary on NFS
-PCP_DST=/usr/local/bin/pcp
-install_pcp() {
-  [ -f "$PCP_SRC" ] || die "$PCP_SRC not found (stage the binary on NFS first)"
-  local want; want=$(cat /mnt/nfs/grant/pcp.version 2>/dev/null || echo "?")
+# ---- install syq system-wide ------------------------------------------------
+SYQ_SRC=/mnt/nfs/grant/syq.bin        # staged static binary on NFS
+SYQ_DST=/usr/local/bin/syq
+install_syq() {
+  [ -f "$SYQ_SRC" ] || die "$SYQ_SRC not found (stage the binary on NFS first)"
+  local want; want=$(cat /mnt/nfs/grant/syq.version 2>/dev/null || echo "?")
   # Tolerate a missing OR broken existing binary (pipefail would abort otherwise).
   local have=""
-  if [ -x "$PCP_DST" ]; then
-    have=$("$PCP_DST" --version 2>/dev/null | awk '{print $2}') || have=""
+  if [ -x "$SYQ_DST" ]; then
+    have=$("$SYQ_DST" --version 2>/dev/null | awk '{print $2}') || have=""
   fi
   if [ "$have" = "$want" ] && [ -n "$have" ]; then
-    say "pcp: /usr/local/bin/pcp already at $have"
+    say "syq: /usr/local/bin/syq already at $have"
   else
-    run install -m 0755 "$PCP_SRC" "$PCP_DST"
-    say "pcp: installed $("$PCP_DST" --version 2>/dev/null || echo '?') to $PCP_DST (was ${have:-absent})"
+    run install -m 0755 "$SYQ_SRC" "$SYQ_DST"
+    say "syq: installed $("$SYQ_DST" --version 2>/dev/null || echo '?') to $SYQ_DST (was ${have:-absent})"
   fi
   # Point out per-user copies that would shadow the system one on PATH.
   for h in /home/*; do
-    [ -e "$h/.local/bin/pcp" ] && say "pcp: NOTE $h/.local/bin/pcp exists and may shadow $PCP_DST on that user's PATH"
+    [ -e "$h/.local/bin/syq" ] && say "syq: NOTE $h/.local/bin/syq exists and may shadow $SYQ_DST on that user's PATH"
   done
 }
 
@@ -279,7 +279,7 @@ case "${1:-}" in
   apply)  need_root apply; echo "== apply on $(hostname)"; sysctl_apply; sshd_apply; ufw_apply; roce_apply; echo "== done" ;;
   status) echo "== status on $(hostname)"; [ "$(id -u)" = 0 ] || say "(run as root for sshd/ufw details)"; sysctl_status || true; sshd_status || true; ufw_status || true; roce_status
           ;;
-  install-pcp) need_root install-pcp; echo "== install-pcp on $(hostname)"; install_pcp; echo "== done" ;;
+  install-syq) need_root install-syq; echo "== install-syq on $(hostname)"; install_syq; echo "== done" ;;
   roce-clean) need_root roce-clean; echo "== roce-clean on $(hostname)"; roce_clean; echo "== done" ;;
   *) sed -n '2,26p' "$0"; exit 1 ;;
 esac

--- a/scripts/sign-release-manifest.sh
+++ b/scripts/sign-release-manifest.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Sign one release manifest with the protected Ed25519 key and prove that key
+# matches the public key embedded in official binaries.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 MANIFEST SIGNATURE_OUTPUT" >&2
+  exit 2
+fi
+manifest=$1
+output=$2
+if [ ! -f "$manifest" ] || [ -L "$manifest" ]; then
+  echo "missing regular release manifest: $manifest" >&2
+  exit 1
+fi
+test -n "${SYQ_RELEASE_PUBLIC_KEY:-}" || {
+  echo 'SYQ_RELEASE_PUBLIC_KEY is not set' >&2
+  exit 1
+}
+test -n "${SYQ_RELEASE_SIGNING_KEY_PEM_B64:-}" || {
+  echo 'SYQ_RELEASE_SIGNING_KEY_PEM_B64 is not set' >&2
+  exit 1
+}
+command -v openssl >/dev/null || { echo 'signing needs openssl' >&2; exit 1; }
+
+umask 077
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-sign-release.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+key="$work/signing.pem"
+public="$work/public.pem"
+signature="$work/manifest.sig"
+encoded="$work/manifest.sig.b64"
+configured_public="$work/configured-public-key"
+
+printf '%s' "$SYQ_RELEASE_SIGNING_KEY_PEM_B64" | openssl base64 -d -A > "$key"
+openssl pkey -in "$key" -pubout -out "$public" >/dev/null
+printf '%s' "$SYQ_RELEASE_PUBLIC_KEY" | openssl base64 -d -A > "$configured_public"
+test "$(wc -c < "$configured_public" | tr -d '[:space:]')" -eq 32 || {
+  echo 'SYQ_RELEASE_PUBLIC_KEY must encode exactly 32 bytes' >&2
+  exit 1
+}
+derived=$(openssl pkey -in "$key" -pubout -outform DER | tail -c 32 | openssl base64 -A)
+test "$derived" = "$SYQ_RELEASE_PUBLIC_KEY" || {
+  echo 'The signing key does not match SYQ_RELEASE_PUBLIC_KEY.' >&2
+  exit 1
+}
+
+openssl pkeyutl -sign -rawin -inkey "$key" -in "$manifest" -out "$signature"
+openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
+  -in "$manifest" -sigfile "$signature" >/dev/null
+openssl base64 -A -in "$signature" -out "$encoded"
+printf '\n' >> "$encoded"
+chmod 644 "$encoded"
+mv -f "$encoded" "$output"

--- a/scripts/sync-github-secrets.sh
+++ b/scripts/sync-github-secrets.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 DOTENVX_VERSION=2.21.0
 CANONICAL_HOST=github.com
 CANONICAL_REPO=greaber/syq
+HOMEBREW_TAP_REPO=greaber/homebrew-tap
+HOMEBREW_DEPLOY_KEY_TITLE='syq release workflow'
 RELEASE_ENVIRONMENT=release
 ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 ENV_FILE="$ROOT_DIR/.env.release"
@@ -70,6 +72,7 @@ else
   command -v "$DOTENVX_BIN" >/dev/null || die "dotenvx $DOTENVX_VERSION is required"
 fi
 command -v openssl >/dev/null || die "openssl is required"
+command -v ssh-keygen >/dev/null || die "ssh-keygen is required"
 [ "$("$DOTENVX_BIN" --version)" = "$DOTENVX_VERSION" ] \
   || die "dotenvx $DOTENVX_VERSION is required"
 [ -f "$ENV_FILE" ] || die "$ENV_FILE not found; run scripts/init-release-secrets.sh"
@@ -80,6 +83,10 @@ gh auth status --hostname "$CANONICAL_HOST" >/dev/null 2>&1 \
 repo=$(gh repo view "$CANONICAL_REPO" --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
   || die "cannot access $CANONICAL_REPO"
 [ "$repo" = "$CANONICAL_REPO" ] || die "gh resolved an unexpected repository: $repo"
+tap_repo=$(gh repo view "$HOMEBREW_TAP_REPO" --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+  || die "cannot access $HOMEBREW_TAP_REPO"
+[ "$tap_repo" = "$HOMEBREW_TAP_REPO" ] \
+  || die "gh resolved an unexpected Homebrew tap repository: $tap_repo"
 gh api "repos/$CANONICAL_REPO/environments/$RELEASE_ENVIRONMENT" >/dev/null 2>&1 \
   || die "GitHub environment $RELEASE_ENVIRONMENT does not exist in $CANONICAL_REPO"
 
@@ -92,11 +99,11 @@ public_key=$(dotenvx_get SYQ_RELEASE_PUBLIC_KEY) \
   || die "failed to decrypt SYQ_RELEASE_PUBLIC_KEY"
 signing_key=$(dotenvx_get SYQ_RELEASE_SIGNING_KEY_PEM_B64) \
   || die "failed to decrypt SYQ_RELEASE_SIGNING_KEY_PEM_B64"
-homebrew_token=$(dotenvx_get HOMEBREW_TAP_TOKEN) \
-  || die "failed to decrypt HOMEBREW_TAP_TOKEN"
+homebrew_deploy_key=$(dotenvx_get HOMEBREW_TAP_DEPLOY_KEY) \
+  || die "failed to decrypt HOMEBREW_TAP_DEPLOY_KEY"
 [ -n "$public_key" ] || die "SYQ_RELEASE_PUBLIC_KEY is empty"
 [ -n "$signing_key" ] || die "SYQ_RELEASE_SIGNING_KEY_PEM_B64 is empty"
-[ -n "$homebrew_token" ] || die "HOMEBREW_TAP_TOKEN is empty"
+[ -n "$homebrew_deploy_key" ] || die "HOMEBREW_TAP_DEPLOY_KEY is empty"
 
 umask 077
 work=$(mktemp -d "${TMPDIR:-/tmp}/syq-sync-secrets.XXXXXXXX")
@@ -104,6 +111,7 @@ cleanup() { rm -rf "$work"; }
 trap cleanup EXIT HUP INT TERM
 private_key="$work/signing.pem"
 configured_public="$work/public-key"
+homebrew_private_key="$work/homebrew-tap"
 printf '%s' "$signing_key" | openssl base64 -d -A > "$private_key"
 openssl pkey -in "$private_key" -noout >/dev/null 2>&1 \
   || die "SYQ_RELEASE_SIGNING_KEY_PEM_B64 is not a valid private key"
@@ -114,6 +122,41 @@ derived_public=$(openssl pkey -in "$private_key" -pubout -outform DER \
   | tail -c 32 | openssl base64 -A)
 [ "$derived_public" = "$public_key" ] \
   || die "the release signing key does not match SYQ_RELEASE_PUBLIC_KEY"
+printf '%s\n' "$homebrew_deploy_key" > "$homebrew_private_key"
+homebrew_public_key=$(ssh-keygen -y -f "$homebrew_private_key" 2>/dev/null) \
+  || die "HOMEBREW_TAP_DEPLOY_KEY is not a valid SSH private key"
+[[ "$homebrew_public_key" == 'ssh-ed25519 '* ]] \
+  || die "HOMEBREW_TAP_DEPLOY_KEY must be an Ed25519 SSH key"
+
+ensure_homebrew_deploy_key() {
+  local existing_identity expected_identity key deploy_keys
+  local -a existing_keys
+  existing_keys=()
+  deploy_keys=$(gh api "repos/$HOMEBREW_TAP_REPO/keys" \
+    --jq ".[] | select(.title == \"$HOMEBREW_DEPLOY_KEY_TITLE\") | .key") \
+    || die "cannot inspect deploy keys for $HOMEBREW_TAP_REPO"
+  while IFS= read -r key; do
+    [ -n "$key" ] && existing_keys+=("$key")
+  done <<< "$deploy_keys"
+  [ "${#existing_keys[@]}" -le 1 ] \
+    || die "multiple Homebrew deploy keys use the title $HOMEBREW_DEPLOY_KEY_TITLE"
+  expected_identity=$(awk '{print $1 " " $2}' <<< "$homebrew_public_key")
+  if [ "${#existing_keys[@]}" -eq 1 ]; then
+    existing_identity=$(awk '{print $1 " " $2}' <<< "${existing_keys[0]}")
+    [ "$existing_identity" = "$expected_identity" ] \
+      || die "the existing Homebrew deploy key does not match the encrypted inventory"
+    printf 'Homebrew tap deploy key already configured.\n'
+    return
+  fi
+  if $EXECUTE; then
+    gh api --method POST "repos/$HOMEBREW_TAP_REPO/keys" \
+      -f title="$HOMEBREW_DEPLOY_KEY_TITLE" \
+      -f key="$homebrew_public_key" -F read_only=false >/dev/null
+    printf 'configured Homebrew tap deploy key\n'
+  else
+    printf '[dry-run] configure Homebrew tap deploy key\n'
+  fi
+}
 
 set_environment_secret() {
   local name=$1 value=$2
@@ -138,11 +181,12 @@ set_repository_variable() {
 
 # The public variable is last. A partial sync therefore leaves release signing
 # fail-closed instead of publishing with an unverified key pair.
+ensure_homebrew_deploy_key
 set_environment_secret SYQ_RELEASE_SIGNING_KEY_PEM_B64 "$signing_key"
-set_environment_secret HOMEBREW_TAP_TOKEN "$homebrew_token"
+set_environment_secret HOMEBREW_TAP_DEPLOY_KEY "$homebrew_deploy_key"
 set_repository_variable SYQ_RELEASE_PUBLIC_KEY "$public_key"
 
-unset signing_key homebrew_token
+unset signing_key homebrew_deploy_key
 if $EXECUTE; then
   printf 'Synchronized the allowlisted release inventory to %s.\n' "$CANONICAL_REPO"
 else

--- a/scripts/sync-github-secrets.sh
+++ b/scripts/sync-github-secrets.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Materialize the small, allowlisted release inventory into GitHub. The dotenvx
+# decryption key remains local and is never forwarded to GitHub or CI.
+set -euo pipefail
+
+DOTENVX_VERSION=2.21.0
+CANONICAL_HOST=github.com
+CANONICAL_REPO=greaber/syq
+RELEASE_ENVIRONMENT=release
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+ENV_FILE="$ROOT_DIR/.env.release"
+KEYS_FILE="$ROOT_DIR/.env.keys"
+DOTENVX_BIN=${DOTENVX_BIN:-dotenvx}
+EXECUTE=false
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+case "$#:${1:-}" in
+  0:) ;;
+  1:--execute) EXECUTE=true ;;
+  *) die "usage: $0 [--execute]" ;;
+esac
+
+redact_remote_url() {
+  local url=$1
+  if [[ "$url" =~ ^([a-zA-Z][a-zA-Z0-9+.-]*://)([^/]*@)(.*)$ ]]; then
+    printf '%s***@%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[3]}"
+  elif [[ "$url" =~ ^([^/@]*:[^/@]*)@(.*)$ ]]; then
+    printf '***@%s' "${BASH_REMATCH[2]}"
+  else
+    printf '%s' "$url"
+  fi
+}
+
+github_slug_from_remote_url() {
+  local url=${1%/}
+  url=${url%.git}
+  if [[ "$url" =~ ^(ssh://)?(git@)?github\.com[:/]+([^/]+)/([^/]+)$ ]]; then
+    printf '%s/%s' "${BASH_REMATCH[3]}" "${BASH_REMATCH[4]}"
+    return 0
+  fi
+  if [[ "$url" =~ ^https?://([^@/]+@)?github\.com/([^/]+)/([^/]+)$ ]]; then
+    printf '%s/%s' "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+    return 0
+  fi
+  return 1
+}
+
+cd "$ROOT_DIR"
+
+# This check precedes every gh invocation. A maintainer running the script in a
+# fork must never copy the official release authority into that fork.
+origin_url=$(git config --get remote.origin.url 2>/dev/null || true)
+[ -n "$origin_url" ] || die "no remote.origin.url; run this from a clone of $CANONICAL_REPO"
+origin_url_safe=$(redact_remote_url "$origin_url")
+target_repo=$(github_slug_from_remote_url "$origin_url") \
+  || die "remote.origin.url is not a $CANONICAL_HOST URL: $origin_url_safe"
+[ "$target_repo" = "$CANONICAL_REPO" ] \
+  || die "refusing to touch secrets for $target_repo; expected $CANONICAL_REPO"
+[ "${GH_HOST:-$CANONICAL_HOST}" = "$CANONICAL_HOST" ] \
+  || die "GH_HOST must be $CANONICAL_HOST"
+
+command -v gh >/dev/null || die "the gh CLI is required"
+if [[ "$DOTENVX_BIN" == */* ]]; then
+  [ -x "$DOTENVX_BIN" ] || die "dotenvx is not executable: $DOTENVX_BIN"
+else
+  command -v "$DOTENVX_BIN" >/dev/null || die "dotenvx $DOTENVX_VERSION is required"
+fi
+command -v openssl >/dev/null || die "openssl is required"
+[ "$("$DOTENVX_BIN" --version)" = "$DOTENVX_VERSION" ] \
+  || die "dotenvx $DOTENVX_VERSION is required"
+[ -f "$ENV_FILE" ] || die "$ENV_FILE not found; run scripts/init-release-secrets.sh"
+[ -f "$KEYS_FILE" ] || die "$KEYS_FILE not found"
+
+gh auth status --hostname "$CANONICAL_HOST" >/dev/null 2>&1 \
+  || die "gh is not authenticated for $CANONICAL_HOST"
+repo=$(gh repo view "$CANONICAL_REPO" --json nameWithOwner --jq .nameWithOwner 2>/dev/null) \
+  || die "cannot access $CANONICAL_REPO"
+[ "$repo" = "$CANONICAL_REPO" ] || die "gh resolved an unexpected repository: $repo"
+gh api "repos/$CANONICAL_REPO/environments/$RELEASE_ENVIRONMENT" >/dev/null 2>&1 \
+  || die "GitHub environment $RELEASE_ENVIRONMENT does not exist in $CANONICAL_REPO"
+
+dotenvx_get() {
+  "$DOTENVX_BIN" get "$1" -f "$ENV_FILE" -fk "$KEYS_FILE" \
+    --strict --overload --no-native
+}
+
+public_key=$(dotenvx_get SYQ_RELEASE_PUBLIC_KEY) \
+  || die "failed to decrypt SYQ_RELEASE_PUBLIC_KEY"
+signing_key=$(dotenvx_get SYQ_RELEASE_SIGNING_KEY_PEM_B64) \
+  || die "failed to decrypt SYQ_RELEASE_SIGNING_KEY_PEM_B64"
+homebrew_token=$(dotenvx_get HOMEBREW_TAP_TOKEN) \
+  || die "failed to decrypt HOMEBREW_TAP_TOKEN"
+[ -n "$public_key" ] || die "SYQ_RELEASE_PUBLIC_KEY is empty"
+[ -n "$signing_key" ] || die "SYQ_RELEASE_SIGNING_KEY_PEM_B64 is empty"
+[ -n "$homebrew_token" ] || die "HOMEBREW_TAP_TOKEN is empty"
+
+umask 077
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-sync-secrets.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+private_key="$work/signing.pem"
+configured_public="$work/public-key"
+printf '%s' "$signing_key" | openssl base64 -d -A > "$private_key"
+openssl pkey -in "$private_key" -noout >/dev/null 2>&1 \
+  || die "SYQ_RELEASE_SIGNING_KEY_PEM_B64 is not a valid private key"
+printf '%s' "$public_key" | openssl base64 -d -A > "$configured_public"
+[ "$(wc -c < "$configured_public" | tr -d '[:space:]')" -eq 32 ] \
+  || die "SYQ_RELEASE_PUBLIC_KEY must encode exactly 32 bytes"
+derived_public=$(openssl pkey -in "$private_key" -pubout -outform DER \
+  | tail -c 32 | openssl base64 -A)
+[ "$derived_public" = "$public_key" ] \
+  || die "the release signing key does not match SYQ_RELEASE_PUBLIC_KEY"
+
+set_environment_secret() {
+  local name=$1 value=$2
+  if $EXECUTE; then
+    printf '%s' "$value" \
+      | gh secret set "$name" --repo "$CANONICAL_REPO" --env "$RELEASE_ENVIRONMENT" >/dev/null
+    printf 'set environment secret %s\n' "$name"
+  else
+    printf '[dry-run] set environment secret %s\n' "$name"
+  fi
+}
+
+set_repository_variable() {
+  local name=$1 value=$2
+  if $EXECUTE; then
+    gh variable set "$name" --repo "$CANONICAL_REPO" --body "$value" >/dev/null
+    printf 'set repository variable %s\n' "$name"
+  else
+    printf '[dry-run] set repository variable %s\n' "$name"
+  fi
+}
+
+# The public variable is last. A partial sync therefore leaves release signing
+# fail-closed instead of publishing with an unverified key pair.
+set_environment_secret SYQ_RELEASE_SIGNING_KEY_PEM_B64 "$signing_key"
+set_environment_secret HOMEBREW_TAP_TOKEN "$homebrew_token"
+set_repository_variable SYQ_RELEASE_PUBLIC_KEY "$public_key"
+
+unset signing_key homebrew_token
+if $EXECUTE; then
+  printf 'Synchronized the allowlisted release inventory to %s.\n' "$CANONICAL_REPO"
+else
+  printf 'Dry run only; rerun with --execute to modify GitHub.\n'
+fi

--- a/scripts/test-homebrew-formula.sh
+++ b/scripts/test-homebrew-formula.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Generate the formula in a path Homebrew recognizes as a tap and run its
+# native style/parser checks. Intended for the disposable macOS CI runner.
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+command -v brew >/dev/null || { echo 'Homebrew formula tests need brew' >&2; exit 1; }
+command -v jq >/dev/null || { echo 'Homebrew formula tests need jq' >&2; exit 1; }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-homebrew-test.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+formula_dir="$work/homebrew-tap/Formula"
+mkdir -p "$formula_dir"
+manifest="$work/manifest.json"
+formula="$formula_dir/syq.rb"
+
+jq -n --sort-keys '
+  {repository:"https://github.com/greaber/syq",version:"0.1.0",tag:"v0.1.0",
+   artifacts:{
+    "linux-x86_64":{binary:{name:"syq-linux-x86_64",sha256:("1"*64)}},
+    "linux-aarch64":{binary:{name:"syq-linux-aarch64",sha256:("2"*64)}},
+    "macos-arm64":{binary:{name:"syq-macos-arm64",sha256:("3"*64)}},
+    "macos-x86_64":{binary:{name:"syq-macos-x86_64",sha256:("4"*64)}}}}
+' > "$manifest"
+"$script_dir/generate-homebrew-formula.sh" "$manifest" "$formula"
+
+HOMEBREW_NO_AUTO_UPDATE=1 brew style "$formula"
+echo 'Homebrew formula tests passed'

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Exercise generated installer target selection and failure paths without
+# network access or real user paths.
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-installer-test.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+export XDG_CONFIG_HOME="$work/config"
+
+release="$work/release"
+fakebin="$work/fakebin"
+mkdir -p "$release" "$fakebin"
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    openssl dgst -sha256 "$1" | sed 's/^.*= //'
+  fi
+}
+
+size_file() {
+  wc -c < "$1" | tr -d '[:space:]'
+}
+
+write_program() {
+  local path=$1 target=$2 version=${3:-0.1.0} helper=${4:-v0.1.0-p4}
+  cat > "$path" <<EOF
+#!/bin/sh
+case "\$1" in
+  --version) echo 'syq $version' ;;
+  --remote-helper-id) echo '$helper' ;;
+  --register-standalone-install) exit 0 ;;
+  --test-target) echo '$target' ;;
+  *) exit 2 ;;
+esac
+EOF
+  chmod 755 "$path"
+}
+
+write_archive() {
+  local target=$1 version=${2:-0.1.0} helper=${3:-v0.1.0-p4}
+  local program="$work/program-$target"
+  write_program "$program" "$target" "$version" "$helper"
+  gzip -9 -n -c "$program" > "$release/syq-$target.gz"
+}
+
+write_manifest() {
+  local output=$1 artifacts='{}'
+  local target archive program archive_sha archive_size binary_sha binary_size entry
+  for target in linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64; do
+    archive="$release/syq-$target.gz"
+    program="$work/program-$target"
+    archive_sha=$(hash_file "$archive")
+    archive_size=$(size_file "$archive")
+    binary_sha=$(hash_file "$program")
+    binary_size=$(size_file "$program")
+    entry=$(jq -cn \
+      --arg name "syq-$target" \
+      --arg binary_sha "$binary_sha" --argjson binary_size "$binary_size" \
+      --arg archive_sha "$archive_sha" --argjson archive_size "$archive_size" \
+      '{binary:{name:$name,sha256:$binary_sha,size:$binary_size},
+        archive:{name:($name+".gz"),sha256:$archive_sha,size:$archive_size}}')
+    artifacts=$(jq -cn \
+      --argjson artifacts "$artifacts" --arg target "$target" --argjson entry "$entry" \
+      '$artifacts + {($target):$entry}')
+  done
+  jq -n --sort-keys --argjson artifacts "$artifacts" '
+    {schema:1,repository:"https://github.com/greaber/syq",version:"0.1.0",
+     tag:"v0.1.0",helper_id:"v0.1.0-p4",artifacts:$artifacts,
+     installer:{name:"install.sh",sha256:("1"*64),size:1},
+     homebrew_formula:{name:"syq.rb",sha256:("2"*64),size:1}}' > "$output"
+}
+
+expect_failure() {
+  local expected=$1
+  shift
+  if "$@" > "$work/failure.out" 2>&1; then
+    echo "command unexpectedly succeeded: $*" >&2
+    exit 1
+  fi
+  grep -F -- "$expected" "$work/failure.out" >/dev/null || {
+    echo "failure did not contain '$expected':" >&2
+    sed 's/^/  /' "$work/failure.out" >&2
+    exit 1
+  }
+}
+
+for target in linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64; do
+  write_archive "$target"
+done
+write_manifest "$work/manifest.json"
+"$script_dir/generate-installer.sh" "$work/manifest.json" "$work/install.sh"
+
+cat > "$fakebin/uname" <<'EOF'
+#!/bin/sh
+case "$1" in
+  -s) printf '%s\n' "$SYQ_TEST_UNAME_S" ;;
+  -m) printf '%s\n' "$SYQ_TEST_UNAME_M" ;;
+  *) exit 2 ;;
+esac
+EOF
+cat > "$fakebin/curl" <<'EOF'
+#!/bin/sh
+output=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output=$2; shift 2 ;;
+    *) url=$1; shift ;;
+  esac
+done
+cp "$SYQ_TEST_RELEASE_DIR/${url##*/}" "$output"
+EOF
+chmod 755 "$fakebin/uname" "$fakebin/curl"
+
+while read -r os arch target; do
+  install_dir="$work/install-$target"
+  SYQ_TEST_UNAME_S="$os" SYQ_TEST_UNAME_M="$arch" \
+    SYQ_TEST_RELEASE_DIR="$release" PATH="$fakebin:$PATH" \
+    sh "$work/install.sh" --bin-dir "$install_dir" >/dev/null
+  test "$("$install_dir/syq" --version)" = 'syq 0.1.0'
+  test "$("$install_dir/syq" --test-target)" = "$target"
+done <<'EOF'
+Linux x86_64 linux-x86_64
+Linux arm64 linux-aarch64
+Darwin arm64 macos-arm64
+Darwin x86_64 macos-x86_64
+EOF
+
+# Exercise the wget-only branch with a PATH containing every required utility
+# except curl.
+wgetbin="$work/wgetbin"
+mkdir -p "$wgetbin"
+checksum_utility=
+for candidate in sha256sum shasum openssl; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    checksum_utility=$candidate
+    break
+  fi
+done
+test -n "$checksum_utility"
+for utility in chmod cp gzip mkdir mktemp mv rm sed tr wc "$checksum_utility"; do
+  ln -s "$(command -v "$utility")" "$wgetbin/$utility"
+done
+cp "$fakebin/uname" "$wgetbin/uname"
+cat > "$wgetbin/wget" <<'EOF'
+#!/bin/sh
+output=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -O) output=$2; shift 2 ;;
+    http*) url=$1; shift ;;
+    *) shift ;;
+  esac
+done
+cp "$SYQ_TEST_RELEASE_DIR/${url##*/}" "$output"
+EOF
+chmod 755 "$wgetbin/uname" "$wgetbin/wget"
+SYQ_TEST_UNAME_S=Linux SYQ_TEST_UNAME_M=x86_64 \
+  SYQ_TEST_RELEASE_DIR="$release" PATH="$wgetbin" \
+  /bin/sh "$work/install.sh" --bin-dir "$work/install-wget" >/dev/null
+test "$("$work/install-wget/syq" --test-target)" = linux-x86_64
+
+test "$(sh "$work/install.sh" --help | head -1)" = 'Install syq 0.1.0 without sudo.'
+expect_failure 'unknown option: --bogus' sh "$work/install.sh" --bogus
+expect_failure '--bin-dir needs a value' sh "$work/install.sh" --bin-dir
+expect_failure 'HOME is not set' env -u HOME -u XDG_CONFIG_HOME sh "$work/install.sh"
+no_receipt_config="$work/no-receipt-config"
+expect_failure 'HOME and XDG_CONFIG_HOME are not set' env -u HOME -u XDG_CONFIG_HOME \
+  sh "$work/install.sh" --bin-dir "$no_receipt_config"
+test ! -e "$no_receipt_config/syq"
+invalid_receipt_config="$work/invalid-receipt-config"
+printf 'not a directory\n' > "$invalid_receipt_config"
+invalid_receipt_bin="$work/invalid-receipt-bin"
+expect_failure 'cannot prepare install receipt directory' env \
+  XDG_CONFIG_HOME="$invalid_receipt_config" \
+  sh "$work/install.sh" --bin-dir "$invalid_receipt_bin"
+test ! -e "$invalid_receipt_bin/syq"
+expect_failure 'unsupported platform: Plan9 mips' env \
+  SYQ_TEST_UNAME_S=Plan9 SYQ_TEST_UNAME_M=mips PATH="$fakebin:$PATH" \
+  sh "$work/install.sh" --bin-dir "$work/unsupported"
+
+directory_destination="$work/directory-destination"
+mkdir -p "$directory_destination/syq"
+expect_failure 'destination is a directory' env \
+  SYQ_TEST_UNAME_S=Linux SYQ_TEST_UNAME_M=x86_64 \
+  SYQ_TEST_RELEASE_DIR="$release" PATH="$fakebin:$PATH" \
+  sh "$work/install.sh" --bin-dir "$directory_destination"
+
+# A bad download must not alter a working installation.
+install_dir="$work/install-linux-x86_64"
+installed_sha=$(hash_file "$install_dir/syq")
+printf 'tamper' >> "$release/syq-linux-x86_64.gz"
+expect_failure 'downloaded archive has size' env \
+  SYQ_TEST_UNAME_S=Linux SYQ_TEST_UNAME_M=x86_64 \
+  SYQ_TEST_RELEASE_DIR="$release" PATH="$fakebin:$PATH" \
+  sh "$work/install.sh" --bin-dir "$install_dir"
+test "$(hash_file "$install_dir/syq")" = "$installed_sha"
+
+# Even correctly hashed content is rejected if its helper identity does not
+# match the release metadata, again without replacing the installed binary.
+write_archive linux-x86_64 0.1.0 v0.1.0-p999
+write_manifest "$work/wrong-identity-manifest.json"
+"$script_dir/generate-installer.sh" \
+  "$work/wrong-identity-manifest.json" "$work/wrong-identity-install.sh"
+expect_failure 'unexpected identity' env \
+  SYQ_TEST_UNAME_S=Linux SYQ_TEST_UNAME_M=x86_64 \
+  SYQ_TEST_RELEASE_DIR="$release" PATH="$fakebin:$PATH" \
+  sh "$work/wrong-identity-install.sh" --bin-dir "$install_dir"
+test "$(hash_file "$install_dir/syq")" = "$installed_sha"
+
+echo 'installer tests passed'

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Exercise complete release assembly and Ed25519 signing with small stand-in
+# binaries.
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_dir=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-release-test.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+
+version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$repo_dir/Cargo.toml" | head -1)
+tag="v$version"
+
+prepare_dist() {
+  local dist=$1 asset
+  mkdir -p "$dist"
+  for asset in syq-linux-x86_64 syq-linux-aarch64 syq-macos-arm64 syq-macos-x86_64; do
+    cp /bin/true "$dist/$asset"
+    gzip -9 -n -c "$dist/$asset" > "$dist/$asset.gz"
+  done
+}
+
+expect_failure() {
+  local expected=$1
+  shift
+  if "$@" > "$work/failure.out" 2>&1; then
+    echo "command unexpectedly succeeded: $*" >&2
+    exit 1
+  fi
+  grep -F -- "$expected" "$work/failure.out" >/dev/null || {
+    echo "failure did not contain '$expected':" >&2
+    sed 's/^/  /' "$work/failure.out" >&2
+    exit 1
+  }
+}
+
+first="$work/first"
+second="$work/second"
+prepare_dist "$first"
+prepare_dist "$second"
+"$script_dir/package-release.sh" "$tag" "$first"
+"$script_dir/package-release.sh" "$tag" "$second"
+
+test "$(find "$first" -mindepth 1 -maxdepth 1 -type f | wc -l)" -eq 19
+(cd "$first" && sha256sum -c syq-linux-x86_64.sha256 syq-linux-x86_64.gz.sha256)
+installer_sha=$(sha256sum "$first/install.sh" | awk '{print $1}')
+formula_sha=$(sha256sum "$first/syq.rb" | awk '{print $1}')
+jq -e \
+  --arg installer_sha "$installer_sha" --arg formula_sha "$formula_sha" '
+    .schema == 1
+    and (.artifacts | length == 4)
+    and .installer.name == "install.sh"
+    and .installer.sha256 == $installer_sha
+    and .homebrew_formula.name == "syq.rb"
+    and .homebrew_formula.sha256 == $formula_sha
+  ' "$first/syq-release-manifest.json" >/dev/null
+sh -n "$first/install.sh"
+grep -q '^class Syq < Formula$' "$first/syq.rb"
+grep -q '/releases/download/v' "$first/syq.rb"
+if command -v ruby >/dev/null 2>&1; then
+  ruby -c "$first/syq.rb" >/dev/null
+fi
+
+# Packaging is reproducible byte-for-byte and rejects both partial and
+# contaminated release directories.
+diff -qr "$first" "$second" >/dev/null
+missing="$work/missing"
+prepare_dist "$missing"
+rm "$missing/syq-macos-arm64.gz"
+expect_failure 'missing regular asset' \
+  "$script_dir/package-release.sh" "$tag" "$missing"
+unexpected="$work/unexpected"
+prepare_dist "$unexpected"
+printf 'not a release asset\n' > "$unexpected/extra"
+expect_failure 'release directory contains missing or unexpected files' \
+  "$script_dir/package-release.sh" "$tag" "$unexpected"
+expect_failure 'does not match Cargo.toml version' \
+  "$script_dir/package-release.sh" v99.99.99 "$first"
+
+# Run the same signing operation used by the release workflow, verify the
+# result independently, and prove that a mismatched configured public key is
+# rejected without creating an output.
+key="$work/signing.pem"
+public="$work/public.pem"
+openssl genpkey -algorithm ED25519 -out "$key" >/dev/null 2>&1
+openssl pkey -in "$key" -pubout -out "$public" >/dev/null
+key_b64=$(openssl base64 -A -in "$key")
+public_b64=$(openssl pkey -in "$key" -pubout -outform DER | tail -c 32 | openssl base64 -A)
+SYQ_RELEASE_SIGNING_KEY_PEM_B64="$key_b64" SYQ_RELEASE_PUBLIC_KEY="$public_b64" \
+  "$script_dir/sign-release-manifest.sh" \
+  "$first/syq-release-manifest.json" "$first/syq-release-manifest.json.sig"
+openssl base64 -d -A -in "$first/syq-release-manifest.json.sig" \
+  -out "$work/signature.raw"
+openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
+  -in "$first/syq-release-manifest.json" -sigfile "$work/signature.raw" >/dev/null
+
+other_key="$work/other.pem"
+openssl genpkey -algorithm ED25519 -out "$other_key" >/dev/null 2>&1
+other_public_b64=$(openssl pkey -in "$other_key" -pubout -outform DER | \
+  tail -c 32 | openssl base64 -A)
+mismatch_output="$work/mismatched.sig"
+expect_failure 'does not match SYQ_RELEASE_PUBLIC_KEY' env \
+  SYQ_RELEASE_SIGNING_KEY_PEM_B64="$key_b64" SYQ_RELEASE_PUBLIC_KEY="$other_public_b64" \
+  "$script_dir/sign-release-manifest.sh" \
+  "$first/syq-release-manifest.json" "$mismatch_output"
+test ! -e "$mismatch_output"
+
+# Verify the workflow's GitHub tag checks against controlled API responses.
+fakebin="$work/fakebin"
+mkdir "$fakebin"
+cat > "$fakebin/gh" <<'EOF'
+#!/bin/sh
+case "$1:$2" in
+  api:*/git/ref/tags/*) printf '%s\n' "$SYQ_TEST_REF_JSON" ;;
+  api:*/git/tags/*) printf '%s\n' "$SYQ_TEST_TAG_JSON" ;;
+  api:*/compare/*) printf '%s\n' "$SYQ_TEST_COMPARE_JSON" ;;
+  release:download)
+    shift 2
+    destination=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --dir) destination=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    cp "$SYQ_TEST_PUBLISHED_DIR/"* "$destination/"
+    ;;
+  *) echo "unexpected fake gh invocation: $*" >&2; exit 2 ;;
+esac
+EOF
+chmod 755 "$fakebin/gh"
+commit=0123456789abcdef0123456789abcdef01234567
+tag_sha=89abcdef0123456789abcdef0123456789abcdef
+ref_json=$(jq -cn --arg sha "$tag_sha" '{object:{type:"tag",sha:$sha}}')
+tag_json=$(jq -cn --arg commit "$commit" '
+  {tag:"v0.1.0",object:{type:"commit",sha:$commit},
+   verification:{verified:true,reason:"valid"}}')
+compare_json=$(jq -cn --arg commit "$commit" \
+  '{base_commit:{sha:$commit},merge_base_commit:{sha:$commit}}')
+SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
+  SYQ_TEST_COMPARE_JSON="$compare_json" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master >/dev/null
+
+lightweight=$(jq -cn --arg sha "$commit" '{object:{type:"commit",sha:$sha}}')
+expect_failure 'is lightweight' env \
+  SYQ_TEST_REF_JSON="$lightweight" SYQ_TEST_TAG_JSON="$tag_json" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master
+unsigned=$(jq -cn --arg commit "$commit" '
+  {tag:"v0.1.0",object:{type:"commit",sha:$commit},
+   verification:{verified:false,reason:"unsigned"}}')
+expect_failure 'reason: unsigned' env \
+  SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$unsigned" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master
+expect_failure 'not workflow commit' env \
+  SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 \
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa master
+unmerged_compare=$(jq -cn --arg commit "$commit" \
+  '{base_commit:{sha:$commit},merge_base_commit:{sha:("b"*40)}}')
+expect_failure 'not reachable from protected branch master' env \
+  SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
+  SYQ_TEST_COMPARE_JSON="$unmerged_compare" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master
+
+# Published-release reruns compare content, not just asset names.
+local_assets="$work/local-assets"
+published_assets="$work/published-assets"
+mkdir "$local_assets" "$published_assets"
+printf 'formula\n' > "$local_assets/syq.rb"
+printf 'binary\n' > "$local_assets/syq-linux-x86_64"
+cp "$local_assets/"* "$published_assets/"
+SYQ_TEST_PUBLISHED_DIR="$published_assets" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-assets.sh" v0.1.0 "$local_assets" >/dev/null
+printf 'changed formula\n' > "$published_assets/syq.rb"
+expect_failure 'published release asset differs' env \
+  SYQ_TEST_PUBLISHED_DIR="$published_assets" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-assets.sh" v0.1.0 "$local_assets"
+cp "$local_assets/syq.rb" "$published_assets/syq.rb"
+rm "$published_assets/syq-linux-x86_64"
+expect_failure 'different asset inventory' env \
+  SYQ_TEST_PUBLISHED_DIR="$published_assets" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-assets.sh" v0.1.0 "$local_assets"
+
+echo 'release tool tests passed'

--- a/scripts/test-secret-tools.sh
+++ b/scripts/test-secret-tools.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-test-secrets.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+expect_failure() {
+  local output=$1
+  shift
+  if "$@" > "$output" 2>&1; then
+    fail "command unexpectedly succeeded: $*"
+  fi
+}
+
+repo="$work/repo"
+fake_bin="$work/bin"
+fake_state="$work/state"
+mkdir -p "$repo/scripts" "$fake_bin" "$fake_state"
+cp "$ROOT_DIR/scripts/init-release-secrets.sh" "$repo/scripts/"
+cp "$ROOT_DIR/scripts/sync-github-secrets.sh" "$repo/scripts/"
+
+cat > "$fake_bin/dotenvx" <<'FAKE_DOTENVX'
+#!/usr/bin/env bash
+set -euo pipefail
+state=${FAKE_DOTENVX_STATE:?}
+command=${1:-}
+case "$command" in
+  --version)
+    printf '2.21.0\n'
+    ;;
+  set)
+    key=$2
+    value=$3
+    shift 3
+    env_file=
+    keys_file=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -f) env_file=$2; shift 2 ;;
+        -fk) keys_file=$2; shift 2 ;;
+        --no-native) shift ;;
+        *) exit 91 ;;
+      esac
+    done
+    [ -n "$env_file" ] && [ -n "$keys_file" ]
+    printf '%s' "$value" > "$state/$key"
+    printf '%s="encrypted:test-value"\n' "$key" >> "$env_file"
+    printf 'DOTENV_PRIVATE_KEY_RELEASE="test-key"\n' > "$keys_file"
+    ;;
+  get)
+    key=$2
+    [ -f "$state/$key" ]
+    cat "$state/$key"
+    ;;
+  *)
+    exit 92
+    ;;
+esac
+FAKE_DOTENVX
+
+cat > "$fake_bin/gh" <<'FAKE_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+state=${FAKE_GH_STATE:?}
+{
+  printf 'gh'
+  printf ' %q' "$@"
+  printf '\n'
+} >> "$state/calls"
+
+case "${1:-}:${2:-}" in
+  auth:status)
+    exit 0
+    ;;
+  repo:view)
+    printf 'greaber/syq\n'
+    ;;
+  api:*)
+    exit 0
+    ;;
+  secret:set)
+    name=$3
+    cat > "$state/secret-$name"
+    ;;
+  variable:set)
+    name=$3
+    shift 3
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --body) printf '%s' "$2" > "$state/variable-$name"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    ;;
+  *)
+    exit 93
+    ;;
+esac
+FAKE_GH
+
+chmod 755 "$fake_bin/dotenvx" "$fake_bin/gh" "$repo/scripts/"*.sh
+git -C "$repo" init -q -b master
+git -C "$repo" remote add origin https://github.com/greaber/pcp.git
+
+common_env=(
+  "PATH=$fake_bin:$PATH"
+  "DOTENVX_BIN=$fake_bin/dotenvx"
+  "FAKE_DOTENVX_STATE=$fake_state"
+  "FAKE_GH_STATE=$fake_state"
+)
+
+tap_token=github_pat_test_homebrew_token
+printf '%s\n' "$tap_token" \
+  | env "${common_env[@]}" "$repo/scripts/init-release-secrets.sh" \
+      > "$work/init-output" 2>&1
+[ -f "$repo/.env.release" ] || fail "initializer did not create .env.release"
+[ -f "$repo/.env.keys" ] || fail "initializer did not create .env.keys"
+[ "$(stat -c '%a' "$repo/.env.keys")" = 600 ] || fail ".env.keys is not mode 0600"
+grep -Fq "$tap_token" "$repo/.env.release" && fail "encrypted inventory contains the plaintext token"
+grep -Fq "$tap_token" "$work/init-output" && fail "initializer printed the token"
+cmp -s "$fake_state/HOMEBREW_TAP_TOKEN" <(printf '%s' "$tap_token") \
+  || fail "initializer stored the wrong Homebrew token"
+
+openssl base64 -d -A -in "$fake_state/SYQ_RELEASE_SIGNING_KEY_PEM_B64" \
+  -out "$work/signing.pem"
+derived_public=$(openssl pkey -in "$work/signing.pem" -pubout -outform DER \
+  | tail -c 32 | openssl base64 -A)
+[ "$derived_public" = "$(cat "$fake_state/SYQ_RELEASE_PUBLIC_KEY")" ] \
+  || fail "initializer stored a mismatched signing key pair"
+
+env_hash=$(sha256sum "$repo/.env.release")
+keys_hash=$(sha256sum "$repo/.env.keys")
+expect_failure "$work/reinit-output" \
+  env "${common_env[@]}" "$repo/scripts/init-release-secrets.sh" <<< 'replacement-token'
+[ "$env_hash" = "$(sha256sum "$repo/.env.release")" ] \
+  || fail "reinitialization changed .env.release"
+[ "$keys_hash" = "$(sha256sum "$repo/.env.keys")" ] \
+  || fail "reinitialization changed .env.keys"
+
+: > "$fake_state/calls"
+expect_failure "$work/wrong-remote-output" \
+  env "${common_env[@]}" "$repo/scripts/sync-github-secrets.sh"
+[ ! -s "$fake_state/calls" ] || fail "wrong-remote guard ran gh"
+
+git -C "$repo" remote set-url origin https://github.com/greaber/syq.git
+: > "$fake_state/calls"
+expect_failure "$work/wrong-host-output" \
+  env "${common_env[@]}" GH_HOST=example.com "$repo/scripts/sync-github-secrets.sh"
+[ ! -s "$fake_state/calls" ] || fail "wrong-host guard ran gh"
+
+: > "$fake_state/calls"
+env "${common_env[@]}" "$repo/scripts/sync-github-secrets.sh" \
+  > "$work/dry-run-output" 2>&1
+grep -q '^\[dry-run\] set environment secret SYQ_RELEASE_SIGNING_KEY_PEM_B64$' \
+  "$work/dry-run-output" || fail "dry run omitted the signing-key action"
+grep -q '^\[dry-run\] set environment secret HOMEBREW_TAP_TOKEN$' \
+  "$work/dry-run-output" || fail "dry run omitted the tap-token action"
+grep -q 'secret set\|variable set' "$fake_state/calls" \
+  && fail "dry run mutated GitHub"
+grep -Fq "$tap_token" "$work/dry-run-output" && fail "dry run printed the token"
+
+: > "$fake_state/calls"
+env "${common_env[@]}" "$repo/scripts/sync-github-secrets.sh" --execute \
+  > "$work/execute-output" 2>&1
+cmp -s "$fake_state/SYQ_RELEASE_SIGNING_KEY_PEM_B64" \
+  "$fake_state/secret-SYQ_RELEASE_SIGNING_KEY_PEM_B64" \
+  || fail "sync forwarded the wrong signing key"
+cmp -s "$fake_state/HOMEBREW_TAP_TOKEN" "$fake_state/secret-HOMEBREW_TAP_TOKEN" \
+  || fail "sync forwarded the wrong Homebrew token"
+cmp -s "$fake_state/SYQ_RELEASE_PUBLIC_KEY" "$fake_state/variable-SYQ_RELEASE_PUBLIC_KEY" \
+  || fail "sync forwarded the wrong public key"
+grep -Fq "$tap_token" "$work/execute-output" && fail "sync printed the token"
+grep -Fq "$tap_token" "$fake_state/calls" && fail "sync put the token in a gh argument"
+
+printf '%s' AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= \
+  > "$fake_state/SYQ_RELEASE_PUBLIC_KEY"
+: > "$fake_state/calls"
+expect_failure "$work/mismatch-output" \
+  env "${common_env[@]}" "$repo/scripts/sync-github-secrets.sh" --execute
+grep -q 'secret set\|variable set' "$fake_state/calls" \
+  && fail "mismatched signing keys mutated GitHub"
+
+expect_failure "$work/unknown-argument-output" \
+  env "${common_env[@]}" "$repo/scripts/sync-github-secrets.sh" --surprise
+
+printf 'secret tooling tests passed\n'

--- a/scripts/test-secret-tools.sh
+++ b/scripts/test-secret-tools.sh
@@ -80,9 +80,29 @@ case "${1:-}:${2:-}" in
     exit 0
     ;;
   repo:view)
-    printf 'greaber/syq\n'
+    case "$3" in
+      greaber/syq|greaber/homebrew-tap) printf '%s\n' "$3" ;;
+      *) exit 94 ;;
+    esac
     ;;
   api:*)
+    if [[ " $* " == *' --method POST '* ]]; then
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          -f)
+            case "$2" in
+              key=*) printf '%s' "${2#key=}" > "$state/homebrew-deploy-public-key" ;;
+            esac
+            shift 2
+            ;;
+          *) shift ;;
+        esac
+      done
+    elif [[ " $* " == *' repos/greaber/homebrew-tap/keys '* ]] \
+      && [ -f "$state/homebrew-deploy-public-key" ]; then
+      cat "$state/homebrew-deploy-public-key"
+      printf '\n'
+    fi
     exit 0
     ;;
   secret:set)
@@ -116,17 +136,20 @@ common_env=(
   "FAKE_GH_STATE=$fake_state"
 )
 
-tap_token=github_pat_test_homebrew_token
-printf '%s\n' "$tap_token" \
-  | env "${common_env[@]}" "$repo/scripts/init-release-secrets.sh" \
-      > "$work/init-output" 2>&1
+env "${common_env[@]}" "$repo/scripts/init-release-secrets.sh" \
+  > "$work/init-output" 2>&1
 [ -f "$repo/.env.release" ] || fail "initializer did not create .env.release"
 [ -f "$repo/.env.keys" ] || fail "initializer did not create .env.keys"
 [ "$(stat -c '%a' "$repo/.env.keys")" = 600 ] || fail ".env.keys is not mode 0600"
-grep -Fq "$tap_token" "$repo/.env.release" && fail "encrypted inventory contains the plaintext token"
-grep -Fq "$tap_token" "$work/init-output" && fail "initializer printed the token"
-cmp -s "$fake_state/HOMEBREW_TAP_TOKEN" <(printf '%s' "$tap_token") \
-  || fail "initializer stored the wrong Homebrew token"
+grep -Fq 'BEGIN OPENSSH PRIVATE KEY' "$repo/.env.release" \
+  && fail "encrypted inventory contains the plaintext Homebrew key"
+grep -Fq 'BEGIN OPENSSH PRIVATE KEY' "$work/init-output" \
+  && fail "initializer printed the Homebrew key"
+printf '%s\n' "$(cat "$fake_state/HOMEBREW_TAP_DEPLOY_KEY")" > "$work/homebrew-tap"
+chmod 600 "$work/homebrew-tap"
+homebrew_public=$(ssh-keygen -y -f "$work/homebrew-tap")
+[[ "$homebrew_public" == 'ssh-ed25519 '* ]] \
+  || fail "initializer did not store an Ed25519 Homebrew key"
 
 openssl base64 -d -A -in "$fake_state/SYQ_RELEASE_SIGNING_KEY_PEM_B64" \
   -out "$work/signing.pem"
@@ -138,7 +161,7 @@ derived_public=$(openssl pkey -in "$work/signing.pem" -pubout -outform DER \
 env_hash=$(sha256sum "$repo/.env.release")
 keys_hash=$(sha256sum "$repo/.env.keys")
 expect_failure "$work/reinit-output" \
-  env "${common_env[@]}" "$repo/scripts/init-release-secrets.sh" <<< 'replacement-token'
+  env "${common_env[@]}" "$repo/scripts/init-release-secrets.sh"
 [ "$env_hash" = "$(sha256sum "$repo/.env.release")" ] \
   || fail "reinitialization changed .env.release"
 [ "$keys_hash" = "$(sha256sum "$repo/.env.keys")" ] \
@@ -160,11 +183,14 @@ env "${common_env[@]}" "$repo/scripts/sync-github-secrets.sh" \
   > "$work/dry-run-output" 2>&1
 grep -q '^\[dry-run\] set environment secret SYQ_RELEASE_SIGNING_KEY_PEM_B64$' \
   "$work/dry-run-output" || fail "dry run omitted the signing-key action"
-grep -q '^\[dry-run\] set environment secret HOMEBREW_TAP_TOKEN$' \
-  "$work/dry-run-output" || fail "dry run omitted the tap-token action"
-grep -q 'secret set\|variable set' "$fake_state/calls" \
+grep -q '^\[dry-run\] set environment secret HOMEBREW_TAP_DEPLOY_KEY$' \
+  "$work/dry-run-output" || fail "dry run omitted the tap-key action"
+grep -q '^\[dry-run\] configure Homebrew tap deploy key$' \
+  "$work/dry-run-output" || fail "dry run omitted the public deploy-key action"
+grep -q 'secret set\|variable set\|--method POST' "$fake_state/calls" \
   && fail "dry run mutated GitHub"
-grep -Fq "$tap_token" "$work/dry-run-output" && fail "dry run printed the token"
+grep -Fq 'BEGIN OPENSSH PRIVATE KEY' "$work/dry-run-output" \
+  && fail "dry run printed the Homebrew key"
 
 : > "$fake_state/calls"
 env "${common_env[@]}" "$repo/scripts/sync-github-secrets.sh" --execute \
@@ -172,12 +198,18 @@ env "${common_env[@]}" "$repo/scripts/sync-github-secrets.sh" --execute \
 cmp -s "$fake_state/SYQ_RELEASE_SIGNING_KEY_PEM_B64" \
   "$fake_state/secret-SYQ_RELEASE_SIGNING_KEY_PEM_B64" \
   || fail "sync forwarded the wrong signing key"
-cmp -s "$fake_state/HOMEBREW_TAP_TOKEN" "$fake_state/secret-HOMEBREW_TAP_TOKEN" \
-  || fail "sync forwarded the wrong Homebrew token"
+cmp -s "$fake_state/HOMEBREW_TAP_DEPLOY_KEY" \
+  "$fake_state/secret-HOMEBREW_TAP_DEPLOY_KEY" \
+  || fail "sync forwarded the wrong Homebrew deploy key"
 cmp -s "$fake_state/SYQ_RELEASE_PUBLIC_KEY" "$fake_state/variable-SYQ_RELEASE_PUBLIC_KEY" \
   || fail "sync forwarded the wrong public key"
-grep -Fq "$tap_token" "$work/execute-output" && fail "sync printed the token"
-grep -Fq "$tap_token" "$fake_state/calls" && fail "sync put the token in a gh argument"
+expected_homebrew_public=$(ssh-keygen -y -f "$work/homebrew-tap")
+[ "$expected_homebrew_public" = "$(cat "$fake_state/homebrew-deploy-public-key")" ] \
+  || fail "sync installed the wrong Homebrew public deploy key"
+grep -Fq 'BEGIN OPENSSH PRIVATE KEY' "$work/execute-output" \
+  && fail "sync printed the Homebrew private key"
+grep -Fq 'BEGIN OPENSSH PRIVATE KEY' "$fake_state/calls" \
+  && fail "sync put the Homebrew private key in a gh argument"
 
 printf '%s' AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= \
   > "$fake_state/SYQ_RELEASE_PUBLIC_KEY"

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Download a GitHub release and require every published asset to be byte-for-
+# byte identical to the locally assembled release directory.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 TAG LOCAL_DIST_DIR" >&2
+  exit 2
+fi
+tag=$1
+local_dist=$2
+test -d "$local_dist" || { echo "missing local release directory: $local_dist" >&2; exit 1; }
+command -v gh >/dev/null || { echo 'release verification needs gh' >&2; exit 1; }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-release-assets.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+published="$work/published"
+mkdir "$published"
+gh release download "$tag" --dir "$published"
+
+local_names="$work/local-names"
+published_names="$work/published-names"
+find "$local_dist" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' | sort > "$local_names"
+find "$published" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' | sort > "$published_names"
+diff -u "$local_names" "$published_names" || {
+  echo "published release $tag has a different asset inventory" >&2
+  exit 1
+}
+
+while IFS= read -r name; do
+  cmp -s "$local_dist/$name" "$published/$name" || {
+    echo "published release asset differs from this build: $name" >&2
+    exit 1
+  }
+done < "$local_names"
+
+echo "published release $tag is byte-for-byte identical to this build"

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Require a GitHub-verified annotated tag that directly names the commit being
+# built by this release workflow and is reachable from the protected branch.
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "usage: $0 OWNER/REPOSITORY TAG EXPECTED_COMMIT PROTECTED_BRANCH" >&2
+  exit 2
+fi
+repository=$1
+tag=$2
+expected_commit=$3
+protected_branch=$4
+case "$repository" in
+  */*) ;;
+  *) echo "invalid GitHub repository: $repository" >&2; exit 2 ;;
+esac
+case "$tag" in
+  ''|*[!A-Za-z0-9._-]*) echo "unsafe release tag: $tag" >&2; exit 2 ;;
+esac
+case "$expected_commit" in
+  *[!0-9a-f]*|'') echo "invalid expected commit: $expected_commit" >&2; exit 2 ;;
+esac
+case "$protected_branch" in
+  ''|*[!A-Za-z0-9._/-]*) echo "unsafe protected branch: $protected_branch" >&2; exit 2 ;;
+esac
+command -v gh >/dev/null || { echo 'tag verification needs gh' >&2; exit 1; }
+command -v jq >/dev/null || { echo 'tag verification needs jq' >&2; exit 1; }
+
+reference=$(gh api "repos/$repository/git/ref/tags/$tag")
+object_type=$(jq -er '.object.type' <<<"$reference")
+tag_sha=$(jq -er '.object.sha' <<<"$reference")
+test "$object_type" = tag || {
+  echo "release tag $tag is lightweight; a signed annotated tag is required" >&2
+  exit 1
+}
+
+tag_object=$(gh api "repos/$repository/git/tags/$tag_sha")
+actual_tag=$(jq -er '.tag' <<<"$tag_object")
+target_type=$(jq -er '.object.type' <<<"$tag_object")
+target_commit=$(jq -er '.object.sha' <<<"$tag_object")
+verified=$(jq -r '.verification.verified' <<<"$tag_object")
+reason=$(jq -r '.verification.reason' <<<"$tag_object")
+test "$actual_tag" = "$tag" || {
+  echo "tag object names $actual_tag, expected $tag" >&2
+  exit 1
+}
+test "$target_type" = commit || {
+  echo "release tag $tag points to a $target_type, not a commit" >&2
+  exit 1
+}
+test "$target_commit" = "$expected_commit" || {
+  echo "release tag $tag resolves to $target_commit, not workflow commit $expected_commit" >&2
+  exit 1
+}
+if [ "$verified" != true ] || [ "$reason" != valid ]; then
+  echo "GitHub did not verify the signature on release tag $tag (reason: $reason)" >&2
+  exit 1
+fi
+
+comparison=$(gh api "repos/$repository/compare/$target_commit...$protected_branch")
+base_commit=$(jq -er '.base_commit.sha' <<<"$comparison")
+merge_base=$(jq -er '.merge_base_commit.sha' <<<"$comparison")
+if [ "$base_commit" != "$target_commit" ] || [ "$merge_base" != "$target_commit" ]; then
+  echo "release commit $target_commit is not reachable from protected branch $protected_branch" >&2
+  exit 1
+fi
+
+echo "verified signed annotated tag $tag at $target_commit on $protected_branch"

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -179,7 +179,7 @@ impl Checkpoint {
                 } => {
                     if format != FORMAT {
                         bail!(
-                            "checkpoint {} has format {format}, but this pcp reads format {FORMAT}",
+                            "checkpoint {} has format {format}, but this syq reads format {FORMAT}",
                             path.display()
                         );
                     }
@@ -225,7 +225,7 @@ impl Checkpoint {
         }
         if has_data && out.existing_identity.is_none() {
             bail!(
-                "{} is not a PCP checkpoint (no valid header); choose another path",
+                "{} is not a SYQ checkpoint (no valid header); choose another path",
                 path.display()
             );
         }
@@ -465,7 +465,7 @@ mod tests {
     #[test]
     fn round_trip_and_metadata_matching() {
         let dir = std::env::temp_dir().join(format!(
-            "pcp-checkpoint-unit-{}-round-trip",
+            "syq-checkpoint-unit-{}-round-trip",
             std::process::id()
         ));
         fs::create_dir_all(&dir).unwrap();
@@ -490,7 +490,7 @@ mod tests {
     #[test]
     fn identity_mismatch_is_rejected() {
         let dir = std::env::temp_dir().join(format!(
-            "pcp-checkpoint-unit-{}-identity",
+            "syq-checkpoint-unit-{}-identity",
             std::process::id()
         ));
         fs::create_dir_all(&dir).unwrap();
@@ -510,7 +510,7 @@ mod tests {
     #[test]
     fn concurrent_writer_is_rejected() {
         let dir =
-            std::env::temp_dir().join(format!("pcp-checkpoint-unit-{}-locked", std::process::id()));
+            std::env::temp_dir().join(format!("syq-checkpoint-unit-{}-locked", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("state.jsonl");
         let _ = fs::remove_file(&path);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,16 +3,29 @@ use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
 #[command(
-    name = "pcp",
+    name = "syq",
     version,
     about = "Parallel copy with an rsync-shaped interface",
     disable_help_flag = true,
-    override_usage = "pcp [OPTIONS] SRC... DEST\n       pcp [OPTIONS] [USER@]HOST:SRC... DEST\n       pcp [OPTIONS] SRC... [USER@]HOST:DEST"
+    override_usage = "syq [OPTIONS] SRC... DEST\n       syq [OPTIONS] [USER@]HOST:SRC... DEST\n       syq [OPTIONS] SRC... [USER@]HOST:DEST\n       syq --self-update\n       syq --enable-auto-update | --disable-auto-update"
 )]
 pub struct Args {
     /// Print help
     #[arg(long, action = clap::ArgAction::Help)]
     pub help: Option<bool>,
+
+    /// Install the newest signed release (standalone installer builds only)
+    #[arg(long, exclusive = true)]
+    pub self_update: bool,
+    /// Opt in to installing signed updates after successful interactive commands
+    #[arg(long, exclusive = true)]
+    pub enable_auto_update: bool,
+    /// Turn automatic updates off; update notices remain enabled
+    #[arg(long, exclusive = true)]
+    pub disable_auto_update: bool,
+    /// Record an installation made by the official standalone installer
+    #[arg(long, hide = true, exclusive = true)]
+    pub register_standalone_install: bool,
 
     /// Archive mode; same as -rlptgoD
     #[arg(short = 'a', long)]
@@ -54,14 +67,14 @@ pub struct Args {
     /// No-op accepted for rsync compatibility (sizes are always human-readable)
     #[arg(short = 'h', long)]
     pub human_readable: bool,
-    /// No-op accepted for rsync compatibility (pcp always uses numeric uid/gid)
+    /// No-op accepted for rsync compatibility (syq always uses numeric uid/gid)
     #[arg(long)]
     pub numeric_ids: bool,
 
     /// Parallel connections/workers. Default for copies: auto-tuned — starts at 8
     /// (32 when local), grows while throughput improves, shrinks when that costs
     /// nothing. Give a number to fix it. --rm uses a fixed 8 (32 when local).
-    #[arg(short = 'j', long, value_name = "N")]
+    #[arg(short = 'j', long = "connections", value_name = "N")]
     pub connections_opt: Option<usize>,
     #[arg(skip)]
     pub connections: usize,
@@ -88,7 +101,7 @@ pub struct Args {
     /// Same as --progress --partial
     #[arg(short = 'P')]
     pub p_flag: bool,
-    /// No-op accepted for rsync compatibility (pcp always keeps partial files)
+    /// No-op accepted for rsync compatibility (syq always keeps partial files)
     #[arg(long)]
     pub partial: bool,
     /// Emit machine-readable progress lines (JSON) on stderr
@@ -126,10 +139,10 @@ pub struct Args {
     /// Remote shell command (default: ssh)
     #[arg(short = 'e', long = "rsh", value_name = "COMMAND")]
     pub rsh: Option<String>,
-    /// Use this exact pcp executable on the remote instead of the managed helper
+    /// Use this exact syq executable on the remote instead of the managed helper
     #[arg(long, value_name = "PATH")]
-    pub pcp_path: Option<String>,
-    /// Require pcp on the remote PATH instead of installing a versioned helper
+    pub syq_path: Option<String>,
+    /// Require syq on the remote PATH instead of installing a versioned helper
     #[arg(long)]
     pub no_bootstrap: bool,
     /// Use TCP data connections without encryption (trusted networks only)
@@ -145,7 +158,7 @@ pub struct Args {
     /// ssh session) and return; progress goes to a log you can watch with --follow
     #[arg(long)]
     pub detach: bool,
-    /// Follow a detached transfer: pcp --follow HOST:LOGFILE
+    /// Follow a detached transfer: syq --follow HOST:LOGFILE
     #[arg(long)]
     pub follow: bool,
     /// Remote-to-remote: relay data through this machine instead of running on the source host
@@ -179,7 +192,16 @@ pub struct Args {
     pub rm: bool,
 
     /// Source(s) and destination (or, with --rm, the paths to remove)
-    #[arg(required = true, num_args = 1.., value_name = "PATH")]
+    #[arg(
+        required_unless_present_any = [
+            "self_update",
+            "enable_auto_update",
+            "disable_auto_update",
+            "register_standalone_install"
+        ],
+        num_args = 1..,
+        value_name = "PATH"
+    )]
     pub paths: Vec<String>,
 }
 
@@ -262,9 +284,9 @@ impl Args {
     }
 }
 
-/// Common rsync flags pcp deliberately doesn't implement get a one-line
+/// Common rsync flags syq deliberately doesn't implement get a one-line
 /// explanation instead of clap's generic "unexpected argument", so pasting an
-/// rsync command tells you exactly what to change. Flags pcp *does* accept
+/// rsync command tells you exactly what to change. Flags syq *does* accept
 /// (including the compatibility no-ops) are not listed here; genuinely unknown
 /// flags fall through to clap. No translation is performed.
 fn reject_unsupported_rsync_flags(argv: &[String]) -> Result<()> {
@@ -280,7 +302,7 @@ fn reject_unsupported_rsync_flags(argv: &[String]) -> Result<()> {
         "--bwlimit",
         "--checkpoint",
         "--tcp-ports",
-        "--pcp-path",
+        "--syq-path",
         "--width",
     ];
     let mut skip_next = false;
@@ -324,26 +346,26 @@ fn unsupported_message(tok: &str) -> Option<String> {
     None
 }
 
-const FILTER_MSG: &str = "pcp has no --exclude/--include/--filter. Use -i/--ignore (or --ignore-from), which takes gitignore-style patterns: e.g. `--exclude node_modules` becomes `-i node_modules`. See the README's \"Ignoring paths\" section.";
-const DELETE_MSG: &str = "pcp does not implement --delete; it never removes files from the destination. To delete paths, run `pcp --rm PATH...` explicitly.";
+const FILTER_MSG: &str = "syq has no --exclude/--include/--filter. Use -i/--ignore (or --ignore-from), which takes gitignore-style patterns: e.g. `--exclude node_modules` becomes `-i node_modules`. See the README's \"Ignoring paths\" section.";
+const DELETE_MSG: &str = "syq does not implement --delete; it never removes files from the destination. To delete paths, run `syq --rm PATH...` explicitly.";
 
 fn message_for_long(base: &str) -> Option<&'static str> {
     Some(match base {
         "exclude" | "exclude-from" | "include" | "include-from" | "filter" => FILTER_MSG,
         "delete" => DELETE_MSG,
         _ if base.starts_with("delete-") => DELETE_MSG,
-        "update" => "pcp does not implement -u/--update (skip files newer on the receiver).",
-        "one-file-system" => "pcp does not implement -x/--one-file-system.",
-        "sparse" => "pcp does not implement -S/--sparse.",
-        "hard-links" => "pcp does not preserve hard links (-H/--hard-links).",
-        "acls" => "pcp does not preserve ACLs (-A/--acls).",
-        "xattrs" => "pcp does not preserve extended attributes (-X/--xattrs).",
+        "update" => "syq does not implement -u/--update (skip files newer on the receiver).",
+        "one-file-system" => "syq does not implement -x/--one-file-system.",
+        "sparse" => "syq does not implement -S/--sparse.",
+        "hard-links" => "syq does not preserve hard links (-H/--hard-links).",
+        "acls" => "syq does not preserve ACLs (-A/--acls).",
+        "xattrs" => "syq does not preserve extended attributes (-X/--xattrs).",
         "copy-links" | "copy-unsafe-links" | "copy-dirlinks" => {
-            "pcp does not implement -L/--copy-links; it copies symlinks as symlinks (-l)."
+            "syq does not implement -L/--copy-links; it copies symlinks as symlinks (-l)."
         }
-        "files-from" => "pcp does not implement --files-from.",
+        "files-from" => "syq does not implement --files-from.",
         "link-dest" | "compare-dest" | "copy-dest" => {
-            "pcp does not implement --link-dest/--compare-dest/--copy-dest."
+            "syq does not implement --link-dest/--compare-dest/--copy-dest."
         }
         _ => return None,
     })

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -117,7 +117,7 @@ impl RemoteConn {
         if let Some(child) = &mut self.child {
             for _ in 0..20 {
                 if let Ok(Some(status)) = child.try_wait() {
-                    return anyhow!("{}: remote pcp exited ({status})", self.label);
+                    return anyhow!("{}: remote syq exited ({status})", self.label);
                 }
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
@@ -189,7 +189,7 @@ impl Drop for RemoteConn {
 }
 
 /// How many *data* ssh sessions may be establishing at once. Starts high:
-/// on a server tuned for pcp (`MaxStartups 100`) a burst of 32 handshakes
+/// on a server tuned for syq (`MaxStartups 100`) a burst of 32 handshakes
 /// takes 14 s where four rounds of 8 would take 26. sshd's default
 /// `MaxStartups 10:30:100` randomly drops new connections beyond 10
 /// unauthenticated ones, so each failed connect halves the limit (down to
@@ -235,8 +235,8 @@ pub struct RemoteSpec {
     pub user: Option<String>,
     pub host: String,
     pub rsh: Vec<String>,
-    pub pcp_path: Option<String>,
-    /// Install and use the versioned helper rather than resolving `pcp` on PATH.
+    pub syq_path: Option<String>,
+    /// Install and use the versioned helper rather than resolving `syq` on PATH.
     pub auto_helper: bool,
     /// Serializes a first-use install across control and worker clones.
     pub helper_install: std::sync::Arc<std::sync::Mutex<bool>>,
@@ -283,17 +283,17 @@ impl RemoteSpec {
         cmd
     }
 
-    /// A shell command that runs pcp with `args` on this host.  Automatic mode
+    /// A shell command that runs syq with `args` on this host.  Automatic mode
     /// addresses the exact versioned helper; explicit mode preserves the
     /// administrator-provided path; --no-bootstrap uses normal PATH lookup.
     pub fn program_command(&self, args: &[String]) -> String {
-        if let Some(p) = &self.pcp_path {
+        if let Some(p) = &self.syq_path {
             return format!("{} {}", shell_words::quote(p), shell_words::join(args));
         }
         if self.auto_helper {
             return remote_helper::launcher(args);
         }
-        format!("pcp {}", shell_words::join(args))
+        format!("syq {}", shell_words::join(args))
     }
 
     /// Connect, retrying a few times: sshd's MaxStartups (default 10) drops
@@ -358,7 +358,7 @@ impl RemoteSpec {
                     };
                     if crate::transfer::debug() {
                         eprintln!(
-                            "pcp: connect to {} failed (attempt {}): {e:#}{}",
+                            "syq: connect to {} failed (attempt {}): {e:#}{}",
                             self.label(),
                             attempt + 1,
                             limit
@@ -450,7 +450,7 @@ impl RemoteSpec {
         };
         if crate::transfer::debug() {
             eprintln!(
-                "pcp: {}: data paths {:?} (advertised {:?})",
+                "syq: {}: data paths {:?} (advertised {:?})",
                 self.label(),
                 addrs,
                 advertised
@@ -523,7 +523,7 @@ impl RemoteSpec {
                 .map(|a| a.to_string())
                 .unwrap_or_default();
             if crate::transfer::debug() {
-                eprintln!("pcp: {}: data connection via tcp {addr_s}", self.label());
+                eprintln!("syq: {}: data connection via tcp {addr_s}", self.label());
             }
             stream.set_nodelay(true)?;
             let conn_id = TCP_CONN_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -648,7 +648,7 @@ fn hello(mut conn: RemoteConn, compress: bool, token: Vec<u8>) -> Result<RemoteC
             }
             Ok(Response::Err(e)) => bail!("{}: {e}", conn.label),
             Ok(other) => bail!("{}: unexpected handshake response {other:?}", conn.label),
-            Err(e) => bail!("{e}\ncould not start the remote pcp on {}", conn.label),
+            Err(e) => bail!("{e}\ncould not start the remote syq on {}", conn.label),
         }
     }
 }
@@ -666,7 +666,7 @@ impl RemoteSpec {
         let target = self.remote_target()?;
         if !self.quiet {
             eprintln!(
-                "pcp: {}: installing {} helper for {}",
+                "syq: {}: installing {} helper for {}",
                 self.label(),
                 remote_helper::release_key(),
                 target.key
@@ -680,13 +680,13 @@ impl RemoteSpec {
             Err(download_error) if Target::local() == Some(target) => {
                 if !self.quiet {
                     eprintln!(
-                        "pcp: {}: release download unavailable; uploading this executable",
+                        "syq: {}: release download unavailable; uploading this executable",
                         self.label()
                     );
                 }
                 if crate::transfer::debug() {
                     eprintln!(
-                        "pcp: {}: remote helper download failed: {download_error:#}",
+                        "syq: {}: remote helper download failed: {download_error:#}",
                         self.label()
                     );
                 }
@@ -701,7 +701,7 @@ impl RemoteSpec {
             Err(download_error) => {
                 let local = Target::local().map_or("unsupported", |t| t.key);
                 bail!(
-                    "could not install {} helper on {} ({}) and cannot upload the local {} executable: {download_error:#}; install a compatible pcp and pass --pcp-path",
+                    "could not install {} helper on {} ({}) and cannot upload the local {} executable: {download_error:#}; install a compatible syq and pass --syq-path",
                     remote_helper::release_key(),
                     self.label(),
                     target.key,
@@ -731,21 +731,23 @@ impl RemoteSpec {
         let text = String::from_utf8_lossy(&out.stdout);
         let value = text
             .lines()
-            .find_map(|line| line.strip_prefix("pcp-helper-target:"))
+            .find_map(|line| line.strip_prefix("syq-helper-target:"))
             .ok_or_else(|| anyhow!("{}: platform probe returned no target", self.label()))?;
         let (os, arch) = value
             .split_once(':')
             .ok_or_else(|| anyhow!("{}: malformed platform response {value:?}", self.label()))?;
         Target::from_uname(os, arch).ok_or_else(|| {
             anyhow!(
-                "{}: automatic remote helpers do not support {os} {arch}; install pcp there and pass --pcp-path",
+                "{}: automatic remote helpers do not support {os} {arch}; install syq there and pass --syq-path",
                 self.label()
             )
         })
     }
 
     fn download_helper(&self, target: Target) -> Result<()> {
-        let script = remote_helper::download_script(target);
+        let expected_sha256 = crate::update::trusted_current_archive_hash(target)
+            .context("verify the signed release manifest")?;
+        let script = remote_helper::download_script(target, &expected_sha256);
         let mut cmd = self.ssh_command();
         cmd.arg(format!("sh -c {}", shell_words::quote(&script)))
             .stdin(Stdio::null())
@@ -765,13 +767,13 @@ impl RemoteSpec {
     }
 
     fn upload_helper(&self, target: Target) -> Result<()> {
-        let exe = std::env::current_exe().context("locate current pcp executable")?;
+        let exe = std::env::current_exe().context("locate current syq executable")?;
         let mut input = std::fs::File::open(&exe)
             .with_context(|| format!("open current executable {}", exe.display()))?;
         let bytes = input.metadata()?.len();
         if !self.quiet {
             eprintln!(
-                "pcp: {}: uploading {:.1} MiB",
+                "syq: {}: uploading {:.1} MiB",
                 self.label(),
                 bytes as f64 / (1 << 20) as f64
             );
@@ -838,7 +840,7 @@ impl Endpoint {
                                 if !i.failed {
                                     i.failed = true;
                                     if !spec.quiet || crate::transfer::debug() {
-                                        eprintln!("pcp: {}: data over ssh (TCP port {} stopped answering: {e:#})", spec.label(), info.port);
+                                        eprintln!("syq: {}: data over ssh (TCP port {} stopped answering: {e:#})", spec.label(), info.port);
                                     }
                                 }
                             }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -13,8 +13,8 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         user: srcs[0].user.clone(),
         host: src_host.clone(),
         rsh: rsh.clone(),
-        pcp_path: args.pcp_path.clone(),
-        auto_helper: args.pcp_path.is_none() && !args.no_bootstrap,
+        syq_path: args.syq_path.clone(),
+        auto_helper: args.syq_path.is_none() && !args.no_bootstrap,
         helper_install: Default::default(),
         quiet: args.quiet,
         tcp: Default::default(),
@@ -96,8 +96,8 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         remote.push("--progress".into());
         remote.push(format!("--width={}", crate::progress::term_width()));
     }
-    if let Some(p) = &args.pcp_path {
-        remote.push(format!("--pcp-path={p}"));
+    if let Some(p) = &args.syq_path {
+        remote.push(format!("--syq-path={p}"));
     }
     if let Some(e) = &args.rsh {
         remote.push("-e".into());
@@ -138,14 +138,14 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         remote.insert(0, "--progress-json".into());
         remote.insert(0, "-v".into());
     }
-    // A detached launcher returns before the background pcp execs, so a
+    // A detached launcher returns before the background syq execs, so a
     // missing helper could otherwise look like a successful start.  Validate
     // and, in automatic mode, install it before detaching.
     if args.detach {
         drop(spec.connect(false)?);
     }
     let dbg = if crate::transfer::debug() {
-        "PCP_DEBUG=1 "
+        "SYQ_DEBUG=1 "
     } else {
         ""
     };
@@ -163,7 +163,7 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
             .trim_end_matches('/')
             .rsplit('/')
             .next()
-            .unwrap_or("pcp");
+            .unwrap_or("syq");
         let name: String = raw
             .chars()
             .map(|c| {
@@ -175,12 +175,12 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
             })
             .collect();
         let name = if name.trim_matches('.').is_empty() {
-            "pcp".to_string()
+            "syq".to_string()
         } else {
             name
         };
         format!(
-            "mkdir -p \"$HOME/.pcp\" && log=\"$HOME/.pcp/{name}-$(date +%Y%m%d-%H%M%S).log\" && (setsid nohup sh -c {} > \"$log\" 2>&1 < /dev/null &) && echo \"$log\"",
+            "mkdir -p \"$HOME/.syq\" && log=\"$HOME/.syq/{name}-$(date +%Y%m%d-%H%M%S).log\" && (setsid nohup sh -c {} > \"$log\" 2>&1 < /dev/null &) && echo \"$log\"",
             shell_words::quote(&remote_cmd)
         )
     } else {
@@ -220,12 +220,12 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         if !out.status.success() || log.is_empty() {
             bail!("could not start detached transfer on {src_host}");
         }
-        println!("pcp: started on {src_host}, log {log}");
-        println!("pcp: follow with:  pcp --follow {src_host}:{log}");
+        println!("syq: started on {src_host}, log {log}");
+        println!("syq: follow with:  syq --follow {src_host}:{log}");
         return Ok(0);
     }
     if !args.quiet {
-        eprintln!("pcp: remote-to-remote: running on {src_host} (use --relay to route data through this machine)");
+        eprintln!("syq: remote-to-remote: running on {src_host} (use --relay to route data through this machine)");
     }
     let run = || {
         let mut cmd = make_command();
@@ -244,7 +244,7 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         Some(c) => {
             bail!("remote-to-remote transfer on {src_host} failed (exit {c}); if {src_host} cannot reach the destination, retry with --relay")
         }
-        None => bail!("remote pcp on {src_host} killed by signal"),
+        None => bail!("remote syq on {src_host} killed by signal"),
     }
 }
 
@@ -257,16 +257,16 @@ fn helper_missing(code: Option<i32>, automatic: bool) -> bool {
         )
 }
 
-/// `pcp --follow HOST:LOG`: tail a detached transfer's log, rendering the JSON
+/// `syq --follow HOST:LOG`: tail a detached transfer's log, rendering the JSON
 /// progress lines as a status line and passing everything else through.
 pub fn follow(args: &Args) -> Result<i32> {
     let target = args
         .paths
         .first()
-        .ok_or_else(|| anyhow::anyhow!("usage: pcp --follow HOST:LOGFILE"))?;
+        .ok_or_else(|| anyhow::anyhow!("usage: syq --follow HOST:LOGFILE"))?;
     let loc = Location::parse(target)?;
     let (Some(host), log) = (&loc.host, &loc.path) else {
-        bail!("usage: pcp --follow HOST:LOGFILE")
+        bail!("usage: syq --follow HOST:LOGFILE")
     };
     let rsh = parse_rsh(&args.rsh)?;
     let mut cmd = Command::new(&rsh[0]);
@@ -324,7 +324,7 @@ pub fn follow(args: &Args) -> Result<i32> {
                 eprint!("\r\x1b[K");
             }
             println!("{line}");
-            if line.starts_with("pcp: transferred") || line.starts_with("pcp: would transfer") {
+            if line.starts_with("syq: transferred") || line.starts_with("syq: would transfer") {
                 let _ = child.kill();
                 return Ok(0);
             }

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1,5 +1,5 @@
 //! Local filesystem operations. Used directly by the local endpoint and
-//! by `pcp --server` for remote endpoints, so both sides behave identically.
+//! by `syq --server` for remote endpoints, so both sides behave identically.
 
 use crate::proto::*;
 use anyhow::{anyhow, bail, Context, Result};
@@ -12,7 +12,7 @@ use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use xxhash_rust::xxh3::{xxh3_128, xxh3_64, Xxh3};
 
-pub const PARTIAL_SUFFIX: &str = ".pcp-partial";
+pub const PARTIAL_SUFFIX: &str = ".syq-partial";
 const FD_CACHE_MAX: usize = 16;
 
 pub fn resolve(p: &[u8]) -> PathBuf {
@@ -309,7 +309,7 @@ fn apply_one(op: &Op) -> Result<()> {
             Op::SetMeta { path, meta, flags } => {
                 let p = resolve(path);
                 #[cfg(debug_assertions)]
-                if let Some(pat) = std::env::var_os("PCP_TEST_FAIL_SETMETA") {
+                if let Some(pat) = std::env::var_os("SYQ_TEST_FAIL_SETMETA") {
                     // Test hook (debug builds only): fail metadata for matching paths.
                     if !pat.is_empty() && p.as_os_str().as_bytes().ends_with(pat.as_bytes()) {
                         return Err(anyhow!("set metadata {}: injected failure", p.display()));
@@ -597,7 +597,7 @@ impl FsOps {
         }
         drop(f);
         #[cfg(debug_assertions)]
-        if let Some(pat) = std::env::var_os("PCP_TEST_FAIL_PUT_SMALL_BEFORE_RENAME") {
+        if let Some(pat) = std::env::var_os("SYQ_TEST_FAIL_PUT_SMALL_BEFORE_RENAME") {
             // Test hook (debug builds only): model interruption after the
             // sidecar is complete but before it becomes the final name.
             if !pat.is_empty() && p.as_os_str().as_bytes().ends_with(pat.as_bytes()) {
@@ -831,7 +831,7 @@ impl FsOps {
 /// Open `target` for writing as a regular file, replacing any existing
 /// symlink/dir/special and refusing to follow a symlink (O_NOFOLLOW), then
 /// verify the opened fd is a regular file. Used for every write target so a
-/// malicious or stale `.pcp-partial` symlink can't redirect the write.
+/// malicious or stale `.syq-partial` symlink can't redirect the write.
 fn open_regular_write(target: &Path, mode: u32) -> Result<File> {
     if let Ok(md) = fs::symlink_metadata(target) {
         if !md.is_file() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod sched;
 mod server;
 mod transfer;
 mod tune;
+mod update;
 
 /// Keep multi-megabyte block buffers in the heap instead of mmap/munmap-ing
 /// each one: page faults and TLB shootdowns across many threads otherwise
@@ -56,7 +57,7 @@ fn main() {
     }
     if argv.get(1).map(String::as_str) == Some("--server") {
         if let Err(e) = server::run() {
-            eprintln!("pcp server: {e:#}");
+            eprintln!("syq server: {e:#}");
             std::process::exit(1);
         }
         return;
@@ -64,11 +65,33 @@ fn main() {
     let mut args = match cli::Args::parse_args() {
         Ok(a) => a,
         Err(e) => {
-            eprintln!("pcp: {e:#}");
+            eprintln!("syq: {e:#}");
             std::process::exit(2);
         }
     };
     args.normalize();
+    if args.self_update {
+        if let Err(e) = update::self_update() {
+            eprintln!("syq: {e:#}");
+            std::process::exit(1);
+        }
+        return;
+    }
+    if args.enable_auto_update || args.disable_auto_update {
+        if let Err(e) = update::set_auto_update(args.enable_auto_update) {
+            eprintln!("syq: {e:#}");
+            std::process::exit(1);
+        }
+        return;
+    }
+    if args.register_standalone_install {
+        if let Err(e) = update::register_standalone_install() {
+            eprintln!("syq: {e:#}");
+            std::process::exit(1);
+        }
+        return;
+    }
+    let quiet = args.quiet;
     let result = if args.follow {
         direct::follow(&args)
     } else if args.rm {
@@ -77,9 +100,14 @@ fn main() {
         transfer::run(args)
     };
     match result {
-        Ok(code) => std::process::exit(code),
+        Ok(code) => {
+            if code == 0 {
+                update::after_success(quiet);
+            }
+            std::process::exit(code)
+        }
         Err(e) => {
-            eprintln!("pcp: {e:#}");
+            eprintln!("syq: {e:#}");
             std::process::exit(1);
         }
     }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -126,7 +126,7 @@ pub enum Request {
         port_lo: u16,
         port_hi: u16,
     },
-    /// `all`: include pcp's own partial files (used by --rm).
+    /// `all`: include syq's own partial files (used by --rm).
     /// `ignore`: gitignore-style patterns relative to `root` (see scan.rs).
     Scan {
         root: PathBytes,

--- a/src/remote_helper.rs
+++ b/src/remote_helper.rs
@@ -8,7 +8,7 @@
 
 use crate::proto::VERSION;
 
-pub const RELEASE_BASE_URL: &str = "https://github.com/greaber/pcp/releases/download";
+pub const RELEASE_BASE_URL: &str = "https://github.com/greaber/syq/releases/download";
 pub const HELPER_MISSING_EXIT: i32 = 125;
 pub const HELPER_NOT_EXECUTABLE_EXIT: i32 = 126;
 
@@ -23,19 +23,19 @@ impl Target {
         match (os.trim(), arch.trim()) {
             ("Linux", "x86_64") => Some(Self {
                 key: "linux-x86_64",
-                asset: "pcp-linux-x86_64",
+                asset: "syq-linux-x86_64",
             }),
             ("Linux", "aarch64" | "arm64") => Some(Self {
                 key: "linux-aarch64",
-                asset: "pcp-linux-aarch64",
+                asset: "syq-linux-aarch64",
             }),
             ("Darwin", "x86_64") => Some(Self {
                 key: "macos-x86_64",
-                asset: "pcp-macos-x86_64",
+                asset: "syq-macos-x86_64",
             }),
             ("Darwin", "arm64" | "aarch64") => Some(Self {
                 key: "macos-arm64",
-                asset: "pcp-macos-arm64",
+                asset: "syq-macos-arm64",
             }),
             _ => None,
         }
@@ -58,7 +58,7 @@ pub fn release_key() -> String {
 }
 
 pub fn probe_command() -> &'static str {
-    "sh -c 'printf \"pcp-helper-target:%s:%s\\n\" \"$(uname -s)\" \"$(uname -m)\"'"
+    "sh -c 'printf \"syq-helper-target:%s:%s\\n\" \"$(uname -s)\" \"$(uname -m)\"'"
 }
 
 /// Run this release's helper from its deterministic cache path.  The target
@@ -73,33 +73,39 @@ Darwin:x86_64) target=macos-x86_64 ;;
 Darwin:arm64|Darwin:aarch64) target=macos-arm64 ;;
 *) exit {HELPER_MISSING_EXIT} ;;
 esac
-program="$HOME/.cache/pcp/helpers/{release}/$target/pcp"
+program="$HOME/.cache/syq/helpers/{release}/$target/syq"
 [ -x "$program" ] || exit {HELPER_MISSING_EXIT}
 exec "$program" "$@""#,
         release = release_key(),
     );
     format!(
-        "sh -c {} pcp {}",
+        "sh -c {} syq {}",
         shell_words::quote(&script),
         shell_words::join(args)
     )
 }
 
-pub fn download_script(target: Target) -> String {
+pub fn download_script(target: Target, expected_sha256: &str) -> String {
+    assert!(
+        expected_sha256.len() == 64
+            && expected_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()),
+        "trusted release hash must be lowercase SHA-256"
+    );
     let release = release_key();
     let tag = format!("v{}", env!("CARGO_PKG_VERSION"));
     let url = format!("{RELEASE_BASE_URL}/{tag}/{}.gz", target.asset);
-    let expected_version = format!("pcp {}", env!("CARGO_PKG_VERSION"));
+    let expected_version = format!("syq {}", env!("CARGO_PKG_VERSION"));
     let expected_helper_id = release_key();
     format!(
         r#"set -eu
-dir="$HOME/.cache/pcp/helpers/{release}/{target_key}"
-program="$dir/pcp"
-tmp="$dir/.pcp.$$.tmp"
+dir="$HOME/.cache/syq/helpers/{release}/{target_key}"
+program="$dir/syq"
+tmp="$dir/.syq.$$.tmp"
 archive="$tmp.gz"
-sum="$archive.sha256"
 mkdir -p "$dir"
-cleanup() {{ rm -f "$tmp" "$archive" "$sum"; }}
+cleanup() {{ rm -f "$tmp" "$archive"; }}
 trap cleanup EXIT HUP INT TERM
 fetch() {{
     if command -v curl >/dev/null 2>&1; then
@@ -107,13 +113,12 @@ fetch() {{
     elif command -v wget >/dev/null 2>&1; then
         wget -q -O "$2" "$1"
     else
-        echo "pcp: remote helper download needs curl or wget" >&2
+        echo "syq: remote helper download needs curl or wget" >&2
         return 1
     fi
 }}
 fetch {url} "$archive"
-fetch {sum_url} "$sum"
-expected=$(sed -n '1{{s/[[:space:]].*$//;p;}}' "$sum")
+expected={expected_sha256}
 if command -v sha256sum >/dev/null 2>&1; then
     actual=$(sha256sum "$archive" | sed 's/[[:space:]].*$//')
 elif command -v shasum >/dev/null 2>&1; then
@@ -121,29 +126,29 @@ elif command -v shasum >/dev/null 2>&1; then
 elif command -v openssl >/dev/null 2>&1; then
     actual=$(openssl dgst -sha256 "$archive" | sed 's/^.*= //')
 else
-    echo "pcp: remote helper verification needs sha256sum, shasum, or openssl" >&2
+    echo "syq: remote helper verification needs sha256sum, shasum, or openssl" >&2
     exit 1
 fi
 [ -n "$expected" ] && [ "$actual" = "$expected" ] || {{
-    echo "pcp: remote helper checksum mismatch" >&2
+    echo "syq: remote helper checksum mismatch" >&2
     exit 1
 }}
 gzip -dc "$archive" > "$tmp"
 chmod 700 "$tmp"
 got=$("$tmp" --version 2>/dev/null) || {{
-    echo "pcp: downloaded helper cannot run on this host" >&2
+    echo "syq: downloaded helper cannot run on this host" >&2
     exit 1
 }}
 [ "$got" = {expected_version} ] || {{
-    echo "pcp: downloaded helper has unexpected version: $got" >&2
+    echo "syq: downloaded helper has unexpected version: $got" >&2
     exit 1
 }}
 got_id=$("$tmp" --remote-helper-id 2>/dev/null) || {{
-    echo "pcp: downloaded helper does not report a helper identity" >&2
+    echo "syq: downloaded helper does not report a helper identity" >&2
     exit 1
 }}
 [ "$got_id" = {expected_helper_id} ] || {{
-    echo "pcp: downloaded helper has unexpected identity: $got_id" >&2
+    echo "syq: downloaded helper has unexpected identity: $got_id" >&2
     exit 1
 }}
 mv "$tmp" "$program"
@@ -151,39 +156,39 @@ cleanup
 trap - EXIT HUP INT TERM"#,
         target_key = target.key,
         url = shell_words::quote(&url),
-        sum_url = shell_words::quote(&format!("{url}.sha256")),
+        expected_sha256 = shell_words::quote(expected_sha256),
         expected_version = shell_words::quote(&expected_version),
         expected_helper_id = shell_words::quote(&expected_helper_id),
     )
 }
 
 pub fn upload_script(target: Target) -> String {
-    let expected_version = format!("pcp {}", env!("CARGO_PKG_VERSION"));
+    let expected_version = format!("syq {}", env!("CARGO_PKG_VERSION"));
     let expected_helper_id = release_key();
     format!(
         r#"set -eu
-dir="$HOME/.cache/pcp/helpers/{release}/{target_key}"
-program="$dir/pcp"
-tmp="$dir/.pcp.$$.tmp"
+dir="$HOME/.cache/syq/helpers/{release}/{target_key}"
+program="$dir/syq"
+tmp="$dir/.syq.$$.tmp"
 mkdir -p "$dir"
 cleanup() {{ rm -f "$tmp"; }}
 trap cleanup EXIT HUP INT TERM
 cat > "$tmp"
 chmod 700 "$tmp"
 got=$("$tmp" --version 2>/dev/null) || {{
-    echo "pcp: uploaded helper cannot run on this host" >&2
+    echo "syq: uploaded helper cannot run on this host" >&2
     exit 1
 }}
 [ "$got" = {expected_version} ] || {{
-    echo "pcp: uploaded helper has unexpected version: $got" >&2
+    echo "syq: uploaded helper has unexpected version: $got" >&2
     exit 1
 }}
 got_id=$("$tmp" --remote-helper-id 2>/dev/null) || {{
-    echo "pcp: uploaded helper does not report a helper identity" >&2
+    echo "syq: uploaded helper does not report a helper identity" >&2
     exit 1
 }}
 [ "$got_id" = {expected_helper_id} ] || {{
-    echo "pcp: uploaded helper has unexpected identity: $got_id" >&2
+    echo "syq: uploaded helper has unexpected identity: $got_id" >&2
     exit 1
 }}
 mv "$tmp" "$program"
@@ -203,7 +208,7 @@ mod tests {
     fn maps_supported_uname_pairs() {
         assert_eq!(
             Target::from_uname("Linux", "x86_64").unwrap().asset,
-            "pcp-linux-x86_64"
+            "syq-linux-x86_64"
         );
         assert_eq!(
             Target::from_uname("Linux", "arm64").unwrap().key,
@@ -211,7 +216,7 @@ mod tests {
         );
         assert_eq!(
             Target::from_uname("Darwin", "arm64").unwrap().asset,
-            "pcp-macos-arm64"
+            "syq-macos-arm64"
         );
         assert!(Target::from_uname("FreeBSD", "x86_64").is_none());
     }
@@ -227,12 +232,13 @@ mod tests {
     #[test]
     fn release_download_is_pinned_and_verified() {
         let target = Target::from_uname("Linux", "x86_64").unwrap();
-        let script = download_script(target);
+        let script = download_script(target, &"a".repeat(64));
         assert!(script.contains(&format!(
-            "/v{}/pcp-linux-x86_64.gz",
+            "/v{}/syq-linux-x86_64.gz",
             env!("CARGO_PKG_VERSION")
         )));
         assert!(script.contains("sha256sum"));
         assert!(script.contains("checksum mismatch"));
+        assert!(!script.contains(".sha256"));
     }
 }

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -1,4 +1,4 @@
-//! `pcp --rm`: recursive removal with N parallel connections. Files are
+//! `syq --rm`: recursive removal with N parallel connections. Files are
 //! unlinked in batches spread across workers; directories are removed
 //! deepest-first, each depth level in parallel.
 
@@ -84,7 +84,7 @@ fn worker(
             Ok(Response::Applied(errs)) => {
                 for (name, err) in names.iter().zip(errs) {
                     match err {
-                        Some(e) => pool.progress.error(&format!("pcp: {e}")),
+                        Some(e) => pool.progress.error(&format!("syq: {e}")),
                         None => {
                             pool.progress.files_done.fetch_add(1, Relaxed);
                             if pool.verbose {
@@ -96,9 +96,9 @@ fn worker(
             }
             Ok(other) => pool
                 .progress
-                .error(&format!("pcp: unexpected response {other:?}")),
+                .error(&format!("syq: unexpected response {other:?}")),
             Err(e) => {
-                pool.progress.error(&format!("pcp: {e:#}"));
+                pool.progress.error(&format!("syq: {e:#}"));
                 pool.done();
                 if conn.is_dead() {
                     pool.abort(); // wake wait_idle so the run doesn't hang on queued ops
@@ -232,7 +232,7 @@ pub fn run(args: Args) -> Result<i32> {
                 }
                 Ok(())
             },
-            &mut |w| progress.error(&format!("pcp: {w}")),
+            &mut |w| progress.error(&format!("syq: {w}")),
         );
         pool.submit(batch);
         if let Err(e) = res {
@@ -270,7 +270,7 @@ pub fn run(args: Args) -> Result<i32> {
     pool.close();
     for w in workers {
         if let Ok(Err(e)) = w.join() {
-            progress.error(&format!("pcp: worker: {e:#}"));
+            progress.error(&format!("syq: worker: {e:#}"));
         }
     }
     progress.stop();
@@ -279,12 +279,12 @@ pub fn run(args: Args) -> Result<i32> {
     }
     progress.clear();
     if let Some(e) = scan_err {
-        progress.error(&format!("pcp: {e:#}"));
+        progress.error(&format!("syq: {e:#}"));
     }
     let errors = progress.errors.load(Relaxed) + if pool.is_aborted() { 1 } else { 0 };
     if !args.quiet {
         println!(
-            "pcp: {} {} entries in {}{}",
+            "syq: {} {} entries in {}{}",
             if args.dry_run {
                 "would remove"
             } else {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-//! `pcp --server`: serve requests over stdin/stdout, and optionally over
+//! `syq --server`: serve requests over stdin/stdout, and optionally over
 //! TCP data connections (see `crypto.rs`) when the client asks for them.
 
 use crate::crypto::{Cipher, RecordReader, RecordWriter};
@@ -171,7 +171,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
     }
     if debug {
         eprintln!(
-            "pcp server{}: {blocks} blocks, {} MiB; waiting for input {:.2}s, handling {:.2}s, writing responses {:.2}s",
+            "syq server{}: {blocks} blocks, {} MiB; waiting for input {:.2}s, handling {:.2}s, writing responses {:.2}s",
             if over_ssh { "" } else { " (tcp)" },
             bytes >> 20,
             t[0],
@@ -279,7 +279,7 @@ fn tcp_listen(
             let id = next_id.fetch_add(1, Relaxed);
             if live.load(Relaxed) >= MAX_LIVE {
                 if debug {
-                    eprintln!("pcp server (tcp): refusing connection, {MAX_LIVE} already live");
+                    eprintln!("syq server (tcp): refusing connection, {MAX_LIVE} already live");
                 }
                 continue; // drop; stream closes
             }
@@ -288,7 +288,7 @@ fn tcp_listen(
             std::thread::spawn(move || {
                 if let Err(e) = serve_tcp(stream, id, key, token, debug, compress, &seen) {
                     if debug {
-                        eprintln!("pcp server (tcp {id}): {e:#}");
+                        eprintln!("syq server (tcp {id}): {e:#}");
                     }
                 }
                 live.fetch_sub(1, Relaxed);

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -46,8 +46,8 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
             user: loc.user.clone(),
             host: h.clone(),
             rsh: parse_rsh(&args.rsh)?,
-            pcp_path: args.pcp_path.clone(),
-            auto_helper: args.pcp_path.is_none() && !args.no_bootstrap,
+            syq_path: args.syq_path.clone(),
+            auto_helper: args.syq_path.is_none() && !args.no_bootstrap,
             helper_install: Default::default(),
             quiet: args.quiet,
             tcp: Default::default(),
@@ -204,7 +204,7 @@ struct CheckpointShared {
 type CheckpointSlot = std::sync::Arc<std::sync::OnceLock<CheckpointShared>>;
 
 pub fn debug() -> bool {
-    std::env::var_os("PCP_DEBUG").is_some()
+    std::env::var_os("SYQ_DEBUG").is_some()
 }
 
 fn read_umask() -> u32 {
@@ -268,7 +268,7 @@ pub fn run(args: Args) -> Result<i32> {
             return crate::direct::run(&args, srcs, dst);
         }
         if !args.quiet {
-            eprintln!("pcp: remote-to-remote transfer: relaying data through this machine");
+            eprintln!("syq: remote-to-remote transfer: relaying data through this machine");
         }
     }
 
@@ -356,7 +356,7 @@ pub fn run(args: Args) -> Result<i32> {
                 };
                 if debug() {
                     eprintln!(
-                        "pcp: worker {id} connected in {:.2}s",
+                        "syq: worker {id} connected in {:.2}s",
                         t0.elapsed().as_secs_f64()
                     );
                 }
@@ -408,7 +408,7 @@ pub fn run(args: Args) -> Result<i32> {
     };
     if debug() {
         eprintln!(
-            "pcp: control connections up in {:.2}s",
+            "syq: control connections up in {:.2}s",
             t0.elapsed().as_secs_f64()
         );
     }
@@ -419,7 +419,7 @@ pub fn run(args: Args) -> Result<i32> {
                 if let Err(e) = spec.setup_tcp(&mut **ctl, args.tcp_plain, ports) {
                     if !args.quiet || debug() {
                         eprintln!(
-                            "pcp: {}: data over ssh (TCP ports {}-{} not reachable: {e:#}); a Tailscale address or an open port is faster",
+                            "syq: {}: data over ssh (TCP ports {}-{} not reachable: {e:#}); a Tailscale address or an open port is faster",
                             spec.label(),
                             ports.0,
                             ports.1
@@ -429,7 +429,7 @@ pub fn run(args: Args) -> Result<i32> {
                 }
                 if debug() {
                     eprintln!(
-                        "pcp: {}: tcp data port {:?}",
+                        "syq: {}: tcp data port {:?}",
                         spec.label(),
                         spec.tcp
                             .lock()
@@ -586,7 +586,7 @@ pub fn run(args: Args) -> Result<i32> {
     progress.scan_done.store(true, Relaxed);
     sched.scan_done();
     if let Some(e) = &scan_err {
-        progress.error(&format!("pcp: {e:#}"));
+        progress.error(&format!("syq: {e:#}"));
         sched.abort();
     }
     if collision {
@@ -612,10 +612,10 @@ pub fn run(args: Args) -> Result<i32> {
             match w.join() {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
-                    progress.error(&format!("pcp: worker: {e:#}"));
+                    progress.error(&format!("syq: worker: {e:#}"));
                     sched.abort();
                 }
-                Err(_) => progress.error("pcp: worker thread panicked"),
+                Err(_) => progress.error("syq: worker thread panicked"),
             }
         }
     }
@@ -647,14 +647,14 @@ pub fn run(args: Args) -> Result<i32> {
         });
         if let Some(e) = failed {
             eprintln!(
-                "pcp: warning: checkpoint recording stopped ({e}); a retry will recheck files completed after that point"
+                "syq: warning: checkpoint recording stopped ({e}); a retry will recheck files completed after that point"
             );
         }
         if !opts.dry_run && !aborted && errors == 0 {
             if let Some(checkpoint) = &state.checkpoint {
                 if let Err(e) = checkpoint.remove() {
                     eprintln!(
-                        "pcp: warning: completed copy but could not remove checkpoint {}: {e:#}",
+                        "syq: warning: completed copy but could not remove checkpoint {}: {e:#}",
                         state.path.display()
                     );
                 }
@@ -666,7 +666,7 @@ pub fn run(args: Args) -> Result<i32> {
     if !args.quiet {
         if opts.verify_only {
             println!(
-                "pcp: verified {} files, {} differ/missing, {} in {}",
+                "syq: verified {} files, {} differ/missing, {} in {}",
                 commas(progress.files_done.load(Relaxed) + errors),
                 errors,
                 human(done),
@@ -679,7 +679,7 @@ pub fn run(args: Args) -> Result<i32> {
                 "transferred"
             };
             println!(
-                "pcp: {} {} files ({}), {} unchanged ({} files), {} dirs{}{}",
+                "syq: {} {} files ({}), {} unchanged ({} files), {} dirs{}{}",
                 verb,
                 commas(progress.files_done.load(Relaxed)),
                 human(if opts.dry_run {
@@ -856,9 +856,9 @@ impl Planner<'_> {
                 // "skipping …" is a notice (nothing the copy owes is missing);
                 // anything else from the scanner means an entry was lost.
                 if w.starts_with("skipping ") {
-                    progress.eprintln(&format!("pcp: {w}"));
+                    progress.eprintln(&format!("syq: {w}"));
                 } else {
-                    progress.error(&format!("pcp: {w}"));
+                    progress.error(&format!("syq: {w}"));
                 }
             },
         )
@@ -943,7 +943,7 @@ impl Planner<'_> {
                 for (name, err) in names.iter().zip(errs) {
                     if let Some(err) = err {
                         failed += 1;
-                        self.progress.error(&format!("pcp: {err}"));
+                        self.progress.error(&format!("syq: {err}"));
                     } else if opts.verbose > 0 {
                         self.progress.println(&format!("{}/", display(name)));
                     }
@@ -1187,7 +1187,7 @@ impl Planner<'_> {
             let (ops, records): (Vec<Op>, Vec<_>) = meta_fixes.into_iter().unzip();
             for (err, rec) in self.apply(true, ops)?.into_iter().zip(records) {
                 match err {
-                    Some(err) => self.progress.error(&format!("pcp: {err}")),
+                    Some(err) => self.progress.error(&format!("syq: {err}")),
                     None => {
                         // Only now is the file complete in every respect.
                         if let (Some(checkpoint), Some((rel, entry))) = (&self.checkpoint, rec) {
@@ -1204,7 +1204,7 @@ impl Planner<'_> {
                 let e1 = errs.get(2 * i).cloned().flatten();
                 let e2 = errs.get(2 * i + 1).cloned().flatten();
                 if let Some(e) = e1.or(e2) {
-                    self.progress.error(&format!("pcp: {e}"));
+                    self.progress.error(&format!("syq: {e}"));
                 } else if opts.verbose > 0 {
                     self.progress.println(name);
                 }
@@ -1231,7 +1231,7 @@ impl Planner<'_> {
             Some(&prev_dir) if prev_dir && is_dir => true,
             Some(_) => {
                 self.progress.error(&format!(
-                    "pcp: {rel}: two sources map to the same destination {} with conflicting types — refusing to clobber it",
+                    "syq: {rel}: two sources map to the same destination {} with conflicting types — refusing to clobber it",
                     display(dst)
                 ));
                 self.collision = true;
@@ -1295,7 +1295,7 @@ impl Planner<'_> {
                 })
                 .collect();
             for err in self.apply(true, ops)?.into_iter().flatten() {
-                self.progress.error(&format!("pcp: {err}"));
+                self.progress.error(&format!("syq: {err}"));
             }
         }
         Ok(())
@@ -1346,7 +1346,7 @@ impl Worker {
                 Item::Exit => {
                     if debug() {
                         eprintln!(
-                            "pcp: worker {} blocked: src recv {:.2}s, dst send {:.2}s, dst ack {:.2}s, idle {:.2}s",
+                            "syq: worker {} blocked: src recv {:.2}s, dst send {:.2}s, dst ack {:.2}s, idle {:.2}s",
                             self.id, self.t[0], self.t[1], self.t[2], self.t[3]
                         );
                     }
@@ -1514,7 +1514,7 @@ impl Worker {
         {
             self.sched.ranges_ready(*idx, vec![]);
             if let Err(e) = res {
-                self.progress.error(&format!("pcp: {}: {e:#}", j.rel));
+                self.progress.error(&format!("syq: {}: {e:#}", j.rel));
                 self.sched.fail_file(*idx);
                 continue;
             }
@@ -1530,7 +1530,7 @@ impl Worker {
             if changed {
                 if let (Some(e), true) = (now, j.attempts + 1 < MAX_ATTEMPTS) {
                     self.progress.eprintln(&format!(
-                        "pcp: {}: changed during transfer, retrying",
+                        "syq: {}: changed during transfer, retrying",
                         j.rel
                     ));
                     let mut all = self.sched.jobs.lock().unwrap();
@@ -1547,7 +1547,7 @@ impl Worker {
                     self.sched.requeue(*idx);
                 } else {
                     self.progress.error(&format!(
-                        "pcp: {}: source changed during transfer (or vanished)",
+                        "syq: {}: source changed during transfer (or vanished)",
                         j.rel
                     ));
                     self.sched.fail_file(*idx);
@@ -1571,7 +1571,7 @@ impl Worker {
         }
         if !self.sched.is_failed(idx) {
             let rel = self.sched.jobs.lock().unwrap()[idx].rel.clone();
-            self.progress.error(&format!("pcp: {rel}: {e:#}"));
+            self.progress.error(&format!("syq: {rel}: {e:#}"));
             self.sched.fail_file(idx);
         }
         Ok(())
@@ -2006,7 +2006,7 @@ impl Worker {
                 flags,
                 fsync: self.opts.fsync,
             })?,
-            "finalize",
+            "finalize destination",
         )?;
         // Did the source change under us?
         let now = stat_one(&mut *self.src, &job.src)?;
@@ -2023,7 +2023,7 @@ impl Worker {
             if job.attempts + 1 < MAX_ATTEMPTS {
                 if let Some(e) = now {
                     self.progress.eprintln(&format!(
-                        "pcp: {}: changed during transfer, retrying",
+                        "syq: {}: changed during transfer, retrying",
                         job.rel
                     ));
                     let mut jobs = self.sched.jobs.lock().unwrap();

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1,6 +1,6 @@
 //! Automatic tuning of the number of parallel workers / connections.
 //!
-//! When `-j` is not given, pcp does not guess: it starts with a few workers
+//! When `-j` is not given, syq does not guess: it starts with a few workers
 //! and measures. Progress (bytes, plus a small credit per completed file so
 //! small-file transfers count too) is sampled every few seconds; a worker
 //! count has been *measured* once the rate has stopped changing — two
@@ -443,7 +443,7 @@ pub fn run(
             sampler.reset();
             if crate::transfer::debug() {
                 eprintln!(
-                    "pcp: tune: {before} -> {n} workers (measured {:.1} MB/s at {before}, state {:?})",
+                    "syq: tune: {before} -> {n} workers (measured {:.1} MB/s at {before}, state {:?})",
                     score / 1e6,
                     policy.state
                 );

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,782 @@
+//! Signed standalone release updates.
+//!
+//! Package-manager and source installs deliberately have no install receipt,
+//! so this module will never replace them. Official release builds embed the
+//! Ed25519 public key supplied by the release workflow at compile time.
+
+use crate::remote_helper::Target;
+use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine as _;
+use ed25519_dalek::{Signature, VerifyingKey};
+use flate2::read::GzDecoder;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufReader, BufWriter, IsTerminal, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+const REPOSITORY: &str = "https://github.com/greaber/syq";
+const RELEASE_DOWNLOADS: &str = "https://github.com/greaber/syq/releases/download";
+const LATEST_DOWNLOADS: &str = "https://github.com/greaber/syq/releases/latest/download";
+const MANIFEST_NAME: &str = "syq-release-manifest.json";
+const SIGNATURE_NAME: &str = "syq-release-manifest.json.sig";
+const RECEIPT_SCHEMA: u32 = 1;
+const MANIFEST_SCHEMA: u32 = 1;
+const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+const RELEASE_PUBLIC_KEY: Option<&str> = option_env!("SYQ_RELEASE_PUBLIC_KEY");
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct InstallReceipt {
+    schema: u32,
+    provider: String,
+    version: String,
+    target: String,
+    binary: PathBuf,
+    #[serde(default)]
+    auto_update: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ReleaseManifest {
+    schema: u32,
+    repository: String,
+    version: String,
+    tag: String,
+    helper_id: String,
+    artifacts: BTreeMap<String, ReleaseArtifact>,
+    installer: ReleaseFile,
+    homebrew_formula: ReleaseFile,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ReleaseArtifact {
+    binary: ReleaseFile,
+    archive: ReleaseFile,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ReleaseFile {
+    name: String,
+    sha256: String,
+    size: u64,
+}
+
+struct VerifiedRelease {
+    manifest: ReleaseManifest,
+    version: Version,
+}
+
+#[derive(Clone, Copy)]
+enum FetchMode {
+    Interactive,
+    BackgroundCheck,
+}
+
+/// Install the latest release when this executable came from the standalone
+/// installer. A package-manager binary cannot accidentally overwrite itself.
+pub fn self_update() -> Result<()> {
+    let (_, mut receipt) = managed_receipt().context(
+        "self-update is only available for installs made by the standalone installer; use your package manager or reinstall with the curl installer",
+    )?;
+    let release = fetch_latest(FetchMode::Interactive)?;
+    match release.version.cmp(&current_version()?) {
+        std::cmp::Ordering::Less => bail!(
+            "refusing to downgrade from {} to {}",
+            env!("CARGO_PKG_VERSION"),
+            release.version
+        ),
+        std::cmp::Ordering::Equal => {
+            println!("syq {} is already the newest release", release.version);
+            return Ok(());
+        }
+        std::cmp::Ordering::Greater => {}
+    }
+    install_release(&release, &mut receipt)?;
+    println!("updated syq to {}", release.version);
+    Ok(())
+}
+
+/// Change the opt-in automatic update setting in the standalone receipt.
+pub fn set_auto_update(enabled: bool) -> Result<()> {
+    let (path, mut receipt) = managed_receipt().context(
+        "automatic updates are only available for installs made by the standalone installer; package-manager installs should be updated by their package manager",
+    )?;
+    receipt.auto_update = enabled;
+    write_receipt(&path, &receipt)?;
+    if enabled {
+        println!("automatic signed updates enabled");
+    } else {
+        println!("automatic updates disabled; interactive update notices remain enabled");
+    }
+    Ok(())
+}
+
+/// Called by the generated installer after the verified binary has reached its
+/// final path. Keeping receipt creation inside syq avoids shell JSON escaping.
+pub fn register_standalone_install() -> Result<()> {
+    embedded_public_key()?;
+    let target = Target::local().ok_or_else(|| {
+        anyhow!(
+            "standalone releases do not support {} {}",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )
+    })?;
+    let binary = canonical_current_exe()?;
+    let path = receipt_path()?;
+    let auto_update = read_receipt(&path)
+        .ok()
+        .filter(|old| canonical_or_original(&old.binary) == binary)
+        .is_some_and(|old| old.auto_update);
+    let receipt = InstallReceipt {
+        schema: RECEIPT_SCHEMA,
+        provider: "standalone".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        target: target.key.into(),
+        binary,
+        auto_update,
+    };
+    write_receipt(&path, &receipt)
+}
+
+/// Check at most once per day after a successful interactive command. Errors
+/// never change the command's exit status. Automatic replacement is opt-in.
+pub fn after_success(quiet: bool) {
+    if quiet || !std::io::stderr().is_terminal() {
+        return;
+    }
+    let Ok((_, mut receipt)) = managed_receipt() else {
+        return;
+    };
+    let Ok(stamp) = check_stamp_path() else {
+        return;
+    };
+    if !check_is_due(&stamp) {
+        return;
+    }
+    // Mark before networking so an outage does not delay every invocation.
+    if touch_check_stamp(&stamp).is_err() {
+        return;
+    }
+    let mode = if receipt.auto_update {
+        FetchMode::Interactive
+    } else {
+        FetchMode::BackgroundCheck
+    };
+    let release = match fetch_latest(mode) {
+        Ok(release) => release,
+        Err(e) => {
+            if receipt.auto_update {
+                eprintln!("syq: automatic update check failed: {e:#}");
+            }
+            return;
+        }
+    };
+    let Ok(current) = current_version() else {
+        return;
+    };
+    if release.version <= current {
+        return;
+    }
+    if receipt.auto_update {
+        match install_release(&release, &mut receipt) {
+            Ok(()) => eprintln!(
+                "syq: installed signed update {} (used on the next command)",
+                release.version
+            ),
+            Err(e) => eprintln!(
+                "syq: automatic update to {} failed: {e:#}; run `syq --self-update` to retry",
+                release.version
+            ),
+        }
+    } else {
+        eprintln!(
+            "syq: update {} is available; run `syq --self-update`",
+            release.version
+        );
+    }
+}
+
+/// Return the archive hash for this exact release after verifying its signed
+/// manifest. Remote bootstrap passes this trusted value to the remote shell;
+/// it never trusts a checksum downloaded beside the executable.
+pub fn trusted_current_archive_hash(target: Target) -> Result<String> {
+    let tag = format!("v{}", env!("CARGO_PKG_VERSION"));
+    let release = fetch_verified(
+        &format!("{}/{tag}", release_downloads()),
+        FetchMode::Interactive,
+    )?;
+    if release.version != current_version()?
+        || release.manifest.helper_id != crate::remote_helper::release_key()
+    {
+        bail!("signed release manifest does not describe this syq build");
+    }
+    let artifact = release
+        .manifest
+        .artifacts
+        .get(target.key)
+        .ok_or_else(|| anyhow!("release has no artifact for {}", target.key))?;
+    if artifact.binary.name != target.asset {
+        bail!("release artifact name does not match target {}", target.key);
+    }
+    Ok(artifact.archive.sha256.clone())
+}
+
+fn current_version() -> Result<Version> {
+    Version::parse(env!("CARGO_PKG_VERSION")).context("parse the current syq version")
+}
+
+fn fetch_latest(mode: FetchMode) -> Result<VerifiedRelease> {
+    fetch_verified(&latest_downloads(), mode)
+}
+
+fn fetch_verified(base_url: &str, mode: FetchMode) -> Result<VerifiedRelease> {
+    let key = embedded_public_key()?;
+    let temp_dir = config_dir()?;
+    create_private_dir(&temp_dir)?;
+    let manifest_temp = TempFile::new(&temp_dir, ".json")?;
+    let signature_temp = TempFile::new(&temp_dir, ".sig")?;
+    fetch(
+        &format!("{base_url}/{MANIFEST_NAME}"),
+        manifest_temp.path(),
+        mode,
+    )?;
+    fetch(
+        &format!("{base_url}/{SIGNATURE_NAME}"),
+        signature_temp.path(),
+        mode,
+    )?;
+    let manifest_bytes = fs::read(manifest_temp.path()).context("read release manifest")?;
+    let signature =
+        fs::read_to_string(signature_temp.path()).context("read release manifest signature")?;
+    verify_manifest(&manifest_bytes, &signature, key.as_ref())?;
+    let manifest: ReleaseManifest =
+        serde_json::from_slice(&manifest_bytes).context("parse signed release manifest")?;
+    let version = validate_manifest(&manifest)?;
+    Ok(VerifiedRelease { manifest, version })
+}
+
+fn embedded_public_key() -> Result<Cow<'static, str>> {
+    #[cfg(debug_assertions)]
+    if let Some(key) = std::env::var_os("SYQ_TEST_RELEASE_PUBLIC_KEY").filter(|v| !v.is_empty()) {
+        return Ok(Cow::Owned(key.to_string_lossy().into_owned()));
+    }
+    RELEASE_PUBLIC_KEY
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(Cow::Borrowed)
+        .ok_or_else(|| {
+            anyhow!(
+                "this syq build has no official release verification key; update it with its package manager"
+            )
+        })
+}
+
+fn verify_manifest(manifest: &[u8], signature_b64: &str, public_key_b64: &str) -> Result<()> {
+    let public = base64::engine::general_purpose::STANDARD
+        .decode(public_key_b64.trim())
+        .context("decode the embedded release public key")?;
+    let public: [u8; 32] = public
+        .try_into()
+        .map_err(|_| anyhow!("the embedded release public key is not 32 bytes"))?;
+    let key = VerifyingKey::from_bytes(&public).context("parse the release public key")?;
+    let signature = base64::engine::general_purpose::STANDARD
+        .decode(signature_b64.trim())
+        .context("decode the release manifest signature")?;
+    let signature =
+        Signature::from_slice(&signature).context("parse the release manifest signature")?;
+    key.verify_strict(manifest, &signature)
+        .context("release manifest signature verification failed")
+}
+
+fn validate_manifest(manifest: &ReleaseManifest) -> Result<Version> {
+    if manifest.schema != MANIFEST_SCHEMA {
+        bail!("unsupported release manifest schema {}", manifest.schema);
+    }
+    if manifest.repository != REPOSITORY {
+        bail!("release manifest names an unexpected repository");
+    }
+    let version = Version::parse(&manifest.version).context("invalid release version")?;
+    if manifest.tag != format!("v{version}") {
+        bail!("release tag does not match its version");
+    }
+    let helper_prefix = format!("{}-p", manifest.tag);
+    let protocol = manifest
+        .helper_id
+        .strip_prefix(&helper_prefix)
+        .filter(|value| !value.is_empty() && value.bytes().all(|b| b.is_ascii_digit()));
+    if protocol.is_none() {
+        bail!("release helper identity is malformed");
+    }
+    for (target, artifact) in &manifest.artifacts {
+        validate_release_file(target, &artifact.binary)?;
+        validate_release_file(target, &artifact.archive)?;
+        if artifact.archive.name != format!("{}.gz", artifact.binary.name) {
+            bail!("archive name does not match binary name for {target}");
+        }
+    }
+    validate_release_file("installer", &manifest.installer)?;
+    validate_release_file("Homebrew formula", &manifest.homebrew_formula)?;
+    if manifest.installer.name != "install.sh" || manifest.homebrew_formula.name != "syq.rb" {
+        bail!("release distribution metadata has unexpected file names");
+    }
+    Ok(version)
+}
+
+fn validate_release_file(target: &str, file: &ReleaseFile) -> Result<()> {
+    if file.name.is_empty()
+        || file.name == "."
+        || file.name == ".."
+        || file.name.contains('/')
+        || file.name.contains('\\')
+    {
+        bail!("release has an unsafe file name for {target}");
+    }
+    if file.size == 0 {
+        bail!("release has an empty file for {target}");
+    }
+    if file.sha256.len() != 64
+        || !file
+            .sha256
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+    {
+        bail!("release has an invalid SHA-256 for {target}");
+    }
+    Ok(())
+}
+
+fn install_release(release: &VerifiedRelease, receipt: &mut InstallReceipt) -> Result<()> {
+    let target = Target::local().ok_or_else(|| {
+        anyhow!(
+            "standalone releases do not support {} {}",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )
+    })?;
+    if receipt.target != target.key {
+        bail!(
+            "standalone install receipt is for {}, but this host is {}",
+            receipt.target,
+            target.key
+        );
+    }
+    let artifact = release
+        .manifest
+        .artifacts
+        .get(target.key)
+        .ok_or_else(|| anyhow!("release has no artifact for {}", target.key))?;
+    if artifact.binary.name != target.asset {
+        bail!("release artifact name does not match target {}", target.key);
+    }
+
+    let executable = canonical_current_exe()?;
+    let parent = executable
+        .parent()
+        .ok_or_else(|| anyhow!("the syq executable has no parent directory"))?;
+    let archive = TempFile::new(parent, ".gz")?;
+    let binary = TempFile::new(parent, ".bin")?;
+    let url = format!(
+        "{}/{}/{}",
+        release_downloads(),
+        release.manifest.tag,
+        artifact.archive.name
+    );
+    fetch(&url, archive.path(), FetchMode::Interactive)?;
+    verify_file(archive.path(), &artifact.archive)?;
+
+    let input = File::open(archive.path()).context("open downloaded release archive")?;
+    let mut decoder = GzDecoder::new(BufReader::new(input));
+    let output = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(binary.path())
+        .context("open temporary update executable")?;
+    let mut output = BufWriter::new(output);
+    std::io::copy(&mut decoder, &mut output).context("decompress the syq update")?;
+    output.flush().context("flush the syq update")?;
+    output.get_ref().sync_all().context("sync the syq update")?;
+    drop(output);
+    set_executable(binary.path())?;
+    verify_executable(binary.path(), release)?;
+
+    fs::rename(binary.path(), &executable).with_context(|| {
+        format!(
+            "replace {} (is its directory writable?)",
+            executable.display()
+        )
+    })?;
+    sync_parent(parent)?;
+    receipt.version = release.version.to_string();
+    write_receipt(&receipt_path()?, receipt)?;
+    Ok(())
+}
+
+fn release_downloads() -> Cow<'static, str> {
+    #[cfg(debug_assertions)]
+    if let Some(url) = std::env::var_os("SYQ_TEST_RELEASE_DOWNLOADS").filter(|v| !v.is_empty()) {
+        return Cow::Owned(url.to_string_lossy().into_owned());
+    }
+    Cow::Borrowed(RELEASE_DOWNLOADS)
+}
+
+fn latest_downloads() -> Cow<'static, str> {
+    #[cfg(debug_assertions)]
+    if let Some(url) = std::env::var_os("SYQ_TEST_LATEST_DOWNLOADS").filter(|v| !v.is_empty()) {
+        return Cow::Owned(url.to_string_lossy().into_owned());
+    }
+    Cow::Borrowed(LATEST_DOWNLOADS)
+}
+
+fn verify_file(path: &Path, expected: &ReleaseFile) -> Result<()> {
+    let metadata = fs::metadata(path).context("stat downloaded release archive")?;
+    if metadata.len() != expected.size {
+        bail!(
+            "downloaded release archive has size {}, expected {}",
+            metadata.len(),
+            expected.size
+        );
+    }
+    let mut input = BufReader::new(File::open(path).context("open release archive for hashing")?);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 128 * 1024];
+    loop {
+        let count = input.read(&mut buffer).context("hash release archive")?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected.sha256 {
+        bail!("downloaded release archive failed SHA-256 verification");
+    }
+    Ok(())
+}
+
+fn verify_executable(path: &Path, release: &VerifiedRelease) -> Result<()> {
+    let version = Command::new(path)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .output()
+        .context("run the downloaded syq update")?;
+    if !version.status.success()
+        || String::from_utf8_lossy(&version.stdout).trim() != format!("syq {}", release.version)
+    {
+        bail!("downloaded executable reports an unexpected version");
+    }
+    let identity = Command::new(path)
+        .arg("--remote-helper-id")
+        .stdin(Stdio::null())
+        .output()
+        .context("read the downloaded syq helper identity")?;
+    if !identity.status.success()
+        || String::from_utf8_lossy(&identity.stdout).trim() != release.manifest.helper_id
+    {
+        bail!("downloaded executable reports an unexpected helper identity");
+    }
+    Ok(())
+}
+
+fn fetch(url: &str, destination: &Path, mode: FetchMode) -> Result<()> {
+    let mut curl = Command::new("curl");
+    curl.args([
+        "--fail",
+        "--silent",
+        "--show-error",
+        "--location",
+        "--proto",
+        "=https",
+        "--proto-redir",
+        "=https",
+        "--connect-timeout",
+    ]);
+    match mode {
+        FetchMode::Interactive => {
+            curl.args(["10", "--retry", "2"]);
+        }
+        FetchMode::BackgroundCheck => {
+            curl.args(["2", "--max-time", "5"]);
+        }
+    }
+    curl.arg("--output").arg(destination).arg(url);
+    match curl.stdin(Stdio::null()).status() {
+        Ok(status) if status.success() => return Ok(()),
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e).context("run curl"),
+    }
+
+    let mut wget = Command::new("wget");
+    wget.args(["--quiet", "--https-only"]);
+    match mode {
+        FetchMode::Interactive => {
+            wget.args(["--timeout=10", "--tries=3"]);
+        }
+        FetchMode::BackgroundCheck => {
+            wget.args(["--timeout=5", "--tries=1"]);
+        }
+    }
+    wget.arg("-O").arg(destination).arg(url);
+    match wget.stdin(Stdio::null()).status() {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => bail!("download {url} failed ({status})"),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            bail!("downloading updates requires curl or wget")
+        }
+        Err(e) => Err(e).context("run wget"),
+    }
+}
+
+fn managed_receipt() -> Result<(PathBuf, InstallReceipt)> {
+    let path = receipt_path()?;
+    let receipt = read_receipt(&path)?;
+    if receipt.schema != RECEIPT_SCHEMA || receipt.provider != "standalone" {
+        bail!("unrecognized standalone install receipt");
+    }
+    let current = canonical_current_exe()?;
+    if canonical_or_original(&receipt.binary) != current {
+        bail!(
+            "standalone install receipt belongs to {}, not {}",
+            receipt.binary.display(),
+            current.display()
+        );
+    }
+    Ok((path, receipt))
+}
+
+fn read_receipt(path: &Path) -> Result<InstallReceipt> {
+    let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    serde_json::from_slice(&bytes).context("parse standalone install receipt")
+}
+
+fn write_receipt(path: &Path, receipt: &InstallReceipt) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("install receipt has no parent directory"))?;
+    create_private_dir(parent)?;
+    let temporary = TempFile::new(parent, ".receipt")?;
+    let file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(temporary.path())
+        .context("open temporary install receipt")?;
+    let mut file = BufWriter::new(file);
+    serde_json::to_writer_pretty(&mut file, receipt).context("serialize install receipt")?;
+    file.write_all(b"\n").context("write install receipt")?;
+    file.flush().context("flush install receipt")?;
+    file.get_ref().sync_all().context("sync install receipt")?;
+    set_private_file(temporary.path())?;
+    fs::rename(temporary.path(), path).context("replace install receipt")?;
+    sync_parent(parent)
+}
+
+fn receipt_path() -> Result<PathBuf> {
+    Ok(config_dir()?.join("install.json"))
+}
+
+fn check_stamp_path() -> Result<PathBuf> {
+    Ok(config_dir()?.join("last-update-check"))
+}
+
+fn config_dir() -> Result<PathBuf> {
+    if let Some(base) = std::env::var_os("XDG_CONFIG_HOME").filter(|v| !v.is_empty()) {
+        return Ok(PathBuf::from(base).join("syq"));
+    }
+    let home = std::env::var_os("HOME")
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
+            anyhow!("HOME is not set, so the standalone install receipt cannot be located")
+        })?;
+    Ok(PathBuf::from(home).join(".config/syq"))
+}
+
+fn canonical_current_exe() -> Result<PathBuf> {
+    let path = std::env::current_exe().context("locate the current syq executable")?;
+    fs::canonicalize(&path)
+        .with_context(|| format!("resolve the current executable {}", path.display()))
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn check_is_due(path: &Path) -> bool {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .and_then(|modified| modified.elapsed().map_err(std::io::Error::other))
+        .map_or(true, |elapsed| elapsed >= CHECK_INTERVAL)
+}
+
+fn touch_check_stamp(path: &Path) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("update check stamp has no parent directory"))?;
+    create_private_dir(parent)?;
+    OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .context("write update check stamp")?;
+    set_private_file(path)
+}
+
+fn create_private_dir(path: &Path) -> Result<()> {
+    fs::create_dir_all(path).with_context(|| format!("create {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("set permissions on {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn set_private_file(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("set permissions on {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn set_executable(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("make {} executable", path.display()))?;
+    }
+    Ok(())
+}
+
+fn sync_parent(parent: &Path) -> Result<()> {
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .with_context(|| format!("sync directory {}", parent.display()))
+}
+
+struct TempFile {
+    path: PathBuf,
+}
+
+impl TempFile {
+    fn new(parent: &Path, suffix: &str) -> Result<Self> {
+        for _ in 0..16 {
+            let mut random = [0u8; 12];
+            getrandom::getrandom(&mut random)
+                .map_err(|e| anyhow!("generate a temporary file name: {e}"))?;
+            let token: String = random.iter().map(|byte| format!("{byte:02x}")).collect();
+            let path = parent.join(format!(".syq-{}-{token}{suffix}", std::process::id()));
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(_) => {
+                    set_private_file(&path)?;
+                    return Ok(Self { path });
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(e) => {
+                    return Err(e)
+                        .with_context(|| format!("create temporary file in {}", parent.display()))
+                }
+            }
+        }
+        bail!(
+            "could not create a unique temporary file in {}",
+            parent.display()
+        )
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn manifest() -> ReleaseManifest {
+        ReleaseManifest {
+            schema: 1,
+            repository: REPOSITORY.into(),
+            version: "1.2.3".into(),
+            tag: "v1.2.3".into(),
+            helper_id: "v1.2.3-p4".into(),
+            artifacts: BTreeMap::from([(
+                "linux-x86_64".into(),
+                ReleaseArtifact {
+                    binary: ReleaseFile {
+                        name: "syq-linux-x86_64".into(),
+                        sha256: "a".repeat(64),
+                        size: 10,
+                    },
+                    archive: ReleaseFile {
+                        name: "syq-linux-x86_64.gz".into(),
+                        sha256: "b".repeat(64),
+                        size: 8,
+                    },
+                },
+            )]),
+            installer: ReleaseFile {
+                name: "install.sh".into(),
+                sha256: "c".repeat(64),
+                size: 12,
+            },
+            homebrew_formula: ReleaseFile {
+                name: "syq.rb".into(),
+                sha256: "d".repeat(64),
+                size: 13,
+            },
+        }
+    }
+
+    #[test]
+    fn verifies_a_signed_manifest_and_rejects_tampering() {
+        let signing = SigningKey::from_bytes(&[7; 32]);
+        let bytes = br#"{"schema":1}"#;
+        let signature = signing.sign(bytes);
+        let signature = base64::engine::general_purpose::STANDARD.encode(signature.to_bytes());
+        let public =
+            base64::engine::general_purpose::STANDARD.encode(signing.verifying_key().to_bytes());
+        verify_manifest(bytes, &signature, &public).unwrap();
+        assert!(verify_manifest(br#"{"schema":2}"#, &signature, &public).is_err());
+    }
+
+    #[test]
+    fn validates_release_identity_and_safe_file_names() {
+        let mut value = manifest();
+        assert_eq!(validate_manifest(&value).unwrap(), Version::new(1, 2, 3));
+        value
+            .artifacts
+            .get_mut("linux-x86_64")
+            .unwrap()
+            .archive
+            .name = "../syq.gz".into();
+        assert!(validate_manifest(&value).is_err());
+    }
+
+    #[test]
+    fn rejects_a_tag_or_helper_id_from_another_release() {
+        let mut value = manifest();
+        value.tag = "v1.2.4".into();
+        assert!(validate_manifest(&value).is_err());
+        value.tag = "v1.2.3".into();
+        value.helper_id = "v1.2.2-p4".into();
+        assert!(validate_manifest(&value).is_err());
+    }
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1,5 +1,7 @@
 //! Integration tests: local -> local copies through the built binary.
 
+use base64::Engine as _;
+use ed25519_dalek::{Signer, SigningKey};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -14,7 +16,7 @@ struct Tmp(PathBuf);
 impl Tmp {
     fn new() -> Tmp {
         let n = COUNTER.fetch_add(1, Ordering::SeqCst);
-        let p = std::env::temp_dir().join(format!("pcp-test-{}-{}", std::process::id(), n));
+        let p = std::env::temp_dir().join(format!("syq-test-{}-{}", std::process::id(), n));
         let _ = fs::remove_dir_all(&p);
         fs::create_dir_all(&p).unwrap();
         Tmp(p)
@@ -49,19 +51,19 @@ impl Drop for Tmp {
     }
 }
 
-fn pcp(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_pcp"))
+fn syq(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_syq"))
         .args(args)
         .arg("--no-progress")
         .output()
-        .expect("run pcp")
+        .expect("run syq")
 }
 
 fn run_ok(args: &[&str]) -> String {
-    let out = pcp(args);
+    let out = syq(args);
     assert!(
         out.status.success(),
-        "pcp {:?} failed: status {:?}\nstdout:\n{}\nstderr:\n{}",
+        "syq {:?} failed: status {:?}\nstdout:\n{}\nstderr:\n{}",
         args,
         out.status.code(),
         String::from_utf8_lossy(&out.stdout),
@@ -70,11 +72,11 @@ fn run_ok(args: &[&str]) -> String {
     String::from_utf8_lossy(&out.stdout).into_owned()
 }
 
-/// Parse "pcp: transferred N files" from the summary line.
+/// Parse "syq: transferred N files" from the summary line.
 fn transferred(stdout: &str) -> u64 {
     let line = stdout
         .lines()
-        .find(|l| l.starts_with("pcp: transferred") || l.starts_with("pcp: would transfer"))
+        .find(|l| l.starts_with("syq: transferred") || l.starts_with("syq: would transfer"))
         .unwrap_or_else(|| panic!("no summary line in {stdout:?}"));
     let after = line.split("transfer").nth(1).unwrap();
     let after = after.trim_start_matches("red").trim_start();
@@ -104,7 +106,7 @@ fn executable(p: &Path, body: &[u8]) {
 }
 
 /// A remote shell that executes the supplied command locally with an isolated
-/// HOME.  This exercises pcp's real remote launcher/server protocol without
+/// HOME.  This exercises syq's real remote launcher/server protocol without
 /// touching ssh or a real remote machine.
 fn fake_rsh(t: &Tmp) -> PathBuf {
     let path = t.path("fake-rsh");
@@ -122,8 +124,8 @@ exec /bin/sh -c "$1"
     path
 }
 
-fn remote_pcp(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_pcp"));
+fn remote_syq(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_syq"));
     cmd.args(["-e", rsh.to_str().unwrap(), "--no-tcp", "-j", "1"])
         .args(args)
         .arg("--no-progress")
@@ -131,15 +133,29 @@ fn remote_pcp(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
         .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
         .env("FAKE_RELEASE_ARCHIVE", t.path("release.gz"))
         .env("FAKE_CURL_LOG", t.path("curl.log"))
+        .env("FAKE_LOCAL_CURL_LOG", t.path("local-curl.log"))
+        .env("FAKE_RELEASE_MANIFEST", t.path("release-manifest.json"))
+        .env(
+            "FAKE_RELEASE_SIGNATURE",
+            t.path("release-manifest.json.sig"),
+        )
         .env("FAKE_RSH_LOG", t.path("rsh.log"))
-        .env("PCP_STATE_DIR", t.path("state"));
-    cmd.output().expect("run pcp through fake remote shell")
+        .env("XDG_CONFIG_HOME", t.path("config"));
+    if let Ok(key) = fs::read_to_string(t.path("release-public-key")) {
+        cmd.env("SYQ_TEST_RELEASE_PUBLIC_KEY", key.trim())
+            .env(
+                "SYQ_TEST_RELEASE_DOWNLOADS",
+                "https://release.invalid/download",
+            )
+            .env("PATH", format!("{}:/usr/bin:/bin", t.s("local-bin")));
+    }
+    cmd.output().expect("run syq through fake remote shell")
 }
 
 fn assert_output_ok(out: &Output) {
     assert!(
         out.status.success(),
-        "pcp failed: status {:?}\nstdout:\n{}\nstderr:\n{}",
+        "syq failed: status {:?}\nstdout:\n{}\nstderr:\n{}",
         out.status.code(),
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
@@ -147,7 +163,7 @@ fn assert_output_ok(out: &Output) {
 }
 
 fn cached_remote_helper(t: &Tmp) -> PathBuf {
-    let root = t.path("remote-home/.cache/pcp/helpers");
+    let root = t.path("remote-home/.cache/syq/helpers");
     let release = fs::read_dir(&root)
         .unwrap()
         .next()
@@ -160,7 +176,7 @@ fn cached_remote_helper(t: &Tmp) -> PathBuf {
         .expect("target cache directory")
         .unwrap()
         .path();
-    target.join("pcp")
+    target.join("syq")
 }
 
 #[cfg(target_os = "linux")]
@@ -170,7 +186,7 @@ fn remote_helper_download_is_verified_and_cached() {
     let rsh = fake_rsh(&t);
     let archive = File::create(t.path("release.gz")).unwrap();
     let status = Command::new("gzip")
-        .args(["-9", "-n", "-c", env!("CARGO_BIN_EXE_pcp")])
+        .args(["-9", "-n", "-c", env!("CARGO_BIN_EXE_syq")])
         .stdout(Stdio::from(archive))
         .status()
         .unwrap();
@@ -186,15 +202,44 @@ fn remote_helper_download_is_verified_and_cached() {
         .next()
         .unwrap()
         .to_string();
+    let archive_size = fs::metadata(t.path("release.gz")).unwrap().len();
+    let (target, asset) = match std::env::consts::ARCH {
+        "x86_64" => ("linux-x86_64", "syq-linux-x86_64"),
+        "aarch64" => ("linux-aarch64", "syq-linux-aarch64"),
+        arch => panic!("unsupported test architecture {arch}"),
+    };
+    let manifest = serde_json::json!({
+        "schema": 1,
+        "repository": "https://github.com/greaber/syq",
+        "version": env!("CARGO_PKG_VERSION"),
+        "tag": format!("v{}", env!("CARGO_PKG_VERSION")),
+        "helper_id": format!("v{}-p{}", env!("CARGO_PKG_VERSION"), crate_protocol_version()),
+        "artifacts": {
+            (target): {
+                "binary": {"name": asset, "sha256": "0".repeat(64), "size": 1},
+                "archive": {"name": format!("{asset}.gz"), "sha256": digest, "size": archive_size}
+            }
+        },
+        "installer": {"name": "install.sh", "sha256": "1".repeat(64), "size": 1},
+        "homebrew_formula": {"name": "syq.rb", "sha256": "2".repeat(64), "size": 1}
+    });
+    let manifest = serde_json::to_vec_pretty(&manifest).unwrap();
+    let signing = SigningKey::from_bytes(&[19; 32]);
+    let signature =
+        base64::engine::general_purpose::STANDARD.encode(signing.sign(&manifest).to_bytes());
+    write(&t.path("release-manifest.json"), &manifest);
+    write(&t.path("release-manifest.json.sig"), signature.as_bytes());
     write(
-        &t.path("release.gz.sha256"),
-        format!("{digest}\n").as_bytes(),
+        &t.path("release-public-key"),
+        base64::engine::general_purpose::STANDARD
+            .encode(signing.verifying_key().to_bytes())
+            .as_bytes(),
     );
 
     executable(
-        &t.path("remote-bin/curl"),
+        &t.path("local-bin/curl"),
         br#"#!/bin/sh
-printf 'fetch\n' >> "$FAKE_CURL_LOG"
+printf 'fetch\n' >> "$FAKE_LOCAL_CURL_LOG"
 out=
 url=
 while [ "$#" -gt 0 ]; do
@@ -204,35 +249,53 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 case "$url" in
-    *.sha256) cp "$FAKE_RELEASE_ARCHIVE.sha256" "$out" ;;
-    *) cp "$FAKE_RELEASE_ARCHIVE" "$out" ;;
+    *.json.sig) cp "$FAKE_RELEASE_SIGNATURE" "$out" ;;
+    *.json) cp "$FAKE_RELEASE_MANIFEST" "$out" ;;
+    *) exit 22 ;;
 esac
+"#,
+    );
+
+    executable(
+        &t.path("remote-bin/curl"),
+        br#"#!/bin/sh
+printf 'fetch\n' >> "$FAKE_CURL_LOG"
+out=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --output) out=$2; shift 2 ;;
+        *) shift ;;
+    esac
+done
+cp "$FAKE_RELEASE_ARCHIVE" "$out"
 "#,
     );
 
     write(&t.path("src"), b"first");
     let remote = format!("fake:{}", t.s("dst"));
-    let out = remote_pcp(&t, &rsh, &["-a", &t.s("src"), &remote]);
+    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"first");
     assert!(cached_remote_helper(&t).is_file());
-    assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
+    assert_eq!(read(&t.path("curl.log")), b"fetch\n");
     assert!(!String::from_utf8_lossy(&out.stderr).contains("uploading this executable"));
     let probes = fs::read_to_string(t.path("rsh.log"))
         .unwrap()
-        .matches("pcp-helper-target:")
+        .matches("syq-helper-target:")
         .count();
     assert_eq!(probes, 1);
 
     // A cache hit goes straight to the helper: no platform probe or download.
     write(&t.path("src"), b"second");
-    let out = remote_pcp(&t, &rsh, &["-a", &t.s("src"), &remote]);
+    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"second");
-    assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
+    assert_eq!(read(&t.path("curl.log")), b"fetch\n");
     let probes = fs::read_to_string(t.path("rsh.log"))
         .unwrap()
-        .matches("pcp-helper-target:")
+        .matches("syq-helper-target:")
         .count();
     assert_eq!(probes, 1, "cache hit should not probe the platform again");
 }
@@ -241,22 +304,21 @@ esac
 fn remote_helper_falls_back_to_same_platform_upload() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
-    executable(
-        &t.path("remote-bin/curl"),
-        br#"#!/bin/sh
-printf 'fetch failed\n' >> "$FAKE_CURL_LOG"
-exit 22
-"#,
-    );
 
     write(&t.path("src"), b"offline");
     let remote = format!("fake:{}", t.s("dst"));
-    let out = remote_pcp(&t, &rsh, &["-a", &t.s("src"), &remote]);
+    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"offline");
     assert!(cached_remote_helper(&t).is_file());
     assert!(String::from_utf8_lossy(&out.stderr).contains("uploading this executable"));
-    assert_eq!(read(&t.path("curl.log")), b"fetch failed\n");
+    assert!(!t.path("curl.log").exists());
+}
+
+fn crate_protocol_version() -> u32 {
+    // Kept explicit in this black-box test so the signed helper identity must
+    // move deliberately when the wire protocol changes.
+    5
 }
 
 #[test]
@@ -264,14 +326,14 @@ fn no_bootstrap_uses_remote_path_without_managed_cache() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
     fs::create_dir_all(t.path("remote-bin")).unwrap();
-    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_pcp"), t.path("remote-bin/pcp")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
 
     write(&t.path("src"), b"preinstalled");
     let remote = format!("fake:{}", t.s("dst"));
-    let out = remote_pcp(&t, &rsh, &["-a", "--no-bootstrap", &t.s("src"), &remote]);
+    let out = remote_syq(&t, &rsh, &["-a", "--no-bootstrap", &t.s("src"), &remote]);
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"preinstalled");
-    assert!(!t.path("remote-home/.cache/pcp/helpers").exists());
+    assert!(!t.path("remote-home/.cache/syq/helpers").exists());
 }
 
 fn set_mtime(p: &Path, secs: i64) {
@@ -473,7 +535,7 @@ fn multiple_sources_require_dir_dest() {
     write(&t.path("src/f.txt"), b"data");
     write(&t.path("src/g.txt"), b"data");
     write(&t.path("dst"), b"a file");
-    let out = pcp(&["-a", &t.s("src/f.txt"), &t.s("src/g.txt"), &t.s("dst")]);
+    let out = syq(&["-a", &t.s("src/f.txt"), &t.s("src/g.txt"), &t.s("dst")]);
     assert!(!out.status.success());
     assert_eq!(read(&t.path("dst")), b"a file");
 }
@@ -547,7 +609,7 @@ fn resume_from_partial() {
     set_mtime(&t.path("src/big.bin"), 1_600_000_000);
     fs::create_dir_all(t.path("dst")).unwrap();
     // Fake an interrupted transfer: first half present, rest preallocated.
-    let partial = t.path("dst/.big.bin.pcp-partial");
+    let partial = t.path("dst/.big.bin.syq-partial");
     {
         let f = File::create(&partial).unwrap();
         (&f).write_all(&data[..data.len() / 2]).unwrap();
@@ -602,7 +664,7 @@ fn verify_only_detects_differences() {
     let t = Tmp::new();
     make_tree(&t.path("src"));
     run_ok(&["-a", &t.s("src/"), &t.s("dst/")]);
-    let out = pcp(&["-a", "--verify-only", &t.s("src/"), &t.s("dst/")]);
+    let out = syq(&["-a", "--verify-only", &t.s("src/"), &t.s("dst/")]);
     assert!(
         out.status.success(),
         "{}",
@@ -618,7 +680,7 @@ fn verify_only_detects_differences() {
     );
     fs::remove_file(t.path("dst/hello.txt")).unwrap();
 
-    let out = pcp(&["-a", "--verify-only", &t.s("src/"), &t.s("dst/")]);
+    let out = syq(&["-a", "--verify-only", &t.s("src/"), &t.s("dst/")]);
     assert_eq!(out.status.code(), Some(23));
     let err = String::from_utf8_lossy(&out.stderr);
     assert!(err.contains("DIFFERS a/med.bin"), "{err}");
@@ -647,10 +709,10 @@ fn large_file_parallel_chunks() {
     ]);
     assert!(read(&t.path("dst/huge.bin")) == data);
     assert_same_tree(&t.path("src/huge.bin"), &t.path("dst/huge.bin"));
-    assert!(!t.path("dst/.huge.bin.pcp-partial").exists());
+    assert!(!t.path("dst/.huge.bin.syq-partial").exists());
     // And partial resume of the same big file with parallel chunks.
     {
-        let f = File::create(t.path("dst/.huge.bin.pcp-partial")).unwrap();
+        let f = File::create(t.path("dst/.huge.bin.syq-partial")).unwrap();
         (&f).write_all(&data[..50 * 1024 * 1024]).unwrap();
         f.set_len(data.len() as u64).unwrap();
     }
@@ -704,7 +766,7 @@ fn bwlimit_is_aggregate_across_workers() {
 fn bwlimit_rejects_invalid_rates() {
     let t = Tmp::new();
     write(&t.path("src/f"), b"x");
-    let out = pcp(&["-a", "--bwlimit", "fast", &t.s("src/"), &t.s("dst/")]);
+    let out = syq(&["-a", "--bwlimit", "fast", &t.s("src/"), &t.s("dst/")]);
     assert!(!out.status.success());
     assert!(
         String::from_utf8_lossy(&out.stderr).contains("bad --bwlimit"),
@@ -734,14 +796,14 @@ fn inplace_leaves_no_partial() {
     set_mtime(&t.path("src/f.bin"), 1_600_000_000);
     run_ok(&["-a", "--inplace", &t.s("src/"), &t.s("dst/")]);
     assert!(read(&t.path("dst/f.bin")) == data);
-    assert!(!t.path("dst/.f.bin.pcp-partial").exists());
+    assert!(!t.path("dst/.f.bin.syq-partial").exists());
     // Update in place when the destination differs.
     let data2 = prng(3 * 1024 * 1024 + 10, 6);
     write(&t.path("src/f.bin"), &data2);
     set_mtime(&t.path("src/f.bin"), 1_600_000_001);
     run_ok(&["-a", "--inplace", &t.s("src/"), &t.s("dst/")]);
     assert!(read(&t.path("dst/f.bin")) == data2);
-    assert!(!t.path("dst/.f.bin.pcp-partial").exists());
+    assert!(!t.path("dst/.f.bin.syq-partial").exists());
     assert_same_tree(&t.path("src"), &t.path("dst"));
 }
 
@@ -755,7 +817,7 @@ fn unreadable_source_reports_error_but_continues() {
     write(&t.path("src/secret.txt"), b"nope");
     write(&t.path("src/also_ok.txt"), b"fine too");
     fs::set_permissions(t.path("src/secret.txt"), fs::Permissions::from_mode(0o000)).unwrap();
-    let out = pcp(&["-a", &t.s("src/"), &t.s("dst/")]);
+    let out = syq(&["-a", &t.s("src/"), &t.s("dst/")]);
     assert_eq!(
         out.status.code(),
         Some(23),
@@ -797,7 +859,7 @@ fn inplace_self_copy_preserves_source() {
     let t = Tmp::new();
     write(&t.path("f"), b"hello world data");
     // Copying a file onto itself must never truncate it.
-    let out = pcp(&["-a", "--inplace", &t.s("f"), &t.s("f")]);
+    let out = syq(&["-a", "--inplace", &t.s("f"), &t.s("f")]);
     assert!(out.status.success());
     assert_eq!(read(&t.path("f")), b"hello world data");
 }
@@ -807,7 +869,7 @@ fn inplace_hardlink_alias_preserves_source() {
     let t = Tmp::new();
     write(&t.path("a"), b"aaaa");
     fs::hard_link(t.path("a"), t.path("b")).unwrap();
-    let out = pcp(&["-a", "--inplace", &t.s("a"), &t.s("b")]);
+    let out = syq(&["-a", "--inplace", &t.s("a"), &t.s("b")]);
     assert!(out.status.success());
     assert_eq!(read(&t.path("a")), b"aaaa");
     assert_eq!(read(&t.path("b")), b"aaaa");
@@ -835,7 +897,7 @@ fn rm_rejects_parent_traversal() {
     fs::create_dir_all(t.path("parent/child")).unwrap();
     write(&t.path("parent/sibling"), b"x");
     write(&t.path("parent/child/y"), b"y");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args(["--rm", ".."])
         .arg("--no-progress")
         .current_dir(t.path("parent/child"))
@@ -849,7 +911,7 @@ fn rm_rejects_parent_traversal() {
 #[test]
 fn rm_rejects_dangerous_roots() {
     for target in ["/", ".", "~", "/tmp/.."] {
-        let out = pcp(&["--rm", target]);
+        let out = syq(&["--rm", target]);
         assert!(!out.status.success(), "should reject --rm {target}");
     }
 }
@@ -869,7 +931,7 @@ fn duplicate_destination_rejected() {
     write(&t.path("a/same"), b"A");
     write(&t.path("b/same"), b"B");
     fs::create_dir_all(t.path("dest")).unwrap();
-    let out = pcp(&["-a", &t.s("a/same"), &t.s("b/same"), &t.s("dest/")]);
+    let out = syq(&["-a", &t.s("a/same"), &t.s("b/same"), &t.s("dest/")]);
     assert!(
         !out.status.success(),
         "two sources named 'same' must be rejected"
@@ -949,7 +1011,7 @@ fn partial_symlink_is_not_followed() {
     write(&t.path("src"), &vec![7u8; 5 * 1024 * 1024]);
     write(&t.path("external"), b"EXTERNAL-DO-NOT-TOUCH");
     // A malicious/stale partial symlink pointing outside must not be followed.
-    std::os::unix::fs::symlink("external", t.path(".out.pcp-partial")).unwrap();
+    std::os::unix::fs::symlink("external", t.path(".out.syq-partial")).unwrap();
     run_ok(&["-a", &t.s("src"), &t.s("out")]);
     assert_eq!(read(&t.path("external")), b"EXTERNAL-DO-NOT-TOUCH");
     assert!(fs::symlink_metadata(t.path("out"))
@@ -963,7 +1025,7 @@ fn partial_symlink_is_not_followed() {
 fn rm_rejects_dot_final_component() {
     let t = Tmp::new();
     write(&t.path("p/f"), b"x");
-    let out = pcp(&["--rm", &format!("{}/.", t.s("p"))]);
+    let out = syq(&["--rm", &format!("{}/.", t.s("p"))]);
     assert!(!out.status.success());
     assert!(t.path("p/f").exists(), "contents must survive rm p/.");
 }
@@ -974,7 +1036,7 @@ fn dir_vs_file_destination_collision_rejected() {
     write(&t.path("A/x"), b"aaa"); // A/x is a file
     write(&t.path("B/x/y"), b"yyy"); // B/x is a directory
     fs::create_dir_all(t.path("dest")).unwrap();
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         &format!("{}/", t.s("A")),
         &format!("{}/", t.s("B")),
@@ -992,12 +1054,13 @@ fn file_over_nonempty_destination_directory_reports_error_without_panicking() {
     write(&t.path("src/foo"), b"source");
     write(&t.path("dest/foo/keep"), b"keep");
 
-    let out = pcp(&["-j", "1", "--no-resume", &t.s("src/foo"), &t.s("dest")]);
+    let out = syq(&["-j", "1", &t.s("src/foo"), &t.s("dest")]);
 
     assert_eq!(out.status.code(), Some(23));
     let err = String::from_utf8_lossy(&out.stderr);
+    let err_lower = err.to_ascii_lowercase();
     assert!(
-        err.contains("destination") && err.contains("is a directory"),
+        err_lower.contains("destination") && err_lower.contains("is a directory"),
         "{err}"
     );
     assert!(!err.contains("panicked"), "{err}");
@@ -1011,7 +1074,7 @@ fn verify_only_detects_symlink_difference() {
     fs::create_dir_all(t.path("d")).unwrap();
     std::os::unix::fs::symlink("target-a", t.path("s/l")).unwrap();
     std::os::unix::fs::symlink("target-b", t.path("d/l")).unwrap();
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         "--verify-only",
         &format!("{}/", t.s("s")),
@@ -1029,7 +1092,7 @@ fn small_files_atomic_no_partials() {
     }
     // A stale sidecar from an earlier interrupted or differently configured
     // run is overwritten by the atomic small-file path and renamed away.
-    write(&t.path("smd/.f7.pcp-partial"), b"stale");
+    write(&t.path("smd/.f7.syq-partial"), b"stale");
     run_ok(&[
         "-a",
         &format!("{}/", t.s("sm")),
@@ -1042,7 +1105,7 @@ fn small_files_atomic_no_partials() {
                 .unwrap()
                 .file_name()
                 .to_string_lossy()
-                .ends_with(".pcp-partial")
+                .ends_with(".syq-partial")
         })
         .count();
     assert_eq!(partials, 0);
@@ -1054,9 +1117,9 @@ fn small_files_atomic_no_partials() {
 fn small_file_failure_never_publishes_partial_contents() {
     let t = Tmp::new();
     write(&t.path("src/f"), b"complete contents");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
-        .env("PCP_TEST_FAIL_PUT_SMALL_BEFORE_RENAME", "/f")
+        .env("SYQ_TEST_FAIL_PUT_SMALL_BEFORE_RENAME", "/f")
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(23));
@@ -1064,11 +1127,11 @@ fn small_file_failure_never_publishes_partial_contents() {
         !t.path("dst/f").exists(),
         "the final name must not appear before the atomic rename"
     );
-    assert_eq!(read(&t.path("dst/.f.pcp-partial")), b"complete contents");
+    assert_eq!(read(&t.path("dst/.f.syq-partial")), b"complete contents");
 
     run_ok(&["-a", &t.s("src/"), &t.s("dst/")]);
     assert_eq!(read(&t.path("dst/f")), b"complete contents");
-    assert!(!t.path("dst/.f.pcp-partial").exists());
+    assert!(!t.path("dst/.f.syq-partial").exists());
 }
 
 // ---- Review round 4 (integrity) ----
@@ -1082,7 +1145,7 @@ fn quick_skipped_file_still_claims_destination() {
     write(&t.path("dest/x"), b"aaa");
     set_mtime(&t.path("A/x"), 1_000_000_000);
     set_mtime(&t.path("dest/x"), 1_000_000_000);
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         &format!("{}/", t.s("A")),
         &format!("{}/", t.s("B")),
@@ -1100,7 +1163,7 @@ fn verify_only_flags_missing_directory() {
     let t = Tmp::new();
     write(&t.path("s/sub/f"), b"f");
     fs::create_dir_all(t.path("d")).unwrap(); // d exists but d/sub does not
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         "--verify-only",
         &format!("{}/", t.s("s")),
@@ -1126,7 +1189,7 @@ fn verify_only_flags_missing_special() {
     unsafe {
         assert_eq!(libc::mkfifo(c.as_ptr(), 0o644), 0);
     }
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         "--verify-only",
         &format!("{}/", t.s("s")),
@@ -1142,7 +1205,7 @@ fn verify_only_flags_missing_special() {
 fn rejects_copying_directory_into_itself() {
     let t = Tmp::new();
     write(&t.path("src/file"), b"hi");
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         &format!("{}/", t.s("src")),
         &format!("{}/", t.s("src/dst")),
@@ -1158,7 +1221,7 @@ fn hardlinked_partial_does_not_corrupt_external_file() {
     write(&t.path("src"), &vec![9u8; 5 * 1024 * 1024]);
     write(&t.path("external"), b"EXTERNAL-DO-NOT-TOUCH");
     // A partial hardlinked to an external file (as a dedup/backup tool might make).
-    fs::hard_link(t.path("external"), t.path(".out.pcp-partial")).unwrap();
+    fs::hard_link(t.path("external"), t.path(".out.syq-partial")).unwrap();
     run_ok(&["-a", &t.s("src"), &t.s("out")]);
     assert_eq!(read(&t.path("external")), b"EXTERNAL-DO-NOT-TOUCH");
     assert_eq!(read(&t.path("out")).len(), 5 * 1024 * 1024);
@@ -1173,7 +1236,7 @@ fn rejects_bare_dir_into_parent_mapping_onto_itself() {
     let t = Tmp::new();
     write(&t.path("sub/f"), b"x");
     // Copying t/sub into t (existing dir) maps to t/sub — the source itself.
-    let out = pcp(&["-a", &t.s("sub"), &t.s(".")]);
+    let out = syq(&["-a", &t.s("sub"), &t.s(".")]);
     // t.s(".") is the tmp dir itself (existing), so effective dest = <tmp>/sub.
     assert!(
         !out.status.success(),
@@ -1326,7 +1389,7 @@ fn ignore_from_file_and_later_negation_wins() {
     ]);
     assert!(!t.path("dst2/x.o").exists());
     // Missing file is an error.
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         "--ignore-from",
         &t.s("nope"),
@@ -1400,13 +1463,13 @@ fn ignore_from_strips_bom_and_hyphen_patterns_work() {
 fn ignore_conflicts_with_rm() {
     let t = Tmp::new();
     make_ignore_tree(&t.path("tree"));
-    let out = pcp(&["--rm", "-i", "keep", &t.s("tree")]);
+    let out = syq(&["--rm", "-i", "keep", &t.s("tree")]);
     assert!(!out.status.success(), "--rm with -i must be rejected");
     assert!(
         t.path("tree/logs/keep/k").is_file(),
         "nothing may be removed"
     );
-    let out = pcp(&[
+    let out = syq(&[
         "--rm",
         "--ignore-from",
         &t.s("tree/hello.txt"),
@@ -1436,7 +1499,7 @@ fn ordinary_copy_needs_no_writable_history_directory() {
     // A regular file cannot contain an application state directory. Ordinary
     // copies must ignore both locations because history is opt-in.
     write(&t.path("not-a-directory"), b"occupied");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
         .env("XDG_STATE_HOME", t.s("not-a-directory"))
         .env("HOME", t.s("not-a-directory"))
@@ -1460,7 +1523,7 @@ fn checkpoint_is_explicit_retained_and_source_sensitive() {
     write(&t.path("src/fail/other"), b"other");
     set_mtime(&t.path("src/f"), 1_600_000_000);
     let checkpoint = t.s("copy.checkpoint");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args([
             "-a",
             "--no-progress",
@@ -1469,7 +1532,7 @@ fn checkpoint_is_explicit_retained_and_source_sensitive() {
             &t.s("src/"),
             &t.s("dest/"),
         ])
-        .env("PCP_TEST_FAIL_SETMETA", "fail")
+        .env("SYQ_TEST_FAIL_SETMETA", "fail")
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(23));
@@ -1508,7 +1571,7 @@ fn checkpoint_skip_still_detects_collision() {
     write(&t.path("A/fail/y"), b"failure trigger");
     fs::create_dir_all(t.path("B")).unwrap();
     let checkpoint = t.s("copy.checkpoint");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args([
             "-a",
             "--no-progress",
@@ -1518,13 +1581,13 @@ fn checkpoint_skip_still_detects_collision() {
             &t.s("B/"),
             &t.s("dest/"),
         ])
-        .env("PCP_TEST_FAIL_SETMETA", "fail")
+        .env("SYQ_TEST_FAIL_SETMETA", "fail")
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(23));
     assert_eq!(read(&t.path("dest/x")), b"from A");
     write(&t.path("B/x"), b"from B");
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         "--checkpoint",
         &checkpoint,
@@ -1557,6 +1620,26 @@ fn readonly_root_copies_and_reruns() {
     assert_eq!(read(&t.path("dst/f")), b"data");
 }
 
+// The old implicit-marker subsystem is gone. Its former filename is ordinary
+// payload and must not make an otherwise identical second run look interrupted.
+#[test]
+fn legacy_pcp_marker_name_is_ordinary_payload() {
+    let t = Tmp::new();
+    write(
+        &t.path("src/.pcp-transfer-session.json"),
+        b"ordinary user data",
+    );
+    write(&t.path("src/file"), b"payload");
+
+    run_ok(&["-a", &t.s("src/"), &t.s("dst/")]);
+    assert_eq!(
+        read(&t.path("dst/.pcp-transfer-session.json")),
+        b"ordinary user data"
+    );
+    run_ok(&["-a", &t.s("src/"), &t.s("dst/")]);
+    assert_eq!(read(&t.path("dst/file")), b"payload");
+}
+
 // Several content sources map onto the destination root; the last one's
 // metadata wins, as for any other directory.
 #[test]
@@ -1572,7 +1655,7 @@ fn multiple_content_sources_root_meta() {
     assert_eq!(read(&t.path("dest/b")), b"b");
 }
 
-// Directories pcp had to open up (no owner write bit) get their own mode back
+// Directories syq had to open up (no owner write bit) get their own mode back
 // at the end when nothing else sets it (no -p); with -p the source mode wins.
 #[test]
 fn opened_up_directories_get_their_mode_back() {
@@ -1602,9 +1685,9 @@ fn opened_up_directories_get_their_mode_back() {
 fn root_meta_failure_is_visible() {
     let t = Tmp::new();
     write(&t.path("src/f"), b"data");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst")])
-        .env("PCP_TEST_FAIL_SETMETA", "dst")
+        .env("SYQ_TEST_FAIL_SETMETA", "dst")
         .output()
         .unwrap();
     let err = String::from_utf8_lossy(&out.stderr);
@@ -1627,7 +1710,7 @@ fn checkpoint_records_quick_check_only_after_meta_repair() {
     fs::set_permissions(t.path("src/f"), fs::Permissions::from_mode(0o600)).unwrap();
     set_mtime(&t.path("src/f"), 1_600_000_000);
     let checkpoint = t.s("copy.checkpoint");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args([
             "-a",
             "--no-progress",
@@ -1636,7 +1719,7 @@ fn checkpoint_records_quick_check_only_after_meta_repair() {
             &t.s("src/"),
             &t.s("dst/"),
         ])
-        .env("PCP_TEST_FAIL_SETMETA", "f")
+        .env("SYQ_TEST_FAIL_SETMETA", "f")
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(23));
@@ -1666,13 +1749,13 @@ fn readonly_modes_create_nothing() {
     let t = Tmp::new();
     write(&t.path("src/f"), b"data");
     let checkpoint = t.s("dry-run.checkpoint");
-    let out = pcp(&["-a", "--verify-only", &t.s("src/"), &t.s("dst/")]);
+    let out = syq(&["-a", "--verify-only", &t.s("src/"), &t.s("dst/")]);
     assert!(
         !t.path("dst").exists(),
         "--verify-only must not create the destination"
     );
     assert!(!out.status.success(), "everything is missing");
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         "-n",
         "--checkpoint",
@@ -1701,7 +1784,7 @@ fn checkpoint_identity_is_spelling_independent() {
     set_mtime(&t.path("src/f"), 1_600_000_000);
     let dotted = format!("{}/./src/", t.s(""));
     let checkpoint = t.s("copy.checkpoint");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args([
             "-a",
             "--no-progress",
@@ -1710,7 +1793,7 @@ fn checkpoint_identity_is_spelling_independent() {
             &dotted,
             &t.s("dst/"),
         ])
-        .env("PCP_TEST_FAIL_SETMETA", "fail")
+        .env("SYQ_TEST_FAIL_SETMETA", "fail")
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(23));
@@ -1737,7 +1820,7 @@ fn removed_destination_restarts() {
     write(&t.path("src/a"), b"aaaa");
     write(&t.path("src/fail/secret"), b"secret");
     let checkpoint = t.s("copy.checkpoint");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args([
             "-a",
             "--no-progress",
@@ -1746,7 +1829,7 @@ fn removed_destination_restarts() {
             &t.s("src/"),
             &t.s("dest/"),
         ])
-        .env("PCP_TEST_FAIL_SETMETA", "fail")
+        .env("SYQ_TEST_FAIL_SETMETA", "fail")
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(23));
@@ -1774,7 +1857,7 @@ fn missing_destination_does_not_replace_an_unrelated_checkpoint_path() {
     let t = Tmp::new();
     write(&t.path("src/a"), b"data");
     write(&t.path("important"), b"not a checkpoint");
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         "--checkpoint",
         &t.s("important"),
@@ -1784,7 +1867,7 @@ fn missing_destination_does_not_replace_an_unrelated_checkpoint_path() {
     assert!(!out.status.success());
     assert_eq!(read(&t.path("important")), b"not a checkpoint");
     let err = String::from_utf8_lossy(&out.stderr);
-    assert!(err.contains("not a PCP checkpoint"), "stderr: {err}");
+    assert!(err.contains("not a SYQ checkpoint"), "stderr: {err}");
 }
 
 // Two ordinary copies into one tree behave like rsync: the union lands, and a
@@ -1797,7 +1880,7 @@ fn concurrent_copies_union() {
         write(&t.path(&format!("B/b{i}")), b"b");
     }
     let spawn = |src: &str| {
-        Command::new(env!("CARGO_BIN_EXE_pcp"))
+        Command::new(env!("CARGO_BIN_EXE_syq"))
             .args(["-a", "--no-progress", &t.s(src), &t.s("dest/")])
             .spawn()
             .unwrap()
@@ -1855,7 +1938,7 @@ fn self_copy_guard_sees_through_symlinks() {
     write(&t.path("src/inner/f"), b"x");
     std::os::unix::fs::symlink(t.path("src/inner"), t.path("link")).unwrap();
     // link/../out == src/out: inside the source.
-    let out = pcp(&["-a", &t.s("src/"), &t.s("link/../out/")]);
+    let out = syq(&["-a", &t.s("src/"), &t.s("link/../out/")]);
     assert!(!out.status.success());
     let err = String::from_utf8_lossy(&out.stderr);
     assert!(err.contains("into itself"), "stderr: {err}");
@@ -1874,7 +1957,7 @@ fn checkpoint_records_metadata_only_reconcile() {
     run_ok(&["-a", &t.s("src/"), &t.s("dst/")]);
     set_mtime(&t.path("src/f"), 1_600_000_001);
     let checkpoint = t.s("copy.checkpoint");
-    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args([
             "-a",
             "--no-progress",
@@ -1883,7 +1966,7 @@ fn checkpoint_records_metadata_only_reconcile() {
             &t.s("src/"),
             &t.s("dst/"),
         ])
-        .env("PCP_TEST_FAIL_SETMETA", "fail")
+        .env("SYQ_TEST_FAIL_SETMETA", "fail")
         .output()
         .unwrap();
     assert_eq!(out.status.code(), Some(23));
@@ -1912,7 +1995,7 @@ fn unsupported_rsync_flags_explain_themselves() {
     let t = Tmp::new();
     write(&t.path("src/f"), b"x");
 
-    let out = pcp(&[
+    let out = syq(&[
         "-a",
         "--exclude",
         "node_modules",
@@ -1924,13 +2007,13 @@ fn unsupported_rsync_flags_explain_themselves() {
     assert!(err.contains("-i/--ignore"), "should point to -i: {err}");
     assert!(err.contains("gitignore"), "should mention gitignore: {err}");
 
-    let out = pcp(&["-a", "--delete", &t.s("src/"), &t.s("dst/")]);
+    let out = syq(&["-a", "--delete", &t.s("src/"), &t.s("dst/")]);
     assert!(!out.status.success());
     assert!(String::from_utf8_lossy(&out.stderr).contains("--rm"));
 
     // Bundled short flags from a pasted `rsync -aHz` are caught too (the
     // unsupported letter is found inside the cluster).
-    let out = pcp(&["-aHz", &t.s("src/"), &t.s("dst/")]);
+    let out = syq(&["-aHz", &t.s("src/"), &t.s("dst/")]);
     assert!(!out.status.success());
     assert!(
         String::from_utf8_lossy(&out.stderr).contains("hard links"),

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -1,0 +1,343 @@
+//! End-to-end standalone updater tests using a copied executable and signed,
+//! local fixtures. No test ever replaces the Cargo-built binary.
+
+use base64::Engine as _;
+use ed25519_dalek::{Signer, SigningKey};
+use flate2::{write::GzEncoder, Compression};
+use semver::Version;
+use sha2::{Digest, Sha256};
+use std::fs::{self, File};
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Self {
+        let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+        let path =
+            std::env::temp_dir().join(format!("syq-update-test-{}-{sequence}", std::process::id()));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self, value: &str) -> PathBuf {
+        self.0.join(value)
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn write_executable(path: &Path, bytes: &[u8]) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, bytes).unwrap();
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+struct UpdateFixture {
+    temp: TempDir,
+    installed: PathBuf,
+    config: PathBuf,
+    public_key: String,
+    original: Vec<u8>,
+}
+
+#[cfg(target_os = "linux")]
+impl UpdateFixture {
+    fn new(release_version: &str, release_helper: &str, executable_helper: &str) -> Self {
+        let temp = TempDir::new();
+        let installed = temp.path("bin/syq");
+        fs::create_dir_all(installed.parent().unwrap()).unwrap();
+        fs::copy(env!("CARGO_BIN_EXE_syq"), &installed).unwrap();
+        fs::set_permissions(&installed, fs::Permissions::from_mode(0o755)).unwrap();
+        let original = fs::read(&installed).unwrap();
+
+        let target = if cfg!(target_arch = "x86_64") {
+            "linux-x86_64"
+        } else {
+            "linux-aarch64"
+        };
+        let asset = format!("syq-{target}");
+        let replacement = format!(
+            "#!/bin/sh\ncase \"$1\" in\n  --version) echo 'syq {release_version}' ;;\n  --remote-helper-id) echo '{executable_helper}' ;;\n  *) exit 2 ;;\nesac\n"
+        );
+        let replacement = replacement.as_bytes();
+        let archive_path = temp.path(&format!("fixtures/{asset}.gz"));
+        fs::create_dir_all(archive_path.parent().unwrap()).unwrap();
+        let mut encoder = GzEncoder::new(File::create(&archive_path).unwrap(), Compression::best());
+        encoder.write_all(replacement).unwrap();
+        encoder.finish().unwrap();
+        let archive = fs::read(&archive_path).unwrap();
+
+        let manifest = serde_json::json!({
+            "schema": 1,
+            "repository": "https://github.com/greaber/syq",
+            "version": release_version,
+            "tag": format!("v{release_version}"),
+            "helper_id": release_helper,
+            "artifacts": {
+                (target): {
+                    "binary": {
+                        "name": asset,
+                        "sha256": format!("{:x}", Sha256::digest(replacement)),
+                        "size": replacement.len()
+                    },
+                    "archive": {
+                        "name": format!("{asset}.gz"),
+                        "sha256": format!("{:x}", Sha256::digest(&archive)),
+                        "size": archive.len()
+                    }
+                }
+            },
+            "installer": {"name": "install.sh", "sha256": "1".repeat(64), "size": 1},
+            "homebrew_formula": {"name": "syq.rb", "sha256": "2".repeat(64), "size": 1}
+        });
+        let manifest = serde_json::to_vec_pretty(&manifest).unwrap();
+        fs::write(temp.path("fixtures/syq-release-manifest.json"), &manifest).unwrap();
+        let signing = SigningKey::from_bytes(&[31; 32]);
+        let signature =
+            base64::engine::general_purpose::STANDARD.encode(signing.sign(&manifest).to_bytes());
+        fs::write(
+            temp.path("fixtures/syq-release-manifest.json.sig"),
+            signature,
+        )
+        .unwrap();
+        let public_key =
+            base64::engine::general_purpose::STANDARD.encode(signing.verifying_key().to_bytes());
+
+        write_executable(
+            &temp.path("fake-bin/curl"),
+            br#"#!/bin/sh
+out=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) out=$2; shift 2 ;;
+    *) url=$1; shift ;;
+  esac
+done
+cp "$SYQ_TEST_FIXTURES/${url##*/}" "$out"
+"#,
+        );
+
+        Self {
+            config: temp.path("config"),
+            temp,
+            installed,
+            public_key,
+            original,
+        }
+    }
+
+    fn command_at(&self, executable: &Path, argument: &str) -> Output {
+        Command::new(executable)
+            .arg(argument)
+            .env("XDG_CONFIG_HOME", &self.config)
+            .env("SYQ_TEST_RELEASE_PUBLIC_KEY", &self.public_key)
+            .env(
+                "SYQ_TEST_LATEST_DOWNLOADS",
+                "https://release.invalid/latest",
+            )
+            .env(
+                "SYQ_TEST_RELEASE_DOWNLOADS",
+                "https://release.invalid/download",
+            )
+            .env("SYQ_TEST_FIXTURES", self.temp.path("fixtures"))
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", self.temp.path("fake-bin").display()),
+            )
+            .output()
+            .unwrap()
+    }
+
+    fn command(&self, argument: &str) -> Output {
+        self.command_at(&self.installed, argument)
+    }
+
+    fn register(&self) {
+        let output = self.command("--register-standalone-install");
+        assert_success(&output);
+    }
+
+    fn receipt(&self) -> serde_json::Value {
+        serde_json::from_slice(
+            &fs::read(self.config.join("syq/install.json")).expect("install receipt should exist"),
+        )
+        .unwrap()
+    }
+
+    fn assert_original_unchanged(&self) {
+        assert_eq!(fs::read(&self.installed).unwrap(), self.original);
+        assert_eq!(
+            self.receipt()["version"],
+            env!("CARGO_PKG_VERSION"),
+            "a failed update must not advance the receipt"
+        );
+    }
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_failure_contains(output: &Output, expected: &str) {
+    assert!(!output.status.success(), "command unexpectedly succeeded");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains(expected),
+        "stderr did not contain {expected:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn signed_self_update_replaces_only_the_receipted_copy() {
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    fixture.register();
+
+    let update = fixture.command("--self-update");
+    assert_success(&update);
+    assert!(String::from_utf8_lossy(&update.stdout).contains("updated syq to 0.2.0"));
+
+    let version = Command::new(&fixture.installed)
+        .arg("--version")
+        .output()
+        .unwrap();
+    assert_eq!(String::from_utf8_lossy(&version.stdout).trim(), "syq 0.2.0");
+    assert_eq!(fixture.receipt()["version"], "0.2.0");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn self_update_rejects_a_tampered_signed_manifest_without_changing_install() {
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    fixture.register();
+    fs::write(
+        fixture.temp.path("fixtures/syq-release-manifest.json"),
+        b"{\"schema\":2}",
+    )
+    .unwrap();
+
+    let update = fixture.command("--self-update");
+    assert_failure_contains(&update, "signature verification failed");
+    fixture.assert_original_unchanged();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn self_update_rejects_a_tampered_archive_without_changing_install() {
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    fixture.register();
+    let target = if cfg!(target_arch = "x86_64") {
+        "linux-x86_64"
+    } else {
+        "linux-aarch64"
+    };
+    let archive = fixture.temp.path(&format!("fixtures/syq-{target}.gz"));
+    File::options()
+        .append(true)
+        .open(archive)
+        .unwrap()
+        .write_all(b"tamper")
+        .unwrap();
+
+    let update = fixture.command("--self-update");
+    assert_failure_contains(&update, "downloaded release archive has size");
+    fixture.assert_original_unchanged();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn self_update_rejects_an_executable_with_the_wrong_identity() {
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p999");
+    fixture.register();
+
+    let update = fixture.command("--self-update");
+    assert_failure_contains(&update, "unexpected helper identity");
+    fixture.assert_original_unchanged();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn self_update_refuses_a_signed_downgrade() {
+    let current = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    let older = if current.patch > 0 {
+        Version::new(current.major, current.minor, current.patch - 1)
+    } else {
+        assert!(
+            current.minor > 0,
+            "test needs a package version above 0.0.0"
+        );
+        Version::new(current.major, current.minor - 1, 0)
+    };
+    let helper = format!("v{older}-p4");
+    let fixture = UpdateFixture::new(&older.to_string(), &helper, &helper);
+    fixture.register();
+
+    let update = fixture.command("--self-update");
+    assert_failure_contains(&update, "refusing to downgrade");
+    fixture.assert_original_unchanged();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn receipt_is_bound_to_the_exact_installed_executable() {
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    fixture.register();
+    let other = fixture.temp.path("other/syq");
+    fs::create_dir_all(other.parent().unwrap()).unwrap();
+    fs::copy(&fixture.installed, &other).unwrap();
+    fs::set_permissions(&other, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let update = fixture.command_at(&other, "--self-update");
+    assert_failure_contains(&update, "standalone install receipt belongs to");
+    fixture.assert_original_unchanged();
+    assert_eq!(fs::read(other).unwrap(), fixture.original);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn auto_update_setting_is_explicit_and_survives_reregistration() {
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    fixture.register();
+    assert_eq!(fixture.receipt()["auto_update"], false);
+
+    assert_success(&fixture.command("--enable-auto-update"));
+    assert_eq!(fixture.receipt()["auto_update"], true);
+    fixture.register();
+    assert_eq!(fixture.receipt()["auto_update"], true);
+
+    assert_success(&fixture.command("--disable-auto-update"));
+    assert_eq!(fixture.receipt()["auto_update"], false);
+    assert_eq!(fs::read(&fixture.installed).unwrap(), fixture.original);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn source_install_cannot_create_or_use_a_standalone_receipt_implicitly() {
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+
+    let update = fixture.command("--self-update");
+    assert_failure_contains(&update, "self-update is only available");
+    assert!(!fixture.config.join("syq/install.json").exists());
+    assert_eq!(fs::read(&fixture.installed).unwrap(), fixture.original);
+}


### PR DESCRIPTION
## Summary

- rename the project and executable from PCP to syq
- publish signed Linux x86-64/ARM64 and macOS Apple Silicon/Intel release artifacts
- add a verified standalone installer, signed self-updates, opt-in automatic updates, and a project-owned Homebrew tap
- make automatic remote-helper downloads verify the signed release manifest
- harden release reruns, signed-tag verification, protected-master ancestry, and installer receipt preflight
- store release authority in a committed dotenvx-encrypted inventory while keeping `.env.keys` developer-side only
- publish to `greaber/homebrew-tap` through a repository-scoped SSH deploy key instead of an account token
- add pinned CI, Dependabot, release documentation, and an open-source license

## Rebase integration

This is rebased onto current `master`, including the merged explicit-checkpoint and probing fixes. The new checkpoint implementation is preserved and renamed to syq; the removed implicit marker/journal subsystem remains removed.

Consequently `.pcp-transfer-session.json` is ordinary payload rather than a reserved name. A regression test copies it and then repeats the identical copy, proving it cannot poison the next run.

## Credential boundary

`.env.release` is committed ciphertext and the canonical inventory. The gitignored `.env.keys` remains local and is never uploaded. A guarded maintainer-side sync forwards only `SYQ_RELEASE_SIGNING_KEY_PEM_B64` and `HOMEBREW_TAP_DEPLOY_KEY` to the protected release environment, installs only the deploy key public half on the tap, and sets the public `SYQ_RELEASE_PUBLIC_KEY` repository variable. Fork remotes and non-GitHub hosts fail before any `gh` invocation.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets` (24 unit, 77 CLI/filesystem, 8 updater tests)
- installer, release-tool, and secret-tool regression suites
- ShellCheck for every distribution and secret-management script
- real dotenvx initialization plus signing-key sign/verify
- Homebrew deploy-key API identity and SSH authentication verification
- `cargo package --locked --allow-dirty --no-verify`
- Homebrew native style check in a disposable Homebrew container
- static Linux release build, confirmed statically linked

## Merge cutover

After merging, immediately rename `greaber/pcp` to `greaber/syq`, make it public, update the shared origin URL, configure the protected `release` environment, and run the guarded secret sync. Linked worktrees share the remote configuration; remaining feature branches then rebase onto renamed `master`.