### PR TITLE
Release syq 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel copy with an rsync-shaped interface"


### PR DESCRIPTION
## Summary

- bump the syq package and lockfile version to 0.1.3
- prepare the current protected `master` contents for the next signed four-platform release

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets` (54 unit, 173 local, 9 updater)
- pinned cargo-deny 0.20.2: `--locked check`
- `cargo publish --locked --allow-dirty --dry-run`
- `git diff --check`