### PR TITLE
Start TCP copies at 16 and remove bootstrap uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ release, verifies its SHA-256 checksum, and installs it atomically. Later runs
 execute that exact path without an extra probe connection. Linux x86-64 and
 ARM64 and macOS Apple Silicon and Intel are published.
 
-If the remote cannot reach GitHub, pcp uploads its current executable when the
-local and remote platforms match. For a different-platform host without
-outbound access, install a compatible binary yourself and pass
-`--pcp-path /path/to/pcp`. `--no-bootstrap` disables managed helpers and
-requires `pcp` on the non-interactive remote `PATH`.
+The managed cache accepts only the downloaded, verified release binary. If the
+remote cannot download it, bootstrapping fails visibly; install a compatible
+binary yourself and pass `--pcp-path /path/to/pcp`, or put it on the
+non-interactive remote `PATH` and use `--no-bootstrap`.
 
 The remote download uses `curl` or `wget`, `gzip`, and one of `sha256sum`,
 `shasum`, or `openssl`. Version directories coexist and the helper cache can be
@@ -44,8 +43,8 @@ removed at any time; pcp recreates the helper it needs on the next connection.
   and uses only POSIX calls; Linux-only optimizations (`fallocate`,
   glibc `mallopt`) are compiled out automatically. copy_file_range's local
   fast path is Linux-only; on macOS same-machine copies use the normal path.
-- For portability across distributions (e.g. for the offline upload fallback
-  to a host with an older glibc), build a static binary:
+- For a manually installed binary that is portable across distributions (for
+  example, a host with an older glibc), build a static binary:
   `RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target x86_64-unknown-linux-gnu`
   (the musl target also works if `musl-gcc` is installed, which `zstd-sys` needs).
 
@@ -326,27 +325,26 @@ implemented, so there is no ordering question for them.
 
 Without `-j`, pcp tunes the number of workers while a copy runs instead of
 guessing (`--rm` keeps a fixed 8, or 32 locally: removal is metadata-bound
-and short). It starts with 8 over the network (32 when both ends are
-local: threads are free, connections are not) and measures: progress (bytes,
-plus a small credit per completed file so small-file trees count) is sampled
-every 2.5 s, and a count has been *measured* only once two consecutive
-samples agree within 10 % — so a burst that gets throttled, or a link still
-ramping up, is waited out (up to 20 s) rather than credited to the last
-change. Each measured count is compared with the previous one: it doubles
-while a doubling gains at least a third of what linear scaling would (up to
-64); when a doubling doesn't, it goes back to the last good count and
-refines upward in 1.3× steps; when even that buys nothing it shrinks by 1.3×
-as long as that costs less than 5 % (down to 2); then it holds. It never stops
-watching: after every 6 measurements it probes one step down (kept if
-throughput doesn't drop — this is what saves a spinning disk from seek
-thrash) or one step up (the route or a shared NAS may have freed up), and a
-direction that keeps failing is tried progressively less often. Surplus
-workers are parked, not closed: they keep their connections and stop taking
-work, handing back the rest of their range, so un-parking is instant.
-Transfers shorter than a measurement or two just run with the starting
-count. The progress line shows the current count (`13 conn`), and `--stats`
-reports the path it took (`connections: auto: settled at 13 (path 8 -> 10 ->
-13 -> 17 -> 13, peak 17)`).
+and short). It starts with 16 when every remote endpoint has a reachable TCP
+data path, 8 over ssh, or 32 when both ends are local (threads are free,
+connections are not), and measures: progress (bytes, plus a small credit per
+completed file so small-file trees count) is sampled every 2.5 s, and a count
+has been *measured* only once two consecutive samples agree within 10 % — so a
+burst that gets throttled, or a link still ramping up, is waited out (up to 20
+s) rather than credited to the last change. Each measured count is compared
+with the previous one: it doubles while a doubling gains at least a third of
+what linear scaling would (up to 64); when a doubling doesn't, it goes back to
+the last good count and refines upward in 1.3× steps; when even that buys
+nothing it shrinks by 1.3× as long as that costs less than 5 % (down to 2);
+then it holds. It never stops watching: after every 6 measurements it probes
+one step down (kept if throughput doesn't drop — this is what saves a spinning
+disk from seek thrash) or one step up (the route or a shared NAS may have freed
+up), and a direction that keeps failing is tried progressively less often.
+Surplus workers are parked, not closed: they keep their connections and stop
+taking work, handing back the rest of their range, so un-parking is instant.
+Transfers shorter than a measurement or two just run with the starting count.
+The progress line shows the current count (`16 conn`), and `--stats` reports
+the path it took (`connections: auto: settled at 16 (path 16, peak 16)`).
 
 Measured from a 1 Gbit box in Germany to a host in Japan (265 ms): over TCP
 data connections it settles around 8–13 at line rate; over ssh data
@@ -476,8 +474,8 @@ fix for that.
   sessions beyond 10 being set up at once — pcp halves that number for the
   rest of the run and retries. On a server set up for pcp (`MaxStartups
   100`, see `scripts/server-setup.sh`) 32 sessions come up in one round.
-  Auto-tuning starts at 8 and only opens more once they have been shown to
-  pay.
+  Auto-tuning starts at 16 for TCP data, or 8 for ssh data, and only opens more
+  once they have been shown to pay.
 - Direct remote→remote with a *forwarded* agent authenticates every session
   through your machine; over a slow link that dominates setup time. Keys on the
   source host avoid it.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ ARM64 and macOS Apple Silicon and Intel are published.
 The managed cache accepts only the downloaded, verified release binary. If the
 remote cannot download it, bootstrapping fails visibly; install a compatible
 binary yourself and pass `--pcp-path /path/to/pcp`, or put it on the
-non-interactive remote `PATH` and use `--no-bootstrap`.
+non-interactive remote `PATH` and use `--no-bootstrap`. Helpers cached by an
+older upload-capable version are never executed and are removed when their
+download-only replacement is installed.
 
 The remote download uses `curl` or `wget`, `gzip`, and one of `sha256sum`,
 `shasum`, or `openssl`. Version directories coexist and the helper cache can be

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,9 +58,10 @@ pub struct Args {
     #[arg(long)]
     pub numeric_ids: bool,
 
-    /// Parallel connections/workers. Default for copies: auto-tuned — starts at 8
-    /// (32 when local), grows while throughput improves, shrinks when that costs
-    /// nothing. Give a number to fix it. --rm uses a fixed 8 (32 when local).
+    /// Parallel connections/workers. Default for copies: auto-tuned — starts at 16
+    /// over TCP, 8 over ssh, or 32 when local; grows while throughput improves and
+    /// shrinks when that costs nothing. Give a number to fix it. --rm uses a fixed
+    /// 8 (32 when local).
     #[arg(short = 'j', long, value_name = "N")]
     pub connections_opt: Option<usize>,
     #[arg(skip)]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -655,8 +655,7 @@ fn hello(mut conn: RemoteConn, compress: bool, token: Vec<u8>) -> Result<RemoteC
 
 impl RemoteSpec {
     /// Ensure the exact release/protocol helper exists in the remote cache.
-    /// Release assets are preferred so unlike architectures work without
-    /// crossing the ssh link; uploading this executable is the offline fallback.
+    /// Only authorized release assets may populate the managed helper cache.
     pub fn install_helper(&self) -> Result<()> {
         let mut installed = self.helper_install.lock().unwrap();
         if *installed {
@@ -672,43 +671,16 @@ impl RemoteSpec {
                 target.key
             );
         }
-        match self.download_helper(target) {
-            Ok(()) => {
-                *installed = true;
-                Ok(())
-            }
-            Err(download_error) if Target::local() == Some(target) => {
-                if !self.quiet {
-                    eprintln!(
-                        "pcp: {}: release download unavailable; uploading this executable",
-                        self.label()
-                    );
-                }
-                if crate::transfer::debug() {
-                    eprintln!(
-                        "pcp: {}: remote helper download failed: {download_error:#}",
-                        self.label()
-                    );
-                }
-                self.upload_helper(target).with_context(|| {
-                    format!(
-                        "download failed ({download_error:#}); local executable upload also failed"
-                    )
-                })?;
-                *installed = true;
-                Ok(())
-            }
-            Err(download_error) => {
-                let local = Target::local().map_or("unsupported", |t| t.key);
-                bail!(
-                    "could not install {} helper on {} ({}) and cannot upload the local {} executable: {download_error:#}; install a compatible pcp and pass --pcp-path",
-                    remote_helper::release_key(),
-                    self.label(),
-                    target.key,
-                    local
-                );
-            }
-        }
+        self.download_helper(target).with_context(|| {
+            format!(
+                "could not install the authorized {} helper on {} ({}); install a compatible pcp and pass --pcp-path",
+                remote_helper::release_key(),
+                self.label(),
+                target.key
+            )
+        })?;
+        *installed = true;
+        Ok(())
     }
 
     fn remote_target(&self) -> Result<Target> {
@@ -757,44 +729,6 @@ impl RemoteSpec {
         if !out.status.success() {
             bail!(
                 "remote download exited {}{}",
-                out.status,
-                output_suffix(&out.stderr)
-            );
-        }
-        Ok(())
-    }
-
-    fn upload_helper(&self, target: Target) -> Result<()> {
-        let exe = std::env::current_exe().context("locate current pcp executable")?;
-        let mut input = std::fs::File::open(&exe)
-            .with_context(|| format!("open current executable {}", exe.display()))?;
-        let bytes = input.metadata()?.len();
-        if !self.quiet {
-            eprintln!(
-                "pcp: {}: uploading {:.1} MiB",
-                self.label(),
-                bytes as f64 / (1 << 20) as f64
-            );
-        }
-
-        let script = remote_helper::upload_script(target);
-        let mut cmd = self.ssh_command();
-        cmd.arg(format!("sh -c {}", shell_words::quote(&script)))
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        let mut child = cmd
-            .spawn()
-            .with_context(|| format!("start helper upload to {}", self.label()))?;
-        {
-            let mut stdin = child.stdin.take().unwrap();
-            std::io::copy(&mut input, &mut stdin)
-                .with_context(|| format!("upload helper to {}", self.label()))?;
-        }
-        let out = child.wait_with_output()?;
-        if !out.status.success() {
-            bail!(
-                "remote install exited {}{}",
                 out.status,
                 output_suffix(&out.stderr)
             );

--- a/src/remote_helper.rs
+++ b/src/remote_helper.rs
@@ -3,8 +3,7 @@
 //! The local client always names the exact release/protocol helper it expects.
 //! A cache hit adds no extra ssh round trip: the normal remote command computes
 //! the target name and execs the cached binary directly.  On a miss, `conn`
-//! probes the target, downloads the matching release asset, or uploads the
-//! current executable when it can run on the remote platform.
+//! probes the target and downloads the matching authorized release asset.
 
 use crate::proto::VERSION;
 
@@ -39,17 +38,6 @@ impl Target {
             }),
             _ => None,
         }
-    }
-
-    pub fn local() -> Option<Self> {
-        Self::from_uname(
-            match std::env::consts::OS {
-                "linux" => "Linux",
-                "macos" => "Darwin",
-                other => other,
-            },
-            std::env::consts::ARCH,
-        )
     }
 }
 
@@ -152,44 +140,6 @@ trap - EXIT HUP INT TERM"#,
         target_key = target.key,
         url = shell_words::quote(&url),
         sum_url = shell_words::quote(&format!("{url}.sha256")),
-        expected_version = shell_words::quote(&expected_version),
-        expected_helper_id = shell_words::quote(&expected_helper_id),
-    )
-}
-
-pub fn upload_script(target: Target) -> String {
-    let expected_version = format!("pcp {}", env!("CARGO_PKG_VERSION"));
-    let expected_helper_id = release_key();
-    format!(
-        r#"set -eu
-dir="$HOME/.cache/pcp/helpers/{release}/{target_key}"
-program="$dir/pcp"
-tmp="$dir/.pcp.$$.tmp"
-mkdir -p "$dir"
-cleanup() {{ rm -f "$tmp"; }}
-trap cleanup EXIT HUP INT TERM
-cat > "$tmp"
-chmod 700 "$tmp"
-got=$("$tmp" --version 2>/dev/null) || {{
-    echo "pcp: uploaded helper cannot run on this host" >&2
-    exit 1
-}}
-[ "$got" = {expected_version} ] || {{
-    echo "pcp: uploaded helper has unexpected version: $got" >&2
-    exit 1
-}}
-got_id=$("$tmp" --remote-helper-id 2>/dev/null) || {{
-    echo "pcp: uploaded helper does not report a helper identity" >&2
-    exit 1
-}}
-[ "$got_id" = {expected_helper_id} ] || {{
-    echo "pcp: uploaded helper has unexpected identity: $got_id" >&2
-    exit 1
-}}
-mv "$tmp" "$program"
-trap - EXIT HUP INT TERM"#,
-        release = release_key(),
-        target_key = target.key,
         expected_version = shell_words::quote(&expected_version),
         expected_helper_id = shell_words::quote(&expected_helper_id),
     )

--- a/src/remote_helper.rs
+++ b/src/remote_helper.rs
@@ -10,6 +10,7 @@ use crate::proto::VERSION;
 pub const RELEASE_BASE_URL: &str = "https://github.com/greaber/pcp/releases/download";
 pub const HELPER_MISSING_EXIT: i32 = 125;
 pub const HELPER_NOT_EXECUTABLE_EXIT: i32 = 126;
+const DOWNLOAD_CACHE_GENERATION: &str = "download-v1";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Target {
@@ -42,6 +43,15 @@ impl Target {
 }
 
 pub fn release_key() -> String {
+    format!(
+        "v{}-p{VERSION}-{DOWNLOAD_CACHE_GENERATION}",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+/// Cache key used before managed helpers became download-only. Helpers at this
+/// path may have been uploaded from a developer machine and must not be run.
+fn legacy_release_key() -> String {
     format!("v{}-p{VERSION}", env!("CARGO_PKG_VERSION"))
 }
 
@@ -75,12 +85,16 @@ exec "$program" "$@""#,
 
 pub fn download_script(target: Target) -> String {
     let release = release_key();
+    let legacy_release = legacy_release_key();
     let tag = format!("v{}", env!("CARGO_PKG_VERSION"));
     let url = format!("{RELEASE_BASE_URL}/{tag}/{}.gz", target.asset);
     let expected_version = format!("pcp {}", env!("CARGO_PKG_VERSION"));
     let expected_helper_id = release_key();
     format!(
         r#"set -eu
+legacy_dir="$HOME/.cache/pcp/helpers/{legacy_release}/{target_key}"
+rm -f "$legacy_dir/pcp"
+rmdir "$legacy_dir" "$HOME/.cache/pcp/helpers/{legacy_release}" 2>/dev/null || :
 dir="$HOME/.cache/pcp/helpers/{release}/{target_key}"
 program="$dir/pcp"
 tmp="$dir/.pcp.$$.tmp"
@@ -138,6 +152,7 @@ mv "$tmp" "$program"
 cleanup
 trap - EXIT HUP INT TERM"#,
         target_key = target.key,
+        legacy_release = legacy_release,
         url = shell_words::quote(&url),
         sum_url = shell_words::quote(&format!("{url}.sha256")),
         expected_version = shell_words::quote(&expected_version),
@@ -170,6 +185,7 @@ mod tests {
     fn launcher_uses_versioned_path_and_quotes_arguments() {
         let command = launcher(&["--server".into(), "argument with spaces".into()]);
         assert!(command.contains(&release_key()));
+        assert!(command.contains(DOWNLOAD_CACHE_GENERATION));
         assert!(command.contains("linux-x86_64"));
         assert!(command.contains("'argument with spaces'"));
     }
@@ -184,5 +200,7 @@ mod tests {
         )));
         assert!(script.contains("sha256sum"));
         assert!(script.contains("checksum mismatch"));
+        assert!(script.contains(&legacy_release_key()));
+        assert!(script.contains("rm -f \"$legacy_dir/pcp\""));
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -253,12 +253,16 @@ pub fn run(args: Args) -> Result<i32> {
     }
     let src_ep = endpoint(&srcs[0], &args)?;
     let dst_ep = endpoint(dst, &args)?;
+    // TCP data connections are the default (auto-selecting the fastest reachable
+    // NIC and falling back to ssh if unreachable); --no-tcp forces ssh data.
+    // Local<->local needs no data plane at all.
+    let use_tcp = !args.no_tcp && (src_ep.is_remote() || dst_ep.is_remote());
     // Without -j the worker count is tuned while the transfer runs (see tune.rs);
-    // this is only where it starts.
+    // start conservatively until TCP reachability has been established below.
     let autotune = args.connections_default;
     if autotune {
         args.connections = if src_ep.is_remote() || dst_ep.is_remote() {
-            tune::START
+            tune::START_SSH
         } else {
             tune::START_LOCAL
         };
@@ -366,8 +370,8 @@ pub fn run(args: Args) -> Result<i32> {
         })
     };
     let tuner: Mutex<Option<std::thread::JoinHandle<tune::Policy>>> = Mutex::new(None);
-    let spawn_workers = || {
-        for id in 0..args.connections {
+    let spawn_workers = |initial: usize| {
+        for id in 0..initial {
             spawn_worker(id);
         }
         if autotune {
@@ -377,18 +381,13 @@ pub fn run(args: Args) -> Result<i32> {
                 progress.clone(),
                 spawn_worker.clone(),
             );
-            let n0 = args.connections;
+            let n0 = initial;
             let policy = tune::Policy::new(n0, tune::MIN, tune::MAX);
             *tuner.lock().unwrap() = Some(std::thread::spawn(move || {
                 tune::run(policy, gate, sched, progress, |id| spawn_worker(id), n0)
             }));
         }
     };
-    // TCP data connections are the default (auto-selecting the fastest reachable
-    // NIC and falling back to ssh if unreachable); --no-tcp forces ssh data.
-    // Local<->local needs no data plane at all.
-    let use_tcp = !args.no_tcp && (src_ep.is_remote() || dst_ep.is_remote());
-
     let t0 = std::time::Instant::now();
     let (mut src_ctl, mut dst_ctl) = {
         let (a, b) = (src_ep.clone(), args.clone());
@@ -441,8 +440,17 @@ pub fn run(args: Args) -> Result<i32> {
             }
         }
     }
+    let all_remote_endpoints_use_tcp = use_tcp
+        && [&src_ep, &dst_ep].into_iter().all(|ep| match ep {
+            Endpoint::Local => true,
+            Endpoint::Remote(spec) => spec.tcp.lock().unwrap().is_some(),
+        });
+    if autotune && all_remote_endpoints_use_tcp {
+        args.connections = tune::START_TCP;
+        gate.set_limit(args.connections);
+    }
     if !opts.dry_run {
-        spawn_workers();
+        spawn_workers(args.connections);
     }
 
     let dst_root = dst.path.as_bytes().to_vec();

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -28,10 +28,12 @@ use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
-/// Workers to start with when auto-tuning over the network: each is an ssh
-/// handshake (seconds on a long path) or a TCP connection, so start modestly
-/// and let the tuner earn more.
-pub const START: usize = 8;
+/// Workers to start with when auto-tuning over ssh: handshakes can take seconds
+/// on a long path, so start modestly and let the tuner earn more.
+pub const START_SSH: usize = 8;
+/// Workers to start with when every remote endpoint has a TCP data path.
+/// TCP data connections are cheap once the ssh control connection is up.
+pub const START_TCP: usize = 16;
 /// Workers to start with when both ends are local: threads are free, network
 /// filesystems like the concurrency, and short bursts never reach the first
 /// measurement. If it's too many for a spinning disk the ramp-down finds out.
@@ -474,7 +476,7 @@ mod tests {
         assert_eq!(step_up(2), 3);
         assert_eq!(step_down(8), 6);
         assert_eq!(step_down(3), 2);
-        let mut n = START;
+        let mut n = START_SSH;
         let mut steps = 0;
         while n < MAX {
             n = step_up(n);
@@ -485,7 +487,7 @@ mod tests {
 
     #[test]
     fn ramps_to_the_plateau_and_holds() {
-        let p = simulate(START, 32, 40, |_| 1.0);
+        let p = simulate(START_SSH, 32, 40, |_| 1.0);
         // Doubles up to the knee, overshoots once, refines, and stays.
         assert_eq!(
             &p.history[..5],
@@ -517,7 +519,7 @@ mod tests {
         // model a sharper case: flat past 20. 16 -> 32 gains 25% (< 33%),
         // so it goes back to 16 and refines: 21 (+25% of 30%: kept), 27
         // (flat), back to 21, then descends 16 (worse), settles 21.
-        let p = simulate(START, 20, 40, |_| 1.0);
+        let p = simulate(START_SSH, 20, 40, |_| 1.0);
         assert_eq!(
             &p.history[..5],
             &[8, 16, 32, 21, 27],
@@ -530,10 +532,10 @@ mod tests {
     #[test]
     fn does_not_grow_when_it_never_pays() {
         // One worker already saturates the link (TCP on a clean path).
-        let p = simulate(START, 1, 40, |_| 1.0);
+        let p = simulate(START_SSH, 1, 40, |_| 1.0);
         // The doubling fails, the fine step fails, then it walks down since
         // nothing drops.
-        assert!(p.settled() < START, "history {:?}", p.history);
+        assert!(p.settled() < START_SSH, "history {:?}", p.history);
         assert_eq!(&p.history[..3], &[8, 16, 10]);
     }
 
@@ -547,7 +549,7 @@ mod tests {
                 30e6
             }
         };
-        let mut p = Policy::new(START, MIN, MAX);
+        let mut p = Policy::new(START_SSH, MIN, MAX);
         for _ in 0..40 {
             p.observe(score(p.n));
         }
@@ -591,17 +593,17 @@ mod tests {
 
     #[test]
     fn ignores_noise_within_tolerance() {
-        let p = simulate(START, 32, 60, |i| if i % 2 == 0 { 1.0 } else { 0.93 });
+        let p = simulate(START_SSH, 32, 60, |i| if i % 2 == 0 { 1.0 } else { 0.93 });
         assert!((20..=42).contains(&p.settled()), "history {:?}", p.history);
     }
 
     #[test]
     fn silence_is_not_a_signal() {
-        let mut p = Policy::new(START, MIN, MAX);
+        let mut p = Policy::new(START_SSH, MIN, MAX);
         for _ in 0..10 {
             p.observe(0.0);
         }
-        assert_eq!(p.history, vec![START]);
+        assert_eq!(p.history, vec![START_SSH]);
     }
 
     #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -132,6 +132,7 @@ fn remote_pcp(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
         .env("FAKE_RELEASE_ARCHIVE", t.path("release.gz"))
         .env("FAKE_CURL_LOG", t.path("curl.log"))
         .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("FAKE_LEGACY_LOG", t.path("legacy.log"))
         .env("PCP_STATE_DIR", t.path("state"));
     cmd.output().expect("run pcp through fake remote shell")
 }
@@ -164,10 +165,35 @@ fn cached_remote_helper(t: &Tmp) -> PathBuf {
 }
 
 #[cfg(target_os = "linux")]
+fn legacy_cached_remote_helper(t: &Tmp) -> PathBuf {
+    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+        .arg("--remote-helper-id")
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let current = String::from_utf8(out.stdout).unwrap();
+    let legacy = current
+        .trim()
+        .strip_suffix("-download-v1")
+        .expect("download-only cache generation suffix");
+    t.path(&format!(
+        "remote-home/.cache/pcp/helpers/{legacy}/linux-x86_64/pcp"
+    ))
+}
+
+#[cfg(target_os = "linux")]
 #[test]
-fn remote_helper_download_is_verified_and_cached() {
+fn legacy_remote_helper_is_replaced_by_verified_download_and_cached() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
+    let legacy_helper = legacy_cached_remote_helper(&t);
+    executable(
+        &legacy_helper,
+        br#"#!/bin/sh
+printf 'legacy helper ran\n' >> "$FAKE_LEGACY_LOG"
+exit 99
+"#,
+    );
     let archive = File::create(t.path("release.gz")).unwrap();
     let status = Command::new("gzip")
         .args(["-9", "-n", "-c", env!("CARGO_BIN_EXE_pcp")])
@@ -216,6 +242,8 @@ esac
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"first");
     assert!(cached_remote_helper(&t).is_file());
+    assert!(!legacy_helper.exists());
+    assert!(!t.path("legacy.log").exists(), "legacy helper was executed");
     assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
     assert!(!String::from_utf8_lossy(&out.stderr).contains("uploading this executable"));
     let probes = fs::read_to_string(t.path("rsh.log"))

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -238,7 +238,7 @@ esac
 }
 
 #[test]
-fn remote_helper_falls_back_to_same_platform_upload() {
+fn remote_helper_download_failure_does_not_upload_local_binary() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
     executable(
@@ -252,10 +252,15 @@ exit 22
     write(&t.path("src"), b"offline");
     let remote = format!("fake:{}", t.s("dst"));
     let out = remote_pcp(&t, &rsh, &["-a", &t.s("src"), &remote]);
-    assert_output_ok(&out);
-    assert_eq!(read(&t.path("dst")), b"offline");
-    assert!(cached_remote_helper(&t).is_file());
-    assert!(String::from_utf8_lossy(&out.stderr).contains("uploading this executable"));
+    assert!(!out.status.success(), "bootstrap unexpectedly succeeded");
+    assert!(!t.path("dst").exists());
+    assert!(!cached_remote_helper(&t).exists());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("could not install the authorized"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("uploading"), "{stderr}");
     assert_eq!(read(&t.path("curl.log")), b"fetch failed\n");
 }
 
@@ -272,6 +277,38 @@ fn no_bootstrap_uses_remote_path_without_managed_cache() {
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"preinstalled");
     assert!(!t.path("remote-home/.cache/pcp/helpers").exists());
+}
+
+#[test]
+fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"tcp default");
+    let remote = format!("127.0.0.1:{}", t.s("dst"));
+
+    let out = Command::new(env!("CARGO_BIN_EXE_pcp"))
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--pcp-path")
+        .arg(env!("CARGO_BIN_EXE_pcp"))
+        .args(["--tcp-plain", "--stats", "-a"])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("PCP_STATE_DIR", t.path("state"))
+        .output()
+        .expect("run pcp over TCP through fake remote shell");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"tcp default");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("connections: auto: settled at 16 (path 16, peak 16)"),
+        "{stdout}"
+    );
 }
 
 fn set_mtime(p: &Path, secs: i64) {


### PR DESCRIPTION
## Summary

- start automatic connection tuning at 16 after every remote endpoint establishes a reachable TCP data path
- retain the existing starts of 8 for SSH data and 32 for local copies
- remove the fallback that uploads the local pcp executable during bootstrap
- require managed helpers to come from the downloaded, checksum-verified release asset
- update CLI help, README guidance, and integration coverage

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- targeted bootstrap and loopback TCP integration tests
- `cargo test --all-targets -- --skip file_over_nonempty_destination_directory_reports_error_without_panicking` (97 tests passed)

The unfiltered suite has one unchanged master failure: `file_over_nonempty_destination_directory_reports_error_without_panicking` still invokes the deliberately removed `--no-resume` option and receives clap exit 2 instead of its expected exit 23.