### PR TITLE
Redesign rsync compatibility tracking

### DIFF
--- a/.github/workflows/rsync-compat.yml
+++ b/.github/workflows/rsync-compat.yml
@@ -12,23 +12,26 @@ permissions:
 jobs:
   conformance:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       CARGO_TARGET_DIR: target/cargo
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install rsync test-build prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf automake build-essential
       - name: Cache pinned rsync source and helpers
+        id: rsync-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             target/rsync-compat/sources
             target/rsync-compat/suites
           key: rsync-compat-${{ runner.os }}-${{ hashFiles('scripts/rsync-compat.py', 'tests/rsync-compat/manifest.toml', 'tests/rsync-compat/inventory.tsv', 'tests/rsync-compat/adaptations/*.patch') }}
+      - name: Install rsync test-build prerequisites
+        if: steps.rsync-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y autoconf automake build-essential
       - name: Cache Cargo dependencies and build output
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -42,7 +45,7 @@ jobs:
       - name: Test compatibility harness
         run: python3 tests/rsync-compat/harness_test.py
       - name: Run classified upstream tests
-        run: python3 scripts/rsync-compat.py --profile default -j 4
+        run: python3 scripts/rsync-compat.py --profile default --test-timeout 120 -j 4
       - name: Run suite as root, including root-only circumstances
         run: |
           sudo env \
@@ -50,7 +53,8 @@ jobs:
             CARGO_TARGET_DIR="$CARGO_TARGET_DIR" \
             GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" \
             python3 scripts/rsync-compat.py --profile default --report-label root \
-              --no-build-syq --syq-bin "$PWD/target/cargo/debug/syq" -j 4
+              --no-build-syq --syq-bin "$PWD/target/cargo/debug/syq" \
+              --test-timeout 120 -j 4
       - name: Upload compatibility report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/rsync-compat.yml
+++ b/.github/workflows/rsync-compat.yml
@@ -45,16 +45,19 @@ jobs:
       - name: Test compatibility harness
         run: python3 tests/rsync-compat/harness_test.py
       - name: Run classified upstream tests
-        run: python3 scripts/rsync-compat.py --profile default --test-timeout 120 -j 4
+        run: python3 scripts/rsync-compat.py --require-tests --test-timeout 120 -j 4
       - name: Run suite as root, including root-only circumstances
         run: |
           sudo env \
             PATH="$PATH" \
             CARGO_TARGET_DIR="$CARGO_TARGET_DIR" \
             GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" \
-            python3 scripts/rsync-compat.py --profile default --report-label root \
+            python3 scripts/rsync-compat.py --require-tests --report-label root \
               --no-build-syq --syq-bin "$PWD/target/cargo/debug/syq" \
               --test-timeout 120 -j 4
+      - name: Restore compatibility-cache ownership
+        if: always()
+        run: sudo chown -R "$(id -u):$(id -g)" target/rsync-compat
       - name: Upload compatibility report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/RSYNC-COMPAT.md
+++ b/RSYNC-COMPAT.md
@@ -10,8 +10,8 @@ Each entry says whether it was **measured** (run against upstream rsync —
 **believed** (from documentation or memory, not yet exercised). A raw run of
 the upstream rsync test suite is not a compatibility score: most of its
 failures come from unsupported options, protocol internals, daemon mode, or
-its harness. The classified non-root Linux subset currently passes 20 of 22
-tests; the two known failures are open issues 2 and 3 below.
+its harness. The automated matrix therefore reports raw observations alongside
+our product position on each behavior instead of reducing them to a percentage.
 
 Categories:
 
@@ -33,11 +33,12 @@ Categories:
 python3 scripts/rsync-compat.py
 ```
 
-The manifest pins rsync commit `7c20b077`, records normal and future strict
-profiles, and gives every runnable test an expected result plus platform and
-environment requirements. `inventory.tsv` names all 351 tests at that commit;
-changing the pin without classifying every added or removed test is an error.
-The classifications deliberately distinguish:
+The manifest pins rsync commit `7c20b077` and defines one target representing
+SYQ's rsync-compatible command surface. It currently invokes native `syq`; once
+the dedicated `syq rsync` command exists, changing the target's argument list
+switches the suite without changing upstream test calls. `inventory.tsv` names
+all 351 tests at that commit; changing the pin without classifying every added
+or removed test is an error. The classifications deliberately distinguish:
 
 - relevant unmodified and adapted conformance tests;
 - user-visible features syq does not implement;
@@ -45,24 +46,27 @@ The classifications deliberately distinguish:
   that syq does not need to pass; and
 - an explicit unassessed category for future pin updates (currently empty).
 
-The upstream runner's expected-result mode is the oracle. A known failure is
-green, while both a regression and an unexpected pass fail CI until the ledger
-is updated. All 351 pinned tests are classified: 26 are runnable conformance
-tests, 141 require unsupported user-facing features, and 184 exercise rsync's
-own internals, protocol, daemon, or restricted wrapper. There are no unassessed
-tests. The normal non-root Linux run selects 22 of the 26 and currently records
-20 passes and 2 known failures; CI also runs the four root-only circumstances.
-That pass rate covers the selected conformance subset, not an overall
-percentage of rsync compatibility.
+Each runnable entry records a raw observation baseline separately from its
+product position: compatible, unimplemented, intentional divergence, undecided
+policy, or unresolved test claim. CI fails when the observation changes in
+either direction until it is reviewed, but an expected test failure is not
+misreported as a harness crash. Runner completeness and output parsing are
+checked independently. All 351 pinned tests are classified: 26 are runnable,
+141 require unsupported user-facing features, and 184 exercise rsync's own
+internals, protocol, daemon, or restricted wrapper. There are no unassessed
+tests. CI runs the 22 non-root and four additional root circumstances and
+publishes JSON, Markdown, static HTML, and raw-log matrices rather than a
+headline score.
 
 The generated `tests/rsync-compat/LEDGER.md` is the readable per-test record;
 CI rejects it if it drifts from the manifest and inventory. An adapted test
 names a patch under `tests/rsync-compat/adaptations/`. Patches may translate an
 incidental implementation detail, such as SYQ's partial-file layout, or isolate
 a supported scenario from an aggregate upstream test, but must preserve the
-claimed behavioral oracle. The future `strict` profile is recorded but disabled
-until its CLI flag exists; the harness will inject that flag without changing
-upstream test invocations.
+claimed behavioral oracle. Their provenance is visible in the matrix, including
+whether they alter an invocation, fixture, or tested subset. Git validates both
+the forward and reverse path sets before the exact patch bytes are applied, so
+adaptations cannot modify rsync sources or the runner outside `testsuite/`.
 
 ## Compatible
 

--- a/scripts/rsync-compat.py
+++ b/scripts/rsync-compat.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import collections
 import hashlib
+from html import escape
 import json
 import os
 from pathlib import Path
@@ -26,6 +27,28 @@ INVENTORY_PATH = COMPAT_DIR / "inventory.tsv"
 LEDGER_PATH = COMPAT_DIR / "LEDGER.md"
 VALID_CLASSES = {"conformance", "adapted", "unsupported", "out-of-scope", "unassessed"}
 VALID_OUTCOMES = {"pass", "fail", "skip", "xfail"}
+VALID_POSITIONS = {
+    "compatible",
+    "unimplemented",
+    "intentional-divergence",
+    "policy-open",
+    "test-unresolved",
+}
+POSITION_LABELS = {
+    "compatible": "Compatible",
+    "unimplemented": "Unimplemented",
+    "intentional-divergence": "Intentional divergence",
+    "policy-open": "Policy open",
+    "test-unresolved": "Test unresolved",
+}
+POSITION_DESCRIPTIONS = {
+    "compatible": "The exercised behavior currently agrees with the reviewed rsync behavior.",
+    "unimplemented": "Relevant behavior that SYQ does not currently implement.",
+    "intentional-divergence": "SYQ deliberately uses different behavior for this scenario.",
+    "policy-open": "SYQ differs and the desired compatibility policy is not decided.",
+    "test-unresolved": "The observation may reflect the fixture, harness, or an unclear test claim.",
+}
+VALID_ADAPTATION_KINDS = {"invocation", "fixture", "subset"}
 RESULT_RE = re.compile(r"^(PASS|FAIL|SKIP|XFAIL)\s+([^\s(]+)")
 
 
@@ -62,7 +85,7 @@ def output(argv: list[str], *, cwd: Path | None = None) -> str:
 def load_manifest() -> dict:
     with MANIFEST_PATH.open("rb") as handle:
         data = tomllib.load(handle)
-    if data.get("schema") != 1:
+    if data.get("schema") != 2:
         raise CompatError(f"{MANIFEST_PATH}: unsupported schema {data.get('schema')!r}")
     return data
 
@@ -103,11 +126,13 @@ def upstream_test_names(source: Path) -> set[str]:
 def validate_ledger(manifest: dict, inventory: dict[str, tuple[str, str | None]], source: Path) -> None:
     reasons = manifest.get("reasons", {})
     tests = manifest.get("tests", [])
-    enabled_profiles = {
-        name
-        for name, profile in manifest.get("profiles", {}).items()
-        if profile.get("enabled", False)
-    }
+    target = manifest.get("target", {})
+    if (
+        not re.fullmatch(r"[a-z0-9][a-z0-9-]*", target.get("name", ""))
+        or not isinstance(target.get("args"), list)
+        or not all(isinstance(arg, str) for arg in target.get("args", []))
+    ):
+        raise CompatError(f"{MANIFEST_PATH}: target requires a name and string args")
     configured: dict[str, dict] = {}
     for test in tests:
         name = test.get("name")
@@ -119,19 +144,19 @@ def validate_ledger(manifest: dict, inventory: dict[str, tuple[str, str | None]]
             raise CompatError(f"{MANIFEST_PATH}: {name}: runnable test has bad classification")
         if name not in inventory or inventory[name][0] != classification:
             raise CompatError(f"{MANIFEST_PATH}: {name}: manifest and inventory disagree")
-        expectations = test.get("expect", {})
-        missing_profiles = sorted(enabled_profiles - expectations.keys())
-        if missing_profiles:
-            raise CompatError(
-                f"{MANIFEST_PATH}: {name}: no expectation for {missing_profiles[0]!r}"
-            )
-        for profile_name, expected in expectations.items():
-            if profile_name not in manifest.get("profiles", {}):
-                raise CompatError(f"{MANIFEST_PATH}: {name}: unknown profile {profile_name!r}")
-            if expected not in VALID_OUTCOMES:
-                raise CompatError(f"{MANIFEST_PATH}: {name}: bad expected outcome {expected!r}")
-        if classification == "adapted" and not test.get("adaptation"):
-            raise CompatError(f"{MANIFEST_PATH}: {name}: adapted test has no adaptation id")
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", test.get("area", "")):
+            raise CompatError(f"{MANIFEST_PATH}: {name}: missing or invalid area")
+        if test.get("position") not in VALID_POSITIONS:
+            raise CompatError(f"{MANIFEST_PATH}: {name}: invalid product position")
+        if test.get("baseline") not in VALID_OUTCOMES:
+            raise CompatError(f"{MANIFEST_PATH}: {name}: invalid observation baseline")
+        if classification == "adapted":
+            if not test.get("adaptation"):
+                raise CompatError(f"{MANIFEST_PATH}: {name}: adapted test has no adaptation id")
+            if test.get("adaptation_kind") not in VALID_ADAPTATION_KINDS:
+                raise CompatError(f"{MANIFEST_PATH}: {name}: invalid adaptation kind")
+        elif test.get("adaptation") or test.get("adaptation_kind"):
+            raise CompatError(f"{MANIFEST_PATH}: {name}: unmodified test names an adaptation")
 
     for name, (classification, reason) in inventory.items():
         if classification in {"conformance", "adapted"} and name not in configured:
@@ -191,83 +216,66 @@ def helpers_ready(source: Path, helpers: list[str]) -> bool:
     )
 
 
-def patch_header_path(raw: str, *, git_prefix: bool) -> str | None:
-    raw = raw.split("\t", 1)[0]
-    if raw.startswith('"'):
-        try:
-            fields = shlex.split(raw)
-        except ValueError as error:
-            raise CompatError(f"malformed quoted patch path: {raw!r}") from error
-        if len(fields) != 1:
-            raise CompatError(f"malformed quoted patch path: {raw!r}")
-        raw = fields[0]
-    if raw == "/dev/null":
-        return None
-    if git_prefix:
-        if not raw.startswith(("a/", "b/")):
-            raise CompatError(f"malformed git patch path: {raw!r}")
-        raw = raw[2:]
-    return raw
+def git_patch_paths(adaptation: str, patch: bytes, *, reverse: bool) -> set[bytes]:
+    argv = ["git", "apply"]
+    if reverse:
+        argv.append("-R")
+    argv.extend(["--numstat", "-z", "-"])
+    result = subprocess.run(
+        argv,
+        cwd=ROOT,
+        input=patch,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise CompatError(f"adaptation {adaptation!r} is not a valid patch: {detail}")
+    paths: set[bytes] = set()
+    for record in result.stdout.split(b"\0"):
+        if not record:
+            continue
+        fields = record.split(b"\t", 2)
+        if len(fields) != 3 or not fields[2]:
+            raise CompatError(f"adaptation {adaptation!r} has malformed git numstat output")
+        paths.add(fields[2])
+    return paths
 
 
-def validate_adaptation_patch(adaptation: str, patch_text: str) -> None:
-    paths: list[str] = []
-    inside_hunk = False
-    for line in patch_text.splitlines():
-        if line.startswith("diff --git "):
-            inside_hunk = False
-            try:
-                fields = shlex.split(line)
-            except ValueError as error:
-                raise CompatError(
-                    f"adaptation {adaptation!r} has a malformed diff header"
-                ) from error
-            if len(fields) != 4:
-                raise CompatError(
-                    f"adaptation {adaptation!r} has a malformed diff header"
-                )
-            for raw in fields[2:]:
-                path = patch_header_path(raw, git_prefix=True)
-                if path is not None:
-                    paths.append(path)
-            continue
-        if line.startswith("@@ "):
-            inside_hunk = True
-            continue
-        if inside_hunk:
-            continue
-        for prefix, git_prefix in (
-            ("--- ", True),
-            ("+++ ", True),
-            ("rename from ", False),
-            ("rename to ", False),
-        ):
-            if line.startswith(prefix):
-                path = patch_header_path(line[len(prefix) :], git_prefix=git_prefix)
-                if path is not None:
-                    paths.append(path)
-                break
-
+def validate_adaptation_patch(adaptation: str, patch: bytes) -> None:
+    # Forward numstat exposes destinations; reverse numstat exposes rename and
+    # copy sources. Git is also the parser that will apply these exact bytes.
+    paths = git_patch_paths(adaptation, patch, reverse=False)
+    paths.update(git_patch_paths(adaptation, patch, reverse=True))
     if not paths or any(
-        not path.startswith("testsuite/") or ".." in Path(path).parts for path in paths
+        not path.startswith(b"testsuite/") or b".." in path.split(b"/")
+        for path in paths
     ):
         raise CompatError(
             f"adaptation {adaptation!r} must change only upstream testsuite files"
         )
 
 
-def suite_key(manifest: dict, commit: str, adaptations: list[str]) -> str:
+def load_adaptations(adaptations: list[str]) -> dict[str, bytes]:
+    loaded: dict[str, bytes] = {}
+    for adaptation in adaptations:
+        path = COMPAT_DIR / "adaptations" / f"{adaptation}.patch"
+        if not path.is_file():
+            raise CompatError(f"adaptation {adaptation!r} has no patch at {path}")
+        patch = path.read_bytes()
+        validate_adaptation_patch(adaptation, patch)
+        loaded[adaptation] = patch
+    return loaded
+
+
+def suite_key(manifest: dict, commit: str, adaptations: dict[str, bytes]) -> str:
     digest = hashlib.sha256()
     digest.update(commit.encode())
     digest.update(json.dumps(manifest["upstream"]["configure_args"]).encode())
     digest.update(json.dumps(manifest["upstream"]["helpers"]).encode())
-    for adaptation in adaptations:
-        patch = COMPAT_DIR / "adaptations" / f"{adaptation}.patch"
-        if not patch.is_file():
-            raise CompatError(f"adaptation {adaptation!r} has no patch at {patch}")
-        validate_adaptation_patch(adaptation, patch.read_text())
+    for adaptation, patch in adaptations.items():
         digest.update(adaptation.encode())
-        digest.update(patch.read_bytes())
+        digest.update(patch)
     return digest.hexdigest()[:20]
 
 
@@ -282,7 +290,7 @@ def prepare_base_suite(
     if source_was_explicit and helpers_ready(source, helpers):
         return source
 
-    key = suite_key(manifest, manifest["upstream"]["commit"], [])
+    key = suite_key(manifest, manifest["upstream"]["commit"], {})
     suites = cache / "suites"
     suites.mkdir(parents=True, exist_ok=True)
     destination = suites / key
@@ -327,7 +335,7 @@ def prepare_suite(
     source: Path,
     cache: Path,
     manifest: dict,
-    adaptations: list[str],
+    adaptations: dict[str, bytes],
     jobs: int,
     source_was_explicit: bool,
 ) -> Path:
@@ -356,14 +364,19 @@ def prepare_suite(
             symlinks=True,
             ignore=shutil.ignore_patterns("testtmp", "__pycache__"),
         )
-        for adaptation in adaptations:
-            patch = COMPAT_DIR / "adaptations" / f"{adaptation}.patch"
-            run(["git", "apply", "--whitespace=nowarn", str(patch)], cwd=temporary)
+        for adaptation, patch in adaptations.items():
+            print(f"+ git apply --whitespace=nowarn {adaptation}.patch", flush=True)
+            subprocess.run(
+                ["git", "apply", "--whitespace=nowarn", "-"],
+                cwd=temporary,
+                input=patch,
+                check=True,
+            )
         (temporary / marker.name).write_text(
             json.dumps(
                 {
                     "commit": manifest["upstream"]["commit"],
-                    "adaptations": adaptations,
+                    "adaptations": list(adaptations),
                 },
                 sort_keys=True,
             )
@@ -385,7 +398,7 @@ def running_as() -> str:
     return "root" if hasattr(os, "geteuid") and os.geteuid() == 0 else "non-root"
 
 
-def select_tests(manifest: dict, profile: str) -> tuple[list[dict], list[dict]]:
+def select_tests(manifest: dict) -> tuple[list[dict], list[dict]]:
     selected: list[dict] = []
     environment_excluded: list[dict] = []
     current_platform = platform_name()
@@ -398,14 +411,18 @@ def select_tests(manifest: dict, profile: str) -> tuple[list[dict], list[dict]]:
         if required_user and required_user != running_as():
             environment_excluded.append(test)
             continue
-        if profile not in test.get("expect", {}):
-            raise CompatError(f"{MANIFEST_PATH}: {test['name']}: no expectation for {profile}")
         selected.append(test)
     return selected, environment_excluded
 
 
 def markdown_cell(value: object) -> str:
     return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def provenance(test: dict) -> str:
+    if test["classification"] == "conformance":
+        return "unmodified upstream"
+    return f"{test['adaptation_kind']} adaptation ({test['adaptation']})"
 
 
 def render_ledger(manifest: dict, inventory: dict[str, tuple[str, str | None]]) -> str:
@@ -421,6 +438,9 @@ def render_ledger(manifest: dict, inventory: dict[str, tuple[str, str | None]]) 
         "```",
         "",
         f"Pinned rsync commit: `{manifest['upstream']['commit']}`.",
+        "Configured command prefix: `syq"
+        + "".join(f" {shlex.quote(arg)}" for arg in manifest["target"]["args"])
+        + "`.",
         "",
         "| Classification | Tests |",
         "|---|---:|",
@@ -428,14 +448,20 @@ def render_ledger(manifest: dict, inventory: dict[str, tuple[str, str | None]]) 
     for classification in ("conformance", "adapted", "unsupported", "out-of-scope", "unassessed"):
         lines.append(f"| {classification} | {counts[classification]} |")
 
-    lines.extend(["", "## Runnable conformance tests", "", "| Test | Kind | Expected | Circumstances | Note |", "|---|---|---|---|---|"])
-    for name, (classification, _) in inventory.items():
-        if classification not in {"conformance", "adapted"}:
-            continue
-        test = runnable[name]
-        expected = ", ".join(
-            f"{profile}: {outcome}" for profile, outcome in sorted(test.get("expect", {}).items())
-        )
+    lines.extend(
+        [
+            "",
+            "## Runnable behavioral tests",
+            "",
+            "The baseline is the last reviewed observation, not a claim that rsync's "
+            "behavior is always the desired product policy.",
+            "",
+            "| Area | Test | Baseline | Product position | Provenance | Circumstances | Note |",
+            "|---|---|---|---|---|---|---|",
+        ]
+    )
+    for test in sorted(runnable.values(), key=lambda item: (item["area"], item["name"])):
+        name = test["name"]
         circumstances = []
         if test.get("platforms"):
             circumstances.append("platform=" + ",".join(test["platforms"]))
@@ -447,9 +473,11 @@ def render_ledger(manifest: dict, inventory: dict[str, tuple[str, str | None]]) 
             + " | ".join(
                 markdown_cell(value)
                 for value in (
+                    test["area"],
                     f"`{name}`",
-                    classification,
-                    expected,
+                    test["baseline"],
+                    POSITION_LABELS[test["position"]],
+                    provenance(test),
                     "; ".join(circumstances) or "portable",
                     test.get("note", ""),
                 )
@@ -564,93 +592,230 @@ def parse_results(
     return outcomes, errors
 
 
-def outcome_class(outcome: str) -> str:
-    return "fail" if outcome in {"fail", "xfail"} else outcome
+def assess_harness(
+    runner_exit_code: int,
+    outcomes: dict[str, str],
+    parser_errors: list[str],
+    *,
+    require_tests: bool,
+    applicable: int,
+) -> tuple[int, list[str]]:
+    expected_exit_code = sum(outcome == "fail" for outcome in outcomes.values())
+    errors = list(parser_errors)
+    if runner_exit_code != expected_exit_code:
+        errors.append(
+            f"runner exit code {runner_exit_code} disagrees with "
+            f"{expected_exit_code} observed test failure(s)"
+        )
+    if require_tests and applicable == 0:
+        errors.append("no tests apply under these circumstances")
+    return expected_exit_code, errors
 
 
 def markdown_report(report: dict) -> str:
-    harness_ok = report["runner_exit_code"] == 0 and not report["parser_errors"]
-    if harness_ok:
+    command = command_text(["syq", *report["target_args"]])
+    if report["harness_ok"]:
         harness_status = (
-            "Harness status: **healthy** — runner exit code `0`; "
-            "no runner-output errors."
+            "Harness execution: **complete** — runner exit code "
+            f"`{report['runner_exit_code']}` agrees with "
+            f"{report['expected_runner_exit_code']} observed test failure(s)."
         )
     else:
-        details = []
-        if report["runner_exit_code"] != 0:
-            details.append(f"runner exit code `{report['runner_exit_code']}`")
-        if report["parser_errors"]:
-            count = len(report["parser_errors"])
-            details.append(f"{count} runner-output error{'s' if count != 1 else ''}")
-        harness_status = "Harness status: **FAILED** — " + "; ".join(details) + "."
+        harness_status = "Harness execution: **FAILED**."
     lines = [
-        "## rsync compatibility",
+        "## rsync behavioral compatibility matrix",
         "",
-        f"Pinned upstream: `{report['upstream_commit']}` · profile: `{report['profile']}` "
+        f"Pinned upstream: `{report['upstream_commit']}` · target: `{report['target_name']}` "
+        f"via `{command}` "
         f"· platform: `{report['platform']}` · run as: `{report['run_as']}`",
         "",
         harness_status,
         "",
-        "| Measure | Count |",
+        "### Product positions",
+        "",
+        "| Position | Applicable tests |",
         "|---|---:|",
-        f"| Applicable tests | {report['applicable']} |",
-        f"| Passing | {report['passing']} |",
-        f"| Known failures | {report['known_failures']} |",
-        f"| Expected skips | {report['skipped']} |",
-        f"| Adapted tests | {report['adapted']} |",
-        f"| Out of scope (ledger) | {report['ledger']['out-of-scope']} |",
-        f"| Unsupported feature (ledger) | {report['ledger']['unsupported']} |",
-        f"| Not yet assessed (ledger) | {report['ledger']['unassessed']} |",
     ]
-    if harness_ok:
+    for position, label in POSITION_LABELS.items():
+        lines.append(f"| {label} | {report['position_counts'].get(position, 0)} |")
+    lines.extend(
+        [
+            f"| **Total applicable** | **{report['applicable']}** |",
+            "",
+            "Inventory outside this matrix: "
+            f"{report['ledger']['unsupported']} unsupported user-facing tests, "
+            f"{report['ledger']['out-of-scope']} rsync-internal/out-of-scope tests, "
+            f"and {report['ledger']['unassessed']} unassessed tests.",
+            "",
+            "### Observations",
+            "",
+        ]
+    )
+    if report["tests"]:
         lines.extend(
             [
-                "",
-                f"Classified runnable-test pass rate: **{report['passing']}/{report['applicable']} "
-                f"({report['score_percent']:.1f}%)**.",
+                "| Area | Test | Observed | Product position | Provenance | Circumstances | Note |",
+                "|---|---|---|---|---|---|---|",
             ]
         )
+        for test in sorted(report["tests"], key=lambda item: (item["area"], item["name"])):
+            observed = test["actual"].upper()
+            if not test["baseline_matches"] and test["actual"] != "notrun":
+                observed += f" (baseline {test['baseline'].upper()})"
+            lines.append(
+                "| "
+                + " | ".join(
+                    markdown_cell(value)
+                    for value in (
+                        test["area"],
+                        f"`{test['name']}`",
+                        observed,
+                        POSITION_LABELS[test["position"]],
+                        provenance(test),
+                        "; ".join(test["circumstances"]) or "portable",
+                        test["note"],
+                    )
+                )
+                + " |"
+            )
     else:
-        notrun = sum(test["actual"] == "notrun" for test in report["tests"])
-        lines.extend(
-            [
-                f"| Unreported after runner failure | {notrun} |",
-                "",
-                "Compatibility score is unavailable; the counts above are partial "
-                "diagnostic observations, not a conformance result.",
-            ]
+        lines.append("No tests apply under these platform and user circumstances.")
+    lines.extend(
+        [
+            "",
+            "### Unsupported feature areas",
+            "",
+            "These user-facing areas are tracked but not yet useful to run through "
+            "their upstream tests.",
+            "",
+            "| Feature area | Upstream tests | Current limitation |",
+            "|---|---:|---|",
+        ]
+    )
+    for feature in report["unsupported_features"]:
+        lines.append(
+            f"| `{feature['area']}` | {feature['tests']} | "
+            f"{markdown_cell(feature['description'])} |"
         )
-    gaps = [test for test in report["tests"] if test["actual"] in {"fail", "xfail"}]
-    if gaps:
-        lines.extend(["", "Known gaps:", ""])
+    changes = [test for test in report["tests"] if not test["baseline_matches"]]
+    if changes:
+        lines.extend(["", "### Observation changes requiring review", ""])
         lines.extend(
-            f"- `{test['name']}` ({', '.join(test['tags']) or 'untagged'}): {test['note']}"
-            for test in gaps
+            f"- `{test['name']}`: baseline {test['baseline']}, observed {test['actual']}"
+            for test in changes
         )
-    mismatches = [
-        test
-        for test in report["tests"]
-        if not test["matches"] and test["actual"] != "notrun"
-    ]
-    if mismatches:
-        title = "Expectation mismatches:" if harness_ok else "Observed expectation mismatches:"
-        lines.extend(["", title, ""])
-        lines.extend(
-            f"- `{test['name']}`: expected {test['expected']}, got {test['actual']}"
-            for test in mismatches
-        )
-    if report["parser_errors"]:
-        lines.extend(["", "Runner output errors:", ""])
-        lines.extend(f"- {error}" for error in report["parser_errors"])
+    if report["harness_errors"]:
+        lines.extend(["", "### Harness errors", ""])
+        lines.extend(f"- {error}" for error in report["harness_errors"])
     lines.append("")
     return "\n".join(lines)
+
+
+def html_report(report: dict) -> str:
+    command = command_text(["syq", *report["target_args"]])
+    cards = "".join(
+        '<div class="card"><strong>'
+        + str(report["position_counts"].get(position, 0))
+        + "</strong><span>"
+        + escape(label)
+        + "</span></div>"
+        for position, label in POSITION_LABELS.items()
+    )
+    rows = []
+    for test in sorted(report["tests"], key=lambda item: (item["area"], item["name"])):
+        observed = test["actual"].upper()
+        if not test["baseline_matches"] and test["actual"] != "notrun":
+            observed += f" (baseline {test['baseline'].upper()})"
+        rows.append(
+            '<tr class="' + ("changed" if not test["baseline_matches"] else "") + '">'
+            f"<td>{escape(test['area'])}</td>"
+            f"<td><code>{escape(test['name'])}</code></td>"
+            f'<td><span class="badge result-{escape(test["actual"])}">{escape(observed)}</span></td>'
+            f'<td><span class="badge position-{escape(test["position"])}">'
+            f"{escape(POSITION_LABELS[test['position']])}</span></td>"
+            f"<td>{escape(provenance(test))}</td>"
+            f"<td>{escape('; '.join(test['circumstances']) or 'portable')}</td>"
+            f"<td>{escape(test['note'])}</td></tr>"
+        )
+    if not rows:
+        rows.append('<tr><td colspan="7">No tests apply under these circumstances.</td></tr>')
+    harness_errors = ""
+    if report["harness_errors"]:
+        harness_errors = '<section class="alert"><h2>Harness errors</h2><ul>' + "".join(
+            f"<li>{escape(error)}</li>" for error in report["harness_errors"]
+        ) + "</ul></section>"
+    changes = [test for test in report["tests"] if not test["baseline_matches"]]
+    change_notice = ""
+    if changes:
+        change_notice = (
+            '<section class="alert"><h2>Observation changes requiring review</h2><ul>'
+            + "".join(
+                f"<li><code>{escape(test['name'])}</code>: baseline "
+                f"{escape(test['baseline'])}, observed {escape(test['actual'])}</li>"
+                for test in changes
+            )
+            + "</ul></section>"
+        )
+    legend = "".join(
+        f"<dt>{escape(label)}</dt><dd>{escape(POSITION_DESCRIPTIONS[position])}</dd>"
+        for position, label in POSITION_LABELS.items()
+    )
+    unsupported_rows = "".join(
+        f"<tr><td><code>{escape(feature['area'])}</code></td>"
+        f"<td>{feature['tests']}</td><td>{escape(feature['description'])}</td></tr>"
+        for feature in report["unsupported_features"]
+    )
+    harness_class = "ok" if report["harness_ok"] else "bad"
+    harness_text = (
+        "Execution complete; runner status agrees with observed outcomes."
+        if report["harness_ok"]
+        else "Harness execution failed; results may be incomplete."
+    )
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<title>SYQ rsync behavioral matrix</title><style>
+:root {{ color-scheme: light dark; font-family: system-ui, sans-serif; }}
+body {{ max-width: 1500px; margin: 2rem auto; padding: 0 1rem; line-height: 1.45; }}
+code {{ font-family: ui-monospace, monospace; }}
+.meta {{ color: #68707a; }} .status {{ padding: .75rem 1rem; border-radius: .5rem; }}
+.status.ok {{ background: #d8f3dc; color: #16351d; }} .status.bad, .alert {{ background: #ffe3e3; color: #4b1111; }}
+.cards {{ display: flex; flex-wrap: wrap; gap: .75rem; margin: 1.25rem 0; }}
+.card {{ border: 1px solid #9aa0a6; border-radius: .5rem; padding: .7rem 1rem; min-width: 9rem; }}
+.card strong {{ display: block; font-size: 1.5rem; }} .card span {{ font-size: .9rem; }}
+table {{ border-collapse: collapse; width: 100%; font-size: .92rem; }}
+th, td {{ border: 1px solid #9aa0a6; padding: .55rem; text-align: left; vertical-align: top; }}
+th {{ position: sticky; top: 0; background: Canvas; }} tr.changed {{ outline: 2px solid #d97706; }}
+.badge {{ display: inline-block; border-radius: 999px; padding: .12rem .5rem; white-space: nowrap; background: #e5e7eb; color: #111827; }}
+.result-pass, .position-compatible {{ background: #d8f3dc; color: #16351d; }}
+.result-fail, .position-unimplemented {{ background: #ffe3e3; color: #4b1111; }}
+.position-intentional-divergence {{ background: #dbeafe; color: #172554; }}
+.position-policy-open, .position-test-unresolved {{ background: #fef3c7; color: #451a03; }}
+.alert {{ padding: .75rem 1rem; border-radius: .5rem; margin: 1rem 0; }}
+dt {{ font-weight: 700; margin-top: .5rem; }} dd {{ margin-left: 1.25rem; }}
+@media (prefers-color-scheme: dark) {{ .meta {{ color: #b0b8c1; }} }}
+</style></head><body>
+<h1>SYQ rsync behavioral compatibility matrix</h1>
+<p class="meta">Pinned rsync <code>{escape(report['upstream_commit'])}</code> · target
+<code>{escape(report['target_name'])}</code> via <code>{escape(command)}</code> ·
+{escape(report['platform'])} · {escape(report['run_as'])}</p>
+<p class="status {harness_class}">{escape(harness_text)}</p>
+<div class="cards">{cards}</div>{harness_errors}{change_notice}
+<h2>Observed tests</h2><table><thead><tr><th>Area</th><th>Test</th><th>Observed</th>
+<th>Product position</th><th>Provenance</th><th>Circumstances</th><th>Note</th></tr></thead>
+<tbody>{''.join(rows)}</tbody></table>
+<h2>Position legend</h2><dl>{legend}</dl>
+<h2>Unsupported feature areas</h2><p>Tracked user-facing areas whose upstream tests are
+not yet useful to run against the target.</p><table><thead><tr><th>Feature area</th>
+<th>Upstream tests</th><th>Current limitation</th></tr></thead><tbody>{unsupported_rows}</tbody></table>
+<h2>Excluded inventory</h2><p>{report['ledger']['out-of-scope']} rsync-internal or
+out-of-scope tests are omitted; {report['ledger']['unassessed']} tests remain unassessed.</p>
+</body></html>"""
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run SYQ's classified compatibility subset of a pinned rsync test suite"
     )
-    parser.add_argument("--profile", default="default")
     parser.add_argument(
         "--syq-bin",
         type=Path,
@@ -672,6 +837,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--preserve-scratch", action="store_true")
     parser.add_argument("--ledger-only", action="store_true")
     parser.add_argument("--update-ledger", action="store_true")
+    parser.add_argument(
+        "--require-tests",
+        action="store_true",
+        help="fail after writing reports if no tests apply (used by CI)",
+    )
     parser.add_argument(
         "--report-label",
         help="append a safe label to report filenames (for example, root)",
@@ -696,13 +866,7 @@ def main() -> int:
         raise CompatError("--report-label may contain only letters, digits, _ and -")
     manifest = load_manifest()
     inventory = load_inventory()
-    profile = manifest.get("profiles", {}).get(args.profile)
-    if profile is None:
-        raise CompatError(f"unknown compatibility profile {args.profile!r}")
-    if not profile.get("enabled", False):
-        raise CompatError(
-            f"profile {args.profile!r} is recorded but disabled: {profile['description']}"
-        )
+    target = manifest["target"]
 
     cache = args.cache_dir.resolve()
     cache.mkdir(parents=True, exist_ok=True)
@@ -718,134 +882,170 @@ def main() -> int:
     if args.ledger_only:
         return 0
 
-    selected, environment_excluded = select_tests(manifest, args.profile)
-    adaptations = sorted(
+    selected, environment_excluded = select_tests(manifest)
+    adaptation_ids = sorted(
         {test["adaptation"] for test in selected if test.get("adaptation")}
     )
-    suite = prepare_suite(
-        source, cache, manifest, adaptations, args.jobs, source_was_explicit
-    )
+    run_dir: Path | None = None
+    runner_exit_code = 0
+    log = ""
+    actual: dict[str, str] = {}
+    parser_errors: list[str] = []
+    if selected:
+        adaptations = load_adaptations(adaptation_ids)
+        suite = prepare_suite(
+            source, cache, manifest, adaptations, args.jobs, source_was_explicit
+        )
 
-    syq = (args.syq_bin or default_syq_binary()).resolve()
-    if not args.no_build_syq:
-        run(["cargo", "build", "--locked", "--bin", "syq"], cwd=ROOT)
-    if not syq.is_file():
-        raise CompatError(f"SYQ binary not found at {syq}")
+        syq = (args.syq_bin or default_syq_binary()).resolve()
+        if not args.no_build_syq:
+            run(["cargo", "build", "--locked", "--bin", "syq"], cwd=ROOT)
+        if not syq.is_file():
+            raise CompatError(f"SYQ binary not found at {syq}")
 
-    # Root-only upstream tests may execute the wrapper after dropping to a
-    # second uid. CI workspace ancestors are not guaranteed to be traversable
-    # by that uid, so keep root-run scratch space under the shared system tmp.
-    run_parent = Path("/tmp") if running_as() == "root" else cache
-    run_dir = Path(tempfile.mkdtemp(prefix=f"syq-rsync-{args.profile}-", dir=run_parent))
-    # Some upstream security tests deliberately drop privileges. They still
-    # need to traverse this directory to execute the generated SYQ wrapper.
-    run_dir.chmod(0o755)
-    run_binary = syq
-    if running_as() == "root":
-        run_binary = run_dir / "syq"
-        shutil.copy2(syq, run_binary)
-        run_binary.chmod(0o755)
-    wrapper = run_dir / "syq-rsync"
-    make_wrapper(wrapper, run_binary, list(profile.get("args", [])))
-    expected = run_dir / "expected.txt"
-    expected.write_text(
-        "".join(f"{test['name']} {test['expect'][args.profile]}\n" for test in selected)
-    )
-    scratch = run_dir / "scratch"
-    scratch.mkdir()
-    runner_args = [
-        sys.executable,
-        str(suite / "runtests.py"),
-        "--rsync-bin",
-        str(wrapper),
-        "--tooldir",
-        str(suite),
-        "--srcdir",
-        str(suite),
-        "--expect-result",
-        str(expected),
-        "--timeout",
-        str(args.test_timeout),
-        "--timing",
-        "-j",
-        str(args.jobs),
-    ]
-    if args.preserve_scratch:
-        runner_args.append("--preserve-scratch")
-    env = os.environ.copy()
-    env["scratchbase"] = str(scratch)
-    returncode, log = stream_command(runner_args, cwd=suite, env=env)
-    actual, parser_errors = parse_results(
-        log, {test["name"] for test in selected}
-    )
+        # Root-only upstream tests may execute the wrapper after dropping to a
+        # second uid. CI workspace ancestors are not guaranteed to be traversable
+        # by that uid, so keep root-run scratch space under the shared system tmp.
+        run_parent = Path("/tmp") if running_as() == "root" else cache
+        run_dir = Path(
+            tempfile.mkdtemp(prefix=f"syq-rsync-{target['name']}-", dir=run_parent)
+        )
+        # Some upstream security tests deliberately drop privileges. They still
+        # need to traverse this directory to execute the generated SYQ wrapper.
+        run_dir.chmod(0o755)
+        run_binary = syq
+        if running_as() == "root":
+            run_binary = run_dir / "syq"
+            shutil.copy2(syq, run_binary)
+            run_binary.chmod(0o755)
+        wrapper = run_dir / "syq-rsync"
+        make_wrapper(wrapper, run_binary, list(target.get("args", [])))
+        scratch = run_dir / "scratch"
+        scratch.mkdir()
+        runner_args = [
+            sys.executable,
+            str(suite / "runtests.py"),
+            "--rsync-bin",
+            str(wrapper),
+            "--tooldir",
+            str(suite),
+            "--srcdir",
+            str(suite),
+            "--timeout",
+            str(args.test_timeout),
+            "--timing",
+            "-j",
+            str(args.jobs),
+        ]
+        if args.preserve_scratch:
+            runner_args.append("--preserve-scratch")
+        runner_args.extend(test["name"] for test in selected)
+        env = os.environ.copy()
+        env["scratchbase"] = str(scratch)
+        runner_exit_code, log = stream_command(runner_args, cwd=suite, env=env)
+        actual, parser_errors = parse_results(
+            log, {test["name"] for test in selected}
+        )
+    else:
+        log = "No upstream tests apply under these circumstances.\n"
 
     test_results = []
     for test in selected:
         name = test["name"]
         got = actual.get(name, "notrun")
-        wanted = test["expect"][args.profile]
+        circumstances = []
+        if test.get("platforms"):
+            circumstances.append("platform=" + ",".join(test["platforms"]))
+        if test.get("run_as"):
+            circumstances.append("run-as=" + test["run_as"])
+        circumstances.extend(test.get("requirements", []))
         test_results.append(
             {
                 "name": name,
                 "classification": test["classification"],
                 "adaptation": test.get("adaptation"),
-                "expected": wanted,
+                "adaptation_kind": test.get("adaptation_kind"),
+                "area": test["area"],
+                "position": test["position"],
+                "baseline": test["baseline"],
                 "actual": got,
-                "matches": got != "notrun" and outcome_class(got) == outcome_class(wanted),
+                "baseline_matches": got == test["baseline"],
                 "tags": test.get("tags", []),
                 "requirements": test.get("requirements", []),
+                "circumstances": circumstances,
                 "note": test.get("note", ""),
             }
         )
 
     ledger_counts = collections.Counter(value[0] for value in inventory.values())
-    passing = sum(test["actual"] == "pass" for test in test_results)
-    known_failures = sum(test["actual"] in {"fail", "xfail"} for test in test_results)
-    skipped = sum(test["actual"] == "skip" for test in test_results)
     applicable = len(test_results)
-    harness_ok = returncode == 0 and not parser_errors
+    expected_runner_exit_code, harness_errors = assess_harness(
+        runner_exit_code,
+        actual,
+        parser_errors,
+        require_tests=args.require_tests,
+        applicable=applicable,
+    )
+    position_counts = collections.Counter(test["position"] for test in test_results)
+    observed_counts = collections.Counter(test["actual"] for test in test_results)
+    unsupported_counts = collections.Counter(
+        reason
+        for classification, reason in inventory.values()
+        if classification == "unsupported"
+    )
+    unsupported_features = [
+        {
+            "area": reason.removeprefix("unsupported-"),
+            "reason": reason,
+            "tests": count,
+            "description": manifest["reasons"][reason],
+        }
+        for reason, count in sorted(unsupported_counts.items())
+    ]
     report = {
-        "schema": 1,
+        "schema": 2,
         "upstream_repository": upstream["repository"],
         "upstream_commit": upstream["commit"],
-        "profile": args.profile,
-        "profile_args": profile.get("args", []),
+        "target_name": target["name"],
+        "target_args": target.get("args", []),
+        "target_description": target.get("description", ""),
         "platform": platform_name(),
         "run_as": running_as(),
         "applicable": applicable,
-        "passing": passing,
-        "known_failures": known_failures,
-        "skipped": skipped,
+        "observed_counts": dict(sorted(observed_counts.items())),
+        "position_counts": dict(sorted(position_counts.items())),
         "adapted": sum(test["classification"] == "adapted" for test in test_results),
         "environment_excluded": [test["name"] for test in environment_excluded],
-        "score_percent": (
-            passing * 100.0 / applicable if harness_ok and applicable else None
-        ),
+        "unsupported_features": unsupported_features,
         "ledger": {key: ledger_counts[key] for key in sorted(VALID_CLASSES)},
         "tests": test_results,
-        "runner_exit_code": returncode,
+        "runner_exit_code": runner_exit_code,
+        "expected_runner_exit_code": expected_runner_exit_code,
         "parser_errors": parser_errors,
-        "harness_ok": harness_ok,
+        "harness_errors": harness_errors,
+        "harness_ok": not harness_errors,
     }
     reports = cache / "reports"
     reports.mkdir(exist_ok=True)
-    report_stem = args.profile + (f"-{args.report_label}" if args.report_label else "")
+    report_stem = target["name"] + (f"-{args.report_label}" if args.report_label else "")
     report_json = reports / f"{report_stem}.json"
     report_md = reports / f"{report_stem}.md"
+    report_html = reports / f"{report_stem}.html"
     report_log = reports / f"{report_stem}.log"
     report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
     summary = markdown_report(report)
     report_md.write_text(summary)
+    report_html.write_text(html_report(report))
     report_log.write_text(log)
     print("\n" + summary, flush=True)
     if github_summary := os.environ.get("GITHUB_STEP_SUMMARY"):
         with Path(github_summary).open("a") as handle:
             handle.write(summary)
 
-    if not args.preserve_scratch:
+    if run_dir is not None and not args.preserve_scratch:
         shutil.rmtree(run_dir, ignore_errors=True)
-    mismatches = [test for test in test_results if not test["matches"]]
-    return 1 if returncode or mismatches or parser_errors else 0
+    baseline_changes = [test for test in test_results if not test["baseline_matches"]]
+    return 1 if harness_errors or baseline_changes else 0
 
 
 if __name__ == "__main__":

--- a/scripts/rsync-compat.py
+++ b/scripts/rsync-compat.py
@@ -103,6 +103,11 @@ def upstream_test_names(source: Path) -> set[str]:
 def validate_ledger(manifest: dict, inventory: dict[str, tuple[str, str | None]], source: Path) -> None:
     reasons = manifest.get("reasons", {})
     tests = manifest.get("tests", [])
+    enabled_profiles = {
+        name
+        for name, profile in manifest.get("profiles", {}).items()
+        if profile.get("enabled", False)
+    }
     configured: dict[str, dict] = {}
     for test in tests:
         name = test.get("name")
@@ -114,7 +119,13 @@ def validate_ledger(manifest: dict, inventory: dict[str, tuple[str, str | None]]
             raise CompatError(f"{MANIFEST_PATH}: {name}: runnable test has bad classification")
         if name not in inventory or inventory[name][0] != classification:
             raise CompatError(f"{MANIFEST_PATH}: {name}: manifest and inventory disagree")
-        for profile_name, expected in test.get("expect", {}).items():
+        expectations = test.get("expect", {})
+        missing_profiles = sorted(enabled_profiles - expectations.keys())
+        if missing_profiles:
+            raise CompatError(
+                f"{MANIFEST_PATH}: {name}: no expectation for {missing_profiles[0]!r}"
+            )
+        for profile_name, expected in expectations.items():
             if profile_name not in manifest.get("profiles", {}):
                 raise CompatError(f"{MANIFEST_PATH}: {name}: unknown profile {profile_name!r}")
             if expected not in VALID_OUTCOMES:
@@ -180,6 +191,71 @@ def helpers_ready(source: Path, helpers: list[str]) -> bool:
     )
 
 
+def patch_header_path(raw: str, *, git_prefix: bool) -> str | None:
+    raw = raw.split("\t", 1)[0]
+    if raw.startswith('"'):
+        try:
+            fields = shlex.split(raw)
+        except ValueError as error:
+            raise CompatError(f"malformed quoted patch path: {raw!r}") from error
+        if len(fields) != 1:
+            raise CompatError(f"malformed quoted patch path: {raw!r}")
+        raw = fields[0]
+    if raw == "/dev/null":
+        return None
+    if git_prefix:
+        if not raw.startswith(("a/", "b/")):
+            raise CompatError(f"malformed git patch path: {raw!r}")
+        raw = raw[2:]
+    return raw
+
+
+def validate_adaptation_patch(adaptation: str, patch_text: str) -> None:
+    paths: list[str] = []
+    inside_hunk = False
+    for line in patch_text.splitlines():
+        if line.startswith("diff --git "):
+            inside_hunk = False
+            try:
+                fields = shlex.split(line)
+            except ValueError as error:
+                raise CompatError(
+                    f"adaptation {adaptation!r} has a malformed diff header"
+                ) from error
+            if len(fields) != 4:
+                raise CompatError(
+                    f"adaptation {adaptation!r} has a malformed diff header"
+                )
+            for raw in fields[2:]:
+                path = patch_header_path(raw, git_prefix=True)
+                if path is not None:
+                    paths.append(path)
+            continue
+        if line.startswith("@@ "):
+            inside_hunk = True
+            continue
+        if inside_hunk:
+            continue
+        for prefix, git_prefix in (
+            ("--- ", True),
+            ("+++ ", True),
+            ("rename from ", False),
+            ("rename to ", False),
+        ):
+            if line.startswith(prefix):
+                path = patch_header_path(line[len(prefix) :], git_prefix=git_prefix)
+                if path is not None:
+                    paths.append(path)
+                break
+
+    if not paths or any(
+        not path.startswith("testsuite/") or ".." in Path(path).parts for path in paths
+    ):
+        raise CompatError(
+            f"adaptation {adaptation!r} must change only upstream testsuite files"
+        )
+
+
 def suite_key(manifest: dict, commit: str, adaptations: list[str]) -> str:
     digest = hashlib.sha256()
     digest.update(commit.encode())
@@ -189,17 +265,7 @@ def suite_key(manifest: dict, commit: str, adaptations: list[str]) -> str:
         patch = COMPAT_DIR / "adaptations" / f"{adaptation}.patch"
         if not patch.is_file():
             raise CompatError(f"adaptation {adaptation!r} has no patch at {patch}")
-        changed_paths = [
-            line[6:]
-            for line in patch.read_text().splitlines()
-            if line.startswith("+++ b/")
-        ]
-        if not changed_paths or any(
-            not path.startswith("testsuite/") for path in changed_paths
-        ):
-            raise CompatError(
-                f"adaptation {adaptation!r} must change only upstream testsuite files"
-            )
+        validate_adaptation_patch(adaptation, patch.read_text())
         digest.update(adaptation.encode())
         digest.update(patch.read_bytes())
     return digest.hexdigest()[:20]
@@ -503,11 +569,27 @@ def outcome_class(outcome: str) -> str:
 
 
 def markdown_report(report: dict) -> str:
+    harness_ok = report["runner_exit_code"] == 0 and not report["parser_errors"]
+    if harness_ok:
+        harness_status = (
+            "Harness status: **healthy** — runner exit code `0`; "
+            "no runner-output errors."
+        )
+    else:
+        details = []
+        if report["runner_exit_code"] != 0:
+            details.append(f"runner exit code `{report['runner_exit_code']}`")
+        if report["parser_errors"]:
+            count = len(report["parser_errors"])
+            details.append(f"{count} runner-output error{'s' if count != 1 else ''}")
+        harness_status = "Harness status: **FAILED** — " + "; ".join(details) + "."
     lines = [
         "## rsync compatibility",
         "",
         f"Pinned upstream: `{report['upstream_commit']}` · profile: `{report['profile']}` "
         f"· platform: `{report['platform']}` · run as: `{report['run_as']}`",
+        "",
+        harness_status,
         "",
         "| Measure | Count |",
         "|---|---:|",
@@ -519,10 +601,25 @@ def markdown_report(report: dict) -> str:
         f"| Out of scope (ledger) | {report['ledger']['out-of-scope']} |",
         f"| Unsupported feature (ledger) | {report['ledger']['unsupported']} |",
         f"| Not yet assessed (ledger) | {report['ledger']['unassessed']} |",
-        "",
-        f"Classified runnable-test pass rate: **{report['passing']}/{report['applicable']} "
-        f"({report['score_percent']:.1f}%)**.",
     ]
+    if harness_ok:
+        lines.extend(
+            [
+                "",
+                f"Classified runnable-test pass rate: **{report['passing']}/{report['applicable']} "
+                f"({report['score_percent']:.1f}%)**.",
+            ]
+        )
+    else:
+        notrun = sum(test["actual"] == "notrun" for test in report["tests"])
+        lines.extend(
+            [
+                f"| Unreported after runner failure | {notrun} |",
+                "",
+                "Compatibility score is unavailable; the counts above are partial "
+                "diagnostic observations, not a conformance result.",
+            ]
+        )
     gaps = [test for test in report["tests"] if test["actual"] in {"fail", "xfail"}]
     if gaps:
         lines.extend(["", "Known gaps:", ""])
@@ -530,9 +627,14 @@ def markdown_report(report: dict) -> str:
             f"- `{test['name']}` ({', '.join(test['tags']) or 'untagged'}): {test['note']}"
             for test in gaps
         )
-    mismatches = [test for test in report["tests"] if not test["matches"]]
+    mismatches = [
+        test
+        for test in report["tests"]
+        if not test["matches"] and test["actual"] != "notrun"
+    ]
     if mismatches:
-        lines.extend(["", "Expectation mismatches:", ""])
+        title = "Expectation mismatches:" if harness_ok else "Observed expectation mismatches:"
+        lines.extend(["", title, ""])
         lines.extend(
             f"- `{test['name']}`: expected {test['expected']}, got {test['actual']}"
             for test in mismatches
@@ -560,6 +662,13 @@ def parse_args() -> argparse.Namespace:
         "--cache-dir", type=Path, default=ROOT / "target" / "rsync-compat"
     )
     parser.add_argument("-j", "--jobs", type=int, default=min(os.cpu_count() or 1, 8))
+    parser.add_argument(
+        "--test-timeout",
+        type=int,
+        default=300,
+        metavar="SECONDS",
+        help="per-test timeout passed to the upstream runner (default: 300)",
+    )
     parser.add_argument("--preserve-scratch", action="store_true")
     parser.add_argument("--ledger-only", action="store_true")
     parser.add_argument("--update-ledger", action="store_true")
@@ -581,6 +690,8 @@ def main() -> int:
     args = parse_args()
     if args.jobs < 1:
         raise CompatError("--jobs must be positive")
+    if args.test_timeout < 1:
+        raise CompatError("--test-timeout must be positive")
     if args.report_label and not re.fullmatch(r"[A-Za-z0-9_-]+", args.report_label):
         raise CompatError("--report-label may contain only letters, digits, _ and -")
     manifest = load_manifest()
@@ -653,6 +764,8 @@ def main() -> int:
         str(suite),
         "--expect-result",
         str(expected),
+        "--timeout",
+        str(args.test_timeout),
         "--timing",
         "-j",
         str(args.jobs),
@@ -690,6 +803,7 @@ def main() -> int:
     known_failures = sum(test["actual"] in {"fail", "xfail"} for test in test_results)
     skipped = sum(test["actual"] == "skip" for test in test_results)
     applicable = len(test_results)
+    harness_ok = returncode == 0 and not parser_errors
     report = {
         "schema": 1,
         "upstream_repository": upstream["repository"],
@@ -704,11 +818,14 @@ def main() -> int:
         "skipped": skipped,
         "adapted": sum(test["classification"] == "adapted" for test in test_results),
         "environment_excluded": [test["name"] for test in environment_excluded],
-        "score_percent": (passing * 100.0 / applicable) if applicable else 0.0,
+        "score_percent": (
+            passing * 100.0 / applicable if harness_ok and applicable else None
+        ),
         "ledger": {key: ledger_counts[key] for key in sorted(VALID_CLASSES)},
         "tests": test_results,
         "runner_exit_code": returncode,
         "parser_errors": parser_errors,
+        "harness_ok": harness_ok,
     }
     reports = cache / "reports"
     reports.mkdir(exist_ok=True)

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -2738,7 +2738,7 @@ fn checkpoint_tombstone_precedes_destination_deletion() {
         .env("SYQ_TEST_HOLD_AFTER_DELETE_MS", "10000")
         .spawn()
         .unwrap();
-    for _ in 0..200 {
+    for _ in 0..300 {
         if !t.path("dst/f").exists() {
             break;
         }

--- a/tests/rsync-compat/LEDGER.md
+++ b/tests/rsync-compat/LEDGER.md
@@ -7,6 +7,7 @@ python3 scripts/rsync-compat.py --ledger-only --update-ledger
 ```
 
 Pinned rsync commit: `7c20b077c980036a19587701cec320cc88e42a4a`.
+Configured command prefix: `syq`.
 
 | Classification | Tests |
 |---|---:|
@@ -16,36 +17,38 @@ Pinned rsync commit: `7c20b077c980036a19587701cec320cc88e42a4a`.
 | out-of-scope | 184 |
 | unassessed | 0 |
 
-## Runnable conformance tests
+## Runnable behavioral tests
 
-| Test | Kind | Expected | Circumstances | Note |
-|---|---|---|---|---|
-| `change-shrink` | adapted | default: pass | platform=linux; threads; bandwidth limiting | Continue a transfer when a source file shrinks after the source scan. |
-| `change-vanish` | adapted | default: pass | platform=linux; threads; bandwidth limiting | Continue a transfer when a source file vanishes after the source scan. |
-| `chgrp` | conformance | default: pass | platform=linux; POSIX groups; chgrp | Preserve a supplementary group with -g. |
-| `chown` | adapted | default: pass | platform=linux; run-as=root; root; chown | Archive mode preserves numeric owners and groups; rsync-only --super and -H are removed. |
-| `deep-path` | adapted | default: pass | platform=linux; paths deeper than 64 components | Copy a 70-level local tree; the rsync-daemon half is outside SYQ's scope. |
-| `dest-symlinked-dir` | conformance | default: pass | platform=linux; symlinks | Follow an operator-named destination symlink to a directory. |
-| `dir-sgid` | conformance | default: pass | platform=linux; POSIX modes | Honor setgid inheritance when creating destination directories. |
-| `duplicates` | conformance | default: fail | platform=linux; symlinks | SYQ still treats repeated identical sources as destination collisions. |
-| `files-from-path-clamp` | conformance | default: fail | platform=linux | SYQ rejects parent components instead of clamping them at the source root. |
-| `growing-file` | adapted | default: pass | platform=linux; threads; bandwidth limiting | Copy the final contents of a file that grows after the source scan. |
-| `highfd-hang` | conformance | default: pass | platform=linux; C compiler; soft fd limit above FD_SETSIZE | An ordinary transfer completes when the child inherits high-numbered descriptors. |
-| `inplace` | adapted | default: pass | platform=linux; stable inode numbers | --inplace retains the destination inode while the default atomic path replaces it. |
-| `longdir` | adapted | default: pass | platform=linux; long path components | Copy and delete within a tree containing three 175-character path components. |
-| `metadata-depth` | adapted | default: pass | platform=linux; POSIX modes and mtimes | Preserve modes and mtimes throughout a deep tree; upstream's unsupported --chmod case is omitted. |
-| `nested-socket-specials` | conformance | default: pass | platform=linux; Unix-domain sockets | Archive mode handles a nested socket without losing ordinary files. |
-| `partial` | adapted | default: pass | platform=linux; signals; bandwidth limiting | An interrupted transfer leaves SYQ's job-scoped deterministic sidecar and a rerun completes it. |
-| `protected-regular` | conformance | default: pass | platform=linux; run-as=root; root; Linux fs.protected_regular | --inplace can update a foreign-owned file in a sticky directory when the caller has authority. |
-| `search-only-destination` | conformance | default: pass | platform=linux; Linux search-only directory semantics; setpriv when run as root | Traverse a searchable but unreadable destination parent. |
-| `sender-scan-dir-escape` | conformance | default: pass | platform=linux; symlinks; C compiler; renameat2 | A raced source parent cannot make the copy enumerate outside the source tree. |
-| `size-filter` | conformance | default: pass | platform=linux | Apply --min-size and --max-size throughout a deep tree. |
-| `ssh-basic` | adapted | default: pass | platform=linux; rsync lsh test helper | Remote-shell copy and follow-up deletion using SYQ's remote executable option. |
-| `symlink-ignore` | conformance | default: pass | platform=linux; symlinks | Without -l/-L/-a, omit symlinks while copying referent files. |
-| `symlink-race-dest` | conformance | default: fail | platform=linux; run-as=root; root; a second uid; symlinks | SYQ follows an attacker-owned symlink in an operator-named absolute destination path. |
-| `symlink-race-relative-dest` | conformance | default: fail | platform=linux; run-as=root; root; a second uid; symlinks | SYQ follows an attacker-owned symlink in an operator-named relative destination path. |
-| `symlink-race-source` | conformance | default: pass | platform=linux; symlinks; C compiler; renameat2 | A raced source parent cannot make SYQ read file contents from outside the source tree. |
-| `update` | adapted | default: pass | platform=linux; symlinks | -u skips a newer deep destination, updates an older one, and still replaces a type mismatch. |
+The baseline is the last reviewed observation, not a claim that rsync's behavior is always the desired product policy.
+
+| Area | Test | Baseline | Product position | Provenance | Circumstances | Note |
+|---|---|---|---|---|---|---|
+| file-selection | `files-from-path-clamp` | fail | Policy open | unmodified upstream | platform=linux | SYQ rejects parent components instead of clamping them at the source root. |
+| file-selection | `size-filter` | pass | Compatible | unmodified upstream | platform=linux | Apply --min-size and --max-size throughout a deep tree. |
+| metadata | `chgrp` | pass | Compatible | unmodified upstream | platform=linux; POSIX groups; chgrp | Preserve a supplementary group with -g. |
+| metadata | `chown` | pass | Compatible | subset adaptation (chown-syq-cli) | platform=linux; run-as=root; root; chown | Archive mode preserves numeric owners and groups; rsync-only --super and -H are removed. |
+| metadata | `dir-sgid` | pass | Compatible | unmodified upstream | platform=linux; POSIX modes | Honor setgid inheritance when creating destination directories. |
+| metadata | `metadata-depth` | pass | Compatible | subset adaptation (metadata-supported-subset) | platform=linux; POSIX modes and mtimes | Preserve modes and mtimes throughout a deep tree; upstream's unsupported --chmod case is omitted. |
+| paths | `deep-path` | pass | Compatible | subset adaptation (deep-path-local) | platform=linux; paths deeper than 64 components | Copy a 70-level local tree; the rsync-daemon half is outside SYQ's scope. |
+| paths | `dest-symlinked-dir` | pass | Compatible | unmodified upstream | platform=linux; symlinks | Follow an operator-named destination symlink to a directory. |
+| paths | `longdir` | pass | Compatible | subset adaptation (longdir-no-hardlinks) | platform=linux; long path components | Copy and delete within a tree containing three 175-character path components. |
+| permissions | `protected-regular` | pass | Compatible | unmodified upstream | platform=linux; run-as=root; root; Linux fs.protected_regular | --inplace can update a foreign-owned file in a sticky directory when the caller has authority. |
+| permissions | `search-only-destination` | pass | Compatible | unmodified upstream | platform=linux; Linux search-only directory semantics; setpriv when run as root | Traverse a searchable but unreadable destination parent. |
+| publication | `inplace` | pass | Compatible | invocation adaptation (inplace-syq-cli) | platform=linux; stable inode numbers | --inplace retains the destination inode while the default atomic path replaces it. |
+| remote | `ssh-basic` | pass | Compatible | invocation adaptation (ssh-syq-path) | platform=linux; rsync lsh test helper | Remote-shell copy and follow-up deletion using SYQ's remote executable option. |
+| resume | `partial` | pass | Intentional divergence | fixture adaptation (syq-partial-layout) | platform=linux; signals; bandwidth limiting | An interrupted transfer leaves SYQ's job-scoped deterministic sidecar and a rerun completes it. |
+| robustness | `change-shrink` | pass | Compatible | invocation adaptation (source-mutation-cli) | platform=linux; threads; bandwidth limiting | Continue a transfer when a source file shrinks after the source scan. |
+| robustness | `change-vanish` | pass | Compatible | invocation adaptation (source-mutation-cli) | platform=linux; threads; bandwidth limiting | Continue a transfer when a source file vanishes after the source scan. |
+| robustness | `growing-file` | pass | Compatible | invocation adaptation (source-mutation-cli) | platform=linux; threads; bandwidth limiting | Copy the final contents of a file that grows after the source scan. |
+| robustness | `highfd-hang` | pass | Compatible | unmodified upstream | platform=linux; C compiler; soft fd limit above FD_SETSIZE | An ordinary transfer completes when the child inherits high-numbered descriptors. |
+| security | `sender-scan-dir-escape` | pass | Compatible | unmodified upstream | platform=linux; symlinks; C compiler; renameat2 | A raced source parent cannot make the copy enumerate outside the source tree. |
+| security | `symlink-race-dest` | fail | Unimplemented | unmodified upstream | platform=linux; run-as=root; root; a second uid; symlinks | SYQ follows an attacker-owned symlink in an operator-named absolute destination path. |
+| security | `symlink-race-relative-dest` | fail | Unimplemented | unmodified upstream | platform=linux; run-as=root; root; a second uid; symlinks | SYQ follows an attacker-owned symlink in an operator-named relative destination path. |
+| security | `symlink-race-source` | pass | Compatible | unmodified upstream | platform=linux; symlinks; C compiler; renameat2 | A raced source parent cannot make SYQ read file contents from outside the source tree. |
+| source-mapping | `duplicates` | fail | Policy open | unmodified upstream | platform=linux; symlinks | SYQ still treats repeated identical sources as destination collisions. |
+| special-files | `nested-socket-specials` | pass | Compatible | unmodified upstream | platform=linux; Unix-domain sockets | Archive mode handles a nested socket without losing ordinary files. |
+| symlinks | `symlink-ignore` | pass | Compatible | unmodified upstream | platform=linux; symlinks | Without -l/-L/-a, omit symlinks while copying referent files. |
+| update | `update` | pass | Compatible | subset adaptation (update-supported-subset) | platform=linux; symlinks | -u skips a newer deep destination, updates an older one, and still replaces a type mismatch. |
 
 ## Exclusion reasons
 

--- a/tests/rsync-compat/README.md
+++ b/tests/rsync-compat/README.md
@@ -1,9 +1,8 @@
-# Upstream rsync compatibility tests
+# Upstream rsync behavioral tests
 
-This directory is SYQ's executable compatibility ledger for the upstream
-rsync test suite. It answers a narrower question than `cargo test`: for rsync
-tests that exercise command-line filesystem behavior relevant to SYQ, did SYQ
-produce the result we have reviewed and recorded?
+This directory tracks what selected upstream rsync tests tell us about SYQ's
+rsync-compatible command surface. It is both a regression suite and a reviewable
+map of compatibility work. It is not an overall compatibility score.
 
 Run it from the repository root:
 
@@ -11,87 +10,88 @@ Run it from the repository root:
 python3 scripts/rsync-compat.py
 ```
 
+The manifest currently routes upstream invocations to native `syq`, because the
+dedicated command does not exist yet. When `syq rsync` lands, changing
+`target.args` from `[]` to `["rsync"]` switches the whole suite without patching
+upstream tests or adding a second harness mode.
+
 The first run fetches the commit pinned in `manifest.toml`, prepares rsync's
 test helpers under `target/rsync-compat/`, builds SYQ, and runs the applicable
 tests. Later runs reuse the prepared suite. Pass `--rsync-src PATH` to use an
-already configured checkout at the exact pin. Reports are written to
-`target/rsync-compat/reports/`.
+already configured checkout at the exact pin. Reports are written as JSON,
+Markdown, static HTML, and a raw log under `target/rsync-compat/reports/`.
 
 Only the classified runnable subset is executed, not all 351 inventoried
 tests. A warm non-root Linux run selects 22 tests and takes about 11 seconds on
-the development machine; four more tests are selected when run as root. A
-first run additionally downloads and prepares the pinned rsync checkout and
-may do a cold Rust build. The exact cold time depends mostly on network and
-Cargo state.
+the development machine; four more tests apply when run as root. A first run
+also downloads and prepares the pinned rsync checkout and may do a cold Rust
+build. The exact cold time depends mostly on network and Cargo state.
 
-The source checkout and prepared test helpers are content-addressed and reused
-until the rsync pin, helper configuration, or adaptation patches change. Cargo
-also performs its normal incremental build. CI caches both sets of artifacts,
-so routine jobs normally pay only an incremental SYQ build and the test run.
-All adapted suites are copied from one configured base, so adding or changing
-a testsuite-only adaptation does not rebuild rsync's C helpers. CI installs the
-rsync build prerequisites only on a suite-cache miss. To manage the SYQ build
+The source checkout and prepared helpers are content-addressed and reused until
+the rsync pin, helper configuration, or adaptation patches change. Cargo uses
+its normal incremental build. CI caches both sets of artifacts and installs
+rsync's build prerequisites only on a suite-cache miss. To manage the SYQ build
 separately, use `--no-build-syq --syq-bin PATH`.
 
 The upstream runner gives each test a 300-second deadline by default; override
-it with `--test-timeout SECONDS`. CI uses 120 seconds per test and also caps the
-whole conformance job at 30 minutes. A per-test timeout is reported normally so
-the JSON, Markdown, and raw-log artifacts are still written.
+it with `--test-timeout SECONDS`. CI uses 120 seconds per test, caps the entire
+job at 30 minutes, and passes `--require-tests` so an accidentally empty Linux
+selection cannot look successful. A local run with no applicable tests still
+writes a valid N/A report.
 
 The harness requires Python 3.11 or newer. Preparing a fresh checkout also
-requires Git, a C toolchain, Make, Autoconf, and Automake. The CI workflow
-installs the build prerequisites.
+requires Git, a C toolchain, Make, Autoconf, and Automake.
 
-## The ledger
+## Inventory, observations, and product positions
 
 `inventory.tsv` names every test at the pinned commit. Updating the pin without
 classifying every added or removed test is an error. Its classifications are:
 
-- `conformance`: an unmodified upstream test that measures relevant observable
-  behavior. It contributes to the compatibility score.
-- `adapted`: still an upstream conformance test, with a patch for an
-  implementation-specific fixture detail or to isolate the supported part of
-  an aggregate test. It contributes to the score and names its adaptation in
-  `manifest.toml`.
-- `unsupported`: a user-visible rsync feature SYQ does not implement. It is
-  tracked separately from internals and from known failures that we actively
-  run.
-- `out-of-scope`: rsync protocol, daemon, restricted-wrapper, build, or
-  implementation-internal testing. SYQ does not need to pass it.
-- `unassessed`: not yet reviewed closely enough to classify. This is visible
-  compatibility-audit debt, not an implicit failure or exclusion. The current
-  pin has zero tests in this category.
+- `conformance`: a relevant upstream test used without modification.
+- `adapted`: a relevant upstream test with a narrow, recorded fixture,
+  invocation, or subset adaptation.
+- `unsupported`: a user-visible rsync feature the target does not implement.
+- `out-of-scope`: rsync protocol, daemon, restricted-wrapper, build, harness,
+  or implementation-internal testing.
+- `unassessed`: a test not yet reviewed closely enough to classify.
 
-Runnable tests have an expected result per enabled profile. The upstream
-runner compares actual results with that manifest: a regression fails, and an
-unexpected pass also fails so the ledger must be updated. Requirements and
-platform restrictions record the circumstances in which an expectation is
-valid.
+Each runnable manifest entry separates three ideas that should not be collapsed
+into one pass percentage:
 
-The reported pass rate covers only the reviewed, runnable conformance tests.
-It is a regression measure, not a claim that unsupported rsync features are
-compatible; their counts are printed beside it. `LEDGER.md` lists all 351 tests
-and is generated with `--ledger-only --update-ledger`; normal runs reject a
-stale generated ledger.
+- `baseline` is the last reviewed raw runner outcome. A change in either
+  direction fails CI until someone reviews and records it.
+- `position` records what the result means for the product: `compatible`,
+  `unimplemented`, `intentional-divergence`, `policy-open`, or
+  `test-unresolved`.
+- provenance says whether the upstream test is unmodified or carries an
+  `invocation`, `fixture`, or `subset` adaptation.
 
-The future `strict` profile is already represented, but disabled until SYQ has
-the corresponding flag. The harness injects profile arguments through a
-generated executable wrapper, so upstream tests do not need to know about the
-flag.
+The runner exit status is checked independently of those baselines. An ordinary
+test failure is not a harness failure when the runner reports it consistently;
+missing, duplicate, or contradictory output is. Markdown and HTML reports show
+the observations grouped by behavioral area, their product positions,
+provenance, platform/user circumstances, any baseline changes, and a compact
+breakdown of unsupported user-facing feature areas. Rsync-internal tests remain
+out of the compatibility matrix.
+
+`LEDGER.md` is the generated readable inventory. Update it with
+`--ledger-only --update-ledger`; normal runs reject a stale copy.
 
 ## Adaptations
 
-An adaptation is a unified diff stored as
-`adaptations/<id>.patch`, referenced by an `adapted` test's `adaptation` field.
-The harness applies patches to a fresh cached checkout and includes their
-contents in the cache key. Adaptations may change an incidental fixture or
-isolate the supported part of an upstream test that combines several features;
-they must not change the semantics claimed by the resulting test. For example,
-SYQ's partial adaptation discovers the full-length sparse
-`.name.syq-part.<job-id>` sidecar instead of rsync's growing destination prefix
-while retaining the same interrupted-transfer-and-successful-resume assertions. The
-manifest's note must identify any omitted unsupported scenario.
+An adaptation is a unified diff stored as `adaptations/<id>.patch`, referenced
+by an `adapted` test. The harness hashes and applies the exact validated bytes.
+It asks Git for both the forward and reverse path sets, so additions, deletions,
+traditional multi-file diffs, renames, and copies must all stay under
+`testsuite/`.
 
-Do not adapt a test merely to make it green. If it exercises rsync internals,
-classify it `out-of-scope`; if SYQ lacks the behavior, use `unsupported`; if
-the behavior is applicable and differs, run it as an expected failure.
+Adaptations may translate an implementation-specific fixture or isolate a
+supported part of an aggregate test. They must not edit rsync sources or its
+runner, and they must not quietly change the behavioral claim. The partial test,
+for example, looks for SYQ's job-scoped sidecar instead of rsync's partial name;
+the manifest labels that fixture adaptation and the current intentional product
+divergence explicitly.
+
+Do not adapt a test merely to make it green. Classify rsync internals as
+`out-of-scope`, unsupported user behavior as `unsupported`, and runnable
+differences according to their actual product position.

--- a/tests/rsync-compat/README.md
+++ b/tests/rsync-compat/README.md
@@ -29,9 +29,14 @@ until the rsync pin, helper configuration, or adaptation patches change. Cargo
 also performs its normal incremental build. CI caches both sets of artifacts,
 so routine jobs normally pay only an incremental SYQ build and the test run.
 All adapted suites are copied from one configured base, so adding or changing
-a testsuite-only adaptation does not rebuild rsync's C helpers. Fresh runners
-still install the rsync build prerequisites. To manage the SYQ build separately,
-use `--no-build-syq --syq-bin PATH`.
+a testsuite-only adaptation does not rebuild rsync's C helpers. CI installs the
+rsync build prerequisites only on a suite-cache miss. To manage the SYQ build
+separately, use `--no-build-syq --syq-bin PATH`.
+
+The upstream runner gives each test a 300-second deadline by default; override
+it with `--test-timeout SECONDS`. CI uses 120 seconds per test and also caps the
+whole conformance job at 30 minutes. A per-test timeout is reported normally so
+the JSON, Markdown, and raw-log artifacts are still written.
 
 The harness requires Python 3.11 or newer. Preparing a fresh checkout also
 requires Git, a C toolchain, Make, Autoconf, and Automake. The CI workflow

--- a/tests/rsync-compat/harness_test.py
+++ b/tests/rsync-compat/harness_test.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import importlib.util
 import os
 from pathlib import Path
+import subprocess
 import sys
+import tempfile
 import unittest
 from unittest import mock
 
@@ -19,61 +21,128 @@ rsync_compat = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(rsync_compat)
 
 
+def sample_report(tests: list[dict] | None = None) -> dict:
+    tests = tests or []
+    return {
+        "upstream_commit": "abc123",
+        "target_name": "rsync",
+        "target_args": [],
+        "platform": "linux",
+        "run_as": "non-root",
+        "applicable": len(tests),
+        "position_counts": {
+            position: sum(test["position"] == position for test in tests)
+            for position in rsync_compat.VALID_POSITIONS
+        },
+        "adapted": sum(test["classification"] == "adapted" for test in tests),
+        "ledger": {
+            "out-of-scope": 50,
+            "unsupported": 30,
+            "unassessed": 4,
+        },
+        "unsupported_features": [
+            {
+                "area": "filters",
+                "reason": "unsupported-filters",
+                "tests": 30,
+                "description": "Filter behavior is not implemented.",
+            }
+        ],
+        "tests": tests,
+        "runner_exit_code": 0,
+        "expected_runner_exit_code": 0,
+        "parser_errors": [],
+        "harness_errors": [],
+        "harness_ok": True,
+    }
+
+
 class HarnessTests(unittest.TestCase):
-    def test_adaptation_scope_rejects_deletion_outside_testsuite(self) -> None:
-        patch = """diff --git a/testsuite/old b/testsuite/old
-deleted file mode 100644
+    def test_scope_rejects_later_file_in_traditional_multi_file_patch(self) -> None:
+        patch = b"""--- a/testsuite/README.md
++++ b/testsuite/README.md
+@@ -1 +1 @@
+-old
++new
 --- a/flist.c
-+++ /dev/null
++++ b/flist.c
+@@ -1 +1 @@
+-old
++new
 """
 
         with self.assertRaisesRegex(rsync_compat.CompatError, "testsuite files"):
-            rsync_compat.validate_adaptation_patch("bad-delete", patch)
+            rsync_compat.validate_adaptation_patch("bad-multi-file", patch)
 
-    def test_adaptation_scope_rejects_rename_metadata_outside_testsuite(self) -> None:
-        patch = """diff --git a/testsuite/old b/testsuite/new
+    def test_scope_rejects_rename_source_outside_testsuite(self) -> None:
+        patch = b"""diff --git a/flist.c b/testsuite/flist.c
 similarity index 100%
 rename from flist.c
-rename to testsuite/new
+rename to testsuite/flist.c
 """
 
         with self.assertRaisesRegex(rsync_compat.CompatError, "testsuite files"):
             rsync_compat.validate_adaptation_patch("bad-rename", patch)
 
-    def test_adaptation_scope_allows_testsuite_deletion(self) -> None:
-        patch = """diff --git a/testsuite/old b/testsuite/old
+    def test_scope_rejects_copy_source_outside_testsuite(self) -> None:
+        patch = b"""diff --git a/flist.c b/testsuite/flist.c
+similarity index 100%
+copy from flist.c
+copy to testsuite/flist.c
+"""
+
+        with self.assertRaisesRegex(rsync_compat.CompatError, "testsuite files"):
+            rsync_compat.validate_adaptation_patch("bad-copy", patch)
+
+    def test_scope_allows_testsuite_deletion(self) -> None:
+        patch = b"""diff --git a/testsuite/old b/testsuite/old
 deleted file mode 100644
 --- a/testsuite/old
 +++ /dev/null
+@@ -1 +0,0 @@
+-old
 """
 
         rsync_compat.validate_adaptation_patch("good-delete", patch)
 
-    def test_ledger_requires_expectations_for_every_enabled_profile(self) -> None:
+    def test_ledger_requires_target_and_product_metadata(self) -> None:
         manifest = {
-            "profiles": {
-                "default": {"enabled": True},
-                "strict": {"enabled": False},
-            },
+            "target": {"name": "rsync", "args": []},
             "reasons": {},
             "tests": [
                 {
-                    "name": "root-only",
+                    "name": "alpha",
                     "classification": "conformance",
-                    "expect": {},
-                    "run_as": "root",
+                    "baseline": "pass",
+                    "position": "compatible",
                 }
             ],
         }
-        inventory = {"root-only": ("conformance", None)}
+        inventory = {"alpha": ("conformance", None)}
 
         with mock.patch.object(
-            rsync_compat, "upstream_test_names", return_value={"root-only"}
+            rsync_compat, "upstream_test_names", return_value={"alpha"}
         ):
-            with self.assertRaisesRegex(
-                rsync_compat.CompatError, "no expectation for 'default'"
-            ):
+            with self.assertRaisesRegex(rsync_compat.CompatError, "area"):
                 rsync_compat.validate_ledger(manifest, inventory, ROOT)
+
+    def test_target_arguments_are_inserted_before_upstream_arguments(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            wrapper = Path(temporary) / "wrapper"
+            rsync_compat.make_wrapper(
+                wrapper,
+                Path(sys.executable),
+                ["-c", "import sys; print('|'.join(sys.argv[1:]))", "rsync"],
+            )
+
+            result = subprocess.run(
+                [wrapper, "-a", "src", "dst"],
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+        self.assertEqual(result.stdout, "rsync|-a|src|dst\n")
 
     def test_stream_command_replaces_non_utf8_output(self) -> None:
         returncode, log = rsync_compat.stream_command(
@@ -112,52 +181,54 @@ PASS    stranger
         self.assertTrue(any("unexpected result for stranger" in error for error in errors))
         self.assertTrue(any("missing result for beta" in error for error in errors))
 
-    def test_runner_failure_suppresses_compatibility_score(self) -> None:
-        report = {
-            "upstream_commit": "abc123",
-            "profile": "default",
-            "platform": "linux",
-            "run_as": "non-root",
-            "applicable": 2,
-            "passing": 1,
-            "known_failures": 0,
-            "skipped": 0,
-            "adapted": 0,
-            "ledger": {
-                "out-of-scope": 0,
-                "unsupported": 0,
-                "unassessed": 0,
-            },
-            "score_percent": None,
-            "tests": [
-                {
-                    "name": "alpha",
-                    "actual": "pass",
-                    "expected": "pass",
-                    "matches": True,
-                    "tags": [],
-                    "note": "",
-                },
-                {
-                    "name": "beta",
-                    "actual": "notrun",
-                    "expected": "pass",
-                    "matches": False,
-                    "tags": [],
-                    "note": "",
-                },
-            ],
-            "runner_exit_code": 2,
-            "parser_errors": ["missing result for beta"],
-        }
+    def test_expected_failure_is_not_a_harness_error(self) -> None:
+        expected, errors = rsync_compat.assess_harness(
+            1, {"alpha": "fail", "beta": "pass"}, [], require_tests=True, applicable=2
+        )
+
+        self.assertEqual(expected, 1)
+        self.assertEqual(errors, [])
+
+    def test_runner_status_inconsistent_with_results_is_a_harness_error(self) -> None:
+        expected, errors = rsync_compat.assess_harness(
+            2, {"alpha": "fail"}, [], require_tests=True, applicable=1
+        )
+
+        self.assertEqual(expected, 1)
+        self.assertRegex(errors[0], "runner exit code 2")
+
+    def test_zero_applicable_tests_render_without_a_score(self) -> None:
+        report = sample_report()
 
         markdown = rsync_compat.markdown_report(report)
+        html = rsync_compat.html_report(report)
 
-        self.assertIn("Harness status: **FAILED**", markdown)
-        self.assertIn("runner exit code `2`", markdown)
-        self.assertIn("Compatibility score is unavailable", markdown)
-        self.assertIn("Unreported after runner failure | 1", markdown)
-        self.assertNotIn("Classified runnable-test pass rate", markdown)
+        self.assertIn("No tests apply", markdown)
+        self.assertIn("No tests apply", html)
+        self.assertNotIn("score", markdown.lower())
+
+    def test_baseline_change_is_separate_from_harness_health(self) -> None:
+        test = {
+            "name": "alpha",
+            "classification": "conformance",
+            "adaptation": None,
+            "adaptation_kind": None,
+            "area": "paths",
+            "position": "policy-open",
+            "baseline": "pass",
+            "actual": "fail",
+            "baseline_matches": False,
+            "circumstances": [],
+            "note": "A <review> is needed.",
+        }
+        report = sample_report([test])
+
+        markdown = rsync_compat.markdown_report(report)
+        html = rsync_compat.html_report(report)
+
+        self.assertIn("Harness execution: **complete**", markdown)
+        self.assertIn("Observation changes requiring review", markdown)
+        self.assertIn("A &lt;review&gt; is needed.", html)
 
 
 if __name__ == "__main__":

--- a/tests/rsync-compat/harness_test.py
+++ b/tests/rsync-compat/harness_test.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import sys
 import unittest
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -19,6 +20,61 @@ SPEC.loader.exec_module(rsync_compat)
 
 
 class HarnessTests(unittest.TestCase):
+    def test_adaptation_scope_rejects_deletion_outside_testsuite(self) -> None:
+        patch = """diff --git a/testsuite/old b/testsuite/old
+deleted file mode 100644
+--- a/flist.c
++++ /dev/null
+"""
+
+        with self.assertRaisesRegex(rsync_compat.CompatError, "testsuite files"):
+            rsync_compat.validate_adaptation_patch("bad-delete", patch)
+
+    def test_adaptation_scope_rejects_rename_metadata_outside_testsuite(self) -> None:
+        patch = """diff --git a/testsuite/old b/testsuite/new
+similarity index 100%
+rename from flist.c
+rename to testsuite/new
+"""
+
+        with self.assertRaisesRegex(rsync_compat.CompatError, "testsuite files"):
+            rsync_compat.validate_adaptation_patch("bad-rename", patch)
+
+    def test_adaptation_scope_allows_testsuite_deletion(self) -> None:
+        patch = """diff --git a/testsuite/old b/testsuite/old
+deleted file mode 100644
+--- a/testsuite/old
++++ /dev/null
+"""
+
+        rsync_compat.validate_adaptation_patch("good-delete", patch)
+
+    def test_ledger_requires_expectations_for_every_enabled_profile(self) -> None:
+        manifest = {
+            "profiles": {
+                "default": {"enabled": True},
+                "strict": {"enabled": False},
+            },
+            "reasons": {},
+            "tests": [
+                {
+                    "name": "root-only",
+                    "classification": "conformance",
+                    "expect": {},
+                    "run_as": "root",
+                }
+            ],
+        }
+        inventory = {"root-only": ("conformance", None)}
+
+        with mock.patch.object(
+            rsync_compat, "upstream_test_names", return_value={"root-only"}
+        ):
+            with self.assertRaisesRegex(
+                rsync_compat.CompatError, "no expectation for 'default'"
+            ):
+                rsync_compat.validate_ledger(manifest, inventory, ROOT)
+
     def test_stream_command_replaces_non_utf8_output(self) -> None:
         returncode, log = rsync_compat.stream_command(
             [sys.executable, "-c", "import os; os.write(1, b'before\\xffafter\\n')"],
@@ -55,6 +111,53 @@ PASS    stranger
         self.assertTrue(any("duplicate result for alpha" in error for error in errors))
         self.assertTrue(any("unexpected result for stranger" in error for error in errors))
         self.assertTrue(any("missing result for beta" in error for error in errors))
+
+    def test_runner_failure_suppresses_compatibility_score(self) -> None:
+        report = {
+            "upstream_commit": "abc123",
+            "profile": "default",
+            "platform": "linux",
+            "run_as": "non-root",
+            "applicable": 2,
+            "passing": 1,
+            "known_failures": 0,
+            "skipped": 0,
+            "adapted": 0,
+            "ledger": {
+                "out-of-scope": 0,
+                "unsupported": 0,
+                "unassessed": 0,
+            },
+            "score_percent": None,
+            "tests": [
+                {
+                    "name": "alpha",
+                    "actual": "pass",
+                    "expected": "pass",
+                    "matches": True,
+                    "tags": [],
+                    "note": "",
+                },
+                {
+                    "name": "beta",
+                    "actual": "notrun",
+                    "expected": "pass",
+                    "matches": False,
+                    "tags": [],
+                    "note": "",
+                },
+            ],
+            "runner_exit_code": 2,
+            "parser_errors": ["missing result for beta"],
+        }
+
+        markdown = rsync_compat.markdown_report(report)
+
+        self.assertIn("Harness status: **FAILED**", markdown)
+        self.assertIn("runner exit code `2`", markdown)
+        self.assertIn("Compatibility score is unavailable", markdown)
+        self.assertIn("Unreported after runner failure | 1", markdown)
+        self.assertNotIn("Classified runnable-test pass rate", markdown)
 
 
 if __name__ == "__main__":

--- a/tests/rsync-compat/manifest.toml
+++ b/tests/rsync-compat/manifest.toml
@@ -1,4 +1,4 @@
-schema = 1
+schema = 2
 
 [upstream]
 repository = "https://github.com/RsyncProject/rsync.git"
@@ -6,15 +6,10 @@ commit = "7c20b077c980036a19587701cec320cc88e42a4a"
 configure_args = ["--disable-md2man", "--disable-xxhash", "--disable-zstd", "--disable-lz4", "--disable-idn"]
 helpers = ["tls", "trimslash", "t_unsafe", "t_chmod_secure", "t_secure_relpath", "wildtest", "getgroups", "getfsdev"]
 
-[profiles.default]
-enabled = true
+[target]
+name = "rsync"
 args = []
-description = "SYQ's normal command-line semantics"
-
-[profiles.strict]
-enabled = false
-args = ["--rsync-compat"]
-description = "Reserved for a strict compatibility flag that is not implemented yet"
+description = "The rsync-compatible command surface; currently routed through native SYQ until the syq rsync subcommand exists"
 
 [reasons]
 rsync-internal = "Exercises rsync's implementation, build, helper programs, or test harness rather than command-line filesystem semantics."
@@ -34,7 +29,9 @@ unsupported-xattrs = "Requires extended-attribute behavior, which SYQ does not i
 [[tests]]
 name = "chgrp"
 classification = "conformance"
-expect = { default = "pass" }
+area = "metadata"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "metadata", "groups"]
 requirements = ["POSIX groups", "chgrp"]
@@ -43,7 +40,9 @@ note = "Preserve a supplementary group with -g."
 [[tests]]
 name = "dest-symlinked-dir"
 classification = "conformance"
-expect = { default = "pass" }
+area = "paths"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "paths", "symlinks"]
 requirements = ["symlinks"]
@@ -52,7 +51,9 @@ note = "Follow an operator-named destination symlink to a directory."
 [[tests]]
 name = "dir-sgid"
 classification = "conformance"
-expect = { default = "pass" }
+area = "metadata"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "metadata", "setgid"]
 requirements = ["POSIX modes"]
@@ -61,7 +62,9 @@ note = "Honor setgid inheritance when creating destination directories."
 [[tests]]
 name = "duplicates"
 classification = "conformance"
-expect = { default = "fail" }
+area = "source-mapping"
+position = "policy-open"
+baseline = "fail"
 platforms = ["linux"]
 tags = ["local", "sources", "known-gap"]
 requirements = ["symlinks"]
@@ -70,7 +73,9 @@ note = "SYQ still treats repeated identical sources as destination collisions."
 [[tests]]
 name = "files-from-path-clamp"
 classification = "conformance"
-expect = { default = "fail" }
+area = "file-selection"
+position = "policy-open"
+baseline = "fail"
 platforms = ["linux"]
 tags = ["local", "files-from", "known-gap"]
 requirements = []
@@ -79,7 +84,9 @@ note = "SYQ rejects parent components instead of clamping them at the source roo
 [[tests]]
 name = "highfd-hang"
 classification = "conformance"
-expect = { default = "pass" }
+area = "robustness"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "robustness", "file-descriptors"]
 requirements = ["C compiler", "soft fd limit above FD_SETSIZE"]
@@ -88,7 +95,9 @@ note = "An ordinary transfer completes when the child inherits high-numbered des
 [[tests]]
 name = "nested-socket-specials"
 classification = "conformance"
-expect = { default = "pass" }
+area = "special-files"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "special-files", "sockets"]
 requirements = ["Unix-domain sockets"]
@@ -97,7 +106,9 @@ note = "Archive mode handles a nested socket without losing ordinary files."
 [[tests]]
 name = "search-only-destination"
 classification = "conformance"
-expect = { default = "pass" }
+area = "permissions"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "permissions", "paths"]
 requirements = ["Linux search-only directory semantics", "setpriv when run as root"]
@@ -106,7 +117,9 @@ note = "Traverse a searchable but unreadable destination parent."
 [[tests]]
 name = "size-filter"
 classification = "conformance"
-expect = { default = "pass" }
+area = "file-selection"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "size-filters"]
 requirements = []
@@ -115,7 +128,9 @@ note = "Apply --min-size and --max-size throughout a deep tree."
 [[tests]]
 name = "symlink-ignore"
 classification = "conformance"
-expect = { default = "pass" }
+area = "symlinks"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "symlinks"]
 requirements = ["symlinks"]
@@ -125,7 +140,10 @@ note = "Without -l/-L/-a, omit symlinks while copying referent files."
 name = "change-shrink"
 classification = "adapted"
 adaptation = "source-mutation-cli"
-expect = { default = "pass" }
+adaptation_kind = "invocation"
+area = "robustness"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "robustness", "concurrent-source-change"]
 requirements = ["threads", "bandwidth limiting"]
@@ -135,7 +153,10 @@ note = "Continue a transfer when a source file shrinks after the source scan."
 name = "change-vanish"
 classification = "adapted"
 adaptation = "source-mutation-cli"
-expect = { default = "pass" }
+adaptation_kind = "invocation"
+area = "robustness"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "robustness", "concurrent-source-change"]
 requirements = ["threads", "bandwidth limiting"]
@@ -145,7 +166,10 @@ note = "Continue a transfer when a source file vanishes after the source scan."
 name = "chown"
 classification = "adapted"
 adaptation = "chown-syq-cli"
-expect = { default = "pass" }
+adaptation_kind = "subset"
+area = "metadata"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 run_as = "root"
 tags = ["local", "metadata", "ownership"]
@@ -156,7 +180,10 @@ note = "Archive mode preserves numeric owners and groups; rsync-only --super and
 name = "deep-path"
 classification = "adapted"
 adaptation = "deep-path-local"
-expect = { default = "pass" }
+adaptation_kind = "subset"
+area = "paths"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "paths", "depth"]
 requirements = ["paths deeper than 64 components"]
@@ -166,7 +193,10 @@ note = "Copy a 70-level local tree; the rsync-daemon half is outside SYQ's scope
 name = "growing-file"
 classification = "adapted"
 adaptation = "source-mutation-cli"
-expect = { default = "pass" }
+adaptation_kind = "invocation"
+area = "robustness"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "robustness", "concurrent-source-change"]
 requirements = ["threads", "bandwidth limiting"]
@@ -176,7 +206,10 @@ note = "Copy the final contents of a file that grows after the source scan."
 name = "inplace"
 classification = "adapted"
 adaptation = "inplace-syq-cli"
-expect = { default = "pass" }
+adaptation_kind = "invocation"
+area = "publication"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "inplace", "inode"]
 requirements = ["stable inode numbers"]
@@ -186,7 +219,10 @@ note = "--inplace retains the destination inode while the default atomic path re
 name = "longdir"
 classification = "adapted"
 adaptation = "longdir-no-hardlinks"
-expect = { default = "pass" }
+adaptation_kind = "subset"
+area = "paths"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "paths", "long-names"]
 requirements = ["long path components"]
@@ -196,7 +232,10 @@ note = "Copy and delete within a tree containing three 175-character path compon
 name = "metadata-depth"
 classification = "adapted"
 adaptation = "metadata-supported-subset"
-expect = { default = "pass" }
+adaptation_kind = "subset"
+area = "metadata"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "metadata", "depth"]
 requirements = ["POSIX modes and mtimes"]
@@ -206,7 +245,10 @@ note = "Preserve modes and mtimes throughout a deep tree; upstream's unsupported
 name = "partial"
 classification = "adapted"
 adaptation = "syq-partial-layout"
-expect = { default = "pass" }
+adaptation_kind = "fixture"
+area = "resume"
+position = "intentional-divergence"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "resume", "partial-files"]
 requirements = ["signals", "bandwidth limiting"]
@@ -215,7 +257,9 @@ note = "An interrupted transfer leaves SYQ's job-scoped deterministic sidecar an
 [[tests]]
 name = "protected-regular"
 classification = "conformance"
-expect = { default = "pass" }
+area = "permissions"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 run_as = "root"
 tags = ["local", "inplace", "permissions"]
@@ -225,7 +269,9 @@ note = "--inplace can update a foreign-owned file in a sticky directory when the
 [[tests]]
 name = "sender-scan-dir-escape"
 classification = "conformance"
-expect = { default = "pass" }
+area = "security"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "security", "source-race"]
 requirements = ["symlinks", "C compiler", "renameat2"]
@@ -235,7 +281,10 @@ note = "A raced source parent cannot make the copy enumerate outside the source 
 name = "ssh-basic"
 classification = "adapted"
 adaptation = "ssh-syq-path"
-expect = { default = "pass" }
+adaptation_kind = "invocation"
+area = "remote"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["remote", "ssh", "delete"]
 requirements = ["rsync lsh test helper"]
@@ -244,7 +293,9 @@ note = "Remote-shell copy and follow-up deletion using SYQ's remote executable o
 [[tests]]
 name = "symlink-race-dest"
 classification = "conformance"
-expect = { default = "fail" }
+area = "security"
+position = "unimplemented"
+baseline = "fail"
 platforms = ["linux"]
 run_as = "root"
 tags = ["local", "security", "destination-symlink", "known-gap"]
@@ -254,7 +305,9 @@ note = "SYQ follows an attacker-owned symlink in an operator-named absolute dest
 [[tests]]
 name = "symlink-race-relative-dest"
 classification = "conformance"
-expect = { default = "fail" }
+area = "security"
+position = "unimplemented"
+baseline = "fail"
 platforms = ["linux"]
 run_as = "root"
 tags = ["local", "security", "destination-symlink", "known-gap"]
@@ -264,7 +317,9 @@ note = "SYQ follows an attacker-owned symlink in an operator-named relative dest
 [[tests]]
 name = "symlink-race-source"
 classification = "conformance"
-expect = { default = "pass" }
+area = "security"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "security", "source-race"]
 requirements = ["symlinks", "C compiler", "renameat2"]
@@ -274,7 +329,10 @@ note = "A raced source parent cannot make SYQ read file contents from outside th
 name = "update"
 classification = "adapted"
 adaptation = "update-supported-subset"
-expect = { default = "pass" }
+adaptation_kind = "subset"
+area = "update"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
 tags = ["local", "update", "depth"]
 requirements = ["symlinks"]


### PR DESCRIPTION
## Summary

- model the suite as one configurable `rsync` target instead of native/strict profiles; it invokes `syq` today and can switch wholesale to `syq rsync` by setting `target.args = ["rsync"]`
- keep the complete 351-test inventory while separating each runnable test's raw observation baseline, behavioral area, product position, and adaptation provenance
- distinguish runner/parser failures from ordinary conformance failures, and fail CI on reviewed-baseline changes without calling either case a compatibility score
- publish JSON, Markdown, static HTML, and raw-log matrices, including a compact breakdown of unsupported user-facing feature areas while omitting rsync-internal details
- validate the exact adaptation bytes with Git in both directions so traditional multi-file diffs, additions, deletions, renames, and copies cannot escape `testsuite/`
- retain bounded per-test/job execution and cache prerequisite gating, and restore cache ownership after the root run

Product positions are explicit: compatible, unimplemented, intentional divergence, policy open, or test unresolved. The adapted partial-file test is therefore recorded as a passing fixture adaptation and an intentional product divergence, not as proof of literal rsync equivalence.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 tests/rsync-compat/harness_test.py` (13 tests)
- all nine adaptation patches validated through forward and reverse Git path inspection
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (54 unit, 173 local integration, 9 update tests)
- `python3 scripts/rsync-compat.py --rsync-src <configured-pin> --no-build-syq --syq-bin target/debug/syq --require-tests --test-timeout 120 -j 4` (20 passes, 2 recorded policy-open failures; complete harness; about 11 seconds)

The root-only circumstances could not be run locally because this machine requires an interactive sudo password; CI exercises them.
