### PR TITLE
Explain transport selection at -vv

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `--self-update` | Install the newest signed release (standalone installer builds only) |
 | `-a`, `--archive` | Same as `-rlptgoD` |
 | `-r` `-l` `-p` `-t` `-g` `-o` `-D` | Recursive; symlinks as symlinks; perms; mtimes; group; owner; devices and specials |
-| `-v` | List files as they complete (also new dirs, symlinks) |
+| `-v`, `-vv` | `-v` lists files as they complete; for copies, `-vv` also explains remote helpers, candidate TCP addresses, the selected transport, and initial concurrency |
 | `-q` | Errors only |
 | `-z`, `--compress` | zstd-compress data in transit (inside syq's protocol, not `ssh -C`) |
 | `-n`, `--dry-run` | Scan and report; change nothing |
@@ -566,6 +566,20 @@ link. Single-homed hosts and laptops use the one best path, unchanged. With ufw:
 sudo ufw allow from 192.0.2.0/24  to any port 47600:47699 proto tcp   # example LAN
 sudo ufw allow from 203.0.113.5   to any port 47600:47699 proto tcp   # a specific client
 ```
+
+Use `-vv` to see the decision made for the real transfer. For each remote it
+reports the authenticated helper identity and platform, every TCP address syq
+considered, reachability and advertised link speed, why a reachable address
+was or was not selected, the resulting TCP/ssh transport, and the initial
+connection count. `-v` alone keeps its existing file-listing behavior.
+
+With `-vv --dry-run`, syq opens and authenticates one disposable data
+connection to each remote after the ordinary control and reachability checks.
+It sends no filesystem request on that connection and closes it immediately.
+The report therefore distinguishes a TCP socket that merely answered from a
+complete syq data handshake, while making clear that dry-run starts no transfer
+workers and creates, updates, or removes no destination paths. If TCP cannot be
+used, the same check verifies the ssh data fallback.
 
 Remote→remote (`syq hostA:src hostB:dst`) works the same way: the
 orchestrator on hostA connects to hostB's listener.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `--self-update` | Install the newest signed release (standalone installer builds only) |
 | `-a`, `--archive` | Same as `-rlptgoD` |
 | `-r` `-l` `-p` `-t` `-g` `-o` `-D` | Recursive; symlinks as symlinks; perms; mtimes; group; owner; devices and specials |
-| `-v`, `-vv` | `-v` lists files as they complete; for copies, `-vv` also explains remote helpers, candidate TCP addresses, the selected transport, and initial concurrency |
+| `-v`, `-vv` | `-v` lists files as they complete; for copies, `-vv` also explains remote helpers, candidate TCP addresses, the planned transport, and initial concurrency |
 | `-q` | Errors only |
 | `-z`, `--compress` | zstd-compress data in transit (inside syq's protocol, not `ssh -C`) |
 | `-n`, `--dry-run` | Scan and report; change nothing |
@@ -567,22 +567,28 @@ sudo ufw allow from 192.0.2.0/24  to any port 47600:47699 proto tcp   # example 
 sudo ufw allow from 203.0.113.5   to any port 47600:47699 proto tcp   # a specific client
 ```
 
-Use `-vv` to see the decision made for the real transfer. For each remote it
-reports the authenticated helper identity and platform, every TCP address syq
-considered, reachability and advertised link speed, why a reachable address
-was or was not selected, the resulting TCP/ssh transport, and the initial
-connection count. `-v` alone keeps its existing file-listing behavior.
+Use `-vv` to see the route planned for the real transfer. For each remote
+endpoint seen by the active orchestrator it reports the authenticated helper
+identity and platform, every TCP address syq considered, reachability and
+advertised link speed, why a reachable address was or was not selected by the
+preflight, the resulting planned TCP/ssh transport, and the initial connection
+count. Workers authenticate their data connections after this report; if TCP
+then fails, syq prints its normal data-over-ssh fallback notice. `-v` alone
+keeps its existing file-listing behavior.
 
-With `-vv --dry-run`, syq opens and authenticates one disposable data
-connection to each remote after the ordinary control and reachability checks.
-It sends no filesystem request on that connection and closes it immediately.
-The report therefore distinguishes a TCP socket that merely answered from a
-complete syq data handshake, while making clear that dry-run starts no transfer
-workers and creates, updates, or removes no destination paths. If TCP cannot be
-used, the same check verifies the ssh data fallback.
+`-vv --dry-run` is observational: it reports the same control connection,
+helper startup, TCP listener, address probes, and fallback decision that plain
+`--dry-run` already performs. It does not open an authenticated data connection
+or start transfer workers, and verbosity does not change dry-run's success or
+failure. The reported route is therefore a plan for a real transfer, not a
+claim that a worker data connection was completed.
 
-Remote→remote (`syq hostA:src hostB:dst`) works the same way: the
-orchestrator on hostA connects to hostB's listener.
+Remote→remote (`syq hostA:src hostB:dst`) works the same way: the orchestrator
+on hostA connects to hostB's listener. Diagnostics are relative to that active
+orchestrator: the existing status message identifies hostA, and the detailed
+remote block describes hostB. If both paths are on hostA, `-vv` reports a local
+filesystem route there. With `--relay`, this machine is the orchestrator and
+both remote endpoints receive detailed blocks.
 
 No special server setup is required. For a measurement-first checklist of
 optional firewall, sshd, TCP, and host-network changes, including their

--- a/SERVER-TUNING.md
+++ b/SERVER-TUNING.md
@@ -18,15 +18,17 @@ exercise the network and storage bandwidth; a tree of small files exercises
 latency and metadata performance.
 
 ```sh
-syq -a --stats SOURCE HOST:DESTINATION
+syq -avv --stats SOURCE HOST:DESTINATION
 SYQ_DEBUG=1 syq -a --stats SOURCE HOST:DESTINATION
 ```
 
-`--stats` reports the connection count syq chose. `SYQ_DEBUG=1` also reports
-connection setup time, whether TCP data paths were usable, and where workers
-spent their time. Check CPU, disk, and network utilization on both endpoints
-at the same time. More network tuning cannot fix a saturated disk, one busy CPU
-core, or a slow destination filesystem.
+`-vv` reports the remote helper and platform, candidate TCP addresses, the
+selected data transport, and the initial connection count; `--stats` reports
+where automatic connection tuning settled. `SYQ_DEBUG=1` adds engineering
+timings showing connection setup and where workers spent their time. Check CPU,
+disk, and network utilization on both endpoints at the same time. More network
+tuning cannot fix a saturated disk, one busy CPU core, or a slow destination
+filesystem.
 
 Change one thing at a time and repeat the same transfer. Record the original
 value, the reason for the change, and the before/after result. If the result is

--- a/SERVER-TUNING.md
+++ b/SERVER-TUNING.md
@@ -23,7 +23,7 @@ SYQ_DEBUG=1 syq -a --stats SOURCE HOST:DESTINATION
 ```
 
 `-vv` reports the remote helper and platform, candidate TCP addresses, the
-selected data transport, and the initial connection count; `--stats` reports
+planned data transport, and the initial connection count; `--stats` reports
 where automatic connection tuning settled. `SYQ_DEBUG=1` adds engineering
 timings showing connection setup and where workers spent their time. Check CPU,
 disk, and network utilization on both endpoints at the same time. More network

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,7 +46,7 @@ pub struct Args {
     #[arg(short = 'D')]
     pub devices: bool,
 
-    /// Increase verbosity (list files as they complete)
+    /// Increase verbosity (-v lists files; -vv also explains copy helpers and transport)
     #[arg(short = 'v', long, action = clap::ArgAction::Count)]
     pub verbose: u8,
     /// Suppress non-error messages

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -38,6 +38,12 @@ pub trait Conn: Send {
     ) -> Result<()>;
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PeerInfo {
+    pub identity: String,
+    pub platform: String,
+}
+
 /// Turn an `Err` response into an error, otherwise pass through.
 pub fn ok(resp: Response, what: &str) -> Result<Response> {
     match resp {
@@ -101,6 +107,7 @@ pub struct RemoteConn {
     rx: std::sync::mpsc::Receiver<std::io::Result<Response>>,
     label: String,
     dead: bool,
+    peer: Option<PeerInfo>,
 }
 
 const READ_AHEAD: usize = 4;
@@ -278,6 +285,44 @@ impl Drop for ConnectSlot {
 
 pub const CIPHERS: &str = "Ciphers=aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-ctr,aes256-ctr,chacha20-poly1305@openssh.com";
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DataAddressSource {
+    RemoteInterface,
+    SshTarget,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TcpCandidate {
+    pub address: String,
+    pub speed_mbps: u32,
+    pub source: DataAddressSource,
+    pub reachable: bool,
+    pub selected: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TcpProbe {
+    pub port: u16,
+    pub encrypted: bool,
+    pub candidates: Vec<TcpCandidate>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RemoteDiagnostics {
+    pub peer: Option<PeerInfo>,
+    pub tcp_probe: Option<TcpProbe>,
+    pub tcp_setup_error: Option<String>,
+    pub data_connection_verified: bool,
+    pub data_connection_error: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DataTransport {
+    Ssh,
+    EncryptedTcp,
+    PlaintextTcp,
+}
+
 #[derive(Clone, Debug)]
 pub struct RemoteSpec {
     pub user: Option<String>,
@@ -292,6 +337,8 @@ pub struct RemoteSpec {
     pub quiet: bool,
     /// Shared across clones so workers see the TCP setup done on the control connection.
     pub tcp: std::sync::Arc<std::sync::Mutex<Option<TcpInfo>>>,
+    /// User-facing facts gathered by the same connection path the transfer uses.
+    pub diagnostics: std::sync::Arc<std::sync::Mutex<RemoteDiagnostics>>,
 }
 
 impl RemoteSpec {
@@ -299,6 +346,40 @@ impl RemoteSpec {
         match &self.user {
             Some(u) => format!("{u}@{}", self.host),
             None => self.host.clone(),
+        }
+    }
+
+    pub fn diagnostics(&self) -> RemoteDiagnostics {
+        self.diagnostics.lock().unwrap().clone()
+    }
+
+    pub fn data_transport(&self) -> DataTransport {
+        match self.tcp.lock().unwrap().as_ref() {
+            Some(info) if !info.failed && info.key.is_some() => DataTransport::EncryptedTcp,
+            Some(info) if !info.failed => DataTransport::PlaintextTcp,
+            _ => DataTransport::Ssh,
+        }
+    }
+
+    pub fn remote_shell_name(&self) -> String {
+        std::path::Path::new(&self.rsh[0])
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new(&self.rsh[0]))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    pub fn record_data_connection_check(&self, result: &Result<()>) {
+        let mut diagnostics = self.diagnostics.lock().unwrap();
+        match result {
+            Ok(()) => diagnostics.data_connection_verified = true,
+            Err(error) => diagnostics.data_connection_error = Some(format!("{error:#}")),
+        }
+    }
+
+    fn record_peer(&self, conn: &RemoteConn) {
+        if let Some(peer) = &conn.peer {
+            self.diagnostics.lock().unwrap().peer = Some(peer.clone());
         }
     }
 
@@ -438,13 +519,30 @@ impl RemoteSpec {
             rx: spawn_reader(Box::new(stdout)),
             label: self.label(),
             dead: false,
+            peer: None,
         };
-        hello(conn, compress, Vec::new())
+        let conn = hello(conn, compress, Vec::new())?;
+        self.record_peer(&conn);
+        Ok(conn)
     }
 
     /// Ask the remote (over the control connection) to accept TCP data
     /// connections; records how to reach it for later `connect` calls.
     pub fn setup_tcp(&self, ctl: &mut dyn Conn, plain: bool, ports: (u16, u16)) -> Result<()> {
+        *self.tcp.lock().unwrap() = None;
+        {
+            let mut diagnostics = self.diagnostics.lock().unwrap();
+            diagnostics.tcp_probe = None;
+            diagnostics.tcp_setup_error = None;
+        }
+        let result = self.setup_tcp_inner(ctl, plain, ports);
+        if let Err(error) = &result {
+            self.diagnostics.lock().unwrap().tcp_setup_error = Some(format!("{error:#}"));
+        }
+        result
+    }
+
+    fn setup_tcp_inner(&self, ctl: &mut dyn Conn, plain: bool, ports: (u16, u16)) -> Result<()> {
         let key = if plain {
             None
         } else {
@@ -457,10 +555,20 @@ impl RemoteSpec {
             port_lo: ports.0,
             port_hi: ports.1,
         })?;
-        let (port, mut advertised) = match ok(resp, "tcp listen")? {
+        let (port, advertised) = match ok(resp, "tcp listen")? {
             Response::TcpListening { port, addrs } => (port, addrs),
             other => bail!("unexpected response {other:?}"),
         };
+        let mut candidates: Vec<TcpCandidate> = advertised
+            .into_iter()
+            .map(|(address, speed_mbps)| TcpCandidate {
+                address,
+                speed_mbps,
+                source: DataAddressSource::RemoteInterface,
+                reachable: false,
+                selected: false,
+            })
+            .collect();
         // Always also try the name we reached ssh through: a server behind
         // NAT / port forwarding advertises only its private addresses, which
         // are unreachable from outside, while its public address is exactly
@@ -468,38 +576,65 @@ impl RemoteSpec {
         // (better when reachable) but before CGNAT / Tailscale ones, which
         // are overlay paths and must not win over the direct public address.
         if let Some(h) = self.resolved_hostname() {
-            if !advertised.iter().any(|(a, _)| *a == h) {
-                let at = advertised
+            if !candidates.iter().any(|candidate| candidate.address == h) {
+                let at = candidates
                     .iter()
-                    .position(|(a, _)| a.starts_with("100."))
-                    .unwrap_or(advertised.len());
-                advertised.insert(at, (h, 0));
+                    .position(|candidate| candidate.address.starts_with("100."))
+                    .unwrap_or(candidates.len());
+                candidates.insert(
+                    at,
+                    TcpCandidate {
+                        address: h,
+                        speed_mbps: 0,
+                        source: DataAddressSource::SshTarget,
+                        reachable: false,
+                        selected: false,
+                    },
+                );
             }
         }
         // Probe which advertised addresses this client can actually reach.
-        let reachable = probe_reachable(&advertised, port);
-        if reachable.is_empty() {
-            bail!("no advertised data address is reachable");
-        }
+        probe_reachable(&mut candidates, port);
         // Multipath only across comparable-speed NICs: keep those within 2x of
         // the fastest reachable one. Mixing a fast and a slow path (a rail and
         // Tailscale, say) would drag the transfer down, so we don't.
-        let fastest = reachable.iter().map(|(_, s)| *s).max().unwrap_or(0);
-        let addrs: Vec<String> = if fastest > 0 {
-            reachable
-                .iter()
-                .filter(|(_, s)| *s * 2 >= fastest)
-                .map(|(a, _)| a.clone())
-                .collect()
-        } else {
-            vec![reachable[0].0.clone()]
-        };
+        let fastest = candidates
+            .iter()
+            .filter(|candidate| candidate.reachable)
+            .map(|candidate| candidate.speed_mbps)
+            .max()
+            .unwrap_or(0);
+        let mut selected_unknown = false;
+        for candidate in &mut candidates {
+            candidate.selected = candidate.reachable
+                && if fastest > 0 {
+                    candidate.speed_mbps.saturating_mul(2) >= fastest
+                } else if selected_unknown {
+                    false
+                } else {
+                    selected_unknown = true;
+                    true
+                };
+        }
+        self.diagnostics.lock().unwrap().tcp_probe = Some(TcpProbe {
+            port,
+            encrypted: key.is_some(),
+            candidates: candidates.clone(),
+        });
+        let addrs: Vec<String> = candidates
+            .iter()
+            .filter(|candidate| candidate.selected)
+            .map(|candidate| candidate.address.clone())
+            .collect();
+        if addrs.is_empty() {
+            bail!("no advertised data address is reachable");
+        }
         if crate::transfer::debug() {
             eprintln!(
                 "syq: {}: data paths {:?} (advertised {:?})",
                 self.label(),
                 addrs,
-                advertised
+                candidates
             );
         }
         *self.tcp.lock().unwrap() = Some(TcpInfo {
@@ -508,6 +643,8 @@ impl RemoteSpec {
             key,
             token,
             failed: false,
+            failure: None,
+            verified: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             next: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         });
         Ok(())
@@ -589,8 +726,13 @@ impl RemoteSpec {
                 rx: spawn_reader(Box::new(reader)),
                 label: format!("{} (tcp {addr_s})", self.label()),
                 dead: false,
+                peer: None,
             };
-            return hello(conn, compress, info.token.clone());
+            let conn = hello(conn, compress, info.token.clone())?;
+            info.verified
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            self.record_peer(&conn);
+            return Ok(conn);
         }
         Err(last)
     }
@@ -609,10 +751,11 @@ fn helper_needs_install(e: &anyhow::Error) -> bool {
 
 /// Concurrently probe which (addr, speed) entries accept a TCP connection on
 /// `port`, preserving the server's priority order. Used once per endpoint.
-fn probe_reachable(advertised: &[(String, u32)], port: u16) -> Vec<(String, u32)> {
+fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
     let (tx, rx) = std::sync::mpsc::channel();
-    for (i, (addr, speed)) in advertised.iter().cloned().enumerate() {
+    for (i, candidate) in candidates.iter().enumerate() {
         let tx = tx.clone();
+        let addr = candidate.address.clone();
         std::thread::spawn(move || {
             // Try every resolved address (a dual-stack name may return IPv6
             // first while the listener is IPv4-only): reachable if any connects.
@@ -625,17 +768,13 @@ fn probe_reachable(advertised: &[(String, u32)], port: u16) -> Vec<(String, u32)
                     })
                 })
                 .unwrap_or(false);
-            let _ = tx.send((i, addr, speed, ok));
+            let _ = tx.send((i, ok));
         });
     }
     drop(tx);
-    let mut hits: Vec<(usize, String, u32)> = rx
-        .iter()
-        .filter(|(_, _, _, ok)| *ok)
-        .map(|(i, a, s, _)| (i, a, s))
-        .collect();
-    hits.sort_by_key(|(i, _, _)| *i);
-    hits.into_iter().map(|(_, a, s)| (a, s)).collect()
+    for (i, reachable) in rx {
+        candidates[i].reachable = reachable;
+    }
 }
 
 static TCP_CONN_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(1);
@@ -649,6 +788,10 @@ pub struct TcpInfo {
     pub token: Vec<u8>,
     /// Set once a connect attempt failed; later connections use ssh.
     pub failed: bool,
+    pub failure: Option<String>,
+    /// Shared across snapshots so diagnostics can distinguish a socket probe
+    /// from a complete authenticated syq handshake.
+    pub verified: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Round-robin cursor so successive data connections use different addresses.
     pub next: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
@@ -672,8 +815,13 @@ fn hello(mut conn: RemoteConn, compress: bool, token: Vec<u8>) -> Result<RemoteC
             token,
         })?;
         match conn.recv() {
-            Ok(Response::HelloOk { identity }) if identity == crate::identity::build() => Ok(conn),
-            Ok(Response::HelloOk { identity }) => {
+            Ok(Response::HelloOk { identity, platform })
+                if identity == crate::identity::build() =>
+            {
+                conn.peer = Some(PeerInfo { identity, platform });
+                Ok(conn)
+            }
+            Ok(Response::HelloOk { identity, .. }) => {
                 bail!(
                     "{}: build identity mismatch (remote {identity}, local {})",
                     conn.label,
@@ -808,6 +956,7 @@ impl Endpoint {
                             if let Some(i) = g.as_mut() {
                                 if !i.failed {
                                     i.failed = true;
+                                    i.failure = Some(format!("{e:#}"));
                                     if !spec.quiet || crate::transfer::debug() {
                                         eprintln!("syq: {}: data over ssh (TCP port {} stopped answering: {e:#})", spec.label(), info.port);
                                     }
@@ -884,6 +1033,7 @@ mod tests {
             helper_install: Default::default(),
             quiet: false,
             tcp: Default::default(),
+            diagnostics: Default::default(),
         };
         let command = spec.ssh_command();
         assert!(!command

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -312,8 +312,6 @@ pub struct RemoteDiagnostics {
     pub peer: Option<PeerInfo>,
     pub tcp_probe: Option<TcpProbe>,
     pub tcp_setup_error: Option<String>,
-    pub data_connection_verified: bool,
-    pub data_connection_error: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -367,14 +365,6 @@ impl RemoteSpec {
             .unwrap_or_else(|| std::ffi::OsStr::new(&self.rsh[0]))
             .to_string_lossy()
             .into_owned()
-    }
-
-    pub fn record_data_connection_check(&self, result: &Result<()>) {
-        let mut diagnostics = self.diagnostics.lock().unwrap();
-        match result {
-            Ok(()) => diagnostics.data_connection_verified = true,
-            Err(error) => diagnostics.data_connection_error = Some(format!("{error:#}")),
-        }
     }
 
     fn record_peer(&self, conn: &RemoteConn) {
@@ -644,7 +634,6 @@ impl RemoteSpec {
             token,
             failed: false,
             failure: None,
-            verified: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             next: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         });
         Ok(())
@@ -729,8 +718,6 @@ impl RemoteSpec {
                 peer: None,
             };
             let conn = hello(conn, compress, info.token.clone())?;
-            info.verified
-                .store(true, std::sync::atomic::Ordering::Relaxed);
             self.record_peer(&conn);
             return Ok(conn);
         }
@@ -789,9 +776,6 @@ pub struct TcpInfo {
     /// Set once a connect attempt failed; later connections use ssh.
     pub failed: bool,
     pub failure: Option<String>,
-    /// Shared across snapshots so diagnostics can distinguish a socket probe
-    /// from a complete authenticated syq handshake.
-    pub verified: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Round-robin cursor so successive data connections use different addresses.
     pub next: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -49,6 +49,7 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         helper_install: Default::default(),
         quiet: args.quiet,
         tcp: Default::default(),
+        diagnostics: Default::default(),
     };
 
     // Rebuild the option list for the remote orchestrator.

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -8,6 +8,13 @@ pub const fn build() -> &'static str {
     env!("SYQ_BUILD_IDENTITY")
 }
 
+/// The platform this executable was built for, reported by remote helpers in
+/// the wire handshake. This avoids a separate `uname` ssh round trip on a
+/// managed-helper cache hit.
+pub fn platform() -> String {
+    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
 pub fn release() -> String {
     format!("v{}", env!("CARGO_PKG_VERSION"))
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -268,6 +268,7 @@ pub enum Request {
 pub enum Response {
     HelloOk {
         identity: String,
+        platform: String,
     },
     /// Each advertised data address with its interface link speed in Mbps
     /// (0 = unknown). The address the client's ssh session arrived on is first.

--- a/src/server.rs
+++ b/src/server.rs
@@ -57,6 +57,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
             w.compress = compress;
             w.write_msg(&Response::HelloOk {
                 identity: expected_identity.to_string(),
+                platform: crate::identity::platform(),
             })?;
         }
         _ => bail!("expected Hello"),

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -125,7 +125,7 @@ fn candidate_status(candidate: &TcpCandidate, fastest: u32) -> String {
     }
     let speed = link_speed(candidate.speed_mbps);
     if candidate.selected {
-        return format!("reachable, {speed}, selected");
+        return format!("reachable, {speed}, selected by preflight");
     }
     let reason = if fastest == 0 {
         "link speeds unknown; first reachable path preferred"
@@ -190,7 +190,11 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
         }
     }
 
-    let verified = args.dry_run && diagnostics.data_connection_verified;
+    let route_state = if args.dry_run {
+        "planned for a real transfer"
+    } else {
+        "planned"
+    };
     let transport = spec.data_transport();
     match transport {
         DataTransport::EncryptedTcp | DataTransport::PlaintextTcp => {
@@ -199,11 +203,7 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
             } else {
                 "plaintext TCP"
             };
-            if verified {
-                eprintln!("  transport: {name} verified by a dry-run data connection");
-            } else {
-                eprintln!("  transport: {name} selected");
-            }
+            eprintln!("  transport: {name} {route_state} (reachability preflight passed)");
         }
         DataTransport::Ssh => {
             let tcp_failure = spec
@@ -214,32 +214,16 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
                 .and_then(|info| info.failure.clone())
                 .or(diagnostics.tcp_setup_error.clone());
             if args.no_tcp {
-                if verified {
-                    eprintln!("  transport: SSH data connection verified (--no-tcp)");
-                } else {
-                    eprintln!("  transport: SSH (--no-tcp)");
-                }
+                eprintln!("  transport: SSH {route_state} (--no-tcp)");
             } else if let Some(error) = tcp_failure {
-                if verified {
-                    eprintln!(
-                        "  transport: SSH fallback verified by a dry-run data connection (TCP unavailable: {})",
-                        one_line(&error)
-                    );
-                } else {
-                    eprintln!(
-                        "  transport: SSH fallback (TCP unavailable: {})",
-                        one_line(&error)
-                    );
-                }
-            } else if verified {
-                eprintln!("  transport: SSH data connection verified");
+                eprintln!(
+                    "  transport: SSH {route_state} (TCP unavailable: {})",
+                    one_line(&error)
+                );
             } else {
-                eprintln!("  transport: SSH selected");
+                eprintln!("  transport: SSH {route_state}");
             }
         }
-    }
-    if let Some(error) = &diagnostics.data_connection_error {
-        eprintln!("  dry-run data connection: failed ({})", one_line(error));
     }
 }
 
@@ -278,31 +262,6 @@ fn print_transport_diagnostics(args: &Args, src: &Endpoint, dst: &Endpoint) {
             args.connections
         );
     }
-}
-
-fn verify_dry_run_data_connections(
-    args: &Args,
-    src: &Endpoint,
-    dst: &Endpoint,
-) -> Option<anyhow::Error> {
-    if !args.dry_run || args.quiet || args.verbose < 2 {
-        return None;
-    }
-    let mut first_error = None;
-    for endpoint in [src, dst] {
-        let Endpoint::Remote(spec) = endpoint else {
-            continue;
-        };
-        let result = endpoint
-            .connect(args.compress)
-            .map(drop)
-            .with_context(|| format!("verify data connection to {} during dry-run", spec.label()));
-        spec.record_data_connection_check(&result);
-        if let Err(error) = result {
-            first_error.get_or_insert(error);
-        }
-    }
-    first_error
 }
 
 /// The canonical form of a path (symlinks and `..` resolved the way the kernel
@@ -755,11 +714,6 @@ pub fn run(args: Args) -> Result<i32> {
             }
         }
     }
-    // Dry-run normally needs only the control connections. At -vv it also
-    // authenticates one disposable data connection per remote endpoint so the
-    // transport report can distinguish a reachable socket from a working syq
-    // data path. No filesystem request is sent over this connection.
-    let dry_run_connection_error = verify_dry_run_data_connections(&args, &src_ep, &dst_ep);
     let all_remote_endpoints_use_tcp = use_tcp
         && [&src_ep, &dst_ep].into_iter().all(|ep| match ep {
             Endpoint::Local => true,
@@ -775,11 +729,6 @@ pub fn run(args: Args) -> Result<i32> {
         gate.set_limit(args.connections);
     }
     print_transport_diagnostics(&args, &src_ep, &dst_ep);
-    if let Some(error) = dry_run_connection_error {
-        sched.abort();
-        progress.stop();
-        return Err(error);
-    }
     if !opts.dry_run {
         spawn_workers(args.connections);
     }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -2,7 +2,7 @@
 
 use crate::bwlimit::BandwidthLimit;
 use crate::cli::{parse_rsh, parse_size, Args, Location};
-use crate::conn::{ok, Conn, Endpoint, RemoteSpec};
+use crate::conn::{ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, TcpCandidate};
 use crate::fsops::{is_partial_name, join};
 use crate::progress::{commas, human, Progress, WorkerStatus};
 use crate::proto::*;
@@ -69,6 +69,7 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
             helper_install: Default::default(),
             quiet: args.quiet,
             tcp: Default::default(),
+            diagnostics: Default::default(),
         }),
     })
 }
@@ -98,6 +99,210 @@ fn parse_ports(s: &str) -> Result<(u16, u16)> {
         bail!("bad port range {s:?}");
     }
     Ok((lo, hi))
+}
+
+fn data_address(address: &str, port: u16) -> String {
+    if address.contains(':') {
+        format!("[{address}]:{port}")
+    } else {
+        format!("{address}:{port}")
+    }
+}
+
+fn link_speed(speed_mbps: u32) -> String {
+    if speed_mbps == 0 {
+        "link speed unknown".to_string()
+    } else if speed_mbps.is_multiple_of(1000) {
+        format!("{} Gbit/s advertised", speed_mbps / 1000)
+    } else {
+        format!("{speed_mbps} Mbit/s advertised")
+    }
+}
+
+fn candidate_status(candidate: &TcpCandidate, fastest: u32) -> String {
+    if !candidate.reachable {
+        return "not reachable".to_string();
+    }
+    let speed = link_speed(candidate.speed_mbps);
+    if candidate.selected {
+        return format!("reachable, {speed}, selected");
+    }
+    let reason = if fastest == 0 {
+        "link speeds unknown; first reachable path preferred"
+    } else if candidate.speed_mbps == 0 {
+        "a faster advertised path was available"
+    } else {
+        "less than half the fastest advertised link speed"
+    };
+    format!("reachable, {speed}, not selected ({reason})")
+}
+
+fn one_line(message: &str) -> String {
+    message
+        .lines()
+        .map(str::trim)
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
+    let diagnostics = spec.diagnostics();
+    eprintln!("syq: {}:", spec.label());
+    if let Some(peer) = &diagnostics.peer {
+        eprintln!(
+            "  control: connected via {}; remote {}",
+            spec.remote_shell_name(),
+            peer.platform
+        );
+        let helper_mode = if spec.auto_helper {
+            if *spec.helper_install.lock().unwrap() {
+                "managed; installed now"
+            } else {
+                "managed helper cache"
+            }
+        } else if spec.syq_path.is_some() {
+            "--syq-path"
+        } else {
+            "remote PATH (--no-bootstrap)"
+        };
+        eprintln!("  helper: {} ({helper_mode})", peer.identity);
+    }
+
+    if let Some(probe) = &diagnostics.tcp_probe {
+        let fastest = probe
+            .candidates
+            .iter()
+            .filter(|candidate| candidate.reachable)
+            .map(|candidate| candidate.speed_mbps)
+            .max()
+            .unwrap_or(0);
+        for candidate in &probe.candidates {
+            let source = if candidate.source == DataAddressSource::SshTarget {
+                " (SSH target)"
+            } else {
+                ""
+            };
+            eprintln!(
+                "  TCP {}{source}: {}",
+                data_address(&candidate.address, probe.port),
+                candidate_status(candidate, fastest)
+            );
+        }
+    }
+
+    let verified = args.dry_run && diagnostics.data_connection_verified;
+    let transport = spec.data_transport();
+    match transport {
+        DataTransport::EncryptedTcp | DataTransport::PlaintextTcp => {
+            let name = if transport == DataTransport::EncryptedTcp {
+                "encrypted TCP"
+            } else {
+                "plaintext TCP"
+            };
+            if verified {
+                eprintln!("  transport: {name} verified by a dry-run data connection");
+            } else {
+                eprintln!("  transport: {name} selected");
+            }
+        }
+        DataTransport::Ssh => {
+            let tcp_failure = spec
+                .tcp
+                .lock()
+                .unwrap()
+                .as_ref()
+                .and_then(|info| info.failure.clone())
+                .or(diagnostics.tcp_setup_error.clone());
+            if args.no_tcp {
+                if verified {
+                    eprintln!("  transport: SSH data connection verified (--no-tcp)");
+                } else {
+                    eprintln!("  transport: SSH (--no-tcp)");
+                }
+            } else if let Some(error) = tcp_failure {
+                if verified {
+                    eprintln!(
+                        "  transport: SSH fallback verified by a dry-run data connection (TCP unavailable: {})",
+                        one_line(&error)
+                    );
+                } else {
+                    eprintln!(
+                        "  transport: SSH fallback (TCP unavailable: {})",
+                        one_line(&error)
+                    );
+                }
+            } else if verified {
+                eprintln!("  transport: SSH data connection verified");
+            } else {
+                eprintln!("  transport: SSH selected");
+            }
+        }
+    }
+    if let Some(error) = &diagnostics.data_connection_error {
+        eprintln!("  dry-run data connection: failed ({})", one_line(error));
+    }
+}
+
+fn print_transport_diagnostics(args: &Args, src: &Endpoint, dst: &Endpoint) {
+    if args.quiet || args.verbose < 2 {
+        return;
+    }
+    for endpoint in [src, dst] {
+        if let Endpoint::Remote(spec) = endpoint {
+            print_remote_diagnostics(spec, args);
+        }
+    }
+    let remote = src.is_remote() || dst.is_remote();
+    let unit = match (remote, args.connections) {
+        (true, 1) => "connection",
+        (true, _) => "connections",
+        (false, 1) => "worker",
+        (false, _) => "workers",
+    };
+    let policy = if args.connections_default {
+        "auto-tuned"
+    } else {
+        "fixed"
+    };
+    if !remote {
+        eprintln!("syq: transport: local filesystem");
+    }
+    if args.dry_run {
+        eprintln!(
+            "syq: concurrency: a real transfer would start with {} {unit} ({policy}); dry-run starts no workers",
+            args.connections
+        );
+    } else {
+        eprintln!(
+            "syq: concurrency: starting with {} {unit} ({policy})",
+            args.connections
+        );
+    }
+}
+
+fn verify_dry_run_data_connections(
+    args: &Args,
+    src: &Endpoint,
+    dst: &Endpoint,
+) -> Option<anyhow::Error> {
+    if !args.dry_run || args.quiet || args.verbose < 2 {
+        return None;
+    }
+    let mut first_error = None;
+    for endpoint in [src, dst] {
+        let Endpoint::Remote(spec) = endpoint else {
+            continue;
+        };
+        let result = endpoint
+            .connect(args.compress)
+            .map(drop)
+            .with_context(|| format!("verify data connection to {} during dry-run", spec.label()));
+        spec.record_data_connection_check(&result);
+        if let Err(error) = result {
+            first_error.get_or_insert(error);
+        }
+    }
+    first_error
 }
 
 /// The canonical form of a path (symlinks and `..` resolved the way the kernel
@@ -550,14 +755,30 @@ pub fn run(args: Args) -> Result<i32> {
             }
         }
     }
+    // Dry-run normally needs only the control connections. At -vv it also
+    // authenticates one disposable data connection per remote endpoint so the
+    // transport report can distinguish a reachable socket from a working syq
+    // data path. No filesystem request is sent over this connection.
+    let dry_run_connection_error = verify_dry_run_data_connections(&args, &src_ep, &dst_ep);
     let all_remote_endpoints_use_tcp = use_tcp
         && [&src_ep, &dst_ep].into_iter().all(|ep| match ep {
             Endpoint::Local => true,
-            Endpoint::Remote(spec) => spec.tcp.lock().unwrap().is_some(),
+            Endpoint::Remote(spec) => spec
+                .tcp
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|info| !info.failed),
         });
     if autotune && all_remote_endpoints_use_tcp {
         args.connections = tune::START_TCP;
         gate.set_limit(args.connections);
+    }
+    print_transport_diagnostics(&args, &src_ep, &dst_ep);
+    if let Some(error) = dry_run_connection_error {
+        sched.abort();
+        progress.stop();
+        return Err(error);
     }
     if !opts.dry_run {
         spawn_workers(args.connections);

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -343,7 +343,7 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
 
     write(&t.path("src"), b"first");
     let remote = format!("fake:{}", t.s("dst"));
-    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
+    let out = remote_syq(&t, &rsh, &["-avv", &t.s("src"), &remote]);
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"first");
     assert!(cached_remote_helper(&t).is_file());
@@ -352,6 +352,14 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
     assert_eq!(read(&t.path("local-curl.log")), b"fetch\n");
     assert_eq!(read(&t.path("curl.log")), b"fetch\n");
     assert!(!String::from_utf8_lossy(&out.stderr).contains("uploading this executable"));
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains(&format!(
+            "helper: {} (managed; installed now)",
+            binary_identity("--build-identity")
+        )),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let probes = fs::read_to_string(t.path("rsh.log"))
         .unwrap()
         .matches("syq-helper-target:")
@@ -360,11 +368,19 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
 
     // A cache hit goes straight to the helper: no platform probe or download.
     write(&t.path("src"), b"second");
-    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
+    let out = remote_syq(&t, &rsh, &["-avv", &t.s("src"), &remote]);
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"second");
     assert_eq!(read(&t.path("local-curl.log")), b"fetch\n");
     assert_eq!(read(&t.path("curl.log")), b"fetch\n");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains(&format!(
+            "helper: {} (managed helper cache)",
+            binary_identity("--build-identity")
+        )),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let probes = fs::read_to_string(t.path("rsh.log"))
         .unwrap()
         .matches("syq-helper-target:")
@@ -438,6 +454,136 @@ fn remote_retained_basis_handles_matching_and_changed_files() {
 }
 
 #[test]
+fn double_verbose_dry_run_verifies_tcp_without_writing() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"diagnose");
+    let remote = format!("127.0.0.1:{}", t.s("dst"));
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args(["--dry-run", "-vv", "-a"])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .output()
+        .expect("run double-verbose dry-run over TCP");
+
+    assert_output_ok(&out);
+    assert!(!t.path("dst").exists());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("control: connected via fake-rsh; remote linux-"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains(&format!(
+            "helper: {} (--syq-path)",
+            binary_identity("--build-identity")
+        )),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("TCP ") && stderr.contains(": reachable"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("transport: encrypted TCP verified by a dry-run data connection"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "a real transfer would start with 16 connections (auto-tuned); dry-run starts no workers"
+        ),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn double_verbose_dry_run_explains_ssh_fallback() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    executable(
+        &t.path("remote-bin/ip"),
+        b"#!/bin/sh\nprintf '2: eth9 inet 192.0.2.1/24 scope global eth9\\n'\n",
+    );
+    write(&t.path("src"), b"fallback");
+    let remote = format!("diagnostic.invalid:{}", t.s("dst"));
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args(["--dry-run", "-vv", "-a"])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .output()
+        .expect("run double-verbose dry-run with TCP fallback");
+
+    assert_output_ok(&out);
+    assert!(!t.path("dst").exists());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("TCP 192.0.2.1:") && stderr.contains("not reachable"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("transport: SSH fallback verified by a dry-run data connection"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "a real transfer would start with 8 connections (auto-tuned); dry-run starts no workers"
+        ),
+        "{stderr}"
+    );
+}
+
+#[test]
+fn single_verbose_keeps_file_listing_semantics() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"listed");
+    let remote = format!("fake:{}", t.s("dst"));
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args(["--no-tcp", "-v", "-a", "-j", "1"])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .output()
+        .expect("run single-verbose remote copy");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"listed");
+    assert!(String::from_utf8_lossy(&out.stdout).contains("src"));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!stderr.contains("  control:"), "{stderr}");
+    assert!(!stderr.contains("syq: concurrency:"), "{stderr}");
+}
+
+#[test]
 fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
@@ -449,7 +595,7 @@ fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
         .arg(&rsh)
         .arg("--syq-path")
         .arg(env!("CARGO_BIN_EXE_syq"))
-        .args(["--tcp-plain", "--stats", "-a"])
+        .args(["--tcp-plain", "--stats", "-avv"])
         .arg(t.s("src"))
         .arg(&remote)
         .arg("--no-progress")
@@ -466,6 +612,15 @@ fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
     assert!(
         stdout.contains("connections: auto: settled at 16 (path 16, peak 16)"),
         "{stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("transport: plaintext TCP selected"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("concurrency: starting with 16 connections (auto-tuned)"),
+        "{stderr}"
     );
 }
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -454,7 +454,7 @@ fn remote_retained_basis_handles_matching_and_changed_files() {
 }
 
 #[test]
-fn double_verbose_dry_run_verifies_tcp_without_writing() {
+fn double_verbose_dry_run_reports_tcp_without_extra_connection() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
     write(&t.path("src"), b"diagnose");
@@ -495,7 +495,9 @@ fn double_verbose_dry_run_verifies_tcp_without_writing() {
         "{stderr}"
     );
     assert!(
-        stderr.contains("transport: encrypted TCP verified by a dry-run data connection"),
+        stderr.contains(
+            "transport: encrypted TCP planned for a real transfer (reachability preflight passed)"
+        ),
         "{stderr}"
     );
     assert!(
@@ -504,10 +506,18 @@ fn double_verbose_dry_run_verifies_tcp_without_writing() {
         ),
         "{stderr}"
     );
+    assert_eq!(
+        fs::read_to_string(t.path("rsh.log"))
+            .unwrap()
+            .lines()
+            .count(),
+        1,
+        "-vv must not add a remote-shell connection during dry-run"
+    );
 }
 
 #[test]
-fn double_verbose_dry_run_explains_ssh_fallback() {
+fn double_verbose_dry_run_reports_ssh_fallback_without_extra_connection() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
     executable(
@@ -541,7 +551,7 @@ fn double_verbose_dry_run_explains_ssh_fallback() {
         "{stderr}"
     );
     assert!(
-        stderr.contains("transport: SSH fallback verified by a dry-run data connection"),
+        stderr.contains("transport: SSH planned for a real transfer (TCP unavailable:"),
         "{stderr}"
     );
     assert!(
@@ -549,6 +559,14 @@ fn double_verbose_dry_run_explains_ssh_fallback() {
             "a real transfer would start with 8 connections (auto-tuned); dry-run starts no workers"
         ),
         "{stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(t.path("rsh.log"))
+            .unwrap()
+            .lines()
+            .count(),
+        1,
+        "-vv must not verify fallback with an extra connection"
     );
 }
 
@@ -615,7 +633,7 @@ fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("transport: plaintext TCP selected"),
+        stderr.contains("transport: plaintext TCP planned (reachability preflight passed)"),
         "{stderr}"
     );
     assert!(
@@ -5169,6 +5187,55 @@ fn files_from_leaves_unlisted_destination_root_metadata_alone() {
         &t.s("dst2"),
     ]);
     assert!(t.path("dst2").is_dir());
+}
+
+#[test]
+fn direct_remote_to_remote_verbose_diagnostics_are_orchestrator_relative() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    write(&t.path("src/a"), b"a");
+
+    let src = format!("hostA:{}", t.s("src/"));
+    let dst = format!("hostB:{}", t.s("dst"));
+    let out = remote_syq(
+        &t,
+        &rsh,
+        &["-avv", "--dry-run", "--no-bootstrap", &src, &dst],
+    );
+    assert_output_ok(&out);
+    assert!(!t.path("dst").exists());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote-to-remote: running on hostA"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("syq: hostB:\n"), "{stderr}");
+    assert!(!stderr.contains("syq: hostA:\n"), "{stderr}");
+    assert!(
+        stderr.contains("transport: SSH planned for a real transfer (--no-tcp)"),
+        "{stderr}"
+    );
+
+    let same_host_dst = format!("hostA:{}", t.s("same-host-dst"));
+    let out = remote_syq(
+        &t,
+        &rsh,
+        &["-avv", "--dry-run", "--no-bootstrap", &src, &same_host_dst],
+    );
+    assert_output_ok(&out);
+    assert!(!t.path("same-host-dst").exists());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote-to-remote: running on hostA"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("syq: transport: local filesystem"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("syq: hostA:\n"), "{stderr}");
 }
 
 #[test]


### PR DESCRIPTION
Summary

- Add user-facing -vv diagnostics for remote helper identity/platform, TCP candidates, preflight decisions, the planned transport, and initial concurrency.
- Keep verbosity observational: -v file-list behavior is unchanged, and -vv --dry-run performs the same network work and has the same success/failure behavior as plain --dry-run. It does not open an authenticated data connection or start transfer workers.
- Describe the route as planned because workers authenticate their first TCP data connections later; the existing runtime fallback notice remains authoritative if that handshake fails.
- Document that direct remote-to-remote diagnostics are relative to the active orchestrator, with coverage for distinct-host and same-host direct copies.
- Update the README and server tuning guide.

Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets

All 240 tests pass. Loopback TCP uses the real syq protocol with the integration-test remote shell; no external SSH host was exercised.