### PR TITLE
Enforce Cargo dependency policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,22 @@ jobs:
         with:
           persist-credentials: false
       - run: rustup component add rustfmt clippy
+      - name: Check dependency policy
+        env:
+          CARGO_DENY_VERSION: 0.20.2
+          CARGO_DENY_SHA256: 9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5f
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/cargo-deny.tar.gz"
+          directory="cargo-deny-$CARGO_DENY_VERSION-x86_64-unknown-linux-musl"
+          curl --fail --silent --show-error --location --proto '=https' \
+            --proto-redir '=https' --output "$archive" \
+            "https://github.com/EmbarkStudios/cargo-deny/releases/download/$CARGO_DENY_VERSION/$directory.tar.gz"
+          printf '%s  %s\n' "$CARGO_DENY_SHA256" "$archive" | sha256sum --check -
+          tar -xzf "$archive" -C "$RUNNER_TEMP"
+          test "$("$RUNNER_TEMP/$directory/cargo-deny" --version)" = \
+            "cargo-deny $CARGO_DENY_VERSION"
+          "$RUNNER_TEMP/$directory/cargo-deny" check
       - run: cargo fmt --all -- --check
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
       - run: cargo test --locked --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           tar -xzf "$archive" -C "$RUNNER_TEMP"
           test "$("$RUNNER_TEMP/$directory/cargo-deny" --version)" = \
             "cargo-deny $CARGO_DENY_VERSION"
-          "$RUNNER_TEMP/$directory/cargo-deny" check
+          "$RUNNER_TEMP/$directory/cargo-deny" --locked check
       - run: cargo fmt --all -- --check
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
       - run: cargo test --locked --all-targets

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,36 @@
+[graph]
+all-features = true
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]
+
+[advisories]
+unmaintained = "workspace"
+yanked = "warn"
+
+[licenses]
+confidence-threshold = 0.93
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "MIT",
+  "Unicode-3.0",
+  "Zlib",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+skip = [
+  { crate = "syn@2.0.119", reason = "curve25519-dalek-derive has not moved to syn 3" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

- check all four supported target dependency graphs for RustSec advisories
- allow only the licenses currently needed to distribute syq under MIT
- reject unknown registries, Git sources, and wildcard dependency requirements
- report duplicate crate versions while documenting the current `syn` 2/3 proc-macro exception
- run exact-version, SHA-256-pinned `cargo-deny` 0.20.2 with `--locked` inside the already-required Linux CI job

The workflow verifies cargo-deny’s official static release artifact before executing it. This preserves the repository setting that permits only GitHub-owned Actions without adding two minutes of source compilation to every CI run. `--locked` ensures the policy check cannot refresh and thereby mask a stale committed `Cargo.lock`.

## Verification

- `cargo deny --locked check`
- exercised the exact download, SHA-256 verification, version check, and policy command used by CI
- reproduced a stale lockfile in a disposable crate and verified that cargo-deny rejects it under `--locked`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets` (51 unit, 172 local, 9 updater)
- `cargo publish --locked --allow-dirty --dry-run`
- parsed all repository YAML with PyYAML
- `git diff --check`