### PR TITLE
Release syq 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel copy with an rsync-shaped interface"


### PR DESCRIPTION
## Summary

- bump the syq package and lockfile version from 0.1.1 to 0.1.2
- prepare the first release with the embedded RFC 8785 manifest signature
- retain the detached signature so the existing 0.1.1 installation can update

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets`
- `scripts/test-installer.sh`
- `scripts/test-release-tools.sh`
- `scripts/test-secret-tools.sh`
- CI shellcheck command

The macOS CI job covers the Homebrew formula test.