### PR TITLE
Tune public repository maintenance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Report reproducible behavior that looks wrong
+title: ""
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Please use disposable test data when possible and remove credentials, private hostnames, and other sensitive information.
+  - type: input
+    id: version
+    attributes:
+      label: syq version
+      description: Paste the output of `syq --version`, or give the commit for a source build.
+      placeholder: syq 0.1.0
+    validations:
+      required: true
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation method
+      options:
+        - Standalone installer
+        - Homebrew
+        - cargo install
+        - Source build
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the operating system and architecture for each machine involved.
+      placeholder: Local macOS arm64; remote Ubuntu 24.04 x86-64
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Give the smallest safe setup and command that reproduces the problem.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and output
+      description: Include relevant output after removing secrets and private data.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for the same problem.
+          required: true
+        - label: This report does not contain credentials, private keys, or sensitive user data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/greaber/syq/security/advisories/new
+    about: Send security-sensitive reports privately instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest a new capability or behavior
+title: ""
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish, and what makes it difficult today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the command-line behavior or outcome you would like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include workarounds or simpler approaches you have tried, if any.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for the same request.
+          required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,21 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+    groups:
+      cargo-patches:
+        patterns: ["*"]
+        update-types: ["patch"]
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are made on `master` and included in the next release. The
+current release is supported; older releases may not receive fixes.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities through
+[GitHub's private vulnerability reporting form](https://github.com/greaber/syq/security/advisories/new),
+not through a public issue.
+
+Include the affected version or commit, the expected impact, and enough detail
+to reproduce the problem with disposable test data. Do not include credentials,
+private keys, or other people's data.
+
+We will acknowledge the report as soon as practical and coordinate a fix and
+disclosure with you. Please allow time for that process before publishing the
+details.


### PR DESCRIPTION
## Summary

- change routine Cargo and GitHub Actions update checks from weekly to monthly, with a seven-day cooldown and smaller PR caps
- group Cargo patch updates and all GitHub Actions updates to reduce notification volume
- add focused bug and feature issue forms, with blank issues disabled
- add a concise security policy that routes sensitive reports to GitHub private vulnerability reporting

This intentionally does not add a `CONTRIBUTING.md` or pull request template before the project has enough outside contribution experience to define useful guidance.

Dependabot security updates remain enabled at the repository level and are not delayed by the version-update cooldown or PR limits.

## Verification

- parsed every YAML file with PyYAML
- checked required issue-form structure and unique field IDs
- `git diff --check`