### PR TITLE
Add typed dry-run preflight summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,18 +283,20 @@ Identical to rsync:
   A colon before the first slash means remote; `./x:y` is local. All sources
   must be on the same host. `host::module` (daemon syntax) is not supported.
 
-### Previewing the concrete copy plan
+### Previewing a copy
 
 `-n` / `--dry-run` connects to the endpoints and scans both sides, but creates,
-updates, and deletes nothing. Its plan makes path placement and the selected
-data route explicit before a real copy:
+updates, and deletes nothing. Its concise preflight summary makes path
+placement, intended changes, logical work, and the selected data route explicit
+before a real copy:
 
 ```text
-syq: dry-run plan
+syq: dry-run summary
   mapping: ./dataset/ -> gpu01:/scratch/run42 (directory contents)
-  plan: 82,411 files, 1.70 TiB to transfer; 18,204 files, 340 GiB unchanged
-  exclusions: 3 paths/subtrees pruned by ignore rules; 12 other entries
+  changes: 82,411 regular files; 96 directories; 14 symlinks; 3 metadata-only entries; 2 type replacements among them
   deletions: 7 entries planned after a successful copy
+  logical data: 1.70 TiB in 82,411 files needing content work (upper bound); 340 GiB in 18,204 files with unchanged content
+  exclusions: 3 paths/subtrees pruned by ignore rules; 12 other entries
   route: encrypted TCP to gpu01; 16 initial connections (auto-tuned)
 ```
 
@@ -302,17 +304,27 @@ Each source gets its own `mapping` line. The annotation distinguishes directory
 contents, a directory copied as a child, a file placed inside a directory, and
 an exact destination path. `--files-from` is identified as a selected-path
 mapping. A destination-root symlink is shown as the effective directory it
-resolves to.
+resolves to. The `changes` line separately accounts for regular files,
+directories, symlinks, special files, and metadata-only updates; type
+replacements are called out as an overlapping subset. This is a current
+preflight assessment, not a frozen mutation ledger that can later be executed
+unchanged.
 
-The transfer byte total is an estimate based on the files that fail the
-planning-time metadata check, using their full logical sizes. Block reuse from
-an existing partial or a content comparison can make the real wire-byte count
-smaller. An ignored directory is pruned without scanning its descendants, so
-the exclusions line counts that directory as one `path/subtree`; it does not
+The logical-data upper bound is the full size of regular files that fail the
+planning-time metadata check. Resume state, block reuse, reflinks, compression,
+server-side copying, or a content comparison can make the real I/O or wire-byte
+count smaller. An ignored directory is pruned without scanning its descendants,
+so the exclusions line counts that directory as one `path/subtree`; it does not
 invent a descendant count. Other exclusions cover state and size options and
 unsupported entry types. With `--delete`, the destination is walked and the
 exact deletion count is shown; scan errors and `--max-delete` guards are shown
 as skipped or blocked rather than as a misleading zero.
+
+Add `-v` for a typed explanation of each intended change, for example `create
+file PATH (destination missing)`, `replace with symlink PATH -> TARGET
+(destination is regular file)`, `update metadata PATH (requested file metadata
+differs)`, or `delete PATH (destination only)`. The default stays compact for
+large trees.
 
 ### What `-a` does here
 
@@ -683,7 +695,7 @@ it is transferred or even scanned — which is why "only `*.jpg`" needs the
 `!*/` line to keep descending. Empty directories are copied like any other
 (this is a filter on the walk, not git's notion of what's tracked). The source
 root itself is never ignored; with several sources each is filtered from its
-own root. `-n` previews exactly what a real run would send. `--rm` does not
+own root. `-n` previews the selected scope and intended changes. `--rm` does not
 take filters (it always removes the whole tree), so `-i` conflicts with it.
 
 As in git, a `!` rule cannot re-include something whose parent directory is
@@ -740,8 +752,9 @@ have is removed. The rules are simpler than rsync's, deliberately:
   removed by `--delete`, inert otherwise.
 - `--max-delete N` refuses to delete anything — not the first N — when more
   than N deletions are planned, says so, and exits 25 (rsync's code for it).
-- `-n --delete -v` lists every `deleting path` line a real run would print.
-  The summary reports `N deleted` / `N would be deleted`. `--delete`
+- `-n --delete -v` lists every intended removal as `delete path (destination
+  only)`. The preflight summary reports the number planned; a real run reports
+  the number deleted. `--delete`
   conflicts with `--verify-only` (deleting is the opposite of writing
   nothing) and with `--files-from` (deletion scope under a file list is
   ambiguous).

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ Identical to rsync:
   created if missing.
 - An existing non-directory `dest` cannot be the parent of that `dest/src`
   mapping; dry-run rejects it instead of presenting an impossible summary.
+  With `--existing`, both dry-run and the real command skip the whole mapping
+  as a no-op because creating `dest/src` is outside the selected scope.
 - `syq -a src/ dest` copies the *contents* of `src` into `dest`. `src/.` and
   `.` behave the same way.
 - A single file source goes to `dest/file` if `dest` is an existing directory,

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ Identical to rsync:
 
 - `syq -a src dest` copies the directory itself → `dest/src`. `dest` is
   created if missing.
+- An existing non-directory `dest` cannot be the parent of that `dest/src`
+  mapping; dry-run rejects it instead of presenting an impossible summary.
 - `syq -a src/ dest` copies the *contents* of `src` into `dest`. `src/.` and
   `.` behave the same way.
 - A single file source goes to `dest/file` if `dest` is an existing directory,
@@ -308,7 +310,9 @@ resolves to. The `changes` line separately accounts for regular files,
 directories, symlinks, special files, and metadata-only updates; type
 replacements are called out as an overlapping subset. This is a current
 preflight assessment, not a frozen mutation ledger that can later be executed
-unchanged.
+unchanged. When a destination leaf will be replaced by a directory, descendants
+are assessed against that post-replacement directory rather than through the
+old leaf (including an old symlink).
 
 The logical-data upper bound is the full size of regular files that fail the
 planning-time metadata check. Resume state, block reuse, reflinks, compression,

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `-v`, `-vv` | `-v` lists files as they complete; for copies, `-vv` also explains remote helpers, candidate TCP addresses, the planned transport, and initial concurrency |
 | `-q` | Errors only |
 | `-z`, `--compress` / `--no-compress` | Enable (the default) or disable zstd compression in syq's protocol; this is not `ssh -C` |
-| `-n`, `--dry-run` | Scan and report; change nothing |
+| `-n`, `--dry-run` | Resolve mappings and transport, estimate transfers/exclusions/deletions; change nothing |
 | `-j N`, `--connections N` | Parallel data connections (default: auto-tuned, see below) |
 | `--bwlimit RATE` | Limit aggregate file-data throughput (bare rate is KiB/s; `0` disables) |
 | `--block-size SIZE` | Transfer and hash block size (default 4M) |
@@ -282,6 +282,37 @@ Identical to rsync:
 - `host:path` is relative to the remote home; `host:/abs` and `host:~/x` work.
   A colon before the first slash means remote; `./x:y` is local. All sources
   must be on the same host. `host::module` (daemon syntax) is not supported.
+
+### Previewing the concrete copy plan
+
+`-n` / `--dry-run` connects to the endpoints and scans both sides, but creates,
+updates, and deletes nothing. Its plan makes path placement and the selected
+data route explicit before a real copy:
+
+```text
+syq: dry-run plan
+  mapping: ./dataset/ -> gpu01:/scratch/run42 (directory contents)
+  plan: 82,411 files, 1.70 TiB to transfer; 18,204 files, 340 GiB unchanged
+  exclusions: 3 paths/subtrees pruned by ignore rules; 12 other entries
+  deletions: 7 entries planned after a successful copy
+  route: encrypted TCP to gpu01; 16 initial connections (auto-tuned)
+```
+
+Each source gets its own `mapping` line. The annotation distinguishes directory
+contents, a directory copied as a child, a file placed inside a directory, and
+an exact destination path. `--files-from` is identified as a selected-path
+mapping. A destination-root symlink is shown as the effective directory it
+resolves to.
+
+The transfer byte total is an estimate based on the files that fail the
+planning-time metadata check, using their full logical sizes. Block reuse from
+an existing partial or a content comparison can make the real wire-byte count
+smaller. An ignored directory is pruned without scanning its descendants, so
+the exclusions line counts that directory as one `path/subtree`; it does not
+invent a descendant count. Other exclusions cover state and size options and
+unsupported entry types. With `--delete`, the destination is walked and the
+exact deletion count is shown; scan errors and `--max-delete` guards are shown
+as skipped or blocked rather than as a misleading zero.
 
 ### What `-a` does here
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -171,7 +171,7 @@ pub struct Args {
     /// Terminal width for the progress display (internal; used for remote-to-remote)
     #[arg(long, hide = true)]
     pub width: Option<usize>,
-    /// Original source endpoint for a remotely orchestrated dry-run plan
+    /// Original source endpoint for a remotely orchestrated dry-run summary
     #[arg(long, hide = true)]
     pub plan_source_host: Option<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,7 +63,8 @@ pub struct Args {
     /// Disable transport compression
     #[arg(long, overrides_with = "compress")]
     pub no_compress: bool,
-    /// Show what would be transferred without doing it
+    /// Resolve mappings and transport, then estimate transfers, exclusions, and deletions;
+    /// change nothing
     #[arg(short = 'n', long)]
     pub dry_run: bool,
     /// No-op accepted for rsync compatibility (sizes are always human-readable)
@@ -170,6 +171,9 @@ pub struct Args {
     /// Terminal width for the progress display (internal; used for remote-to-remote)
     #[arg(long, hide = true)]
     pub width: Option<usize>,
+    /// Original source endpoint for a remotely orchestrated dry-run plan
+    #[arg(long, hide = true)]
+    pub plan_source_host: Option<String>,
 
     /// Skip paths matching PATTERN (gitignore syntax: `foo` matches at any depth, `/foo` only
     /// at the source root, `foo/` only directories, `!pat` re-includes). Repeatable; together

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -139,6 +139,9 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     if args.progress_json && !args.quiet {
         remote.push("--progress-json".into());
     }
+    if args.dry_run {
+        remote.push(format!("--plan-source-host={src_target}"));
+    }
     // --ignore-from files were read locally; forward the merged lines.
     for l in &args.ignore_lines {
         // One argument, so a pattern starting with '-' can't be taken for a flag.

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -395,7 +395,10 @@ pub fn follow(args: &Args) -> Result<i32> {
                 eprint!("\r\x1b[K");
             }
             println!("{line}");
-            if line.starts_with("syq: transferred") || line.starts_with("syq: would transfer") {
+            if line.starts_with("syq: transferred")
+                || line.starts_with("syq: would transfer")
+                || line.starts_with("  route:")
+            {
                 let _ = child.kill();
                 return Ok(0);
             }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -28,6 +28,10 @@ pub struct Progress {
     /// Source files deliberately not transferred (-u, size limits, --existing,
     /// symlinks without -l, ...); neither "transferred" nor "unchanged".
     pub files_excluded: AtomicU64,
+    /// Source paths matched by ignore rules during a dry run. An ignored
+    /// directory is one path here even though its unscanned subtree may
+    /// contain many entries.
+    pub paths_ignored: AtomicU64,
     pub scanned: AtomicU64,
     pub scan_done: AtomicBool,
     pub errors: AtomicU64,
@@ -65,6 +69,7 @@ impl Progress {
             files_done: AtomicU64::new(0),
             files_skipped: AtomicU64::new(0),
             files_excluded: AtomicU64::new(0),
+            paths_ignored: AtomicU64::new(0),
             scanned: AtomicU64::new(0),
             scan_done: AtomicBool::new(false),
             errors: AtomicU64::new(0),

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -835,6 +835,8 @@ pub fn run(args: Args) -> Result<i32> {
         && !args.dry_run
         && !args.verify_only
         && !args.existing;
+    let dry_run_creates_root =
+        args.dry_run && dst_root_entry.is_none() && dst_is_dir && !args.existing;
     if create_root && srcs.len() == 1 {
         mkdir_root(&mut *dst_ctl, &dst_root)?;
     }
@@ -889,6 +891,13 @@ pub fn run(args: Args) -> Result<i32> {
         keep_dirs: args.files_from.is_some(),
         delete_roots: Vec::new(),
         deletes: Deletes::default(),
+        dry_run_changes: {
+            let mut changes = DryRunChanges::default();
+            if dry_run_creates_root {
+                changes.directories.insert(dst_root.clone());
+            }
+            changes
+        },
     };
 
     let mut scan_err = None;
@@ -1030,6 +1039,7 @@ pub fn run(args: Args) -> Result<i32> {
         st.apply_deferred()?;
     }
     let max_delete_hit = st.max_delete_hit;
+    let dry_run_changes = std::mem::take(&mut st.dry_run_changes);
     drop(st);
 
     progress.stop();
@@ -1062,7 +1072,13 @@ pub fn run(args: Args) -> Result<i32> {
     let done = progress.bytes_done.load(Relaxed);
     if !args.quiet && !aborted {
         if opts.dry_run {
-            print_dry_run_plan(
+            if args.verbose > 0 && dry_run_creates_root {
+                println!(
+                    "create directory {} (destination missing)",
+                    display_directory(&dst_root)
+                );
+            }
+            print_dry_run_summary(
                 srcs,
                 dst,
                 &dry_run_mappings,
@@ -1072,9 +1088,9 @@ pub fn run(args: Args) -> Result<i32> {
                 &opts,
                 &progress,
                 delete_plan,
+                &dry_run_changes,
             );
-        }
-        if opts.verify_only {
+        } else if opts.verify_only {
             println!(
                 "syq: verified {} files, {} differ/missing, {} in {}",
                 commas(progress.files_done.load(Relaxed) + errors),
@@ -1083,33 +1099,19 @@ pub fn run(args: Args) -> Result<i32> {
                 crate::progress::hms(elapsed)
             );
         } else {
-            let verb = if opts.dry_run {
-                "would transfer"
-            } else {
-                "transferred"
-            };
             println!(
-                "syq: {} {} files ({}), {} unchanged ({} files), {} dirs{}{}{}",
-                verb,
+                "syq: transferred {} files ({}), {} unchanged ({} files), {} dirs{}{}{}",
                 commas(progress.files_done.load(Relaxed)),
-                human(if opts.dry_run {
-                    progress.bytes_total.load(Relaxed)
-                } else {
-                    done
-                }),
+                human(done),
                 human(progress.bytes_skipped.load(Relaxed)),
                 commas(progress.files_skipped.load(Relaxed)),
                 commas(st_dirs(&progress)),
-                deletion_summary(delete_plan, deleted, opts.dry_run, opts.max_delete),
-                if opts.dry_run {
-                    String::new()
-                } else {
-                    format!(
-                        ", {} at {}/s",
-                        crate::progress::hms(elapsed),
-                        human((done as f64 / elapsed.max(0.001)) as u64)
-                    )
-                },
+                deletion_summary(delete_plan, deleted, opts.max_delete),
+                format_args!(
+                    ", {} at {}/s",
+                    crate::progress::hms(elapsed),
+                    human((done as f64 / elapsed.max(0.001)) as u64)
+                ),
                 if errors > 0 {
                     format!(", {errors} errors")
                 } else {
@@ -1118,13 +1120,36 @@ pub fn run(args: Args) -> Result<i32> {
             );
         }
         if args.stats {
+            let (
+                files_label,
+                unchanged_files_label,
+                bytes_label,
+                unchanged_bytes_label,
+                bytes_work,
+            ) = if opts.dry_run {
+                (
+                    "files needing content work",
+                    "files with unchanged content",
+                    "logical bytes needing content work",
+                    "logical bytes with unchanged content",
+                    progress.bytes_total.load(Relaxed),
+                )
+            } else {
+                (
+                    "files to transfer",
+                    "files unchanged",
+                    "bytes transferred",
+                    "bytes unchanged",
+                    done,
+                )
+            };
             println!(
-                "  scanned entries: {}\n  files to transfer: {}\n  files unchanged: {}\n  files excluded: {}\n  bytes transferred: {}\n  bytes unchanged: {}\n  elapsed: {:.2}s\n  connections: {}",
+                "  scanned entries: {}\n  {files_label}: {}\n  {unchanged_files_label}: {}\n  files excluded: {}\n  {bytes_label}: {}\n  {unchanged_bytes_label}: {}\n  elapsed: {:.2}s\n  connections: {}",
                 commas(progress.scanned.load(Relaxed)),
                 commas(progress.files_total.load(Relaxed)),
                 commas(progress.files_skipped.load(Relaxed)),
                 commas(progress.files_excluded.load(Relaxed)),
-                commas(done),
+                commas(bytes_work),
                 commas(progress.bytes_skipped.load(Relaxed)),
                 elapsed,
                 match &tuned {
@@ -1311,6 +1336,35 @@ fn display(p: &[u8]) -> String {
     String::from_utf8_lossy(p).into_owned()
 }
 
+fn display_directory(p: &[u8]) -> String {
+    let mut shown = display(p);
+    if !shown.ends_with('/') {
+        shown.push('/');
+    }
+    shown
+}
+
+fn kind_label(kind: Kind) -> &'static str {
+    match kind {
+        Kind::Dir => "directory",
+        Kind::File => "regular file",
+        Kind::Symlink => "symlink",
+        Kind::Fifo => "FIFO",
+        Kind::Socket => "socket",
+        Kind::CharDev => "character device",
+        Kind::BlockDev => "block device",
+        Kind::Other => "unsupported entry",
+    }
+}
+
+fn metadata_differs(source: &Entry, destination: &Entry, flags: u8) -> bool {
+    (flags & flags::MODE != 0 && source.mode & 0o7777 != destination.mode & 0o7777)
+        || (flags & flags::OWNER != 0 && source.uid != destination.uid)
+        || (flags & flags::GROUP != 0 && source.gid != destination.gid)
+        || (flags & flags::TIMES != 0
+            && (source.mtime, source.mtime_nsec) != (destination.mtime, destination.mtime_nsec))
+}
+
 fn display_location(loc: &Location, path: &[u8]) -> String {
     let path = display(path);
     let Some(host) = &loc.host else {
@@ -1402,6 +1456,54 @@ struct DryRunMapping {
     semantics: &'static str,
 }
 
+/// A typed summary of final-state mutations found during a dry run. Type
+/// replacements overlap the primary categories; all others are disjoint.
+#[derive(Default)]
+struct DryRunChanges {
+    regular_files: u64,
+    directories: std::collections::HashSet<PathBytes>,
+    symlinks: u64,
+    specials: u64,
+    metadata_files: u64,
+    metadata_directories: std::collections::HashSet<PathBytes>,
+    type_replacements: u64,
+}
+
+impl DryRunChanges {
+    fn summary(&self) -> String {
+        let mut categories = Vec::new();
+        for (n, singular, plural) in [
+            (self.regular_files, "regular file", "regular files"),
+            (self.directories.len() as u64, "directory", "directories"),
+            (self.symlinks, "symlink", "symlinks"),
+            (self.specials, "special file", "special files"),
+            (
+                self.metadata_files + self.metadata_directories.len() as u64,
+                "metadata-only entry",
+                "metadata-only entries",
+            ),
+        ] {
+            if n > 0 {
+                categories.push(count_label(n, singular, plural));
+            }
+        }
+        if categories.is_empty() {
+            return "none".to_string();
+        }
+        if self.type_replacements > 0 {
+            categories.push(format!(
+                "{} among them",
+                count_label(
+                    self.type_replacements,
+                    "type replacement",
+                    "type replacements"
+                )
+            ));
+        }
+        categories.join("; ")
+    }
+}
+
 #[derive(Clone, Copy)]
 enum DeletePlan {
     Disabled,
@@ -1413,7 +1515,7 @@ fn count_label(n: u64, singular: &str, plural: &str) -> String {
     format!("{} {}", commas(n), if n == 1 { singular } else { plural })
 }
 
-fn deletion_summary(plan: DeletePlan, deleted: u64, dry_run: bool, max: Option<u64>) -> String {
+fn deletion_summary(plan: DeletePlan, deleted: u64, max: Option<u64>) -> String {
     match plan {
         DeletePlan::Disabled => String::new(),
         DeletePlan::Planned(n) => {
@@ -1423,15 +1525,7 @@ fn deletion_summary(plan: DeletePlan, deleted: u64, dry_run: bool, max: Option<u
                     commas(n)
                 )
             } else {
-                format!(
-                    ", {} {}",
-                    commas(deleted),
-                    if dry_run {
-                        "would be deleted"
-                    } else {
-                        "deleted"
-                    }
-                )
+                format!(", {} deleted", commas(deleted))
             }
         }
         DeletePlan::Skipped(reason) => format!(", deletions skipped ({reason})"),
@@ -1439,7 +1533,7 @@ fn deletion_summary(plan: DeletePlan, deleted: u64, dry_run: bool, max: Option<u
 }
 
 #[allow(clippy::too_many_arguments)]
-fn print_dry_run_plan(
+fn print_dry_run_summary(
     srcs: &[Location],
     dst: &Location,
     mappings: &[DryRunMapping],
@@ -1449,8 +1543,9 @@ fn print_dry_run_plan(
     opts: &Opts,
     progress: &Progress,
     deletes: DeletePlan,
+    changes: &DryRunChanges,
 ) {
-    println!("syq: dry-run plan");
+    println!("syq: dry-run summary");
     for (source, mapping) in srcs.iter().zip(mappings) {
         println!(
             "  mapping: {} -> {} ({})",
@@ -1459,12 +1554,31 @@ fn print_dry_run_plan(
             mapping.semantics
         );
     }
+    println!("  changes: {}", changes.summary());
+
+    match deletes {
+        DeletePlan::Disabled => println!("  deletions: disabled"),
+        DeletePlan::Planned(n) => {
+            if let Some(limit) = opts.max_delete.filter(|limit| n > *limit) {
+                println!(
+                    "  deletions: {} planned; blocked by --max-delete {limit}",
+                    count_label(n, "entry", "entries")
+                );
+            } else {
+                println!(
+                    "  deletions: {} planned after a successful copy",
+                    count_label(n, "entry", "entries")
+                );
+            }
+        }
+        DeletePlan::Skipped(reason) => println!("  deletions: skipped ({reason})"),
+    }
     println!(
-        "  plan: {}, {} to transfer; {}, {} unchanged",
-        count_label(progress.files_total.load(Relaxed), "file", "files"),
+        "  logical data: {} in {} needing content work (upper bound); {} in {} with unchanged content",
         human(progress.bytes_total.load(Relaxed)),
-        count_label(progress.files_skipped.load(Relaxed), "file", "files"),
-        human(progress.bytes_skipped.load(Relaxed))
+        count_label(progress.files_total.load(Relaxed), "file", "files"),
+        human(progress.bytes_skipped.load(Relaxed)),
+        count_label(progress.files_skipped.load(Relaxed), "file", "files")
     );
 
     let ignored = progress.paths_ignored.load(Relaxed);
@@ -1492,23 +1606,6 @@ fn print_dry_run_plan(
         }
     );
 
-    match deletes {
-        DeletePlan::Disabled => println!("  deletions: disabled"),
-        DeletePlan::Planned(n) => {
-            if let Some(limit) = opts.max_delete.filter(|limit| n > *limit) {
-                println!(
-                    "  deletions: {} planned; blocked by --max-delete {limit}",
-                    count_label(n, "entry", "entries")
-                );
-            } else {
-                println!(
-                    "  deletions: {} planned after a successful copy",
-                    count_label(n, "entry", "entries")
-                );
-            }
-        }
-        DeletePlan::Skipped(reason) => println!("  deletions: skipped ({reason})"),
-    }
     println!("  route: {}", selected_route(src_ep, dst_ep, args));
 }
 
@@ -1578,6 +1675,7 @@ struct Planner<'a> {
     /// directory source; --delete removes extras inside these.
     delete_roots: Vec<(PathBytes, String)>,
     deletes: Deletes,
+    dry_run_changes: DryRunChanges,
 }
 
 /// What a source entry asserts about its destination path. Two dirs merge;
@@ -2130,13 +2228,8 @@ impl Planner<'_> {
         // Directories: one stat pass decides everything about each one, and
         // the same filtered list drives creation, listing and deferred
         // metadata so they can't disagree.
-        let need_stats = opts.verify_only || !opts.dry_run || opts.existing || opts.ignore_existing;
-        if !dirs.is_empty() && (need_stats || opts.verbose > 0) {
-            let stats: Vec<Option<Entry>> = if need_stats {
-                self.stat_many(dirs.iter().map(|(p, _, _)| p.clone()).collect())?
-            } else {
-                vec![None; dirs.len()]
-            };
+        if !dirs.is_empty() {
+            let stats = self.stat_many(dirs.iter().map(|(p, _, _)| p.clone()).collect())?;
             let mut planned: Vec<(PathBytes, PathBytes, Entry, Option<Entry>)> = Vec::new();
             for ((p, dst_rel, e), st) in dirs.into_iter().zip(stats) {
                 let is_dir = matches!(st, Some(ref d) if d.kind == Kind::Dir);
@@ -2177,9 +2270,43 @@ impl Planner<'_> {
                 planned.push((p, dst_rel, e, st));
             }
             if opts.dry_run {
-                if opts.verbose > 0 {
-                    for (p, _, _, _) in &planned {
-                        self.progress.println(&format!("{}/", display(p)));
+                let mut meta_flags = opts.flags;
+                if !opts.perms {
+                    meta_flags &= !flags::MODE;
+                }
+                for (p, _, e, destination) in &planned {
+                    match destination {
+                        None => {
+                            self.dry_run_changes.directories.insert(p.clone());
+                            if opts.verbose > 0 {
+                                self.progress.println(&format!(
+                                    "create directory {} (destination missing)",
+                                    display_directory(p)
+                                ));
+                            }
+                        }
+                        Some(d) if d.kind != Kind::Dir => {
+                            if self.dry_run_changes.directories.insert(p.clone()) {
+                                self.dry_run_changes.type_replacements += 1;
+                            }
+                            if opts.verbose > 0 {
+                                self.progress.println(&format!(
+                                    "replace with directory {} (destination is {})",
+                                    display_directory(p),
+                                    kind_label(d.kind)
+                                ));
+                            }
+                        }
+                        Some(d) if metadata_differs(e, d, meta_flags) => {
+                            self.dry_run_changes.metadata_directories.insert(p.clone());
+                            if opts.verbose > 0 {
+                                self.progress.println(&format!(
+                                    "update metadata {} (requested directory metadata differs)",
+                                    display_directory(p)
+                                ));
+                            }
+                        }
+                        Some(_) => {}
                     }
                 }
             } else if !opts.verify_only {
@@ -2376,6 +2503,18 @@ impl Planner<'_> {
                                 ff |= flags::GROUP;
                             }
                             if ff != 0 {
+                                self.progress.files_skipped.fetch_add(1, Relaxed);
+                                self.progress.bytes_skipped.fetch_add(e.size, Relaxed);
+                                if opts.dry_run {
+                                    self.dry_run_changes.metadata_files += 1;
+                                    if opts.verbose > 0 {
+                                        self.progress.println(&format!(
+                                            "update metadata {} (requested file metadata differs)",
+                                            display(&dst_path)
+                                        ));
+                                    }
+                                    continue;
+                                }
                                 meta_fixes.push((
                                     Op::SetFileMetaIfSame {
                                         path: dst_path.clone(),
@@ -2388,8 +2527,6 @@ impl Planner<'_> {
                                         .as_ref()
                                         .map(|_| (dst_rel.clone(), e.clone())),
                                 ));
-                                self.progress.files_skipped.fetch_add(1, Relaxed);
-                                self.progress.bytes_skipped.fetch_add(e.size, Relaxed);
                                 continue;
                             }
                         }
@@ -2402,8 +2539,35 @@ impl Planner<'_> {
                         self.progress.files_total.fetch_add(1, Relaxed);
                         self.progress.bytes_total.fetch_add(e.size, Relaxed);
                         self.progress.files_done.fetch_add(1, Relaxed);
+                        self.dry_run_changes.regular_files += 1;
+                        if dst_entry.as_ref().is_some_and(|d| d.kind != Kind::File) {
+                            self.dry_run_changes.type_replacements += 1;
+                        }
                         if opts.verbose > 0 {
-                            self.progress.println(&rel);
+                            let shown = display(&dst_path);
+                            let action = match &dst_entry {
+                                None => format!("create file {shown} (destination missing)"),
+                                Some(d) if d.kind != Kind::File => format!(
+                                    "replace with file {shown} (destination is {})",
+                                    kind_label(d.kind)
+                                ),
+                                Some(d) if d.size != e.size => {
+                                    format!("update file {shown} (size differs)")
+                                }
+                                Some(_) if opts.checksum => {
+                                    format!("update file {shown} (content comparison requested)")
+                                }
+                                Some(d)
+                                    if opts.flags & flags::TIMES != 0
+                                        && (d.mtime, d.mtime_nsec) != (e.mtime, e.mtime_nsec) =>
+                                {
+                                    format!("update file {shown} (modification time differs)")
+                                }
+                                Some(_) => {
+                                    format!("update file {shown} (content quick check unavailable)")
+                                }
+                            };
+                            self.progress.println(&action);
                         }
                     } else {
                         self.enqueue(
@@ -2435,9 +2599,28 @@ impl Planner<'_> {
                         continue;
                     }
                     if opts.dry_run {
+                        self.dry_run_changes.symlinks += 1;
+                        if dst_entry.as_ref().is_some_and(|d| d.kind != Kind::Symlink) {
+                            self.dry_run_changes.type_replacements += 1;
+                        }
                         if opts.verbose > 0 {
-                            self.progress
-                                .println(&format!("{rel} -> {}", display(&target)));
+                            let shown = display(&dst_path);
+                            let action = match &dst_entry {
+                                None => format!(
+                                    "create symlink {shown} -> {} (destination missing)",
+                                    display(&target)
+                                ),
+                                Some(d) if d.kind != Kind::Symlink => format!(
+                                    "replace with symlink {shown} -> {} (destination is {})",
+                                    display(&target),
+                                    kind_label(d.kind)
+                                ),
+                                Some(_) => format!(
+                                    "update symlink {shown} -> {} (target differs)",
+                                    display(&target)
+                                ),
+                            };
+                            self.progress.println(&action);
                         }
                         continue;
                     }
@@ -2476,8 +2659,30 @@ impl Planner<'_> {
                         continue;
                     }
                     if same || opts.dry_run {
-                        if opts.dry_run && !same && opts.verbose > 0 {
-                            self.progress.println(&rel);
+                        if opts.dry_run && !same {
+                            self.dry_run_changes.specials += 1;
+                            if dst_entry.as_ref().is_some_and(|d| d.kind != e.kind) {
+                                self.dry_run_changes.type_replacements += 1;
+                            }
+                            if opts.verbose > 0 {
+                                let shown = display(&dst_path);
+                                let action = match &dst_entry {
+                                    None => format!(
+                                        "create {} {shown} (destination missing)",
+                                        kind_label(e.kind)
+                                    ),
+                                    Some(d) if d.kind != e.kind => format!(
+                                        "replace with {} {shown} (destination is {})",
+                                        kind_label(e.kind),
+                                        kind_label(d.kind)
+                                    ),
+                                    Some(_) => format!(
+                                        "update {} {shown} (device identity differs)",
+                                        kind_label(e.kind)
+                                    ),
+                                };
+                                self.progress.println(&action);
+                            }
                         }
                         continue;
                     }
@@ -2934,7 +3139,8 @@ impl Planner<'_> {
                     for (_, rel, _) in chunk {
                         n += 1;
                         if opts.verbose > 0 {
-                            me.progress.println(&format!("deleting {rel}"));
+                            me.progress
+                                .println(&format!("delete {rel} (destination only)"));
                         }
                     }
                     continue;

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1782,6 +1782,7 @@ impl Planner<'_> {
                         && pl.opts.recursive
                         && dst_existed
                         && !dst_is_dir
+                        && !pl.opts.existing
                     {
                         bail!(
                             "destination {} is not a directory; cannot place directory {} inside it",

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -864,6 +864,7 @@ pub fn run(args: Args) -> Result<i32> {
         checkpoint: checkpoint_writer,
         dst_seen: std::collections::HashMap::new(),
         missing_dirs: std::collections::HashSet::new(),
+        dry_run_replaced_dirs: std::collections::HashSet::new(),
         payload_paths: std::collections::HashMap::new(),
         sidecar_paths: std::collections::HashMap::new(),
         live_sidecars: Vec::new(),
@@ -934,8 +935,11 @@ pub fn run(args: Args) -> Result<i32> {
             &src_root,
             follow,
             &sub,
-            &dst_root,
-            dst_is_dir,
+            DestinationRoot {
+                path: &dst_root,
+                existed: dst_existed,
+                is_dir: dst_is_dir,
+            },
         ) {
             Ok(mapping) => dry_run_mappings.push(mapping),
             Err(e) => {
@@ -1628,6 +1632,10 @@ struct Planner<'a> {
     /// (or aren't directories); --ignore-existing: an existing non-directory
     /// sits at their path. Nothing under them is touched.
     missing_dirs: std::collections::HashSet<PathBytes>,
+    /// Directories that a dry run would create over destination leaves. Until
+    /// that virtual replacement exists, lstat would follow an old in-tree
+    /// symlink in an intermediate component and inspect the wrong subtree.
+    dry_run_replaced_dirs: std::collections::HashSet<PathBytes>,
     completed:
         Option<std::sync::Arc<std::collections::HashMap<PathBytes, crate::checkpoint::Completed>>>,
     checkpoint: Option<std::sync::Arc<crate::checkpoint::Checkpoint>>,
@@ -1751,9 +1759,11 @@ impl Planner<'_> {
         src_root: &[u8],
         follow: bool,
         sub: &str,
-        dst_root: &[u8],
-        dst_is_dir: bool,
+        destination: DestinationRoot<'_>,
     ) -> Result<DryRunMapping> {
+        let dst_root = destination.path;
+        let dst_is_dir = destination.is_dir;
+        let dst_existed = destination.existed;
         let mut first = true;
         let mut sub = sub.to_string();
         let mut skip_all = false;
@@ -1766,6 +1776,19 @@ impl Planner<'_> {
             if first {
                 first = false;
                 if let Some(root) = batch.first() {
+                    if pl.opts.dry_run
+                        && root.kind == Kind::Dir
+                        && !follow
+                        && pl.opts.recursive
+                        && dst_existed
+                        && !dst_is_dir
+                    {
+                        bail!(
+                            "destination {} is not a directory; cannot place directory {} inside it",
+                            display(dst_root),
+                            display(src_root)
+                        );
+                    }
                     if root.kind != Kind::Dir && !dst_is_dir {
                         sub = String::new();
                     }
@@ -2229,9 +2252,15 @@ impl Planner<'_> {
         // the same filtered list drives creation, listing and deferred
         // metadata so they can't disagree.
         if !dirs.is_empty() {
-            let stats = self.stat_many(dirs.iter().map(|(p, _, _)| p.clone()).collect())?;
+            let stats = self.stat_directories_with_dry_run_overlay(&dirs, dst_root)?;
             let mut planned: Vec<(PathBytes, PathBytes, Entry, Option<Entry>)> = Vec::new();
-            for ((p, dst_rel, e), st) in dirs.into_iter().zip(stats) {
+            for ((p, dst_rel, e), mut st) in dirs.into_iter().zip(stats) {
+                // Keep the parent-first overlay invariant explicit here too:
+                // a directory below a replacement is missing in the virtual
+                // destination tree.
+                if opts.dry_run && Self::under_any(&self.dry_run_replaced_dirs, &p, dst_root) {
+                    st = None;
+                }
                 let is_dir = matches!(st, Some(ref d) if d.kind == Kind::Dir);
                 if opts.verify_only {
                     if !is_dir {
@@ -2266,6 +2295,9 @@ impl Planner<'_> {
                     }
                     self.missing_dirs.insert(p);
                     continue;
+                }
+                if opts.dry_run && st.as_ref().is_some_and(|d| d.kind != Kind::Dir) {
+                    self.dry_run_replaced_dirs.insert(p.clone());
                 }
                 planned.push((p, dst_rel, e, st));
             }
@@ -2380,7 +2412,9 @@ impl Planner<'_> {
             let completed = self.completed.clone().unwrap();
             let mut kept = Vec::with_capacity(others.len());
             for p in others.into_iter() {
-                if p.e.kind == Kind::File {
+                let virtually_missing =
+                    opts.dry_run && Self::under_any(&self.dry_run_replaced_dirs, &p.dst, dst_root);
+                if p.e.kind == Kind::File && !virtually_missing {
                     if let Some(c) = completed.get(&p.dst_rel) {
                         if c.matches(&p.e, opts.flags) {
                             self.progress.files_skipped.fetch_add(1, Relaxed);
@@ -2393,7 +2427,10 @@ impl Planner<'_> {
             }
             others = kept;
         }
-        let stats = self.stat_many(others.iter().map(|p| p.dst.clone()).collect())?;
+        let stats = self.stat_many_with_dry_run_overlay(
+            others.iter().map(|p| p.dst.clone()).collect(),
+            dst_root,
+        )?;
         let mut ops: Vec<Op> = Vec::new();
         let mut op_names: Vec<String> = Vec::new();
         // Metadata repairs for quick-check-identical files, each with the
@@ -3212,6 +3249,95 @@ impl Planner<'_> {
 
     fn stat_many(&mut self, paths: Vec<PathBytes>) -> Result<Vec<Option<Entry>>> {
         stat_many(self.dst, paths, false)
+    }
+
+    /// lstat paths that remain reachable after the directory replacements a
+    /// dry run has already planned. Descendants of those replacements are
+    /// virtually missing; querying them would follow the old intermediate
+    /// leaf that the real run removes first.
+    fn stat_many_with_dry_run_overlay(
+        &mut self,
+        paths: Vec<PathBytes>,
+        dst_root: &[u8],
+    ) -> Result<Vec<Option<Entry>>> {
+        if !self.opts.dry_run || self.dry_run_replaced_dirs.is_empty() {
+            return self.stat_many(paths);
+        }
+        let mut visible = Vec::new();
+        let mut indexes = Vec::new();
+        let mut results = vec![None; paths.len()];
+        for (index, path) in paths.into_iter().enumerate() {
+            if !Self::under_any(&self.dry_run_replaced_dirs, &path, dst_root) {
+                indexes.push(index);
+                visible.push(path);
+            }
+        }
+        for (index, entry) in indexes.into_iter().zip(self.stat_many(visible)?) {
+            results[index] = entry;
+        }
+        Ok(results)
+    }
+
+    /// Stat dry-run directories parent-depth first. Discovering a destination
+    /// leaf at one depth makes its whole source-directory subtree virtually
+    /// missing at deeper levels, so no request traverses the leaf that the
+    /// real run would already have replaced.
+    fn stat_directories_with_dry_run_overlay(
+        &mut self,
+        dirs: &[(PathBytes, PathBytes, Entry)],
+        dst_root: &[u8],
+    ) -> Result<Vec<Option<Entry>>> {
+        if !self.opts.dry_run {
+            return self.stat_many(dirs.iter().map(|(path, _, _)| path.clone()).collect());
+        }
+        let existing = self.opts.existing;
+        let ignore_existing = self.opts.ignore_existing;
+        let mut replaced = self.dry_run_replaced_dirs.clone();
+        let mut missing = self.missing_dirs.clone();
+        let mut by_depth: std::collections::BTreeMap<usize, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        for (index, (_, dst_rel, _)) in dirs.iter().enumerate() {
+            let depth = if dst_rel.is_empty() {
+                0
+            } else {
+                1 + dst_rel.iter().filter(|&&byte| byte == b'/').count()
+            };
+            by_depth.entry(depth).or_default().push(index);
+        }
+
+        let mut results = vec![None; dirs.len()];
+        for indexes in by_depth.into_values() {
+            let mut visible = Vec::new();
+            let mut visible_indexes = Vec::new();
+            for &index in &indexes {
+                let path = &dirs[index].0;
+                let hidden_by_replacement = Self::under_any(&replaced, path, dst_root);
+                let hidden_by_option =
+                    (existing || ignore_existing) && Self::under_any(&missing, path, dst_root);
+                if !hidden_by_replacement && !hidden_by_option {
+                    visible_indexes.push(index);
+                    visible.push(path.clone());
+                }
+            }
+            for (index, entry) in visible_indexes.into_iter().zip(self.stat_many(visible)?) {
+                results[index] = entry;
+            }
+            for index in indexes {
+                let path = &dirs[index].0;
+                let entry = &results[index];
+                let is_dir = entry.as_ref().is_some_and(|item| item.kind == Kind::Dir);
+                let conflict = ignore_existing && !is_dir && entry.is_some();
+                if conflict
+                    || (existing && !is_dir)
+                    || ((existing || ignore_existing) && Self::under_any(&missing, path, dst_root))
+                {
+                    missing.insert(path.clone());
+                } else if entry.as_ref().is_some_and(|item| item.kind != Kind::Dir) {
+                    replaced.insert(path.clone());
+                }
+            }
+        }
+        Ok(results)
     }
 
     fn partial_paths(

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -892,16 +892,21 @@ pub fn run(args: Args) -> Result<i32> {
     };
 
     let mut scan_err = None;
+    let mut dry_run_mappings = Vec::with_capacity(srcs.len());
     if args.files_from.is_some() {
         let src = &srcs[0];
-        if let Err(e) = st.scan_files_from(
+        match st.scan_files_from(
             &mut *src_ctl,
             src.path.as_bytes(),
             &dst_root,
             &args.files_from_lines,
             args.recursive_explicit,
         ) {
-            scan_err = Some(e);
+            Ok(()) => dry_run_mappings.push(DryRunMapping {
+                target: dst_root.clone(),
+                semantics: "paths selected by --files-from",
+            }),
+            Err(e) => scan_err = Some(e),
         }
     }
     for src in srcs.iter().filter(|_| args.files_from.is_none()) {
@@ -915,7 +920,7 @@ pub fn run(args: Args) -> Result<i32> {
         } else {
             src.basename()
         };
-        if let Err(e) = st.scan_source(
+        match st.scan_source(
             &mut *src_ctl,
             &src_root,
             follow,
@@ -923,8 +928,11 @@ pub fn run(args: Args) -> Result<i32> {
             &dst_root,
             dst_is_dir,
         ) {
-            scan_err = Some(e);
-            break;
+            Ok(mapping) => dry_run_mappings.push(mapping),
+            Err(e) => {
+                scan_err = Some(e);
+                break;
+            }
         }
     }
     if scan_err.is_none() && !st.collision {
@@ -987,6 +995,11 @@ pub fn run(args: Args) -> Result<i32> {
 
     let aborted = sched.is_aborted();
     let mut deleted = 0u64;
+    let mut delete_plan = if opts.delete {
+        DeletePlan::Skipped("the copy plan did not complete")
+    } else {
+        DeletePlan::Disabled
+    };
     // --delete runs once the workers are done, so the destination walk sees a
     // quiescent tree (no partials being renamed, no entries being replaced),
     // and before apply_deferred, since unlinking bumps directory mtimes. Any
@@ -994,14 +1007,22 @@ pub fn run(args: Args) -> Result<i32> {
     // read would otherwise look like one whose contents vanished.
     if !aborted && opts.delete && scan_err.is_none() && !collision {
         if st.scan_warned {
+            delete_plan = DeletePlan::Skipped("source scan errors");
             progress.eprintln("syq: source scan reported errors; skipping deletions");
         } else {
             match st.plan_deletes() {
                 Ok(()) if st.delete_walk_failed => {
+                    delete_plan = DeletePlan::Skipped("destination walk errors");
                     progress.eprintln("syq: destination walk reported errors; skipping deletions")
                 }
-                Ok(()) => deleted = st.run_deletes()?,
-                Err(e) => progress.error(&format!("syq: delete: {e:#}")),
+                Ok(()) => {
+                    delete_plan = DeletePlan::Planned(st.deletes.len());
+                    deleted = st.run_deletes()?;
+                }
+                Err(e) => {
+                    delete_plan = DeletePlan::Skipped("destination planning failed");
+                    progress.error(&format!("syq: delete: {e:#}"));
+                }
             }
         }
     }
@@ -1040,6 +1061,19 @@ pub fn run(args: Args) -> Result<i32> {
     let elapsed = progress.start.elapsed().as_secs_f64();
     let done = progress.bytes_done.load(Relaxed);
     if !args.quiet && !aborted {
+        if opts.dry_run {
+            print_dry_run_plan(
+                srcs,
+                dst,
+                &dry_run_mappings,
+                &src_ep,
+                &dst_ep,
+                &args,
+                &opts,
+                &progress,
+                delete_plan,
+            );
+        }
         if opts.verify_only {
             println!(
                 "syq: verified {} files, {} differ/missing, {} in {}",
@@ -1066,19 +1100,7 @@ pub fn run(args: Args) -> Result<i32> {
                 human(progress.bytes_skipped.load(Relaxed)),
                 commas(progress.files_skipped.load(Relaxed)),
                 commas(st_dirs(&progress)),
-                if opts.delete {
-                    format!(
-                        ", {} {}",
-                        commas(deleted),
-                        if opts.dry_run {
-                            "would be deleted"
-                        } else {
-                            "deleted"
-                        }
-                    )
-                } else {
-                    String::new()
-                },
+                deletion_summary(delete_plan, deleted, opts.dry_run, opts.max_delete),
                 if opts.dry_run {
                     String::new()
                 } else {
@@ -1214,14 +1236,20 @@ fn scan_into_planner(
 ) -> Result<()> {
     let progress = pl.progress;
     let quiet = pl.opts.quiet;
+    let report_ignored = pl.opts.dry_run;
     let warned = std::cell::Cell::new(false);
     let res = src.scan(
         root,
         follow_root,
         ignore,
-        false,
+        report_ignored,
         &mut |batch| f(pl, batch),
-        &mut |_| Ok(()),
+        &mut |paths| {
+            progress
+                .paths_ignored
+                .fetch_add(paths.len() as u64, Relaxed);
+            Ok(())
+        },
         &mut |w| {
             // "skipping …" is a notice (nothing the copy owes is missing);
             // anything else from the scanner means an entry was lost.
@@ -1281,6 +1309,207 @@ fn follow_dir_symlink(
 
 fn display(p: &[u8]) -> String {
     String::from_utf8_lossy(p).into_owned()
+}
+
+fn display_location(loc: &Location, path: &[u8]) -> String {
+    let path = display(path);
+    let Some(host) = &loc.host else {
+        return path;
+    };
+    let host = if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host.clone()
+    };
+    match &loc.user {
+        Some(user) => format!("{user}@{host}:{path}"),
+        None => format!("{host}:{path}"),
+    }
+}
+
+fn display_plan_source(loc: &Location, args: &Args) -> String {
+    if !loc.is_remote() {
+        if let Some(host) = &args.plan_source_host {
+            return format!("{host}:{}", display(loc.path.as_bytes()));
+        }
+    }
+    display_location(loc, loc.path.as_bytes())
+}
+
+fn display_plan_target(loc: &Location, path: &[u8], args: &Args) -> String {
+    if !loc.is_remote() {
+        if let Some(host) = &args.plan_source_host {
+            return format!("{host}:{}", display(path));
+        }
+    }
+    display_location(loc, path)
+}
+
+fn remote_data_transport(spec: &RemoteSpec) -> &'static str {
+    match spec.tcp.lock().unwrap().as_ref() {
+        Some(info) if info.key.is_some() => "encrypted TCP",
+        Some(_) => "plaintext TCP",
+        None => "ssh",
+    }
+}
+
+fn selected_route(src: &Endpoint, dst: &Endpoint, args: &Args) -> String {
+    let route = match (src, dst) {
+        (Endpoint::Local, Endpoint::Local) => args.plan_source_host.as_ref().map_or_else(
+            || "local filesystem".to_string(),
+            |host| format!("local filesystem on {host}"),
+        ),
+        (Endpoint::Local, Endpoint::Remote(spec)) => match &args.plan_source_host {
+            Some(source) => format!(
+                "{} from {source} to {}",
+                remote_data_transport(spec),
+                spec.label()
+            ),
+            None => format!("{} to {}", remote_data_transport(spec), spec.label()),
+        },
+        (Endpoint::Remote(spec), Endpoint::Local) => {
+            format!("{} from {}", remote_data_transport(spec), spec.label())
+        }
+        (Endpoint::Remote(source), Endpoint::Remote(target)) => format!(
+            "{} from {} through this machine, {} to {}",
+            remote_data_transport(source),
+            source.label(),
+            remote_data_transport(target),
+            target.label()
+        ),
+    };
+    let remote = src.is_remote() || dst.is_remote();
+    let unit = |n: usize| match (remote, n) {
+        (true, 1) => "connection",
+        (true, _) => "connections",
+        (false, 1) => "worker",
+        (false, _) => "workers",
+    };
+    let concurrency = if args.connections_default {
+        format!(
+            "{} initial {} (auto-tuned)",
+            args.connections,
+            unit(args.connections)
+        )
+    } else {
+        format!("{} {} (fixed)", args.connections, unit(args.connections))
+    };
+    format!("{route}; {concurrency}")
+}
+
+struct DryRunMapping {
+    target: PathBytes,
+    semantics: &'static str,
+}
+
+#[derive(Clone, Copy)]
+enum DeletePlan {
+    Disabled,
+    Planned(u64),
+    Skipped(&'static str),
+}
+
+fn count_label(n: u64, singular: &str, plural: &str) -> String {
+    format!("{} {}", commas(n), if n == 1 { singular } else { plural })
+}
+
+fn deletion_summary(plan: DeletePlan, deleted: u64, dry_run: bool, max: Option<u64>) -> String {
+    match plan {
+        DeletePlan::Disabled => String::new(),
+        DeletePlan::Planned(n) => {
+            if let Some(limit) = max.filter(|limit| n > *limit) {
+                format!(
+                    ", {} planned for deletion (blocked by --max-delete {limit})",
+                    commas(n)
+                )
+            } else {
+                format!(
+                    ", {} {}",
+                    commas(deleted),
+                    if dry_run {
+                        "would be deleted"
+                    } else {
+                        "deleted"
+                    }
+                )
+            }
+        }
+        DeletePlan::Skipped(reason) => format!(", deletions skipped ({reason})"),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_dry_run_plan(
+    srcs: &[Location],
+    dst: &Location,
+    mappings: &[DryRunMapping],
+    src_ep: &Endpoint,
+    dst_ep: &Endpoint,
+    args: &Args,
+    opts: &Opts,
+    progress: &Progress,
+    deletes: DeletePlan,
+) {
+    println!("syq: dry-run plan");
+    for (source, mapping) in srcs.iter().zip(mappings) {
+        println!(
+            "  mapping: {} -> {} ({})",
+            display_plan_source(source, args),
+            display_plan_target(dst, &mapping.target, args),
+            mapping.semantics
+        );
+    }
+    println!(
+        "  plan: {}, {} to transfer; {}, {} unchanged",
+        count_label(progress.files_total.load(Relaxed), "file", "files"),
+        human(progress.bytes_total.load(Relaxed)),
+        count_label(progress.files_skipped.load(Relaxed), "file", "files"),
+        human(progress.bytes_skipped.load(Relaxed))
+    );
+
+    let ignored = progress.paths_ignored.load(Relaxed);
+    let other = progress.files_excluded.load(Relaxed);
+    let mut exclusions = Vec::new();
+    if ignored > 0 {
+        exclusions.push(format!(
+            "{} pruned by ignore rules",
+            count_label(ignored, "path/subtree", "paths/subtrees")
+        ));
+    }
+    if other > 0 {
+        exclusions.push(count_label(other, "other entry", "other entries"));
+    }
+    println!(
+        "  exclusions: {}",
+        if exclusions.is_empty() {
+            if opts.ignore.is_empty() {
+                "none".to_string()
+            } else {
+                "none matched (ignore rules active)".to_string()
+            }
+        } else {
+            exclusions.join("; ")
+        }
+    );
+
+    match deletes {
+        DeletePlan::Disabled => println!("  deletions: disabled"),
+        DeletePlan::Planned(n) => {
+            if let Some(limit) = opts.max_delete.filter(|limit| n > *limit) {
+                println!(
+                    "  deletions: {} planned; blocked by --max-delete {limit}",
+                    count_label(n, "entry", "entries")
+                );
+            } else {
+                println!(
+                    "  deletions: {} planned after a successful copy",
+                    count_label(n, "entry", "entries")
+                );
+            }
+        }
+        DeletePlan::Skipped(reason) => println!("  deletions: skipped ({reason})"),
+    }
+    println!("  route: {}", selected_route(src_ep, dst_ep, args));
 }
 
 fn path_has_partial_component(path: &[u8]) -> bool {
@@ -1406,6 +1635,17 @@ struct Deletes {
     dirs: std::collections::BTreeMap<usize, Vec<(PathBytes, String, PathBytes)>>,
 }
 
+impl Deletes {
+    fn len(&self) -> u64 {
+        self.leaves.len() as u64
+            + self
+                .dirs
+                .values()
+                .map(|items| items.len() as u64)
+                .sum::<u64>()
+    }
+}
+
 impl Planner<'_> {
     fn scan_source(
         &mut self,
@@ -1415,10 +1655,11 @@ impl Planner<'_> {
         sub: &str,
         dst_root: &[u8],
         dst_is_dir: bool,
-    ) -> Result<()> {
+    ) -> Result<DryRunMapping> {
         let mut first = true;
         let mut sub = sub.to_string();
         let mut skip_all = false;
+        let mut mapping = None;
         let ignore = self.opts.ignore.clone();
         scan_into_planner(self, src, src_root, follow, &ignore, |pl, batch| {
             if skip_all {
@@ -1430,6 +1671,15 @@ impl Planner<'_> {
                     if root.kind != Kind::Dir && !dst_is_dir {
                         sub = String::new();
                     }
+                    mapping = Some(DryRunMapping {
+                        target: join(dst_root, sub.as_bytes()),
+                        semantics: match (root.kind, follow, dst_is_dir) {
+                            (Kind::Dir, true, _) => "directory contents",
+                            (Kind::Dir, false, _) => "directory as child",
+                            (_, _, true) => "entry inside destination directory",
+                            _ => "exact destination path",
+                        },
+                    });
                     if root.kind == Kind::Dir && !pl.opts.recursive {
                         if !pl.opts.quiet {
                             pl.progress
@@ -1446,7 +1696,8 @@ impl Planner<'_> {
             }
             pl.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
             pl.handle_batch(batch, src_root, &sub, dst_root)
-        })
+        })?;
+        mapping.ok_or_else(|| anyhow::anyhow!("source scan returned no root entry"))
     }
 
     /// --files-from: instead of walking the source, stat each listed path (and

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1726,6 +1726,91 @@ fn dry_run_accounts_for_changed_symlinks_and_type_replacements() {
 }
 
 #[test]
+fn dry_run_directory_replacement_makes_descendants_virtually_missing() {
+    let t = Tmp::new();
+    write(&t.path("src/d/f"), b"same");
+    write(&t.path("outside/f"), b"same");
+    fs::create_dir_all(t.path("dst")).unwrap();
+    std::os::unix::fs::symlink(t.path("outside"), t.path("dst/d")).unwrap();
+    set_mtime(&t.path("src/d/f"), 1_600_000_000);
+    set_mtime(&t.path("outside/f"), 1_600_000_000);
+    set_mtime(&t.path("src"), 1_600_000_100);
+    set_mtime(&t.path("dst"), 1_600_000_100);
+
+    let out = run_ok(&["-anv", &t.s("src/"), &t.s("dst")]);
+    let changes = out
+        .lines()
+        .find(|line| line.starts_with("  changes:"))
+        .unwrap_or_else(|| panic!("missing changes line in {out}"));
+    assert!(changes.contains("1 regular file"), "{out}");
+    assert!(changes.contains("1 directory"), "{out}");
+    assert!(changes.contains("1 type replacement among them"), "{out}");
+    assert!(
+        out.contains("4 B in 1 file needing content work (upper bound)"),
+        "{out}"
+    );
+    assert!(
+        out.contains("0 B in 0 files with unchanged content"),
+        "{out}"
+    );
+    assert!(
+        out.contains(&format!(
+            "replace with directory {}/ (destination is symlink)",
+            t.s("dst/d")
+        )),
+        "{out}"
+    );
+    assert!(
+        out.contains(&format!(
+            "create file {} (destination missing)",
+            t.s("dst/d/f")
+        )),
+        "{out}"
+    );
+    assert!(t.path("dst/d").symlink_metadata().unwrap().is_symlink());
+    assert_eq!(read(&t.path("outside/f")), b"same");
+
+    let actual = run_ok(&["-a", &t.s("src/"), &t.s("dst")]);
+    assert_eq!(transferred(&actual), 1, "{actual}");
+    assert!(t.path("dst/d").is_dir());
+    assert_eq!(read(&t.path("dst/d/f")), b"same");
+    assert_eq!(read(&t.path("outside/f")), b"same");
+}
+
+#[test]
+fn dry_run_rejects_bare_directory_into_existing_file() {
+    let t = Tmp::new();
+    write(&t.path("src/f"), b"source");
+    write(&t.path("destination"), b"keep me");
+
+    let skipped = syq(&["-n", &t.s("src"), &t.s("destination")]);
+    assert!(skipped.status.success(), "{}", stderr_of(&skipped));
+    assert!(stderr_of(&skipped).contains("skipping directory"));
+
+    let dry = syq(&["-an", &t.s("src"), &t.s("destination")]);
+    assert!(!dry.status.success());
+    assert!(
+        stderr_of(&dry).contains(&format!(
+            "destination {} is not a directory; cannot place directory {} inside it",
+            t.s("destination"),
+            t.s("src")
+        )),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&dry.stdout),
+        stderr_of(&dry)
+    );
+    assert!(
+        !String::from_utf8_lossy(&dry.stdout).contains("syq: dry-run summary"),
+        "a rejected mapping must not print a successful summary"
+    );
+    assert_eq!(read(&t.path("destination")), b"keep me");
+
+    let actual = syq(&["-a", &t.s("src"), &t.s("destination")]);
+    assert_eq!(actual.status.code(), Some(23), "{}", stderr_of(&actual));
+    assert_eq!(read(&t.path("destination")), b"keep me");
+}
+
+#[test]
 fn inplace_leaves_no_partial() {
     let t = Tmp::new();
     let data = prng(3 * 1024 * 1024, 5);

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1541,12 +1541,16 @@ fn dry_run_creates_nothing() {
         !t.path("dst").exists(),
         "dry run must not create the destination"
     );
-    assert!(out.contains("would transfer"), "{out}");
-    assert!(transferred(&out) > 0);
+    assert!(out.contains("syq: dry-run summary"), "{out}");
+    assert!(out.contains("regular files"), "{out}");
+    assert!(out.contains("directories"), "{out}");
+    assert!(out.contains("symlinks"), "{out}");
+    assert!(out.contains("special file"), "{out}");
+    assert!(out.contains("logical data:"), "{out}");
 }
 
 #[test]
-fn dry_run_reports_concrete_plan() {
+fn dry_run_reports_typed_preflight_summary() {
     let t = Tmp::new();
     write(&t.path("src/send"), b"new");
     write(&t.path("src/same"), b"same");
@@ -1556,6 +1560,8 @@ fn dry_run_reports_concrete_plan() {
     write(&t.path("dst/extra"), b"delete me");
     set_mtime(&t.path("src/same"), 1_600_000_000);
     set_mtime(&t.path("dst/same"), 1_600_000_000);
+    set_mtime(&t.path("src"), 1_600_000_100);
+    set_mtime(&t.path("dst"), 1_600_000_100);
 
     let out = run_ok(&[
         "-an",
@@ -1567,7 +1573,7 @@ fn dry_run_reports_concrete_plan() {
         &t.s("src/"),
         &t.s("dst"),
     ]);
-    assert!(out.contains("syq: dry-run plan"), "{out}");
+    assert!(out.contains("syq: dry-run summary"), "{out}");
     assert!(
         out.contains(&format!(
             "mapping: {} -> {} (directory contents)",
@@ -1576,8 +1582,11 @@ fn dry_run_reports_concrete_plan() {
         )),
         "{out}"
     );
+    assert!(out.contains("changes: 1 regular file"), "{out}");
     assert!(
-        out.contains("plan: 1 file, 3 B to transfer; 1 file, 4 B unchanged"),
+        out.contains(
+            "logical data: 3 B in 1 file needing content work (upper bound); 4 B in 1 file with unchanged content"
+        ),
         "{out}"
     );
     assert!(
@@ -1596,7 +1605,7 @@ fn dry_run_reports_concrete_plan() {
 }
 
 #[test]
-fn dry_run_plan_resolves_path_semantics() {
+fn dry_run_summary_resolves_path_semantics() {
     let t = Tmp::new();
     write(&t.path("src/file"), b"data");
 
@@ -1629,6 +1638,91 @@ fn dry_run_plan_resolves_path_semantics() {
         )),
         "{exact}"
     );
+}
+
+#[test]
+fn dry_run_does_not_apply_metadata_repairs() {
+    let t = Tmp::new();
+    write(&t.path("src/f"), b"same");
+    write(&t.path("dst/f"), b"same");
+    fs::set_permissions(t.path("src/f"), fs::Permissions::from_mode(0o600)).unwrap();
+    fs::set_permissions(t.path("dst/f"), fs::Permissions::from_mode(0o644)).unwrap();
+    set_mtime(&t.path("src/f"), 1_600_000_000);
+    set_mtime(&t.path("dst/f"), 1_600_000_000);
+    set_mtime(&t.path("src"), 1_600_000_100);
+    set_mtime(&t.path("dst"), 1_600_000_100);
+
+    let out = run_ok(&["-anv", &t.s("src/"), &t.s("dst")]);
+    assert_eq!(
+        fs::symlink_metadata(t.path("dst/f")).unwrap().mode() & 0o777,
+        0o644,
+        "dry run changed destination permissions\n{out}"
+    );
+    assert!(out.contains("changes: 1 metadata-only entry"), "{out}");
+    assert!(
+        out.contains(&format!(
+            "update metadata {} (requested file metadata differs)",
+            t.s("dst/f")
+        )),
+        "{out}"
+    );
+    assert!(
+        out.contains("4 B in 1 file with unchanged content"),
+        "{out}"
+    );
+
+    run_ok(&["-a", &t.s("src/"), &t.s("dst")]);
+    assert_eq!(
+        fs::symlink_metadata(t.path("dst/f")).unwrap().mode() & 0o777,
+        0o600,
+        "the corresponding real run must still repair metadata"
+    );
+}
+
+#[test]
+fn dry_run_accounts_for_changed_symlinks_and_type_replacements() {
+    let t = Tmp::new();
+    fs::create_dir_all(t.path("src")).unwrap();
+    fs::create_dir_all(t.path("dst")).unwrap();
+    std::os::unix::fs::symlink("new-target", t.path("src/link")).unwrap();
+    std::os::unix::fs::symlink("old-target", t.path("dst/link")).unwrap();
+    write(&t.path("src/replaced"), b"file");
+    std::os::unix::fs::symlink("old-target", t.path("dst/replaced")).unwrap();
+    set_mtime(&t.path("src"), 1_600_000_100);
+    set_mtime(&t.path("dst"), 1_600_000_100);
+
+    let out = run_ok(&["-anv", &t.s("src/"), &t.s("dst")]);
+    assert!(
+        out.contains("changes: 1 regular file; 1 symlink; 1 type replacement among them"),
+        "{out}"
+    );
+    assert!(
+        out.contains(&format!(
+            "update symlink {} -> new-target (target differs)",
+            t.s("dst/link")
+        )),
+        "{out}"
+    );
+    assert!(
+        out.contains(&format!(
+            "replace with file {} (destination is symlink)",
+            t.s("dst/replaced")
+        )),
+        "{out}"
+    );
+    assert!(
+        out.contains("4 B in 1 file needing content work (upper bound)"),
+        "{out}"
+    );
+    assert_eq!(
+        fs::read_link(t.path("dst/link")).unwrap(),
+        PathBuf::from("old-target")
+    );
+    assert!(t
+        .path("dst/replaced")
+        .symlink_metadata()
+        .unwrap()
+        .is_symlink());
 }
 
 #[test]
@@ -2300,7 +2394,7 @@ fn ignore_applies_per_source_root_and_dry_run() {
     // Dry run with the root itself matching a pattern: the root is never ignored.
     let out = run_ok(&["-an", "-i", "s1", "-i", "*.o", &t.s("s1"), &t.s("dst2")]);
     assert!(!t.path("dst2").exists());
-    assert!(out.contains("would transfer 9 files"), "{out}");
+    assert!(out.contains("in 9 files needing content work"), "{out}");
 }
 
 #[test]
@@ -2398,18 +2492,21 @@ fn delete_removes_extras_and_protects_ignored() {
     assert!(out.status.success());
     let so = String::from_utf8_lossy(&out.stdout);
     for l in [
-        "deleting c",
-        "deleting extra/x/y",
-        "deleting extra/x/",
-        "deleting extra/",
-        "deleting keep/gone",
-        "deleting dangling",
+        "delete c (destination only)",
+        "delete extra/x/y (destination only)",
+        "delete extra/x/ (destination only)",
+        "delete extra/ (destination only)",
+        "delete keep/gone (destination only)",
+        "delete dangling (destination only)",
     ] {
         assert!(so.contains(l), "missing {l:?} in {so}");
     }
     assert!(!so.contains("k.log"), "{so}");
-    assert!(!so.lines().any(|l| l == "deleting keep/"), "{so}");
-    assert!(so.contains("6 would be deleted"), "{so}");
+    assert!(!so.contains("delete keep/ (destination only)"), "{so}");
+    assert!(
+        so.contains("deletions: 6 entries planned after a successful copy"),
+        "{so}"
+    );
     assert!(
         stderr_of(&out).contains("not deleting keep/"),
         "{}",
@@ -2529,7 +2626,10 @@ fn delete_only_inside_directories_the_sources_map_onto() {
     );
     // A dry run into a destination that doesn't exist yet has nothing to delete.
     let so = run_ok(&["-a", "-n", "--delete", &t.s("s1/"), &t.s("nowhere")]);
-    assert!(so.contains("0 would be deleted"), "{so}");
+    assert!(
+        so.contains("deletions: 0 entries planned after a successful copy"),
+        "{so}"
+    );
     assert!(!t.path("nowhere").exists());
     // A single-file source deletes nothing.
     write(&t.path("dst2/junk"), b"j");
@@ -2800,14 +2900,14 @@ fn files_from_repeats_and_late_listed_dirs_across_chunks() {
 }
 
 #[test]
-fn existing_dry_run_lists_no_missing_directories() {
+fn existing_dry_run_reports_no_missing_directory_changes() {
     let t = Tmp::new();
     write(&t.path("src/there/f"), b"f");
     write(&t.path("src/missing/g"), b"g");
     fs::create_dir_all(t.path("dst/there")).unwrap();
     let so = run_ok(&["-a", "-n", "-v", "--existing", &t.s("src/"), &t.s("dst")]);
-    assert!(so.contains("dst/there/"), "{so}");
-    assert!(!so.contains("missing"), "{so}");
+    assert!(!so.contains("create directory"), "{so}");
+    assert!(!so.contains(&t.s("dst/missing")), "{so}");
     assert!(!so.contains("there/f"), "--existing creates no files: {so}");
 }
 
@@ -3079,7 +3179,7 @@ fn existing_does_not_write_through_a_destination_symlink_dir() {
     assert_eq!(read(&t.path("elsewhere/sub/g")), b"old", "{so}");
     assert!(t.path("dst/d").symlink_metadata().unwrap().is_symlink());
     let so = run_ok(&["-a", "-n", "--existing", &t.s("src/"), &t.s("dst")]);
-    assert!(so.contains("would transfer 0 files"), "{so}");
+    assert!(so.contains("0 files needing content work"), "{so}");
 }
 
 #[test]
@@ -5002,10 +5102,6 @@ fn max_delete_refuses_everything_past_the_limit() {
         dry_stdout.contains("deletions: 5 entries planned; blocked by --max-delete 3"),
         "{dry_stdout}"
     );
-    assert!(
-        dry_stdout.contains("5 planned for deletion (blocked by --max-delete 3)"),
-        "{dry_stdout}"
-    );
     assert_eq!(listing(&t.path("dst")).len(), 5, "dry run changed files");
 
     let out = syq(&[
@@ -5309,7 +5405,7 @@ fn sidecar_patterned_extras_do_not_block_directory_deletion() {
     write(&t.path(&foreign), b"unclaimed");
     write(&t.path("dst/extra/gone"), b"an ordinary extra");
     let so = run_ok(&["-a", "-n", "-v", "--delete", &t.s("src/"), &t.s("dst")]);
-    assert!(so.contains("deleting extra/"), "{so}");
+    assert!(so.contains("delete extra/ (destination only)"), "{so}");
     let out = syq(&["-a", "-v", "--delete", &t.s("src/"), &t.s("dst")]);
     assert!(out.status.success(), "{}", stderr_of(&out));
     assert_eq!(listing(&t.path("dst")), ["a"]);
@@ -5815,7 +5911,7 @@ fn ignore_existing_keeps_a_file_where_a_source_directory_maps() {
     write(&t.path("dst/d"), b"precious");
     // Dry run and real run agree; the existing file survives; the rest copies.
     let so = run_ok(&["-r", "-n", "--ignore-existing", &t.s("src/"), &t.s("dst")]);
-    assert_eq!(transferred(&so), 1, "{so}");
+    assert!(so.contains("1 B in 1 file needing content work"), "{so}");
     let out = syq(&["-r", "--ignore-existing", &t.s("src/"), &t.s("dst")]);
     assert!(out.status.success(), "{}", stderr_of(&out));
     assert!(

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1787,6 +1787,29 @@ fn dry_run_rejects_bare_directory_into_existing_file() {
     assert!(skipped.status.success(), "{}", stderr_of(&skipped));
     assert!(stderr_of(&skipped).contains("skipping directory"));
 
+    let existing_dry = syq(&["-an", "--existing", &t.s("src"), &t.s("destination")]);
+    assert!(
+        existing_dry.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&existing_dry.stdout),
+        stderr_of(&existing_dry)
+    );
+    assert!(
+        String::from_utf8_lossy(&existing_dry.stdout).contains("changes: none"),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&existing_dry.stdout),
+        stderr_of(&existing_dry)
+    );
+    assert_eq!(read(&t.path("destination")), b"keep me");
+
+    let existing_actual = syq(&["-a", "--existing", &t.s("src"), &t.s("destination")]);
+    assert!(
+        existing_actual.status.success(),
+        "{}",
+        stderr_of(&existing_actual)
+    );
+    assert_eq!(read(&t.path("destination")), b"keep me");
+
     let dry = syq(&["-an", &t.s("src"), &t.s("destination")]);
     assert!(!dry.status.success());
     assert!(

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -960,6 +960,29 @@ fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
     write(&t.path("src"), b"tcp default");
     let remote = format!("127.0.0.1:{}", t.s("dst"));
 
+    let dry = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args(["--dry-run", "-a"])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .output()
+        .expect("dry-run syq over encrypted TCP through fake remote shell");
+    assert_output_ok(&dry);
+    assert!(!t.path("dst").exists());
+    let stdout = String::from_utf8_lossy(&dry.stdout);
+    assert!(
+        stdout.contains("route: encrypted TCP to 127.0.0.1; 16 initial connections (auto-tuned)"),
+        "{stdout}"
+    );
+
     let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .arg("-e")
         .arg(&rsh)
@@ -1520,6 +1543,92 @@ fn dry_run_creates_nothing() {
     );
     assert!(out.contains("would transfer"), "{out}");
     assert!(transferred(&out) > 0);
+}
+
+#[test]
+fn dry_run_reports_concrete_plan() {
+    let t = Tmp::new();
+    write(&t.path("src/send"), b"new");
+    write(&t.path("src/same"), b"same");
+    write(&t.path("src/too-big"), b"123456");
+    write(&t.path("src/skip.log"), b"ignored");
+    write(&t.path("dst/same"), b"same");
+    write(&t.path("dst/extra"), b"delete me");
+    set_mtime(&t.path("src/same"), 1_600_000_000);
+    set_mtime(&t.path("dst/same"), 1_600_000_000);
+
+    let out = run_ok(&[
+        "-an",
+        "--delete",
+        "--max-size",
+        "5",
+        "-i",
+        "*.log",
+        &t.s("src/"),
+        &t.s("dst"),
+    ]);
+    assert!(out.contains("syq: dry-run plan"), "{out}");
+    assert!(
+        out.contains(&format!(
+            "mapping: {} -> {} (directory contents)",
+            t.s("src/"),
+            t.s("dst")
+        )),
+        "{out}"
+    );
+    assert!(
+        out.contains("plan: 1 file, 3 B to transfer; 1 file, 4 B unchanged"),
+        "{out}"
+    );
+    assert!(
+        out.contains("exclusions: 1 path/subtree pruned by ignore rules; 1 other entry"),
+        "{out}"
+    );
+    assert!(
+        out.contains("deletions: 1 entry planned after a successful copy"),
+        "{out}"
+    );
+    assert!(
+        out.contains("route: local filesystem; 32 initial workers (auto-tuned)"),
+        "{out}"
+    );
+    assert!(t.path("dst/extra").exists());
+}
+
+#[test]
+fn dry_run_plan_resolves_path_semantics() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"data");
+
+    let child = run_ok(&["-an", &t.s("src"), &t.s("child-target")]);
+    assert!(
+        child.contains(&format!(
+            "mapping: {} -> {} (directory as child)",
+            t.s("src"),
+            t.s("child-target/src")
+        )),
+        "{child}"
+    );
+
+    let contents = run_ok(&["-an", &t.s("src/"), &t.s("contents-target/")]);
+    assert!(
+        contents.contains(&format!(
+            "mapping: {} -> {} (directory contents)",
+            t.s("src/"),
+            t.s("contents-target")
+        )),
+        "{contents}"
+    );
+
+    let exact = run_ok(&["-an", &t.s("src/file"), &t.s("exact-target")]);
+    assert!(
+        exact.contains(&format!(
+            "mapping: {} -> {} (exact destination path)",
+            t.s("src/file"),
+            t.s("exact-target")
+        )),
+        "{exact}"
+    );
 }
 
 #[test]
@@ -4879,6 +4988,26 @@ fn max_delete_refuses_everything_past_the_limit() {
     for i in 0..5 {
         write(&t.path(&format!("dst/extra{i}")), b"x");
     }
+    let dry = syq(&[
+        "-an",
+        "--delete",
+        "--max-delete",
+        "3",
+        &t.s("src/"),
+        &t.s("dst"),
+    ]);
+    assert_eq!(dry.status.code(), Some(25), "{}", stderr_of(&dry));
+    let dry_stdout = String::from_utf8_lossy(&dry.stdout);
+    assert!(
+        dry_stdout.contains("deletions: 5 entries planned; blocked by --max-delete 3"),
+        "{dry_stdout}"
+    );
+    assert!(
+        dry_stdout.contains("5 planned for deletion (blocked by --max-delete 3)"),
+        "{dry_stdout}"
+    );
+    assert_eq!(listing(&t.path("dst")).len(), 5, "dry run changed files");
+
     let out = syq(&[
         "-a",
         "--delete",
@@ -5601,6 +5730,21 @@ fn direct_remote_to_remote_passes_through_defined_exit_codes() {
     write(&t.path("dst/extra2"), b"y");
     let src = format!("fake:{}", t.s("src/"));
     let dst = format!("fake:{}", t.s("dst"));
+    let dry = remote_syq(&t, &rsh, &["-an", "--no-bootstrap", &src, &dst]);
+    assert_output_ok(&dry);
+    let dry_stdout = String::from_utf8_lossy(&dry.stdout);
+    assert!(
+        dry_stdout.contains(&format!(
+            "mapping: fake:{} -> fake:{} (directory contents)",
+            t.s("src/"),
+            t.s("dst")
+        )),
+        "{dry_stdout}"
+    );
+    assert!(
+        dry_stdout.contains("route: local filesystem on fake; 1 worker (fixed)"),
+        "{dry_stdout}"
+    );
     // --max-delete refusal on the remote orchestrator must surface as 25.
     let out = remote_syq(
         &t,


### PR DESCRIPTION
## Summary

- show resolved source-to-target mappings and directory path semantics during dry runs
- report typed final-state changes for regular files, directories, symlinks, special files, metadata-only updates, and type replacements
- describe regular-file sizes as a logical-data upper bound instead of bytes guaranteed to transfer
- give `-v` output typed actions and reasons (`create`, `replace`, `update metadata`, and `delete`) while keeping the default summary concise
- fix the existing no-mutation violation where a quick-check-identical file could have its mode/owner/group repaired during `--dry-run`
- model directory replacements as a virtual destination overlay, so descendants are missing instead of being statted through an old in-tree symlink
- reject a bare-directory `dest/src` preflight when the existing destination cannot serve as its parent, except when `--existing` makes the mapping a valid no-op
- retain original endpoint names for direct remote-to-remote summaries and keep the selected route compact

## Relationship to #35

#35 is now merged into `master`, and this branch is rebased on it. The integrated hierarchy keeps the compact selected-route line in the ordinary preflight summary while `-vv` supplies the deeper transport-selection diagnostics and authenticated dry-run data-path verification.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (264 tests on the rebased branch)
- regression coverage confirms `-an` leaves a destination mode unchanged while the matching real run still repairs it
- directory-over-symlink descendants, impossible bare-directory mappings, the `--existing` no-op exception, changed symlinks, and file-over-symlink changes have focused coverage