### PR TITLE
Fetch one signed release manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,8 @@ jobs:
           SYQ_RELEASE_SIGNING_KEY_PEM_B64: ${{ secrets.SYQ_RELEASE_SIGNING_KEY_PEM_B64 }}
         run: |
           scripts/sign-release-manifest.sh \
-            dist/syq-release-manifest.json dist/syq-release-manifest.json.sig
+            dist/syq-release-manifest.json dist/syq-release-manifest.json.sig \
+            dist/syq-linux-x86_64
       - name: Verify final release inventory
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,8 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+      - name: Restore canonicalizer permission
+        run: chmod 755 dist/syq-linux-x86_64
       - name: Build and validate release metadata
         run: scripts/package-release.sh "$GITHUB_REF_NAME" dist
       - name: Sign release manifest and verify the configured key

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +851,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -950,6 +967,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_json_canonicalizer",
  "sha2",
  "shell-words",
  "xxhash-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde_bytes = "0.11"
 aes-gcm = "0.11"
 getrandom = "0.4"
 serde_json = "1"
+serde_json_canonicalizer = "0.3"
 base64 = { version = "0.23", default-features = false, features = ["std"] }
 ed25519-dalek = "3"
 flate2 = "1"

--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ only in official release binaries. To use a source build remotely, install the
 same build there and pass `--syq-path /path/to/syq` (or put it on the remote
 `PATH` and use `--no-bootstrap`).
 
-Standalone installs check the signed release manifest at most once a day after
-a successful interactive command. They only print an update notice by default:
-`syq --self-update` performs the update, and `syq --enable-auto-update` opts in
-to installing a signed update after a successful interactive command. Use
-`syq --disable-auto-update` to opt out again. The install receipt lives at
+Standalone installs download and verify one signed release manifest at most
+once a day after a successful interactive command. They only print an update
+notice by default: `syq --self-update` performs the update, and
+`syq --enable-auto-update` opts in to installing a signed update after a
+successful interactive command. Use `syq --disable-auto-update` to opt out
+again. The install receipt lives at
 `$XDG_CONFIG_HOME/syq/install.json` (normally `~/.config/syq/install.json`) and
 must name the running executable, so a Homebrew or source build never replaces
 itself. Update Homebrew installs with `brew upgrade syq`.
@@ -82,13 +83,14 @@ non-interactive remote `PATH` and use `--no-bootstrap`. Helpers cached under an
 older identity or cache layout are never executed; they may be removed with the
 rest of the disposable helper cache.
 
-The local client verifies the Ed25519-signed manifest and passes its trusted
-hash to the remote install script. The remote uses `curl` or `wget`, `gzip`, and
-one of `sha256sum`, `shasum`, or `openssl`. Version directories coexist and the
-helper cache can be removed at any time; syq recreates the helper it needs on
-the next connection. After launch, both peers require the same build identity:
-the release tag for official binaries, or the Git-derived identity when an
-explicit source-built helper is used.
+The local client verifies the manifest's embedded Ed25519 signature over its
+RFC 8785 canonical JSON and passes its trusted hash to the remote install
+script. The remote uses `curl` or `wget`, `gzip`, and one of `sha256sum`,
+`shasum`, or `openssl`. Version directories coexist and the helper cache can be
+removed at any time; syq recreates the helper it needs on the next connection.
+After launch, both peers require the same build identity: the release tag for
+official binaries, or the Git-derived identity when an explicit source-built
+helper is used.
 
 - **macOS (Apple Silicon / Intel):** build natively on the Mac with
   `cargo build --release` (needs the Xcode command-line tools, `xcode-select

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -134,10 +134,11 @@ connection, so enable it only for a trusted release host rather than globally.
    first verifies that the annotated tag's signature is valid and that it
    directly targets the workflow commit, and that this commit is reachable
    from protected `master`. It then builds static GNU Linux x86-64/ARM64
-   binaries and native macOS Apple Silicon/Intel binaries, signs the manifest,
-   verifies the exact asset inventory, creates provenance attestations,
-   uploads a draft, checks every uploaded byte, publishes it, and finally
-   updates the tap.
+   binaries and native macOS Apple Silicon/Intel binaries, embeds an Ed25519
+   signature over the manifest's RFC 8785 canonical JSON, retains a detached
+   signature for updaters through 0.1.1, verifies the exact asset inventory,
+   creates provenance attestations, uploads a draft, checks every uploaded
+   byte, publishes it, and finally updates the tap.
 4. Verify one or more downloaded artifacts and exercise both install paths:
 
    ```sh

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -78,7 +78,8 @@ jq --sort-keys \
   --arg formula_sha "$formula_hash" --argjson formula_size "$formula_size" \
   '. + {
     installer:{name:"install.sh",sha256:$installer_sha,size:$installer_size},
-    homebrew_formula:{name:"syq.rb",sha256:$formula_sha,size:$formula_size}
+    homebrew_formula:{name:"syq.rb",sha256:$formula_sha,size:$formula_size},
+    signature_scheme:"ed25519-jcs-v1"
   }' "$manifest_core" > "$dist/syq-release-manifest.json"
 rm -f "$manifest_core"
 

--- a/scripts/sign-release-manifest.sh
+++ b/scripts/sign-release-manifest.sh
@@ -3,14 +3,19 @@
 # matches the public key embedded in official binaries.
 set -euo pipefail
 
-if [ "$#" -ne 2 ]; then
-  echo "usage: $0 MANIFEST SIGNATURE_OUTPUT" >&2
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 MANIFEST SIGNATURE_OUTPUT SYQ_BINARY" >&2
   exit 2
 fi
 manifest=$1
 output=$2
+canonicalizer=$3
 if [ ! -f "$manifest" ] || [ -L "$manifest" ]; then
   echo "missing regular release manifest: $manifest" >&2
+  exit 1
+fi
+if [ ! -x "$canonicalizer" ]; then
+  echo "missing executable syq canonicalizer: $canonicalizer" >&2
   exit 1
 fi
 test -n "${SYQ_RELEASE_PUBLIC_KEY:-}" || {
@@ -22,6 +27,15 @@ test -n "${SYQ_RELEASE_SIGNING_KEY_PEM_B64:-}" || {
   exit 1
 }
 command -v openssl >/dev/null || { echo 'signing needs openssl' >&2; exit 1; }
+command -v jq >/dev/null || { echo 'signing needs jq' >&2; exit 1; }
+jq -e '
+  type == "object"
+  and .signature_scheme == "ed25519-jcs-v1"
+  and (has("signature") | not)
+' "$manifest" >/dev/null || {
+  echo 'release manifest is not unsigned ed25519-jcs-v1 metadata' >&2
+  exit 1
+}
 
 umask 077
 work=$(mktemp -d "${TMPDIR:-/tmp}/syq-sign-release.XXXXXXXX")
@@ -29,7 +43,11 @@ cleanup() { rm -rf "$work"; }
 trap cleanup EXIT HUP INT TERM
 key="$work/signing.pem"
 public="$work/public.pem"
-signature="$work/manifest.sig"
+payload="$work/manifest.jcs"
+verified_payload="$work/verified-manifest.jcs"
+embedded_signature="$work/embedded.sig"
+signed_manifest="$work/signed-manifest.json"
+detached_signature="$work/detached.sig"
 encoded="$work/manifest.sig.b64"
 configured_public="$work/configured-public-key"
 
@@ -46,10 +64,28 @@ test "$derived" = "$SYQ_RELEASE_PUBLIC_KEY" || {
   exit 1
 }
 
-openssl pkeyutl -sign -rawin -inkey "$key" -in "$manifest" -out "$signature"
+"$canonicalizer" --release-manifest-signing-payload "$manifest" > "$payload"
+openssl pkeyutl -sign -rawin -inkey "$key" -in "$payload" -out "$embedded_signature"
 openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
-  -in "$manifest" -sigfile "$signature" >/dev/null
-openssl base64 -A -in "$signature" -out "$encoded"
+  -in "$payload" -sigfile "$embedded_signature" >/dev/null
+embedded_b64=$(openssl base64 -A -in "$embedded_signature")
+jq --sort-keys --arg signature "$embedded_b64" \
+  '. + {signature:$signature}' "$manifest" > "$signed_manifest"
+"$canonicalizer" --release-manifest-signing-payload "$signed_manifest" > "$verified_payload"
+cmp -s "$payload" "$verified_payload" || {
+  echo 'embedded signature changed the canonical manifest payload' >&2
+  exit 1
+}
+openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
+  -in "$verified_payload" -sigfile "$embedded_signature" >/dev/null
+
+# Updaters through 0.1.1 verify this detached signature over the completed
+# manifest. New updaters verify the embedded JCS signature with one download.
+openssl pkeyutl -sign -rawin -inkey "$key" -in "$signed_manifest" -out "$detached_signature"
+openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
+  -in "$signed_manifest" -sigfile "$detached_signature" >/dev/null
+openssl base64 -A -in "$detached_signature" -out "$encoded"
 printf '\n' >> "$encoded"
-chmod 644 "$encoded"
+chmod 644 "$signed_manifest" "$encoded"
+mv -f "$signed_manifest" "$manifest"
 mv -f "$encoded" "$output"

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -11,6 +11,10 @@ trap cleanup EXIT HUP INT TERM
 
 version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$repo_dir/Cargo.toml" | head -1)
 tag="v$version"
+cargo build --locked --manifest-path "$repo_dir/Cargo.toml" --bin syq
+target_dir=$(cargo metadata --no-deps --format-version 1 \
+  --manifest-path "$repo_dir/Cargo.toml" | jq -r .target_directory)
+canonicalizer="$target_dir/debug/syq"
 
 prepare_dist() {
   local dist=$1 asset
@@ -55,6 +59,8 @@ jq -e \
     and .installer.sha256 == $installer_sha
     and .homebrew_formula.name == "syq.rb"
     and .homebrew_formula.sha256 == $formula_sha
+    and .signature_scheme == "ed25519-jcs-v1"
+    and (has("signature") | not)
   ' "$first/syq-release-manifest.json" >/dev/null
 sh -n "$first/install.sh"
 grep -q '^class Syq < Formula$' "$first/syq.rb"
@@ -90,7 +96,14 @@ key_b64=$(openssl base64 -A -in "$key")
 public_b64=$(openssl pkey -in "$key" -pubout -outform DER | tail -c 32 | openssl base64 -A)
 SYQ_RELEASE_SIGNING_KEY_PEM_B64="$key_b64" SYQ_RELEASE_PUBLIC_KEY="$public_b64" \
   "$script_dir/sign-release-manifest.sh" \
-  "$first/syq-release-manifest.json" "$first/syq-release-manifest.json.sig"
+  "$first/syq-release-manifest.json" "$first/syq-release-manifest.json.sig" \
+  "$canonicalizer"
+embedded_b64=$(jq -er '.signature' "$first/syq-release-manifest.json")
+printf '%s' "$embedded_b64" | openssl base64 -d -A > "$work/embedded-signature.raw"
+"$canonicalizer" --release-manifest-signing-payload \
+  "$first/syq-release-manifest.json" > "$work/manifest.jcs"
+openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
+  -in "$work/manifest.jcs" -sigfile "$work/embedded-signature.raw" >/dev/null
 openssl base64 -d -A -in "$first/syq-release-manifest.json.sig" \
   -out "$work/signature.raw"
 openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
@@ -104,7 +117,7 @@ mismatch_output="$work/mismatched.sig"
 expect_failure 'does not match SYQ_RELEASE_PUBLIC_KEY' env \
   SYQ_RELEASE_SIGNING_KEY_PEM_B64="$key_b64" SYQ_RELEASE_PUBLIC_KEY="$other_public_b64" \
   "$script_dir/sign-release-manifest.sh" \
-  "$first/syq-release-manifest.json" "$mismatch_output"
+  "$second/syq-release-manifest.json" "$mismatch_output" "$canonicalizer"
 test ! -e "$mismatch_output"
 
 # Verify the workflow's GitHub tag checks against controlled API responses.

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,17 @@ fn main() {
         println!("{}", identity::legacy_helper_id());
         return;
     }
+    if argv.get(1).map(String::as_str) == Some("--release-manifest-signing-payload") {
+        if argv.len() != 3 {
+            eprintln!("syq: --release-manifest-signing-payload requires one manifest path");
+            std::process::exit(2);
+        }
+        if let Err(e) = update::write_manifest_signing_payload(std::path::Path::new(&argv[2])) {
+            eprintln!("syq: {e:#}");
+            std::process::exit(1);
+        }
+        return;
+    }
     if argv.get(1).map(String::as_str) == Some("--server") {
         if let Err(e) = server::run() {
             eprintln!("syq server: {e:#}");

--- a/src/update.rs
+++ b/src/update.rs
@@ -24,9 +24,10 @@ const REPOSITORY: &str = "https://github.com/greaber/syq";
 const RELEASE_DOWNLOADS: &str = "https://github.com/greaber/syq/releases/download";
 const LATEST_DOWNLOADS: &str = "https://github.com/greaber/syq/releases/latest/download";
 const MANIFEST_NAME: &str = "syq-release-manifest.json";
-const SIGNATURE_NAME: &str = "syq-release-manifest.json.sig";
 const RECEIPT_SCHEMA: u32 = 1;
 const MANIFEST_SCHEMA: u32 = 1;
+const MANIFEST_SIGNATURE_SCHEME: &str = "ed25519-jcs-v1";
+const MAX_SAFE_JSON_INTEGER: u64 = (1 << 53) - 1;
 const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const RELEASE_PUBLIC_KEY: Option<&str> = option_env!("SYQ_RELEASE_PUBLIC_KEY");
 
@@ -41,7 +42,8 @@ struct InstallReceipt {
     auto_update: bool,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct ReleaseManifest {
     schema: u32,
     repository: String,
@@ -53,15 +55,18 @@ struct ReleaseManifest {
     artifacts: BTreeMap<String, ReleaseArtifact>,
     installer: ReleaseFile,
     homebrew_formula: ReleaseFile,
+    signature_scheme: String,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct ReleaseArtifact {
     binary: ReleaseFile,
     archive: ReleaseFile,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 struct ReleaseFile {
     name: String,
     sha256: String,
@@ -241,23 +246,13 @@ fn fetch_verified(base_url: &str, mode: FetchMode) -> Result<VerifiedRelease> {
     let temp_dir = config_dir()?;
     create_private_dir(&temp_dir)?;
     let manifest_temp = TempFile::new(&temp_dir, ".json")?;
-    let signature_temp = TempFile::new(&temp_dir, ".sig")?;
     fetch(
         &format!("{base_url}/{MANIFEST_NAME}"),
         manifest_temp.path(),
         mode,
     )?;
-    fetch(
-        &format!("{base_url}/{SIGNATURE_NAME}"),
-        signature_temp.path(),
-        mode,
-    )?;
     let manifest_bytes = fs::read(manifest_temp.path()).context("read release manifest")?;
-    let signature =
-        fs::read_to_string(signature_temp.path()).context("read release manifest signature")?;
-    verify_manifest(&manifest_bytes, &signature, key.as_ref())?;
-    let manifest: ReleaseManifest =
-        serde_json::from_slice(&manifest_bytes).context("parse signed release manifest")?;
+    let manifest = verified_manifest(&manifest_bytes, key.as_ref())?;
     let version = validate_manifest(&manifest)?;
     Ok(VerifiedRelease { manifest, version })
 }
@@ -278,7 +273,21 @@ fn embedded_public_key() -> Result<Cow<'static, str>> {
         })
 }
 
-fn verify_manifest(manifest: &[u8], signature_b64: &str, public_key_b64: &str) -> Result<()> {
+fn verified_manifest(bytes: &[u8], public_key_b64: &str) -> Result<ReleaseManifest> {
+    let mut value: serde_json::Value =
+        serde_json::from_slice(bytes).context("parse signed release manifest")?;
+    let signature = value
+        .as_object_mut()
+        .and_then(|object| object.remove("signature"))
+        .and_then(|signature| signature.as_str().map(str::to_owned))
+        .ok_or_else(|| anyhow!("signed release manifest has no embedded signature"))?;
+    let canonical =
+        serde_json_canonicalizer::to_vec(&value).context("canonicalize signed release manifest")?;
+    verify_signature(&canonical, &signature, public_key_b64)?;
+    serde_json::from_value(value).context("parse verified release manifest")
+}
+
+fn verify_signature(payload: &[u8], signature_b64: &str, public_key_b64: &str) -> Result<()> {
     let public = base64::engine::general_purpose::STANDARD
         .decode(public_key_b64.trim())
         .context("decode the embedded release public key")?;
@@ -291,7 +300,7 @@ fn verify_manifest(manifest: &[u8], signature_b64: &str, public_key_b64: &str) -
         .context("decode the release manifest signature")?;
     let signature =
         Signature::from_slice(&signature).context("parse the release manifest signature")?;
-    key.verify_strict(manifest, &signature)
+    key.verify_strict(payload, &signature)
         .context("release manifest signature verification failed")
 }
 
@@ -301,6 +310,12 @@ fn validate_manifest(manifest: &ReleaseManifest) -> Result<Version> {
     }
     if manifest.repository != REPOSITORY {
         bail!("release manifest names an unexpected repository");
+    }
+    if manifest.signature_scheme != MANIFEST_SIGNATURE_SCHEME {
+        bail!(
+            "unsupported release manifest signature scheme {}",
+            manifest.signature_scheme
+        );
     }
     let version = Version::parse(&manifest.version).context("invalid release version")?;
     if manifest.tag != format!("v{version}") {
@@ -342,6 +357,9 @@ fn validate_release_file(target: &str, file: &ReleaseFile) -> Result<()> {
     }
     if file.size == 0 {
         bail!("release has an empty file for {target}");
+    }
+    if file.size > MAX_SAFE_JSON_INTEGER {
+        bail!("release file size is outside the JCS safe integer range for {target}");
     }
     if file.sha256.len() != 64
         || !file
@@ -434,6 +452,30 @@ fn latest_downloads() -> Cow<'static, str> {
         return Cow::Owned(url.to_string_lossy().into_owned());
     }
     Cow::Borrowed(LATEST_DOWNLOADS)
+}
+
+/// Emit the RFC 8785 signing payload for release tooling. The signature field
+/// is the only field excluded; every other present field is authenticated.
+pub fn write_manifest_signing_payload(path: &Path) -> Result<()> {
+    let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let mut value: serde_json::Value =
+        serde_json::from_slice(&bytes).context("parse release manifest signing input")?;
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("release manifest signing input is not a JSON object"))?;
+    if object
+        .get("signature")
+        .is_some_and(|signature| !signature.is_string())
+    {
+        bail!("release manifest signature is not a string");
+    }
+    object.remove("signature");
+    let mut output = BufWriter::new(std::io::stdout().lock());
+    serde_json_canonicalizer::to_writer(&value, &mut output)
+        .context("canonicalize release manifest signing input")?;
+    output
+        .flush()
+        .context("write release manifest signing payload")
 }
 
 fn verify_file(path: &Path, expected: &ReleaseFile) -> Result<()> {
@@ -749,19 +791,32 @@ mod tests {
                 sha256: "d".repeat(64),
                 size: 13,
             },
+            signature_scheme: MANIFEST_SIGNATURE_SCHEME.into(),
         }
     }
 
     #[test]
     fn verifies_a_signed_manifest_and_rejects_tampering() {
         let signing = SigningKey::from_bytes(&[7; 32]);
-        let bytes = br#"{"schema":1}"#;
-        let signature = signing.sign(bytes);
+        let mut value = serde_json::to_value(manifest()).unwrap();
+        let canonical = serde_json_canonicalizer::to_vec(&value).unwrap();
+        let signature = signing.sign(&canonical);
         let signature = base64::engine::general_purpose::STANDARD.encode(signature.to_bytes());
+        value["signature"] = signature.into();
+        let bytes = serde_json::to_vec_pretty(&value).unwrap();
         let public =
             base64::engine::general_purpose::STANDARD.encode(signing.verifying_key().to_bytes());
-        verify_manifest(bytes, &signature, &public).unwrap();
-        assert!(verify_manifest(br#"{"schema":2}"#, &signature, &public).is_err());
+        verified_manifest(&bytes, &public).unwrap();
+        value["schema"] = 2.into();
+        let tampered = serde_json::to_vec_pretty(&value).unwrap();
+        assert!(verified_manifest(&tampered, &public).is_err());
+    }
+
+    #[test]
+    fn pins_the_release_signature_canonical_json_contract() {
+        let value = serde_json::json!({"n": 1e30, "b": 2, "a": "€"});
+        let canonical = serde_json_canonicalizer::to_vec(&value).unwrap();
+        assert_eq!(canonical, r#"{"a":"€","b":2,"n":1e+30}"#.as_bytes());
     }
 
     #[test]
@@ -784,6 +839,16 @@ mod tests {
         assert!(validate_manifest(&value).is_err());
         value.tag = "v1.2.3".into();
         value.helper_id = "v1.2.2-p0".into();
+        assert!(validate_manifest(&value).is_err());
+        value.helper_id = "v1.2.3-p0".into();
+        value.signature_scheme = "unknown".into();
+        assert!(validate_manifest(&value).is_err());
+    }
+
+    #[test]
+    fn rejects_file_sizes_outside_the_jcs_safe_integer_range() {
+        let mut value = manifest();
+        value.installer.size = MAX_SAFE_JSON_INTEGER + 1;
         assert!(validate_manifest(&value).is_err());
     }
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -135,10 +135,6 @@ fn remote_syq(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
         .env("FAKE_CURL_LOG", t.path("curl.log"))
         .env("FAKE_LOCAL_CURL_LOG", t.path("local-curl.log"))
         .env("FAKE_RELEASE_MANIFEST", t.path("release-manifest.json"))
-        .env(
-            "FAKE_RELEASE_SIGNATURE",
-            t.path("release-manifest.json.sig"),
-        )
         .env("FAKE_RSH_LOG", t.path("rsh.log"))
         .env("FAKE_LEGACY_LOG", t.path("legacy.log"))
         .env("XDG_CONFIG_HOME", t.path("config"));
@@ -256,14 +252,19 @@ exit 99
             }
         },
         "installer": {"name": "install.sh", "sha256": "1".repeat(64), "size": 1},
-        "homebrew_formula": {"name": "syq.rb", "sha256": "2".repeat(64), "size": 1}
+        "homebrew_formula": {"name": "syq.rb", "sha256": "2".repeat(64), "size": 1},
+        "signature_scheme": "ed25519-jcs-v1"
     });
-    let manifest = serde_json::to_vec_pretty(&manifest).unwrap();
     let signing = SigningKey::from_bytes(&[19; 32]);
+    let canonical = serde_json_canonicalizer::to_vec(&manifest).unwrap();
     let signature =
-        base64::engine::general_purpose::STANDARD.encode(signing.sign(&manifest).to_bytes());
-    write(&t.path("release-manifest.json"), &manifest);
-    write(&t.path("release-manifest.json.sig"), signature.as_bytes());
+        base64::engine::general_purpose::STANDARD.encode(signing.sign(&canonical).to_bytes());
+    let mut manifest = manifest;
+    manifest["signature"] = signature.into();
+    write(
+        &t.path("release-manifest.json"),
+        &serde_json::to_vec_pretty(&manifest).unwrap(),
+    );
     write(
         &t.path("release-public-key"),
         base64::engine::general_purpose::STANDARD
@@ -284,7 +285,6 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 case "$url" in
-    *.json.sig) cp "$FAKE_RELEASE_SIGNATURE" "$out" ;;
     *.json) cp "$FAKE_RELEASE_MANIFEST" "$out" ;;
     *) exit 22 ;;
 esac
@@ -314,7 +314,7 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
     assert!(cached_remote_helper(&t).is_file());
     assert!(legacy_helpers.iter().all(|helper| helper.exists()));
     assert!(!t.path("legacy.log").exists(), "legacy helper was executed");
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\n");
     assert_eq!(read(&t.path("curl.log")), b"fetch\n");
     assert!(!String::from_utf8_lossy(&out.stderr).contains("uploading this executable"));
     let probes = fs::read_to_string(t.path("rsh.log"))
@@ -328,7 +328,7 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
     let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"second");
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\n");
     assert_eq!(read(&t.path("curl.log")), b"fetch\n");
     let probes = fs::read_to_string(t.path("rsh.log"))
         .unwrap()

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -109,16 +109,18 @@ impl UpdateFixture {
                 }
             },
             "installer": {"name": "install.sh", "sha256": "1".repeat(64), "size": 1},
-            "homebrew_formula": {"name": "syq.rb", "sha256": "2".repeat(64), "size": 1}
+            "homebrew_formula": {"name": "syq.rb", "sha256": "2".repeat(64), "size": 1},
+            "signature_scheme": "ed25519-jcs-v1"
         });
-        let manifest = serde_json::to_vec_pretty(&manifest).unwrap();
-        fs::write(temp.path("fixtures/syq-release-manifest.json"), &manifest).unwrap();
         let signing = SigningKey::from_bytes(&[31; 32]);
+        let canonical = serde_json_canonicalizer::to_vec(&manifest).unwrap();
         let signature =
-            base64::engine::general_purpose::STANDARD.encode(signing.sign(&manifest).to_bytes());
+            base64::engine::general_purpose::STANDARD.encode(signing.sign(&canonical).to_bytes());
+        let mut manifest = manifest;
+        manifest["signature"] = signature.into();
         fs::write(
-            temp.path("fixtures/syq-release-manifest.json.sig"),
-            signature,
+            temp.path("fixtures/syq-release-manifest.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
         )
         .unwrap();
         let public_key =
@@ -237,11 +239,11 @@ fn signed_self_update_replaces_only_the_receipted_copy() {
 fn self_update_rejects_a_tampered_signed_manifest_without_changing_install() {
     let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
     fixture.register();
-    fs::write(
-        fixture.temp.path("fixtures/syq-release-manifest.json"),
-        b"{\"schema\":2}",
-    )
-    .unwrap();
+    let path = fixture.temp.path("fixtures/syq-release-manifest.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    manifest["version"] = "9.9.9".into();
+    fs::write(path, serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
 
     let update = fixture.command("--self-update");
     assert_failure_contains(&update, "signature verification failed");


### PR DESCRIPTION
## Summary

- embed an Ed25519 signature over RFC 8785 canonical release-manifest JSON
- fetch and verify only the manifest for update checks and managed remote bootstrap
- keep the detached signature over the completed manifest for updaters through `v0.1.1`
- pin canonicalization and one-fetch behavior in updater, bootstrap, and release-tool tests

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets`
- `scripts/test-installer.sh`
- `scripts/test-release-tools.sh`
- `scripts/test-secret-tools.sh`
- CI shellcheck command

`scripts/test-homebrew-formula.sh` requires Homebrew, which is unavailable in the local Linux environment; the PR macOS job runs it.