### PR TITLE
Stop publishing detached manifest signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,8 +141,7 @@ jobs:
           SYQ_RELEASE_SIGNING_KEY_PEM_B64: ${{ secrets.SYQ_RELEASE_SIGNING_KEY_PEM_B64 }}
         run: |
           scripts/sign-release-manifest.sh \
-            dist/syq-release-manifest.json dist/syq-release-manifest.json.sig \
-            dist/syq-linux-x86_64
+            dist/syq-release-manifest.json dist/syq-linux-x86_64
       - name: Verify final release inventory
         shell: bash
         run: |
@@ -151,7 +150,7 @@ jobs:
           for asset in syq-linux-x86_64 syq-linux-aarch64 syq-macos-arm64 syq-macos-x86_64; do
             printf '%s\n' "$asset" "$asset.sha256" "$asset.gz" "$asset.gz.sha256"
           done > "$expected"
-          printf '%s\n' install.sh syq-release-manifest.json syq-release-manifest.json.sig syq.rb >> "$expected"
+          printf '%s\n' install.sh syq-release-manifest.json syq.rb >> "$expected"
           sort -o "$expected" "$expected"
           find dist -mindepth 1 -maxdepth 1 -printf '%f\n' | sort > "$RUNNER_TEMP/actual-assets"
           diff -u "$expected" "$RUNNER_TEMP/actual-assets"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -135,10 +135,9 @@ connection, so enable it only for a trusted release host rather than globally.
    directly targets the workflow commit, and that this commit is reachable
    from protected `master`. It then builds static GNU Linux x86-64/ARM64
    binaries and native macOS Apple Silicon/Intel binaries, embeds an Ed25519
-   signature over the manifest's RFC 8785 canonical JSON, retains a detached
-   signature for updaters through 0.1.1, verifies the exact asset inventory,
-   creates provenance attestations, uploads a draft, checks every uploaded
-   byte, publishes it, and finally updates the tap.
+   signature over the manifest's RFC 8785 canonical JSON, verifies the exact
+   asset inventory, creates provenance attestations, uploads a draft, checks
+   every uploaded byte, publishes it, and finally updates the tap.
 4. Verify one or more downloaded artifacts and exercise both install paths:
 
    ```sh

--- a/scripts/sign-release-manifest.sh
+++ b/scripts/sign-release-manifest.sh
@@ -3,13 +3,12 @@
 # matches the public key embedded in official binaries.
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-  echo "usage: $0 MANIFEST SIGNATURE_OUTPUT SYQ_BINARY" >&2
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 MANIFEST SYQ_BINARY" >&2
   exit 2
 fi
 manifest=$1
-output=$2
-canonicalizer=$3
+canonicalizer=$2
 if [ ! -f "$manifest" ] || [ -L "$manifest" ]; then
   echo "missing regular release manifest: $manifest" >&2
   exit 1
@@ -47,8 +46,6 @@ payload="$work/manifest.jcs"
 verified_payload="$work/verified-manifest.jcs"
 embedded_signature="$work/embedded.sig"
 signed_manifest="$work/signed-manifest.json"
-detached_signature="$work/detached.sig"
-encoded="$work/manifest.sig.b64"
 configured_public="$work/configured-public-key"
 
 printf '%s' "$SYQ_RELEASE_SIGNING_KEY_PEM_B64" | openssl base64 -d -A > "$key"
@@ -79,13 +76,5 @@ cmp -s "$payload" "$verified_payload" || {
 openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
   -in "$verified_payload" -sigfile "$embedded_signature" >/dev/null
 
-# Updaters through 0.1.1 verify this detached signature over the completed
-# manifest. New updaters verify the embedded JCS signature with one download.
-openssl pkeyutl -sign -rawin -inkey "$key" -in "$signed_manifest" -out "$detached_signature"
-openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
-  -in "$signed_manifest" -sigfile "$detached_signature" >/dev/null
-openssl base64 -A -in "$detached_signature" -out "$encoded"
-printf '\n' >> "$encoded"
-chmod 644 "$signed_manifest" "$encoded"
+chmod 644 "$signed_manifest"
 mv -f "$signed_manifest" "$manifest"
-mv -f "$encoded" "$output"

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -87,7 +87,7 @@ expect_failure 'does not match Cargo.toml version' \
 
 # Run the same signing operation used by the release workflow, verify the
 # result independently, and prove that a mismatched configured public key is
-# rejected without creating an output.
+# rejected without modifying the manifest.
 key="$work/signing.pem"
 public="$work/public.pem"
 openssl genpkey -algorithm ED25519 -out "$key" >/dev/null 2>&1
@@ -96,29 +96,26 @@ key_b64=$(openssl base64 -A -in "$key")
 public_b64=$(openssl pkey -in "$key" -pubout -outform DER | tail -c 32 | openssl base64 -A)
 SYQ_RELEASE_SIGNING_KEY_PEM_B64="$key_b64" SYQ_RELEASE_PUBLIC_KEY="$public_b64" \
   "$script_dir/sign-release-manifest.sh" \
-  "$first/syq-release-manifest.json" "$first/syq-release-manifest.json.sig" \
-  "$canonicalizer"
+  "$first/syq-release-manifest.json" "$canonicalizer"
+test "$(find "$first" -mindepth 1 -maxdepth 1 -type f | wc -l)" -eq 19
 embedded_b64=$(jq -er '.signature' "$first/syq-release-manifest.json")
 printf '%s' "$embedded_b64" | openssl base64 -d -A > "$work/embedded-signature.raw"
 "$canonicalizer" --release-manifest-signing-payload \
   "$first/syq-release-manifest.json" > "$work/manifest.jcs"
 openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
   -in "$work/manifest.jcs" -sigfile "$work/embedded-signature.raw" >/dev/null
-openssl base64 -d -A -in "$first/syq-release-manifest.json.sig" \
-  -out "$work/signature.raw"
-openssl pkeyutl -verify -rawin -pubin -inkey "$public" \
-  -in "$first/syq-release-manifest.json" -sigfile "$work/signature.raw" >/dev/null
 
 other_key="$work/other.pem"
 openssl genpkey -algorithm ED25519 -out "$other_key" >/dev/null 2>&1
 other_public_b64=$(openssl pkey -in "$other_key" -pubout -outform DER | \
   tail -c 32 | openssl base64 -A)
-mismatch_output="$work/mismatched.sig"
+second_sha=$(sha256sum "$second/syq-release-manifest.json" | awk '{print $1}')
 expect_failure 'does not match SYQ_RELEASE_PUBLIC_KEY' env \
   SYQ_RELEASE_SIGNING_KEY_PEM_B64="$key_b64" SYQ_RELEASE_PUBLIC_KEY="$other_public_b64" \
   "$script_dir/sign-release-manifest.sh" \
-  "$second/syq-release-manifest.json" "$mismatch_output" "$canonicalizer"
-test ! -e "$mismatch_output"
+  "$second/syq-release-manifest.json" "$canonicalizer"
+test "$(sha256sum "$second/syq-release-manifest.json" | awk '{print $1}')" = "$second_sha"
+jq -e 'has("signature") | not' "$second/syq-release-manifest.json" >/dev/null
 
 # Verify the workflow's GitHub tag checks against controlled API responses.
 fakebin="$work/fakebin"


### PR DESCRIPTION
Summary:
- stop generating, inventorying, attesting, and uploading the detached manifest signature
- retain the single-file embedded Ed25519/JCS signature path used by syq 0.1.2
- update release documentation and release-tool coverage for the 19-file inventory

Verification:
- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets
- scripts/test-release-tools.sh
- scripts/test-installer.sh
- scripts/test-secret-tools.sh
- full CI shellcheck command

The Homebrew formula test requires brew and is covered by the required macOS CI job.