### PR TITLE
Release 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel copy with an rsync-shaped interface"


### PR DESCRIPTION
Prepare the sanitized history for a replacement release.

- replace the site-specific server setup script with a general server tuning guide
- remove the deployment-specific README example
- bump the package version to 0.1.1

Checks run locally:
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets`
- `scripts/test-release-tools.sh`