### PR TITLE
Post-merge errata: -u type-change note, clean_root table test

### DIFF
--- a/RSYNC-COMPAT.md
+++ b/RSYNC-COMPAT.md
@@ -119,7 +119,11 @@ item.
    `delete_is_skipped_when_the_source_scan_has_errors`.*
 3. **`-u` applies to regular files only.** rsync also compares mtimes for
    symlinks and devices (believed, not measured). Low impact; could be
-   aligned.
+   aligned. Deliberately, a *type change* replaces regardless of mtimes —
+   a source directory still replaces a newer destination file (as in
+   rsync): `-u` is about not regressing newer file content, not about
+   protecting whatever exists; that stronger promise is
+   `--ignore-existing`'s (see "Incompatible on purpose" 5).
 4. **`--files-from` cannot combine with `--ignore`/`--ignore-from` or
    `--delete`, and direct remote→remote needs `--relay`** (the list is read
    on the invoking machine). rsync allows all three. Restrictions rather than

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -3514,3 +3514,33 @@ impl Worker {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_root_pins_the_edge_cases() {
+        for (given, want) in [
+            ("/", "/"),
+            ("//", "/"),
+            ("/.", "/"),
+            (".", "."),
+            ("./", "."),
+            ("././//", "."),
+            ("dst", "dst"),
+            ("dst/", "dst"),
+            ("dst/.", "dst"),
+            ("dst//x", "dst/x"),
+            ("./dst/./x/", "dst/x"),
+            ("~/x//y/.", "~/x/y"),
+            ("/a//b/./c", "/a/b/c"),
+        ] {
+            assert_eq!(
+                clean_root(given.as_bytes()),
+                want.as_bytes(),
+                "clean_root({given:?})"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Two errata from the final PR #16 review round, both non-behavioral:

- RSYNC-COMPAT.md states explicitly that `-u` does not stop a source directory from replacing a newer destination file (as in rsync; the stronger protection is `--ignore-existing`'s), so it reads as decided rather than missed.
- `clean_root` gets a direct table test for its edge cases (`/`, `//`, `.`, `~/x//y/.`, …) instead of only indirect coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)