### PR TITLE
Harden remote paths and SSH defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `--ignore-from FILE` | Read ignore patterns from a file (repeatable, stacks with `-i`) |
 | `--rm` | Remove the given paths recursively and in parallel (see below) |
 | `--relay` | Remote-to-remote: route data through this machine instead of running on the source host |
+| `--no-forward-agent` | Remote-to-remote: disable SSH agent forwarding to the source host |
 | `--detach` | Remote-to-remote: run the transfer detached on the source host so it survives losing this ssh session |
 | `--follow HOST:LOG` | Attach to a detached transfer's log and stream its progress |
 | `-h` | No-op for rsync compatibility; sizes are always human-readable. Use `--help` for help |
@@ -183,7 +184,18 @@ own keys). Progress and `-v` output are streamed back. If hostA can't reach
 hostB, `--relay` keeps the orchestrator here and routes every byte A → you → B
 — always works, at half the bandwidth.
 `syq hostA:src hostA:dst` (same host and user on both ends) simply runs a
-local copy on hostA.
+local copy on hostA and disables agent forwarding.
+
+Agent forwarding does not copy private keys to hostA, but a process that can
+access the forwarded socket while the SSH connection is alive can ask the
+agent to authenticate on its behalf. Pass `--no-forward-agent` to use `ssh -a`
+and override any `ForwardAgent yes` in SSH configuration; hostA must then have
+its own credentials for hostB. `--relay` also avoids exposing the agent to
+hostA, at the cost of routing the file data through this machine.
+
+Like rsync, SYQ leaves host-key checking to `ssh` and therefore inherits the
+user's SSH configuration and OpenSSH defaults. An `-e` command can supply a
+different policy when needed.
 
 Add `--detach` to let a remote-to-remote transfer outlive the ssh session that
 launched it: syq starts it on hostA, returns, and writes progress to a log on
@@ -281,8 +293,11 @@ needed for this normal resumption. Resume works at two levels.
 - Files whose size and mtime already match are skipped (the rsync quick check).
 - If this job's range-transfer `.name.syq-part.<job-id>` exists, both sides
   hash it and the source in `--block-size` blocks and only the mismatching
-  blocks are sent. On NFS this requires the receiver to reread the partial;
-  syq deliberately keeps no separate block-completion map.
+  blocks are sent. A leftover is reused only when it is a regular file owned
+  by the receiving process with exactly one hard link; anything else is not
+  reused and is either safely replaced or reported as an error. On NFS this
+  requires the receiver to reread the partial; syq deliberately keeps no
+  separate block-completion map.
   Pipelined small files are rewritten wholesale on retry instead of paying an
   extra partial-file probe.
 - If the destination file exists but differs, its blocks are hashed against

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -160,6 +160,10 @@ pub struct Args {
     /// Remote-to-remote: relay data through this machine instead of running on the source host
     #[arg(long)]
     pub relay: bool,
+    /// Remote-to-remote: disable SSH agent forwarding to the source host; it must authenticate
+    /// to the destination with its own credentials
+    #[arg(long)]
+    pub no_forward_agent: bool,
     /// Terminal width for the progress display (internal; used for remote-to-remote)
     #[arg(long, hide = true)]
     pub width: Option<usize>,

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -108,6 +108,34 @@ fn spawn_reader(
     rx
 }
 
+fn validate_remote_scan_batch(batch: &[Entry], saw_root: &mut bool) -> Result<()> {
+    for entry in batch {
+        if !*saw_root {
+            if !entry.path.is_empty() {
+                bail!("scan response did not begin with the root entry");
+            }
+            *saw_root = true;
+            continue;
+        }
+        if entry.path.is_empty() {
+            bail!("scan response contained the root entry more than once");
+        }
+        if entry.path.starts_with(b"/")
+            || entry.path.contains(&0)
+            || entry
+                .path
+                .split(|byte| *byte == b'/')
+                .any(|part| part.is_empty() || part == b"." || part == b"..")
+        {
+            bail!(
+                "scan response contained unsafe relative path {:?}",
+                String::from_utf8_lossy(&entry.path)
+            );
+        }
+    }
+    Ok(())
+}
+
 impl RemoteConn {
     fn io_err(&mut self, e: anyhow::Error) -> anyhow::Error {
         self.dead = true;
@@ -161,11 +189,17 @@ impl Conn for RemoteConn {
             follow_root,
             ignore: ignore.to_vec(),
         })?;
+        let mut saw_root = false;
         loop {
             match self.recv()? {
-                Response::ScanBatch(b) => sink(b)?,
+                Response::ScanBatch(b) => {
+                    validate_remote_scan_batch(&b, &mut saw_root)
+                        .with_context(|| format!("{}: unsafe remote scan", self.label))?;
+                    sink(b)?;
+                }
                 Response::ScanWarn(w) => warn(w),
-                Response::ScanDone => return Ok(()),
+                Response::ScanDone if saw_root => return Ok(()),
+                Response::ScanDone => bail!("{}: remote scan returned no root entry", self.label),
                 Response::Err(e) => bail!("{}: scan: {e}", self.label),
                 other => bail!("{}: unexpected response during scan: {other:?}", self.label),
             }
@@ -263,8 +297,6 @@ impl RemoteSpec {
                 "ControlMaster=no",
                 "-o",
                 "ControlPath=none",
-                "-o",
-                "StrictHostKeyChecking=accept-new",
                 "-o",
                 CIPHERS,
             ]);
@@ -769,5 +801,86 @@ impl Endpoint {
                 Ok(Box::new(spec.connect(compress)?))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    fn entry(path: &[u8]) -> Entry {
+        Entry {
+            path: path.to_vec(),
+            kind: Kind::File,
+            size: 0,
+            mtime: 0,
+            mtime_nsec: 0,
+            mode: 0,
+            uid: 0,
+            gid: 0,
+            rdev: 0,
+            dev: 0,
+            ino: 0,
+            link: None,
+        }
+    }
+
+    #[test]
+    fn remote_scan_paths_are_rooted_and_normalized() {
+        let mut saw_root = false;
+        validate_remote_scan_batch(&[entry(b""), entry(b"dir/file")], &mut saw_root).unwrap();
+        assert!(saw_root);
+
+        for bad in [
+            &b"/absolute"[..],
+            &b"../escape"[..],
+            &b"dir/../escape"[..],
+            &b"dir/./file"[..],
+            &b"dir//file"[..],
+            &b"dir/"[..],
+            &b"nul\0byte"[..],
+        ] {
+            let mut saw_root = true;
+            assert!(validate_remote_scan_batch(&[entry(bad)], &mut saw_root).is_err());
+        }
+    }
+
+    #[test]
+    fn remote_scan_requires_exactly_one_leading_root() {
+        let mut saw_root = false;
+        assert!(validate_remote_scan_batch(&[entry(b"file")], &mut saw_root).is_err());
+
+        let mut saw_root = true;
+        assert!(validate_remote_scan_batch(&[entry(b"")], &mut saw_root).is_err());
+    }
+
+    #[test]
+    fn ssh_inherits_host_key_policy() {
+        let spec = RemoteSpec {
+            user: None,
+            host: "example".to_string(),
+            rsh: vec!["ssh".to_string()],
+            syq_path: None,
+            auto_helper: false,
+            helper_install: Default::default(),
+            quiet: false,
+            tcp: Default::default(),
+        };
+        let command = spec.ssh_command();
+        assert!(!command
+            .get_args()
+            .any(|arg| arg.to_string_lossy().starts_with("StrictHostKeyChecking=")));
+
+        let mut configured = spec;
+        configured.rsh = vec![
+            "ssh".to_string(),
+            "-o".to_string(),
+            "StrictHostKeyChecking=yes".to_string(),
+        ];
+        assert!(configured
+            .ssh_command()
+            .get_args()
+            .any(|arg| arg == OsStr::new("StrictHostKeyChecking=yes")));
     }
 }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -6,6 +6,30 @@ use anyhow::{bail, Context, Result};
 use std::io::IsTerminal;
 use std::process::{Command, Stdio};
 
+fn direct_command(
+    rsh: &[String],
+    user: Option<&str>,
+    host: &str,
+    remote_cmd: &str,
+    forward_agent: bool,
+) -> Command {
+    let mut cmd = Command::new(&rsh[0]);
+    cmd.args(&rsh[1..]);
+    if rsh[0].ends_with("ssh") {
+        // Pass an explicit setting in both directions so ~/.ssh/config cannot
+        // silently override --no-forward-agent (or same-host suppression).
+        cmd.arg(if forward_agent { "-A" } else { "-a" });
+        if let Some(user) = user {
+            cmd.args(["-l", user]);
+        }
+        cmd.arg("--");
+    } else if let Some(user) = user {
+        cmd.args(["-l", user]);
+    }
+    cmd.arg(host).arg(remote_cmd);
+    cmd
+}
+
 pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     let rsh = parse_rsh(&args.rsh)?;
     let src_host = srcs[0].host.clone().unwrap();
@@ -150,9 +174,9 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
 
     let remote_cmd = if args.detach {
         // Survive the loss of this ssh session: new session, no controlling
-        // terminal, everything to a log file. The transfer itself still needs
-        // the forwarded agent only for its initial connections, so hostA must
-        // be able to reach hostB with its own credentials for a long run.
+        // terminal, everything to a log file. A forwarded agent disappears
+        // when the launcher session ends, so hostA needs its own credentials
+        // for a detached transfer to hostB.
         // The basename is interpolated into a remote shell command; allow only
         // safe characters so a crafted filename can't inject commands.
         let raw = srcs[0]
@@ -184,21 +208,15 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         remote_cmd
     };
 
+    let forward_agent = !args.no_forward_agent && !srcs[0].same_host(dst);
     let make_command = || {
-        let mut cmd = Command::new(&rsh[0]);
-        cmd.args(&rsh[1..]);
-        if rsh[0].ends_with("ssh") {
-            // Agent forwarding so the source host can authenticate to the destination.
-            cmd.arg("-A");
-            if let Some(u) = &srcs[0].user {
-                cmd.args(["-l", u]);
-            }
-            cmd.arg("--");
-        } else if let Some(u) = &srcs[0].user {
-            cmd.args(["-l", u]);
-        }
-        cmd.arg(&src_host).arg(&remote_cmd);
-        cmd
+        direct_command(
+            &rsh,
+            srcs[0].user.as_deref(),
+            &src_host,
+            &remote_cmd,
+            forward_agent,
+        )
     };
     if args.detach {
         let run = || {
@@ -331,4 +349,37 @@ pub fn follow(args: &Args) -> Result<i32> {
         eprintln!();
     }
     Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    fn args(command: &Command) -> Vec<&OsStr> {
+        command.get_args().collect()
+    }
+
+    #[test]
+    fn direct_ssh_controls_agent_forwarding_explicitly() {
+        let rsh = vec!["ssh".to_string(), "-p".to_string(), "2222".to_string()];
+        let forwarded = direct_command(&rsh, Some("alice"), "source", "syq ...", true);
+        let forwarded = args(&forwarded);
+        assert!(forwarded.contains(&OsStr::new("-A")));
+        assert!(!forwarded.contains(&OsStr::new("-a")));
+
+        let disabled = direct_command(&rsh, Some("alice"), "source", "syq ...", false);
+        let disabled = args(&disabled);
+        assert!(disabled.contains(&OsStr::new("-a")));
+        assert!(!disabled.contains(&OsStr::new("-A")));
+    }
+
+    #[test]
+    fn custom_remote_shell_does_not_get_ssh_agent_flags() {
+        let rsh = vec!["custom-rsh".to_string()];
+        let command = direct_command(&rsh, None, "source", "syq ...", false);
+        let args = args(&command);
+        assert!(!args.contains(&OsStr::new("-a")));
+        assert!(!args.contains(&OsStr::new("-A")));
+    }
 }

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -321,6 +321,8 @@ struct FdKey {
     /// Source files and partials get a fresh cache entry after a source-change
     /// retry. An old descriptor may point at an inode that was renamed away.
     attempt: u32,
+    /// Keep a privately-owned sidecar from sharing an unchecked cache entry.
+    private: bool,
 }
 
 struct PartialTarget<'a> {
@@ -343,22 +345,21 @@ impl FsOps {
         }
     }
 
-    fn cached(&mut self, p: &Path, write: bool, attempt: u32) -> Result<&File> {
+    fn cached(&mut self, p: &Path, write: bool, attempt: u32, private: bool) -> Result<&File> {
         let key = FdKey {
             path: p.to_path_buf(),
             attempt,
+            private,
         };
         if !self.fds.contains_key(&key) {
             if self.fds.len() >= FD_CACHE_MAX {
                 let victim = self.fd_order.remove(0);
                 self.fds.remove(&victim);
             }
-            let f = if write {
-                OpenOptions::new().write(true).open(p)
-            } else {
-                File::open(p)
+            let f = open_existing_regular(p, write)?;
+            if private {
+                require_owned_private(&f, p)?;
             }
-            .with_context(|| format!("open {}", p.display()))?;
             self.fds.insert(key.clone(), f);
             self.fd_order.push(key.clone());
         }
@@ -709,7 +710,13 @@ impl FsOps {
         let pp = partial_path(&p, partial_id)?;
         let partial_size = match fs::symlink_metadata(&pp) {
             Err(error) if error.kind() == io::ErrorKind::NotFound => None,
-            Ok(metadata) if metadata.is_file() && metadata.nlink() == 1 => Some(metadata.len()),
+            Ok(metadata)
+                if metadata.is_file()
+                    && metadata.nlink() == 1
+                    && metadata.uid() == unsafe { libc::geteuid() } =>
+            {
+                Some(metadata.len())
+            }
             Ok(_) => None,
             Err(error) => return Err(error).with_context(|| format!("stat {}", pp.display())),
         };
@@ -724,7 +731,11 @@ impl FsOps {
         let mut repaired_permissions = false;
         for _ in 0..8 {
             match fs::symlink_metadata(pp) {
-                Ok(md) if md.is_file() && md.nlink() == 1 => {
+                Ok(md)
+                    if md.is_file()
+                        && md.nlink() == 1
+                        && md.uid() == unsafe { libc::geteuid() } =>
+                {
                     match OpenOptions::new()
                         .read(true)
                         .write(true)
@@ -736,6 +747,7 @@ impl FsOps {
                             let path_meta = fs::symlink_metadata(pp)?;
                             if !fd_meta.file_type().is_file()
                                 || fd_meta.nlink() != 1
+                                || fd_meta.uid() != unsafe { libc::geteuid() }
                                 || fd_meta.dev() != path_meta.dev()
                                 || fd_meta.ino() != path_meta.ino()
                             {
@@ -761,14 +773,11 @@ impl FsOps {
                             let fd_meta = readonly.metadata()?;
                             if !fd_meta.file_type().is_file()
                                 || fd_meta.nlink() != 1
+                                || fd_meta.uid() != unsafe { libc::geteuid() }
                                 || fd_meta.dev() != md.dev()
                                 || fd_meta.ino() != md.ino()
                             {
                                 continue;
-                            }
-                            if fd_meta.uid() != unsafe { libc::geteuid() } && !is_root() {
-                                return Err(error)
-                                    .with_context(|| format!("open {}", pp.display()));
                             }
                             readonly
                                 .set_permissions(fs::Permissions::from_mode(0o600))
@@ -794,7 +803,10 @@ impl FsOps {
                         .mode(0o600)
                         .open(pp)
                     {
-                        Ok(file) => Ok((file, None)),
+                        Ok(file) => {
+                            require_owned_private(&file, pp)?;
+                            Ok((file, None))
+                        }
                         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
                         Err(error) => {
                             Err(error).with_context(|| format!("create {}", pp.display()))
@@ -963,7 +975,7 @@ impl FsOps {
         mode: u32,
     ) -> Result<()> {
         let sp = resolve(src);
-        let s = File::open(&sp).with_context(|| format!("open {}", sp.display()))?;
+        let s = open_existing_regular(&sp, false)?;
         let dp = resolve(dst);
         // Never truncate the source: if the destination resolves to the same
         // file (same path, a hardlink, or a symlink pointing back), refuse.
@@ -1117,7 +1129,10 @@ impl FsOps {
         } else {
             p
         };
-        let mut f = File::open(&p).with_context(|| format!("open {}", p.display()))?;
+        let mut f = open_existing_regular(&p, false)?;
+        if which == Which::Partial {
+            require_owned_private(&f, &p)?;
+        }
         hash_reader(&mut f, block, len)
     }
 
@@ -1129,7 +1144,7 @@ impl FsOps {
         len: u32,
     ) -> Result<Response> {
         let p = resolve(path);
-        let f = self.cached(&p, false, attempt)?;
+        let f = self.cached(&p, false, attempt, false)?;
         let mut data = vec![0u8; len as usize];
         f.read_exact_at(&mut data, off)
             .with_context(|| format!("read {} @{off}+{len}", p.display()))?;
@@ -1155,7 +1170,7 @@ impl FsOps {
         } else {
             partial_path(&p, target.id)?
         };
-        let f = self.cached(&p, true, attempt)?;
+        let f = self.cached(&p, true, attempt, !inplace)?;
         f.write_all_at(data, off)
             .with_context(|| format!("write {} @{off}", p.display()))
     }
@@ -1174,13 +1189,17 @@ impl FsOps {
         } else {
             partial_path(&p, partial_id)?
         };
-        let f = self.uncache(&src).map(Ok).unwrap_or_else(|| {
-            OpenOptions::new()
-                .write(true)
-                .custom_flags(libc::O_NOFOLLOW)
-                .open(&src)
-                .with_context(|| format!("open {}", src.display()))
-        })?;
+        let f = self
+            .uncache(&src)
+            .map(Ok)
+            .unwrap_or_else(|| open_existing_regular(&src, true))?;
+        if inplace {
+            if !f.metadata()?.file_type().is_file() {
+                bail!("destination {} is not a regular file", src.display());
+            }
+        } else {
+            require_owned_private(&f, &src)?;
+        }
         set_meta_file(&f, meta, flags)
             .with_context(|| format!("set metadata {}", src.display()))?;
         if !inplace {
@@ -1197,7 +1216,7 @@ impl FsOps {
 
     pub fn file_hash(&mut self, path: &[u8]) -> Result<Response> {
         let p = resolve(path);
-        let mut f = File::open(&p).with_context(|| format!("open {}", p.display()))?;
+        let mut f = open_existing_regular(&p, false)?;
         let mut h = Xxh3::new();
         let mut buf = vec![0u8; 1 << 20];
         let mut size = 0u64;
@@ -1375,6 +1394,37 @@ fn open_regular_write(target: &Path, mode: u32) -> Result<File> {
     Ok(f)
 }
 
+/// Open an existing leaf without following a last-component symlink. Parent
+/// component confinement is a separate, root-fd-based design problem.
+fn open_existing_regular(target: &Path, write: bool) -> Result<File> {
+    let mut options = OpenOptions::new();
+    options
+        .read(!write)
+        .write(write)
+        .custom_flags(libc::O_NOFOLLOW);
+    let file = options
+        .open(target)
+        .with_context(|| format!("open {}", target.display()))?;
+    if !file.metadata()?.file_type().is_file() {
+        bail!("{} is not a regular file", target.display());
+    }
+    Ok(file)
+}
+
+fn require_owned_private(file: &File, target: &Path) -> Result<()> {
+    let metadata = file.metadata()?;
+    if !metadata.file_type().is_file()
+        || metadata.nlink() != 1
+        || metadata.uid() != unsafe { libc::geteuid() }
+    {
+        bail!(
+            "partial {} is not an owned, singly-linked regular file",
+            target.display()
+        );
+    }
+    Ok(())
+}
+
 fn mkdir(p: &Path, mode: u32) -> io::Result<()> {
     std::os::unix::fs::DirBuilderExt::mode(&mut fs::DirBuilder::new(), (mode & 0o7777) | 0o700)
         .create(p)
@@ -1524,6 +1574,51 @@ fn apply_owner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::symlink;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn test_dir() -> PathBuf {
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        std::env::temp_dir().join(format!(
+            "syq-fsops-test-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn existing_regular_open_does_not_follow_leaf_symlinks() {
+        let dir = test_dir();
+        fs::create_dir(&dir).unwrap();
+        let file = dir.join("file");
+        let link = dir.join("link");
+        fs::write(&file, b"data").unwrap();
+        symlink(&file, &link).unwrap();
+
+        let regular_opened = open_existing_regular(&file, false).is_ok();
+        let link_rejected = open_existing_regular(&link, false).is_err();
+        fs::remove_dir_all(&dir).unwrap();
+
+        assert!(regular_opened);
+        assert!(link_rejected);
+    }
+
+    #[test]
+    fn private_partial_must_have_one_link() {
+        let dir = test_dir();
+        fs::create_dir(&dir).unwrap();
+        let file = dir.join("partial");
+        let alias = dir.join("alias");
+        fs::write(&file, b"data").unwrap();
+        fs::hard_link(&file, &alias).unwrap();
+
+        let opened = open_existing_regular(&file, true).unwrap();
+        let rejected = require_owned_private(&opened, &file).is_err();
+        drop(opened);
+        fs::remove_dir_all(&dir).unwrap();
+
+        assert!(rejected);
+    }
 
     #[test]
     fn partial_name_keeps_job_id_and_fits_name_max() {


### PR DESCRIPTION
## Summary

- validate streamed remote scan paths before they enter destination mapping
- open existing transfer leaves without following symlinks and only reuse owned, singly-linked partials
- inherit the SSH host-key policy like rsync instead of forcing `accept-new`
- add `--no-forward-agent`, using explicit `ssh -a`; same-host remote copies also suppress forwarding
- document the SSH and partial-file behavior and add focused regression tests

This keeps the existing XXH3 hot-path hashes and PR7 exact sidecar collision preflight unchanged. It is stacked on #7.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (42 unit, 103 local integration, 8 update tests)
- release-mode 20,000 one-byte-file ext4 check: 679 ms hardened average versus 689 ms PR7 baseline across six alternating-order runs

Live SSH, TCP, and NFS performance were not exercised.