### PR TITLE
Clarify authorization for merging other PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,15 @@ outlive its premise and steer later work in the wrong direction.
   `master` go through a pull request; do not commit them directly on `master` or
   merge task branches from the coordination checkout. Do not merge a pull
   request unless the user explicitly asks.
+- When the conversation is unambiguously about completing the pull request for
+  the agent's own task branch, a bare instruction such as "merge" counts as an
+  explicit request to merge that pull request into its configured base branch.
+- Merging any other branch or pull request into `master`, including a dependency
+  or the base of a stacked pull request, requires an explicit instruction that
+  names both the branch or pull request and `master` as the destination. For
+  example, while working on pull request #16, "merge pull request #7" does not
+  authorize merging pull request #7 into `master`; ask when the intended
+  destination is unclear.
 - Before rebasing, resetting, or otherwise synchronizing a task branch with
   advancing `master`, require its worktree to be clean, including staged and
   untracked changes. Prefer a checkpoint commit on the task branch. Never use


### PR DESCRIPTION
## Summary

- allow a contextual bare “merge” for the agent’s own task PR
- require an explicit PR or branch and `master` destination before landing any other branch
- call out stacked-PR dependencies as requiring separate authorization

## Verification

- `git diff --check`
- Code tests not run (documentation-only change)