### PR TITLE
Remove automatic self-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,17 @@ same build there and pass `--syq-path /path/to/syq` (or put it on the remote
 `PATH` and use `--no-bootstrap`).
 
 Standalone installs download and verify one signed release manifest at most
-once a day after a successful interactive command. They only print an update
-notice by default: `syq --self-update` performs the update, and
-`syq --enable-auto-update` opts in to installing a signed update after a
-successful interactive command. Use `syq --disable-auto-update` to opt out
-again. The install receipt lives at
+once a day after a successful interactive command. When a newer release is
+available they print a reminder; updates are never installed as a side effect
+of a copy. Run `syq --self-update` to install the update, or set
+`SYQ_NO_UPDATE_CHECK=1` to disable automatic checks and reminders. Explicit
+`syq --self-update` checks still work when that variable is set. The install
+receipt lives at
 `$XDG_CONFIG_HOME/syq/install.json` (normally `~/.config/syq/install.json`) and
 must name the running executable, so a Homebrew or source build never replaces
-itself. Update Homebrew installs with `brew upgrade syq`.
+itself. Self-update is deliberately limited to standalone installs because a
+package manager must remain the owner of its files. Update Homebrew installs
+with `brew upgrade syq`.
 
 Release binaries are published for Linux x86-64/ARM64 and macOS Apple
 Silicon/Intel. Terminal downloads and Homebrew normally do not attach macOS's
@@ -132,7 +135,6 @@ syq -a --checkpoint ./copy.state src host:dst # retain completed-file state if t
 | Option | Meaning |
 |---|---|
 | `--self-update` | Install the newest signed release (standalone installer builds only) |
-| `--enable-auto-update` / `--disable-auto-update` | Opt in/out of signed updates after successful interactive commands |
 | `-a`, `--archive` | Same as `-rlptgoD` |
 | `-r` `-l` `-p` `-t` `-g` `-o` `-D` | Recursive; symlinks as symlinks; perms; mtimes; group; owner; devices and specials |
 | `-v` | List files as they complete (also new dirs, symlinks) |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use clap::Parser;
     version,
     about = "Parallel copy with an rsync-shaped interface",
     disable_help_flag = true,
-    override_usage = "syq [OPTIONS] SRC... DEST\n       syq [OPTIONS] [USER@]HOST:SRC... DEST\n       syq [OPTIONS] SRC... [USER@]HOST:DEST\n       syq --self-update\n       syq --enable-auto-update | --disable-auto-update"
+    override_usage = "syq [OPTIONS] SRC... DEST\n       syq [OPTIONS] [USER@]HOST:SRC... DEST\n       syq [OPTIONS] SRC... [USER@]HOST:DEST\n       syq --self-update"
 )]
 pub struct Args {
     /// Print help
@@ -17,12 +17,6 @@ pub struct Args {
     /// Install the newest signed release (standalone installer builds only)
     #[arg(long, exclusive = true)]
     pub self_update: bool,
-    /// Opt in to installing signed updates after successful interactive commands
-    #[arg(long, exclusive = true)]
-    pub enable_auto_update: bool,
-    /// Turn automatic updates off; update notices remain enabled
-    #[arg(long, exclusive = true)]
-    pub disable_auto_update: bool,
     /// Record an installation made by the official standalone installer
     #[arg(long, hide = true, exclusive = true)]
     pub register_standalone_install: bool,
@@ -194,12 +188,7 @@ pub struct Args {
 
     /// Source(s) and destination (or, with --rm, the paths to remove)
     #[arg(
-        required_unless_present_any = [
-            "self_update",
-            "enable_auto_update",
-            "disable_auto_update",
-            "register_standalone_install"
-        ],
+        required_unless_present_any = ["self_update", "register_standalone_install"],
         num_args = 1..,
         value_name = "PATH"
     )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,13 +95,6 @@ fn main() {
         }
         return;
     }
-    if args.enable_auto_update || args.disable_auto_update {
-        if let Err(e) = update::set_auto_update(args.enable_auto_update) {
-            eprintln!("syq: {e:#}");
-            std::process::exit(1);
-        }
-        return;
-    }
     if args.register_standalone_install {
         if let Err(e) = update::register_standalone_install() {
             eprintln!("syq: {e:#}");

--- a/src/update.rs
+++ b/src/update.rs
@@ -38,8 +38,6 @@ struct InstallReceipt {
     version: String,
     target: String,
     binary: PathBuf,
-    #[serde(default)]
-    auto_update: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -88,7 +86,7 @@ enum FetchMode {
 /// installer. A package-manager binary cannot accidentally overwrite itself.
 pub fn self_update() -> Result<()> {
     let (_, mut receipt) = managed_receipt().context(
-        "self-update is only available for installs made by the standalone installer; use your package manager or reinstall with the curl installer",
+        "self-update is only available for installs made by the standalone installer; Homebrew installs should use `brew upgrade syq`, and source builds should be rebuilt or replaced with a standalone install",
     )?;
     let release = fetch_latest(FetchMode::Interactive)?;
     match release.version.cmp(&current_version()?) {
@@ -108,21 +106,6 @@ pub fn self_update() -> Result<()> {
     Ok(())
 }
 
-/// Change the opt-in automatic update setting in the standalone receipt.
-pub fn set_auto_update(enabled: bool) -> Result<()> {
-    let (path, mut receipt) = managed_receipt().context(
-        "automatic updates are only available for installs made by the standalone installer; package-manager installs should be updated by their package manager",
-    )?;
-    receipt.auto_update = enabled;
-    write_receipt(&path, &receipt)?;
-    if enabled {
-        println!("automatic signed updates enabled");
-    } else {
-        println!("automatic updates disabled; interactive update notices remain enabled");
-    }
-    Ok(())
-}
-
 /// Called by the generated installer after the verified binary has reached its
 /// final path. Keeping receipt creation inside syq avoids shell JSON escaping.
 pub fn register_standalone_install() -> Result<()> {
@@ -136,30 +119,29 @@ pub fn register_standalone_install() -> Result<()> {
     })?;
     let binary = canonical_current_exe()?;
     let path = receipt_path()?;
-    let auto_update = read_receipt(&path)
-        .ok()
-        .filter(|old| canonical_or_original(&old.binary) == binary)
-        .is_some_and(|old| old.auto_update);
     let receipt = InstallReceipt {
         schema: RECEIPT_SCHEMA,
         provider: "standalone".into(),
         version: env!("CARGO_PKG_VERSION").into(),
         target: target.key.into(),
         binary,
-        auto_update,
     };
     write_receipt(&path, &receipt)
 }
 
-/// Check at most once per day after a successful interactive command. Errors
-/// never change the command's exit status. Automatic replacement is opt-in.
+/// Check at most once per day after a successful interactive command and print
+/// an update notice when needed. Errors never change the command's exit status.
 pub fn after_success(quiet: bool) {
-    if quiet || !std::io::stderr().is_terminal() {
+    if !should_check_for_updates(
+        quiet,
+        std::io::stderr().is_terminal(),
+        std::env::var_os("SYQ_NO_UPDATE_CHECK").is_some(),
+    ) {
         return;
     }
-    let Ok((_, mut receipt)) = managed_receipt() else {
+    if managed_receipt().is_err() {
         return;
-    };
+    }
     let Ok(stamp) = check_stamp_path() else {
         return;
     };
@@ -170,19 +152,9 @@ pub fn after_success(quiet: bool) {
     if touch_check_stamp(&stamp).is_err() {
         return;
     }
-    let mode = if receipt.auto_update {
-        FetchMode::Interactive
-    } else {
-        FetchMode::BackgroundCheck
-    };
-    let release = match fetch_latest(mode) {
+    let release = match fetch_latest(FetchMode::BackgroundCheck) {
         Ok(release) => release,
-        Err(e) => {
-            if receipt.auto_update {
-                eprintln!("syq: automatic update check failed: {e:#}");
-            }
-            return;
-        }
+        Err(_) => return,
     };
     let Ok(current) = current_version() else {
         return;
@@ -190,23 +162,14 @@ pub fn after_success(quiet: bool) {
     if release.version <= current {
         return;
     }
-    if receipt.auto_update {
-        match install_release(&release, &mut receipt) {
-            Ok(()) => eprintln!(
-                "syq: installed signed update {} (used on the next command)",
-                release.version
-            ),
-            Err(e) => eprintln!(
-                "syq: automatic update to {} failed: {e:#}; run `syq --self-update` to retry",
-                release.version
-            ),
-        }
-    } else {
-        eprintln!(
-            "syq: update {} is available; run `syq --self-update`",
-            release.version
-        );
-    }
+    eprintln!(
+        "syq: update {} is available; run `syq --self-update`",
+        release.version
+    );
+}
+
+fn should_check_for_updates(quiet: bool, stderr_is_terminal: bool, disabled: bool) -> bool {
+    !quiet && stderr_is_terminal && !disabled
 }
 
 /// Return the archive hash for this exact release after verifying its signed
@@ -850,5 +813,13 @@ mod tests {
         let mut value = manifest();
         value.installer.size = MAX_SAFE_JSON_INTEGER + 1;
         assert!(validate_manifest(&value).is_err());
+    }
+
+    #[test]
+    fn update_checks_require_an_unsuppressed_interactive_command() {
+        assert!(should_check_for_updates(false, true, false));
+        assert!(!should_check_for_updates(true, true, false));
+        assert!(!should_check_for_updates(false, false, false));
+        assert!(!should_check_for_updates(false, true, true));
     }
 }

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -324,19 +324,32 @@ fn receipt_is_bound_to_the_exact_installed_executable() {
 
 #[cfg(target_os = "linux")]
 #[test]
-fn auto_update_setting_is_explicit_and_survives_reregistration() {
+fn legacy_auto_update_setting_is_discarded_on_reregistration() {
     let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
     fixture.register();
-    assert_eq!(fixture.receipt()["auto_update"], false);
+    let path = fixture.config.join("syq/install.json");
+    let mut receipt = fixture.receipt();
+    receipt["auto_update"] = true.into();
+    fs::write(&path, serde_json::to_vec_pretty(&receipt).unwrap()).unwrap();
 
-    assert_success(&fixture.command("--enable-auto-update"));
-    assert_eq!(fixture.receipt()["auto_update"], true);
     fixture.register();
-    assert_eq!(fixture.receipt()["auto_update"], true);
-
-    assert_success(&fixture.command("--disable-auto-update"));
-    assert_eq!(fixture.receipt()["auto_update"], false);
+    assert!(fixture.receipt().get("auto_update").is_none());
     assert_eq!(fs::read(&fixture.installed).unwrap(), fixture.original);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn automatic_update_flags_are_no_longer_supported() {
+    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
+
+    assert_failure_contains(
+        &fixture.command("--enable-auto-update"),
+        "unexpected argument '--enable-auto-update'",
+    );
+    assert_failure_contains(
+        &fixture.command("--disable-auto-update"),
+        "unexpected argument '--disable-auto-update'",
+    );
 }
 
 #[cfg(target_os = "linux")]
@@ -346,6 +359,7 @@ fn source_install_cannot_create_or_use_a_standalone_receipt_implicitly() {
 
     let update = fixture.command("--self-update");
     assert_failure_contains(&update, "self-update is only available");
+    assert!(String::from_utf8_lossy(&update.stderr).contains("`brew upgrade syq`"));
     assert!(!fixture.config.join("syq/install.json").exists());
     assert_eq!(fs::read(&fixture.installed).unwrap(), fixture.original);
 }


### PR DESCRIPTION
## Summary

- remove the automatic self-update setting and its CLI flags
- retain at-most-daily interactive update reminders and add `SYQ_NO_UPDATE_CHECK=1` to suppress them
- keep legacy install receipts readable while dropping their obsolete `auto_update` field on registration
- direct Homebrew users to `brew upgrade syq` because Homebrew owns formula-installed files

## Rationale

A normal copy command should not replace the executable as a side effect. Signed, explicit `syq --self-update` remains available for standalone installs, while package-manager installations continue to be updated by their package manager.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (118 tests)
- `scripts/test-installer.sh`
- `scripts/test-release-tools.sh`

The native Homebrew formula check was not run locally because the development host is Linux without Homebrew.