### PR TITLE
Use release identities for remote helpers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,16 @@ jobs:
         env:
           RUSTFLAGS: ${{ matrix.flags }}
           SYQ_RELEASE_PUBLIC_KEY: ${{ vars.SYQ_RELEASE_PUBLIC_KEY }}
+          SYQ_RELEASE_BUILD: "1"
         run: cargo build --locked --release --bin syq --target '${{ matrix.target }}'
+      - name: Validate release identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          program='target/${{ matrix.target }}/release/syq'
+          test "$("$program" --version)" = "syq ${GITHUB_REF_NAME#v}"
+          test "$("$program" --build-identity)" = "$GITHUB_REF_NAME"
+          test "$("$program" --remote-helper-id)" = "$GITHUB_REF_NAME-p0"
       - name: Stage raw and compressed binaries
         shell: bash
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["copy", "rsync", "ssh", "parallel", "transfer"]
 categories = ["command-line-utilities", "filesystem"]
 include = [
+    "/build.rs",
     "/src/**",
     "/tests/**",
     "/Cargo.toml",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ release also has an immutable versioned installer, for example
 another directory, download the script and run `sh install.sh --bin-dir DIR`
 (or pipe it to `sh -s -- --bin-dir DIR`). The script detects the target,
 verifies the archive's embedded SHA-256 and size, runs the temporary binary to
-check its version and protocol identity, and then replaces `syq` atomically.
+check its version and release identity, and then replaces `syq` atomically.
 Even with `--bin-dir`, either `HOME` or `XDG_CONFIG_HOME` must be set so every
 successful standalone installation can record its managed-install receipt.
 
@@ -44,6 +44,12 @@ Or build from source with the pinned Rust toolchain:
 cargo build --release          # binary at target/release/syq
 cargo install --locked --path . # or: put it on your PATH
 ```
+
+Source builds carry a Git-derived build identity and deliberately do not claim
+to be an immutable release. Managed remote bootstrap is therefore available
+only in official release binaries. To use a source build remotely, install the
+same build there and pass `--syq-path /path/to/syq` (or put it on the remote
+`PATH` and use `--no-bootstrap`).
 
 Standalone installs check the signed release manifest at most once a day after
 a successful interactive command. They only print an update notice by default:
@@ -62,7 +68,7 @@ browser-oriented distribution would need Apple Developer ID signing and
 notarization in addition to this terminal-first path.
 
 The remote side runs `syq --server`, but it does not need to be installed or
-configured first. syq uses an exact versioned helper under
+configured first. An official syq uses its exact release helper under
 `~/.cache/syq/helpers/`. On first use of a version it detects the remote
 platform, downloads the matching compressed binary from that version's GitHub
 release, verifies its SHA-256 against the separately signed release manifest,
@@ -72,15 +78,17 @@ probe connection.
 The managed cache accepts only the downloaded, verified release binary. If the
 remote cannot download it, bootstrapping fails visibly; install a compatible
 binary yourself and pass `--syq-path /path/to/syq`, or put it on the
-non-interactive remote `PATH` and use `--no-bootstrap`. Helpers cached by an
-older upload-capable version are never executed and are removed when their
-download-only replacement is installed.
+non-interactive remote `PATH` and use `--no-bootstrap`. Helpers cached under an
+older identity or cache layout are never executed; they may be removed with the
+rest of the disposable helper cache.
 
 The local client verifies the Ed25519-signed manifest and passes its trusted
 hash to the remote install script. The remote uses `curl` or `wget`, `gzip`, and
 one of `sha256sum`, `shasum`, or `openssl`. Version directories coexist and the
 helper cache can be removed at any time; syq recreates the helper it needs on
-the next connection.
+the next connection. After launch, both peers require the same build identity:
+the release tag for official binaries, or the Git-derived identity when an
+explicit source-built helper is used.
 
 - **macOS (Apple Silicon / Intel):** build natively on the Mac with
   `cargo build --release` (needs the Xcode command-line tools, `xcode-select

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -158,9 +158,9 @@ The release workflow sets `SYQ_RELEASE_BUILD=1`, which makes each platform
 binary report the tag (for example `v0.2.0`) as its build identity. Ordinary
 source builds instead include their Git revision and cannot populate the
 managed remote-helper cache. The manifest's `helper_id: v<release>-p0` and the
-binary's `--remote-helper-id` output are deprecated compatibility shims for the
-0.1.0 updater; `p0` is fixed and must not be treated or bumped as a protocol
-version.
+binary's `--remote-helper-id` output are deprecated compatibility shims for
+updaters through 0.1.1; `p0` is fixed and must not be treated or bumped as a
+protocol version.
 
 ## macOS signing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -117,8 +117,9 @@ connection, so enable it only for a trusted release host rather than globally.
 
 1. Update the package version in `Cargo.toml`, run `cargo check` to refresh
    `Cargo.lock`, then run the normal locked checks to validate it. Update
-   release notes and merge through the protected branch. Change the protocol
-   version in `src/proto.rs` only for a wire-incompatible release.
+   release notes and merge through the protected branch. Peer compatibility is
+   the immutable release identity, so there is no separate protocol number to
+   maintain.
 2. Create and push a signed annotated tag matching the package version. Its
    signing key and email must be configured on your GitHub account so GitHub
    reports the tag-object signature as verified:
@@ -152,6 +153,14 @@ overwriting it. The workflow refuses to reuse drafts. It may safely be rerun
 after a fully published release: it downloads every published asset and
 requires byte-for-byte equality with the rebuilt release before forwarding the
 formula to the tap job.
+
+The release workflow sets `SYQ_RELEASE_BUILD=1`, which makes each platform
+binary report the tag (for example `v0.2.0`) as its build identity. Ordinary
+source builds instead include their Git revision and cannot populate the
+managed remote-helper cache. The manifest's `helper_id: v<release>-p0` and the
+binary's `--remote-helper-id` output are deprecated compatibility shims for the
+0.1.0 updater; `p0` is fixed and must not be treated or bumped as a protocol
+version.
 
 ## macOS signing
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,133 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn main() {
+    println!("cargo::rerun-if-env-changed=SYQ_RELEASE_BUILD");
+    register_inputs();
+
+    let version = env::var("CARGO_PKG_VERSION").expect("Cargo sets CARGO_PKG_VERSION");
+    let release_identity = format!("v{version}");
+    let release_build = env::var("SYQ_RELEASE_BUILD").as_deref() == Ok("1");
+    let build_identity = if release_build {
+        release_identity
+    } else {
+        development_identity(&release_identity)
+    };
+
+    println!("cargo::rustc-env=SYQ_BUILD_IDENTITY={build_identity}");
+    println!(
+        "cargo::rustc-env=SYQ_IS_RELEASE_BUILD={}",
+        if release_build { "1" } else { "0" }
+    );
+}
+
+fn register_inputs() {
+    if let Ok(output) = Command::new("git")
+        .args([
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+        ])
+        .output()
+    {
+        if output.status.success() {
+            for path in output
+                .stdout
+                .split(|byte| *byte == 0)
+                .filter(|path| !path.is_empty())
+            {
+                println!("cargo::rerun-if-changed={}", String::from_utf8_lossy(path));
+            }
+        }
+    }
+    for git_path in [
+        git(&["rev-parse", "--git-path", "HEAD"]),
+        git(&["rev-parse", "--git-path", "index"]),
+        git(&["symbolic-ref", "-q", "HEAD"])
+            .and_then(|name| git(&["rev-parse", "--git-path", &name])),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        println!("cargo::rerun-if-changed={git_path}");
+    }
+}
+
+fn development_identity(release_identity: &str) -> String {
+    let revision = git(&["rev-parse", "--short=12", "HEAD"])
+        .filter(|value| value.len() == 12 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .unwrap_or_else(|| format!("source.{}", build_nonce()));
+    let dirty = working_tree_hash()
+        .map(|hash| format!(".dirty.{hash}"))
+        .unwrap_or_default();
+    format!("{release_identity}+dev.{revision}{dirty}")
+}
+
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Hash every modified or untracked package input. Two independently built
+/// dirty trees match only when their actual source content matches.
+fn working_tree_hash() -> Option<String> {
+    let tracked = Command::new("git")
+        .args(["diff", "--binary", "--no-ext-diff", "HEAD", "--", "."])
+        .output()
+        .ok()?;
+    let names = Command::new("git")
+        .args(["ls-files", "-z", "--others", "--exclude-standard"])
+        .output()
+        .ok()?;
+    if !tracked.status.success() || !names.status.success() {
+        return None;
+    }
+    if tracked.stdout.is_empty() && names.stdout.is_empty() {
+        return None;
+    }
+
+    let mut content = tracked.stdout;
+    for name in names
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|name| !name.is_empty())
+    {
+        content.extend_from_slice(name);
+        content.push(0);
+        if let Ok(bytes) = fs::read(String::from_utf8_lossy(name).as_ref()) {
+            content.extend_from_slice(&bytes);
+        }
+        content.push(0);
+    }
+
+    let mut child = Command::new("git")
+        .args(["hash-object", "--stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .ok()?;
+    child.stdin.take()?.write_all(&content).ok()?;
+    let output = child.wait_with_output().ok()?;
+    let hash = output.status.success().then(|| {
+        String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .chars()
+            .take(12)
+            .collect::<String>()
+    })?;
+    (hash.len() == 12 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())).then_some(hash)
+}
+
+fn build_nonce() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos())
+}

--- a/scripts/generate-installer.sh
+++ b/scripts/generate-installer.sh
@@ -13,7 +13,6 @@ command -v jq >/dev/null || { echo "generate-installer needs jq" >&2; exit 1; }
 
 version=$(jq -er '.version' "$manifest")
 tag=$(jq -er '.tag' "$manifest")
-helper_id=$(jq -er '.helper_id' "$manifest")
 repository=$(jq -er '.repository' "$manifest")
 test "$repository" = 'https://github.com/greaber/syq' || { echo "unexpected repository" >&2; exit 1; }
 
@@ -35,7 +34,6 @@ set -eu
 
 version='$version'
 tag='$tag'
-helper_id='$helper_id'
 base_url=\${SYQ_INSTALL_BASE_URL:-'$repository/releases/download/$tag'}
 bin_dir=\${HOME:+\$HOME/.local/bin}
 
@@ -47,7 +45,7 @@ Usage: install.sh [--bin-dir DIR]
 
 The default is \$HOME/.local/bin. The installer detects this host, downloads
 the pinned release archive, checks its embedded SHA-256 and size, verifies the
-binary's version and helper identity, then replaces the destination atomically.
+binary's version and release identity, then replaces the destination atomically.
 USAGE
 }
 
@@ -154,11 +152,11 @@ got=$("$program" --version 2>/dev/null) || {
   echo "install.sh: downloaded binary reports an unexpected version: $got" >&2
   exit 1
 }
-got_id=$("$program" --remote-helper-id 2>/dev/null) || {
-  echo 'install.sh: downloaded syq has no helper identity' >&2
+got_id=$("$program" --build-identity 2>/dev/null) || {
+  echo 'install.sh: downloaded syq has no build identity' >&2
   exit 1
 }
-[ "$got_id" = "$helper_id" ] || {
+[ "$got_id" = "$tag" ] || {
   echo "install.sh: downloaded binary reports an unexpected identity: $got_id" >&2
   exit 1
 }

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -25,9 +25,6 @@ test "$version" = "$package_version" || {
   echo "tag $tag does not match Cargo.toml version $package_version" >&2
   exit 1
 }
-protocol=$(sed -n 's/^pub const VERSION: u32 = \([0-9][0-9]*\);/\1/p' "$repo_dir/src/proto.rs")
-test -n "$protocol" || { echo "could not read protocol version" >&2; exit 1; }
-
 targets=(linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64)
 assets=(syq-linux-x86_64 syq-linux-aarch64 syq-macos-arm64 syq-macos-x86_64)
 artifacts='{}'
@@ -65,7 +62,7 @@ jq -n --sort-keys \
   --arg repository 'https://github.com/greaber/syq' \
   --arg version "$version" \
   --arg tag "$tag" \
-  --arg helper_id "$tag-p$protocol" \
+  --arg helper_id "$tag-p0" \
   --argjson artifacts "$artifacts" \
   '{schema:1,repository:$repository,version:$version,tag:$tag,helper_id:$helper_id,artifacts:$artifacts}' \
   > "$manifest_core"

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -28,12 +28,13 @@ size_file() {
 }
 
 write_program() {
-  local path=$1 target=$2 version=${3:-0.1.0} helper=${4:-v0.1.0-p4}
+  local path=$1 target=$2 version=${3:-0.1.0} identity=${4:-v0.1.0}
   cat > "$path" <<EOF
 #!/bin/sh
 case "\$1" in
   --version) echo 'syq $version' ;;
-  --remote-helper-id) echo '$helper' ;;
+  --build-identity) echo '$identity' ;;
+  --remote-helper-id) echo 'v$version-p0' ;;
   --register-standalone-install) exit 0 ;;
   --test-target) echo '$target' ;;
   *) exit 2 ;;
@@ -43,9 +44,9 @@ EOF
 }
 
 write_archive() {
-  local target=$1 version=${2:-0.1.0} helper=${3:-v0.1.0-p4}
+  local target=$1 version=${2:-0.1.0} identity=${3:-v0.1.0}
   local program="$work/program-$target"
-  write_program "$program" "$target" "$version" "$helper"
+  write_program "$program" "$target" "$version" "$identity"
   gzip -9 -n -c "$program" > "$release/syq-$target.gz"
 }
 
@@ -71,7 +72,7 @@ write_manifest() {
   done
   jq -n --sort-keys --argjson artifacts "$artifacts" '
     {schema:1,repository:"https://github.com/greaber/syq",version:"0.1.0",
-     tag:"v0.1.0",helper_id:"v0.1.0-p4",artifacts:$artifacts,
+     tag:"v0.1.0",helper_id:"v0.1.0-p0",artifacts:$artifacts,
      installer:{name:"install.sh",sha256:("1"*64),size:1},
      homebrew_formula:{name:"syq.rb",sha256:("2"*64),size:1}}' > "$output"
 }
@@ -203,9 +204,9 @@ expect_failure 'downloaded archive has size' env \
   sh "$work/install.sh" --bin-dir "$install_dir"
 test "$(hash_file "$install_dir/syq")" = "$installed_sha"
 
-# Even correctly hashed content is rejected if its helper identity does not
+# Even correctly hashed content is rejected if its build identity does not
 # match the release metadata, again without replacing the installed binary.
-write_archive linux-x86_64 0.1.0 v0.1.0-p999
+write_archive linux-x86_64 0.1.0 v0.1.0+dev.wrong
 write_manifest "$work/wrong-identity-manifest.json"
 "$script_dir/generate-installer.sh" \
   "$work/wrong-identity-manifest.json" "$work/wrong-identity-install.sh"

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -49,6 +49,7 @@ formula_sha=$(sha256sum "$first/syq.rb" | awk '{print $1}')
 jq -e \
   --arg installer_sha "$installer_sha" --arg formula_sha "$formula_sha" '
     .schema == 1
+    and .helper_id == (.tag + "-p0")
     and (.artifacts | length == 4)
     and .installer.name == "install.sh"
     and .installer.sha256 == $installer_sha

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -284,7 +284,7 @@ impl RemoteSpec {
     }
 
     /// A shell command that runs syq with `args` on this host.  Automatic mode
-    /// addresses the exact versioned helper; explicit mode preserves the
+    /// addresses the exact release/build-identified helper; explicit mode preserves the
     /// administrator-provided path; --no-bootstrap uses normal PATH lookup.
     pub fn program_command(&self, args: &[String]) -> String {
         if let Some(p) = &self.syq_path {
@@ -305,8 +305,8 @@ impl RemoteSpec {
 
     /// `limited`: take a connect slot (data connections). The control
     /// connection passes false: everything waits on it, so it must never
-    /// queue behind workers. Either way the versioned helper is installed on
-    /// first use if the remote lacks it.
+    /// queue behind workers. In managed mode the release helper is installed
+    /// on first use if the remote lacks it.
     pub fn connect_with(&self, compress: bool, limited: bool) -> Result<RemoteConn> {
         let first = self.connect_retried(compress, limited);
         let Err(first_error) = first else {
@@ -320,7 +320,7 @@ impl RemoteSpec {
         self.connect_retried(compress, limited).with_context(|| {
             format!(
                 "could not start the {} helper installed on {}",
-                remote_helper::release_key(),
+                remote_helper::helper_identity(),
                 self.label()
             )
         })
@@ -333,11 +333,11 @@ impl RemoteSpec {
             let _slot = limited.then(connect_slot);
             match self.connect_once(compress) {
                 Ok(c) => return Ok(c),
-                // Don't retry what won't change: missing binary (127) or a version mismatch.
+                // Don't retry what won't change: a missing binary (127) or a
+                // build identity mismatch.
                 Err(e)
                     if attempt == 5
-                        || e.to_string().contains("version mismatch")
-                        || e.to_string().contains("release mismatch")
+                        || e.to_string().contains("build identity mismatch")
                         || e.to_string().contains("exit status: 127")
                         || e.to_string().contains(&format!(
                             "exit status: {}",
@@ -558,8 +558,7 @@ fn helper_needs_install(e: &anyhow::Error) -> bool {
     )) || message.contains(&format!(
         "exit status: {}",
         remote_helper::HELPER_NOT_EXECUTABLE_EXIT
-    )) || message.contains("version mismatch")
-        || message.contains("release mismatch")
+    )) || message.contains("build identity mismatch")
 }
 
 /// Concurrently probe which (addr, speed) entries accept a TCP connection on
@@ -621,29 +620,18 @@ impl std::fmt::Debug for TcpInfo {
 fn hello(mut conn: RemoteConn, compress: bool, token: Vec<u8>) -> Result<RemoteConn> {
     {
         conn.send(Request::Hello {
-            version: VERSION,
-            release: env!("CARGO_PKG_VERSION").to_string(),
+            identity: crate::identity::build().to_string(),
             compress,
             debug: crate::transfer::debug(),
             token,
         })?;
         match conn.recv() {
-            Ok(Response::HelloOk { version, release })
-                if version == VERSION && release == env!("CARGO_PKG_VERSION") =>
-            {
-                Ok(conn)
-            }
-            Ok(Response::HelloOk { version, release }) => {
-                if release != env!("CARGO_PKG_VERSION") {
-                    bail!(
-                        "{}: release mismatch (remote {release}, local {})",
-                        conn.label,
-                        env!("CARGO_PKG_VERSION")
-                    );
-                }
+            Ok(Response::HelloOk { identity }) if identity == crate::identity::build() => Ok(conn),
+            Ok(Response::HelloOk { identity }) => {
                 bail!(
-                    "{}: protocol version mismatch (remote {version}, local {VERSION})",
-                    conn.label
+                    "{}: build identity mismatch (remote {identity}, local {})",
+                    conn.label,
+                    crate::identity::build()
                 )
             }
             Ok(Response::Err(e)) => bail!("{}: {e}", conn.label),
@@ -654,9 +642,10 @@ fn hello(mut conn: RemoteConn, compress: bool, token: Vec<u8>) -> Result<RemoteC
 }
 
 impl RemoteSpec {
-    /// Ensure the exact release/protocol helper exists in the remote cache.
+    /// Ensure the exact release helper exists in the remote cache.
     /// Only authorized release assets may populate the managed helper cache.
     pub fn install_helper(&self) -> Result<()> {
+        crate::identity::require_release_build()?;
         let mut installed = self.helper_install.lock().unwrap();
         if *installed {
             return Ok(());
@@ -667,14 +656,14 @@ impl RemoteSpec {
             eprintln!(
                 "syq: {}: installing {} helper for {}",
                 self.label(),
-                remote_helper::release_key(),
+                remote_helper::helper_identity(),
                 target.key
             );
         }
         self.download_helper(target).with_context(|| {
             format!(
                 "could not install the authorized {} helper on {} ({}); install a compatible syq and pass --syq-path",
-                remote_helper::release_key(),
+                remote_helper::helper_identity(),
                 self.label(),
                 target.key
             )

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -12,7 +12,7 @@ pub fn release() -> String {
     format!("v{}", env!("CARGO_PKG_VERSION"))
 }
 
-/// Kept so the 0.1.0 updater can validate newer binaries. It is no longer a
+/// Kept so updaters through 0.1.1 can validate newer binaries. It is no longer a
 /// protocol identity and deliberately has a fixed numeric suffix.
 pub fn legacy_helper_id() -> String {
     format!("{}-p0", release())

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,0 +1,58 @@
+//! Build identities shared by the wire handshake and managed helpers.
+
+use anyhow::{bail, Result};
+
+/// Official builds use the immutable release tag. Development builds include
+/// their Git revision so two source builds do not claim release compatibility.
+pub const fn build() -> &'static str {
+    env!("SYQ_BUILD_IDENTITY")
+}
+
+pub fn release() -> String {
+    format!("v{}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Kept so the 0.1.0 updater can validate newer binaries. It is no longer a
+/// protocol identity and deliberately has a fixed numeric suffix.
+pub fn legacy_helper_id() -> String {
+    format!("{}-p0", release())
+}
+
+pub fn require_release_build() -> Result<()> {
+    if is_release_build() {
+        return Ok(());
+    }
+    bail!(
+        "managed remote bootstrap is only available from an official syq release build (this build is {}); install this build on the remote and pass --syq-path, or use an official release",
+        build()
+    )
+}
+
+fn is_release_build() -> bool {
+    if env!("SYQ_IS_RELEASE_BUILD") == "1" {
+        return true;
+    }
+    #[cfg(debug_assertions)]
+    if std::env::var_os("SYQ_TEST_RELEASE_BUILD").is_some_and(|value| value == "1") {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn development_builds_do_not_claim_the_release_identity() {
+        if env!("SYQ_IS_RELEASE_BUILD") == "0" {
+            assert!(build().starts_with(&format!("{}+dev.", release())));
+            assert_ne!(build(), release());
+        }
+    }
+
+    #[test]
+    fn legacy_identity_is_not_a_protocol_version() {
+        assert_eq!(legacy_helper_id(), format!("{}-p0", release()));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod conn;
 mod crypto;
 mod direct;
 mod fsops;
+mod identity;
 mod progress;
 mod proto;
 mod remote_helper;
@@ -51,8 +52,14 @@ fn main() {
     tune_allocator();
     raise_nofile();
     let argv: Vec<String> = std::env::args().collect();
+    if argv.get(1).map(String::as_str) == Some("--build-identity") {
+        println!("{}", identity::build());
+        return;
+    }
+    // Compatibility with the 0.1.0 standalone updater. New code uses the
+    // release/build identity above and never interprets this as a protocol.
     if argv.get(1).map(String::as_str) == Some("--remote-helper-id") {
-        println!("{}", remote_helper::release_key());
+        println!("{}", identity::legacy_helper_id());
         return;
     }
     if argv.get(1).map(String::as_str) == Some("--server") {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -8,7 +8,6 @@
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 
-pub const VERSION: u32 = 5;
 pub const MAX_FRAME: usize = 256 * 1024 * 1024;
 const COMPRESS_MIN: usize = 512;
 
@@ -112,8 +111,7 @@ pub enum Op {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Request {
     Hello {
-        version: u32,
-        release: String,
+        identity: String,
         compress: bool,
         debug: bool,
         token: Vec<u8>,
@@ -212,8 +210,7 @@ pub enum Request {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Response {
     HelloOk {
-        version: u32,
-        release: String,
+        identity: String,
     },
     /// Each advertised data address with its interface link speed in Mbps
     /// (0 = unknown). The address the client's ssh session arrived on is first.

--- a/src/remote_helper.rs
+++ b/src/remote_helper.rs
@@ -1,16 +1,15 @@
-//! Versioned remote helper discovery and installation commands.
+//! Release/build-identified remote helper discovery and installation commands.
 //!
-//! The local client always names the exact release/protocol helper it expects.
-//! A cache hit adds no extra ssh round trip: the normal remote command computes
-//! the target name and execs the cached binary directly.  On a miss, `conn`
-//! probes the target and downloads the matching authorized release asset.
-
-use crate::proto::VERSION;
+//! Official clients name their exact release; development clients carry a Git
+//! identity but may not populate the managed cache. A cache hit adds no extra
+//! ssh round trip: the normal remote command computes the target name and execs
+//! the cached binary directly. On a miss, `conn` probes the target and downloads
+//! the matching authorized release asset.
 
 pub const RELEASE_BASE_URL: &str = "https://github.com/greaber/syq/releases/download";
 pub const HELPER_MISSING_EXIT: i32 = 125;
 pub const HELPER_NOT_EXECUTABLE_EXIT: i32 = 126;
-const DOWNLOAD_CACHE_GENERATION: &str = "download-v1";
+const DOWNLOAD_CACHE_GENERATION: &str = "release-v1";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Target {
@@ -53,15 +52,15 @@ impl Target {
     }
 }
 
-pub fn release_key() -> String {
-    format!("v{}-p{VERSION}", env!("CARGO_PKG_VERSION"))
+pub fn helper_identity() -> &'static str {
+    crate::identity::build()
 }
 
-/// Keep cache provenance separate from the helper identity recorded in signed
-/// release manifests. The generation suffix invalidates upload-capable caches
-/// without requiring otherwise-identical release assets to be republished.
+/// Keep cache layout separate from peer identity. Changing the generation
+/// prevents older cache formats from being executed without changing which
+/// builds are wire-compatible.
 fn cache_key() -> String {
-    format!("{}-{DOWNLOAD_CACHE_GENERATION}", release_key())
+    format!("{}-{DOWNLOAD_CACHE_GENERATION}", helper_identity())
 }
 
 pub fn probe_command() -> &'static str {
@@ -101,18 +100,12 @@ pub fn download_script(target: Target, expected_sha256: &str) -> String {
         "trusted release hash must be lowercase SHA-256"
     );
     let release = cache_key();
-    let legacy_release = release_key();
     let tag = format!("v{}", env!("CARGO_PKG_VERSION"));
     let url = format!("{RELEASE_BASE_URL}/{tag}/{}.gz", target.asset);
     let expected_version = format!("syq {}", env!("CARGO_PKG_VERSION"));
-    let expected_helper_id = release_key();
+    let expected_identity = helper_identity();
     format!(
         r#"set -eu
-legacy_dir="$HOME/.cache/syq/helpers/{legacy_release}/{target_key}"
-legacy_pcp_dir="$HOME/.cache/pcp/helpers/{legacy_release}/{target_key}"
-rm -f "$legacy_dir/syq" "$legacy_pcp_dir/pcp"
-rmdir "$legacy_dir" "$HOME/.cache/syq/helpers/{legacy_release}" 2>/dev/null || :
-rmdir "$legacy_pcp_dir" "$HOME/.cache/pcp/helpers/{legacy_release}" 2>/dev/null || :
 dir="$HOME/.cache/syq/helpers/{release}/{target_key}"
 program="$dir/syq"
 tmp="$dir/.syq.$$.tmp"
@@ -156,11 +149,11 @@ got=$("$tmp" --version 2>/dev/null) || {{
     echo "syq: downloaded helper has unexpected version: $got" >&2
     exit 1
 }}
-got_id=$("$tmp" --remote-helper-id 2>/dev/null) || {{
-    echo "syq: downloaded helper does not report a helper identity" >&2
+got_id=$("$tmp" --build-identity 2>/dev/null) || {{
+    echo "syq: downloaded helper does not report a build identity" >&2
     exit 1
 }}
-[ "$got_id" = {expected_helper_id} ] || {{
+[ "$got_id" = {expected_identity} ] || {{
     echo "syq: downloaded helper has unexpected identity: $got_id" >&2
     exit 1
 }}
@@ -168,11 +161,10 @@ mv "$tmp" "$program"
 cleanup
 trap - EXIT HUP INT TERM"#,
         target_key = target.key,
-        legacy_release = legacy_release,
         url = shell_words::quote(&url),
         expected_sha256 = shell_words::quote(expected_sha256),
         expected_version = shell_words::quote(&expected_version),
-        expected_helper_id = shell_words::quote(&expected_helper_id),
+        expected_identity = shell_words::quote(expected_identity),
     )
 }
 
@@ -217,7 +209,8 @@ mod tests {
         assert!(script.contains("sha256sum"));
         assert!(script.contains("checksum mismatch"));
         assert!(!script.contains(".sha256"));
-        assert!(script.contains(&release_key()));
-        assert!(script.contains("rm -f \"$legacy_dir/syq\" \"$legacy_pcp_dir/pcp\""));
+        assert!(script.contains(helper_identity()));
+        assert!(script.contains("--build-identity"));
+        assert!(!script.contains("--remote-helper-id"));
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -30,8 +30,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
     let debug;
     match r.read_msg::<Request>()? {
         Request::Hello {
-            version,
-            release,
+            identity,
             compress,
             debug: d,
             token,
@@ -43,28 +42,21 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 }
             }
             // The token is the credential: once it matches, the peer is
-            // authenticated. Mark it now so a later failure (version mismatch,
-            // a failed HelloOk write) can't free the connection id for replay.
+            // authenticated. Mark it now so a later failure (identity mismatch
+            // or a failed HelloOk write) can't free the connection id for replay.
             if let Some(a) = authed {
                 a.store(true, std::sync::atomic::Ordering::SeqCst);
             }
-            if version != VERSION {
+            let expected_identity = crate::identity::build();
+            if identity != expected_identity {
                 w.write_msg(&Response::Err(format!(
-                    "protocol version mismatch (remote {VERSION}, client {version})"
+                    "build identity mismatch (remote {expected_identity}, client {identity})"
                 )))?;
-                bail!("protocol version mismatch");
-            }
-            let expected_release = env!("CARGO_PKG_VERSION");
-            if release != expected_release {
-                w.write_msg(&Response::Err(format!(
-                    "release mismatch (remote {expected_release}, client {release})"
-                )))?;
-                bail!("release mismatch");
+                bail!("build identity mismatch");
             }
             w.compress = compress;
             w.write_msg(&Response::HelloOk {
-                version: VERSION,
-                release: expected_release.to_string(),
+                identity: expected_identity.to_string(),
             })?;
         }
         _ => bail!("expected Hello"),

--- a/src/update.rs
+++ b/src/update.rs
@@ -47,7 +47,7 @@ struct ReleaseManifest {
     repository: String,
     version: String,
     tag: String,
-    /// Required so the 0.1.0 updater can consume future manifests. New code
+    /// Required so updaters through 0.1.1 can consume future manifests. New code
     /// does not use this legacy field as a compatibility decision.
     helper_id: String,
     artifacts: BTreeMap<String, ReleaseArtifact>,
@@ -306,7 +306,7 @@ fn validate_manifest(manifest: &ReleaseManifest) -> Result<Version> {
     if manifest.tag != format!("v{version}") {
         bail!("release tag does not match its version");
     }
-    // Versions through 0.1.0 require this shape before accepting an update.
+    // Versions through 0.1.1 require this shape before accepting an update.
     // The numeric suffix is retained as manifest compatibility data only.
     let helper_prefix = format!("{}-p", manifest.tag);
     let legacy_suffix = manifest

--- a/src/update.rs
+++ b/src/update.rs
@@ -47,6 +47,8 @@ struct ReleaseManifest {
     repository: String,
     version: String,
     tag: String,
+    /// Required so the 0.1.0 updater can consume future manifests. New code
+    /// does not use this legacy field as a compatibility decision.
     helper_id: String,
     artifacts: BTreeMap<String, ReleaseArtifact>,
     installer: ReleaseFile,
@@ -206,14 +208,13 @@ pub fn after_success(quiet: bool) {
 /// manifest. Remote bootstrap passes this trusted value to the remote shell;
 /// it never trusts a checksum downloaded beside the executable.
 pub fn trusted_current_archive_hash(target: Target) -> Result<String> {
+    crate::identity::require_release_build()?;
     let tag = format!("v{}", env!("CARGO_PKG_VERSION"));
     let release = fetch_verified(
         &format!("{}/{tag}", release_downloads()),
         FetchMode::Interactive,
     )?;
-    if release.version != current_version()?
-        || release.manifest.helper_id != crate::remote_helper::release_key()
-    {
+    if release.version != current_version()? {
         bail!("signed release manifest does not describe this syq build");
     }
     let artifact = release
@@ -305,12 +306,14 @@ fn validate_manifest(manifest: &ReleaseManifest) -> Result<Version> {
     if manifest.tag != format!("v{version}") {
         bail!("release tag does not match its version");
     }
+    // Versions through 0.1.0 require this shape before accepting an update.
+    // The numeric suffix is retained as manifest compatibility data only.
     let helper_prefix = format!("{}-p", manifest.tag);
-    let protocol = manifest
+    let legacy_suffix = manifest
         .helper_id
         .strip_prefix(&helper_prefix)
         .filter(|value| !value.is_empty() && value.bytes().all(|b| b.is_ascii_digit()));
-    if protocol.is_none() {
+    if legacy_suffix.is_none() {
         bail!("release helper identity is malformed");
     }
     for (target, artifact) in &manifest.artifacts {
@@ -475,14 +478,14 @@ fn verify_executable(path: &Path, release: &VerifiedRelease) -> Result<()> {
         bail!("downloaded executable reports an unexpected version");
     }
     let identity = Command::new(path)
-        .arg("--remote-helper-id")
+        .arg("--build-identity")
         .stdin(Stdio::null())
         .output()
-        .context("read the downloaded syq helper identity")?;
+        .context("read the downloaded syq build identity")?;
     if !identity.status.success()
-        || String::from_utf8_lossy(&identity.stdout).trim() != release.manifest.helper_id
+        || String::from_utf8_lossy(&identity.stdout).trim() != release.manifest.tag
     {
-        bail!("downloaded executable reports an unexpected helper identity");
+        bail!("downloaded executable reports an unexpected build identity");
     }
     Ok(())
 }
@@ -720,7 +723,7 @@ mod tests {
             repository: REPOSITORY.into(),
             version: "1.2.3".into(),
             tag: "v1.2.3".into(),
-            helper_id: "v1.2.3-p4".into(),
+            helper_id: "v1.2.3-p0".into(),
             artifacts: BTreeMap::from([(
                 "linux-x86_64".into(),
                 ReleaseArtifact {
@@ -775,12 +778,12 @@ mod tests {
     }
 
     #[test]
-    fn rejects_a_tag_or_helper_id_from_another_release() {
+    fn rejects_a_tag_or_legacy_helper_id_from_another_release() {
         let mut value = manifest();
         value.tag = "v1.2.4".into();
         assert!(validate_manifest(&value).is_err());
         value.tag = "v1.2.3".into();
-        value.helper_id = "v1.2.2-p4".into();
+        value.helper_id = "v1.2.2-p0".into();
         assert!(validate_manifest(&value).is_err());
     }
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -144,6 +144,7 @@ fn remote_syq(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
         .env("XDG_CONFIG_HOME", t.path("config"));
     if let Ok(key) = fs::read_to_string(t.path("release-public-key")) {
         cmd.env("SYQ_TEST_RELEASE_PUBLIC_KEY", key.trim())
+            .env("SYQ_TEST_RELEASE_BUILD", "1")
             .env(
                 "SYQ_TEST_RELEASE_DOWNLOADS",
                 "https://release.invalid/download",
@@ -164,30 +165,28 @@ fn assert_output_ok(out: &Output) {
 }
 
 fn cached_remote_helper(t: &Tmp) -> PathBuf {
-    let root = t.path("remote-home/.cache/syq/helpers");
-    let release = fs::read_dir(&root)
-        .unwrap()
-        .next()
-        .expect("release cache directory")
-        .unwrap()
-        .path();
-    let target = fs::read_dir(release)
-        .unwrap()
-        .next()
-        .expect("target cache directory")
-        .unwrap()
-        .path();
-    target.join("syq")
+    let identity = binary_identity("--build-identity");
+    let target = match std::env::consts::ARCH {
+        "x86_64" => "linux-x86_64",
+        "aarch64" => "linux-aarch64",
+        arch => panic!("unsupported test architecture {arch}"),
+    };
+    t.path(&format!(
+        "remote-home/.cache/syq/helpers/{identity}-release-v1/{target}/syq"
+    ))
+}
+
+fn binary_identity(argument: &str) -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg(argument)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
 }
 
 #[cfg(target_os = "linux")]
 fn legacy_cached_remote_helpers(t: &Tmp) -> [PathBuf; 2] {
-    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
-        .arg("--remote-helper-id")
-        .output()
-        .unwrap();
-    assert!(out.status.success());
-    let helper_id = String::from_utf8(out.stdout).unwrap();
     let target = match std::env::consts::ARCH {
         "x86_64" => "linux-x86_64",
         "aarch64" => "linux-aarch64",
@@ -195,19 +194,19 @@ fn legacy_cached_remote_helpers(t: &Tmp) -> [PathBuf; 2] {
     };
     [
         t.path(&format!(
-            "remote-home/.cache/syq/helpers/{}/{target}/syq",
-            helper_id.trim()
+            "remote-home/.cache/syq/helpers/v{}-p5-download-v1/{target}/syq",
+            env!("CARGO_PKG_VERSION")
         )),
         t.path(&format!(
-            "remote-home/.cache/pcp/helpers/{}/{target}/pcp",
-            helper_id.trim()
+            "remote-home/.cache/syq/helpers/v{}-p5/{target}/syq",
+            env!("CARGO_PKG_VERSION")
         )),
     ]
 }
 
 #[cfg(target_os = "linux")]
 #[test]
-fn legacy_remote_helper_is_replaced_by_verified_download_and_cached() {
+fn release_keyed_remote_helper_ignores_legacy_protocol_caches() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
     let legacy_helpers = legacy_cached_remote_helpers(&t);
@@ -249,7 +248,7 @@ exit 99
         "repository": "https://github.com/greaber/syq",
         "version": env!("CARGO_PKG_VERSION"),
         "tag": format!("v{}", env!("CARGO_PKG_VERSION")),
-        "helper_id": format!("v{}-p{}", env!("CARGO_PKG_VERSION"), crate_protocol_version()),
+        "helper_id": format!("v{}-p0", env!("CARGO_PKG_VERSION")),
         "artifacts": {
             (target): {
                 "binary": {"name": asset, "sha256": "0".repeat(64), "size": 1},
@@ -313,7 +312,7 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"first");
     assert!(cached_remote_helper(&t).is_file());
-    assert!(legacy_helpers.iter().all(|helper| !helper.exists()));
+    assert!(legacy_helpers.iter().all(|helper| helper.exists()));
     assert!(!t.path("legacy.log").exists(), "legacy helper was executed");
     assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
     assert_eq!(read(&t.path("curl.log")), b"fetch\n");
@@ -339,7 +338,7 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
 }
 
 #[test]
-fn remote_helper_download_failure_does_not_upload_local_binary() {
+fn development_build_refuses_managed_remote_bootstrap() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
 
@@ -351,17 +350,13 @@ fn remote_helper_download_failure_does_not_upload_local_binary() {
     assert!(!t.path("remote-home/.cache/syq/helpers").exists());
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("could not install the authorized"),
+        stderr.contains(
+            "managed remote bootstrap is only available from an official syq release build"
+        ),
         "{stderr}"
     );
     assert!(!stderr.contains("uploading"), "{stderr}");
     assert!(!t.path("curl.log").exists());
-}
-
-fn crate_protocol_version() -> u32 {
-    // Kept explicit in this black-box test so the signed helper identity must
-    // move deliberately when the wire protocol changes.
-    5
 }
 
 #[test]

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -57,7 +57,7 @@ struct UpdateFixture {
 
 #[cfg(target_os = "linux")]
 impl UpdateFixture {
-    fn new(release_version: &str, release_helper: &str, executable_helper: &str) -> Self {
+    fn new(release_version: &str, executable_identity: &str) -> Self {
         let temp = TempDir::new();
         let installed = temp.path("bin/syq");
         fs::create_dir_all(installed.parent().unwrap()).unwrap();
@@ -72,7 +72,7 @@ impl UpdateFixture {
         };
         let asset = format!("syq-{target}");
         let replacement = format!(
-            "#!/bin/sh\ncase \"$1\" in\n  --version) echo 'syq {release_version}' ;;\n  --remote-helper-id) echo '{executable_helper}' ;;\n  *) exit 2 ;;\nesac\n"
+            "#!/bin/sh\ncase \"$1\" in\n  --version) echo 'syq {release_version}' ;;\n  --build-identity) echo '{executable_identity}' ;;\n  --remote-helper-id) echo 'v{release_version}-p0' ;;\n  *) exit 2 ;;\nesac\n"
         );
         let replacement = replacement.as_bytes();
         let archive_path = temp.path(&format!("fixtures/{asset}.gz"));
@@ -87,7 +87,7 @@ impl UpdateFixture {
             "repository": "https://github.com/greaber/syq",
             "version": release_version,
             "tag": format!("v{release_version}"),
-            "helper_id": release_helper,
+            "helper_id": format!("v{release_version}-p0"),
             "artifacts": {
                 (target): {
                     "binary": {
@@ -217,7 +217,7 @@ fn assert_failure_contains(output: &Output, expected: &str) {
 #[cfg(target_os = "linux")]
 #[test]
 fn signed_self_update_replaces_only_the_receipted_copy() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
     fixture.register();
 
     let update = fixture.command("--self-update");
@@ -235,7 +235,7 @@ fn signed_self_update_replaces_only_the_receipted_copy() {
 #[cfg(target_os = "linux")]
 #[test]
 fn self_update_rejects_a_tampered_signed_manifest_without_changing_install() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
     fixture.register();
     fs::write(
         fixture.temp.path("fixtures/syq-release-manifest.json"),
@@ -251,7 +251,7 @@ fn self_update_rejects_a_tampered_signed_manifest_without_changing_install() {
 #[cfg(target_os = "linux")]
 #[test]
 fn self_update_rejects_a_tampered_archive_without_changing_install() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
     fixture.register();
     let target = if cfg!(target_arch = "x86_64") {
         "linux-x86_64"
@@ -273,12 +273,12 @@ fn self_update_rejects_a_tampered_archive_without_changing_install() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn self_update_rejects_an_executable_with_the_wrong_identity() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p999");
+fn self_update_rejects_an_executable_with_the_wrong_build_identity() {
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0+dev.wrong");
     fixture.register();
 
     let update = fixture.command("--self-update");
-    assert_failure_contains(&update, "unexpected helper identity");
+    assert_failure_contains(&update, "unexpected build identity");
     fixture.assert_original_unchanged();
 }
 
@@ -295,8 +295,8 @@ fn self_update_refuses_a_signed_downgrade() {
         );
         Version::new(current.major, current.minor - 1, 0)
     };
-    let helper = format!("v{older}-p4");
-    let fixture = UpdateFixture::new(&older.to_string(), &helper, &helper);
+    let identity = format!("v{older}");
+    let fixture = UpdateFixture::new(&older.to_string(), &identity);
     fixture.register();
 
     let update = fixture.command("--self-update");
@@ -307,7 +307,7 @@ fn self_update_refuses_a_signed_downgrade() {
 #[cfg(target_os = "linux")]
 #[test]
 fn receipt_is_bound_to_the_exact_installed_executable() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
     fixture.register();
     let other = fixture.temp.path("other/syq");
     fs::create_dir_all(other.parent().unwrap()).unwrap();
@@ -323,7 +323,7 @@ fn receipt_is_bound_to_the_exact_installed_executable() {
 #[cfg(target_os = "linux")]
 #[test]
 fn auto_update_setting_is_explicit_and_survives_reregistration() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
     fixture.register();
     assert_eq!(fixture.receipt()["auto_update"], false);
 
@@ -340,7 +340,7 @@ fn auto_update_setting_is_explicit_and_survives_reregistration() {
 #[cfg(target_os = "linux")]
 #[test]
 fn source_install_cannot_create_or_use_a_standalone_receipt_implicitly() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0-p4", "v0.2.0-p4");
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
 
     let update = fixture.command("--self-update");
     assert_failure_contains(&update, "self-update is only available");


### PR DESCRIPTION
## Summary

- replace the manually bumped wire protocol number with exact release/build identity checks
- identify official helpers by release while giving source builds Git-derived identities and refusing managed bootstrap from non-release builds
- update helper caching, signed release metadata, installer/updater validation, release CI, documentation, and regression coverage
- retain `v<release>-p0` only as a fixed compatibility shim so the 0.1.0 updater can install future releases

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (28 unit, 78 CLI/filesystem, 8 updater tests)
- `scripts/test-installer.sh`
- `scripts/test-release-tools.sh`
- `cargo package --locked --allow-dirty --no-verify`

ShellCheck was not available on the verification host.