### PR TITLE
Protect dir-only ignores from type-mismatched deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,8 +625,11 @@ have is removed. The rules are simpler than rsync's, deliberately:
 - **Ignored means out of scope, on both sides.** The `-i` patterns are applied
   to the destination walk from the same roots, so an ignored path is neither
   copied nor deleted, and a directory that holds one is kept (`not deleting
-  keep/: it holds ignored paths`, on stderr, not an error). `--delete-excluded`
-  drops that protection: ignored paths on the destination are extras too.
+  keep/: it holds ignored paths`, on stderr, not an error). Protection follows
+  a source path across a type mismatch: if `cache/` is an ignored source
+  directory, a destination file named `cache` is protected too.
+  `--delete-excluded` drops that protection: ignored paths on the destination
+  are extras too.
 - **Anything the source has is safe.** A file skipped by `-u`, `--existing`,
   `--ignore-existing`, `--max-size` or `--min-size` — or a symlink or special
   file skipped for lack of `-l`/`-D` — still exists in the source, so its

--- a/RSYNC-COMPAT.md
+++ b/RSYNC-COMPAT.md
@@ -74,7 +74,7 @@ behavior; an entry without one is only believed, not held.
 | Path rules: `src` copies the directory, `src/` its contents; a single file lands as `dest/file` when `dest` is a directory; several sources need a directory destination | measured | `trailing_slash_copies_contents`, `dir_into_existing_dir`, `dir_into_missing_dest_creates_basename`, `single_file_into_existing_dir`, `single_file_to_new_name`, `multiple_sources_require_dir_dest` |
 | Quick check: size + mtime; without `-t` every file is re-sent | measured | `updates_changed_file_and_skips_symlink_only_when_same`, `skip_reconciles_mode` |
 | `--delete` scope: only inside the directories being synced; a single-file source deletes nothing | measured | `delete_only_inside_directories_the_sources_map_onto`, `delete_with_nested_roots_deletes_once` |
-| Ignored/excluded paths are protected from deletion by default; `--delete-excluded` lifts that | measured | `delete_removes_extras_and_protects_ignored`, `delete_nested_roots_keep_their_own_anchored_ignores`, `delete_excluded_removes_ignored_destination_paths` |
+| Ignored/excluded paths are protected from deletion by default; `--delete-excluded` lifts that | measured; see "Incompatible on purpose" 6 for a type-mismatch safety extension | `delete_removes_extras_and_protects_ignored`, `delete_nested_roots_keep_their_own_anchored_ignores`, `delete_excluded_removes_ignored_destination_paths`, `delete_protects_an_ignored_source_directory_across_a_type_change` |
 | A directory that can't be emptied because of protected content is reported and left (rsync: `cannot delete non-empty directory`; syq: `not deleting keep/: it holds ignored paths`) | measured | `delete_removes_extras_and_protects_ignored` |
 | Deletion is skipped when listing the source hit errors (rsync: `IO error encountered -- skipping file deletion`) | measured; see "Different" 2 for the transfer-time case | `delete_is_skipped_when_the_source_scan_has_errors`, `unreadable_source_root_disables_delete` |
 | Files the source has but a rule skips — `-u`, `--existing`, `--ignore-existing`, `--max-size`/`--min-size`, symlinks without `-l`, specials without `-D` — are not deleted, even when the destination entry is a non-empty directory | measured on 3.2.7 and 3.5.0 (an earlier README claim that rsync deletes a `--max-size` casualty was wrong) | `delete_never_removes_paths_the_source_has_but_skips`, `delete_leaves_directory_contents_under_a_skipped_source_path`, `size_limits_filter_files_and_protect_them_from_delete`, `delete_keeps_partials_of_filtered_files` |
@@ -142,6 +142,16 @@ item.
    "what exists is authoritative", that is unrecoverable data loss; syq keeps
    the file and skips the mapped directory with its subtree, with a notice.
    *Test: `ignore_existing_keeps_a_file_where_a_source_directory_maps`.*
+
+6. **A directory-only ignore protects the mapped destination name even when
+   a non-directory occupies it.** rsync evaluates `cache/` against the
+   destination object's current type, so an ignored source directory named
+   `cache` does not protect a destination file of that name from `--delete`.
+   syq treats the source's ignored pathname as out of scope regardless of a
+   destination type mismatch; deleting it would violate the documented
+   protection promise. A destination-only file still does not match `cache/`,
+   and `--delete-excluded` deliberately drops the protection. *Test:
+   `delete_protects_an_ignored_source_directory_across_a_type_change`.*
 
 ## Different, no claim of better
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -24,14 +24,14 @@ pub trait Conn: Send {
         false
     }
     /// Streamed scan; `sink` gets batches, `warn` gets non-fatal messages,
-    /// `ignored` gets the paths the patterns pruned (only if `report_ignored`).
+    /// `ignored` gets the subset of pruned paths selected by `report_ignored`.
     #[allow(clippy::too_many_arguments)]
     fn scan(
         &mut self,
         root: &[u8],
         follow_root: bool,
         ignore: &[String],
-        report_ignored: bool,
+        report_ignored: IgnoredReport,
         sink: &mut dyn FnMut(Vec<Entry>) -> Result<()>,
         ignored: &mut dyn FnMut(Vec<PathBytes>) -> Result<()>,
         warn: &mut dyn FnMut(String),
@@ -76,7 +76,7 @@ impl Conn for LocalConn {
         root: &[u8],
         follow_root: bool,
         ignore: &[String],
-        report_ignored: bool,
+        report_ignored: IgnoredReport,
         sink: &mut dyn FnMut(Vec<Entry>) -> Result<()>,
         ignored: &mut dyn FnMut(Vec<PathBytes>) -> Result<()>,
         warn: &mut dyn FnMut(String),
@@ -195,7 +195,7 @@ impl Conn for RemoteConn {
         root: &[u8],
         follow_root: bool,
         ignore: &[String],
-        report_ignored: bool,
+        report_ignored: IgnoredReport,
         sink: &mut dyn FnMut(Vec<Entry>) -> Result<()>,
         ignored: &mut dyn FnMut(Vec<PathBytes>) -> Result<()>,
         warn: &mut dyn FnMut(String),

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -30,6 +30,16 @@ pub enum Kind {
     Other,
 }
 
+/// Which ignored paths a scan should report to its caller.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum IgnoredReport {
+    None,
+    All,
+    /// Ignored directories that would not be ignored if a non-directory
+    /// occupied the same relative path.
+    TypeSensitiveDirs,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Entry {
     /// Relative to the scan root; empty means the root itself.
@@ -143,12 +153,12 @@ pub enum Request {
         port_hi: u16,
     },
     /// `ignore`: gitignore-style patterns relative to `root` (see scan.rs).
-    /// `report_ignored`: also send the paths the patterns pruned (ScanIgnored).
+    /// `report_ignored`: which paths pruned by the patterns to send as ScanIgnored.
     Scan {
         root: PathBytes,
         follow_root: bool,
         ignore: Vec<String>,
-        report_ignored: bool,
+        report_ignored: IgnoredReport,
     },
     /// lstat each path; with `follow`, stat through symlinks instead.
     StatMany {

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -211,7 +211,7 @@ pub fn run(args: Args) -> Result<i32> {
             &root,
             false,
             &[],
-            false,
+            IgnoredReport::None,
             &mut |entries: Vec<Entry>| {
                 for e in entries {
                     let full = join(&root, &e.path);

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,7 +1,7 @@
 //! Parallel directory walk producing `Entry` batches in parent-before-child order.
 
 use crate::fsops::{lstat_entry, path_bytes};
-use crate::proto::{Entry, PathBytes};
+use crate::proto::{Entry, IgnoredReport, PathBytes};
 use anyhow::{Context, Result};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use jwalk::WalkDirGeneric;
@@ -42,14 +42,14 @@ pub fn build_ignore(lines: &[String]) -> Result<Option<Gitignore>> {
 /// planner decides what they mean). `warn` receives non-fatal errors
 /// (unreadable directories etc.). `ignore` holds gitignore-style patterns
 /// relative to `root`; a matching directory is pruned with its whole subtree.
-/// The root itself is never ignored. With `report_ignored`, the pruned paths
-/// are handed to `ignored` (in batches).
+/// The root itself is never ignored. `report_ignored` selects which pruned
+/// paths are handed to `ignored` (in batches).
 #[allow(clippy::too_many_arguments)]
 pub fn scan(
     root: &Path,
     follow_root: bool,
     ignore: &[String],
-    report_ignored: bool,
+    report_ignored: IgnoredReport,
     sink: &mut dyn FnMut(Vec<Entry>) -> Result<()>,
     ignored: &mut dyn FnMut(Vec<PathBytes>) -> Result<()>,
     warn: &mut dyn FnMut(String),
@@ -90,10 +90,15 @@ pub fn scan(
                     if ig.matched(rel, is_dir).is_ignore() {
                         // Pruned: neither listed nor descended into.
                         child.read_children = None;
-                        child.client_state = if report_ignored {
-                            State::Ignored
-                        } else {
-                            State::Skipped
+                        child.client_state = match report_ignored {
+                            IgnoredReport::None => State::Skipped,
+                            IgnoredReport::All => State::Ignored,
+                            IgnoredReport::TypeSensitiveDirs
+                                if is_dir && !ig.matched(rel, false).is_ignore() =>
+                            {
+                                State::Ignored
+                            }
+                            IgnoredReport::TypeSensitiveDirs => State::Skipped,
                         };
                         continue;
                     }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -718,6 +718,7 @@ pub fn run(args: Args) -> Result<i32> {
         },
         keep_dirs: args.files_from.is_some(),
         delete_roots: Vec::new(),
+        source_ignored_dirs: std::collections::HashSet::new(),
         deletes: Deletes::default(),
     };
 
@@ -1040,18 +1041,23 @@ fn scan_into_planner(
     root: &[u8],
     follow_root: bool,
     ignore: &[String],
+    report_ignored: IgnoredReport,
     mut f: impl FnMut(&mut Planner<'_>, Vec<Entry>) -> Result<()>,
-) -> Result<()> {
+) -> Result<Vec<PathBytes>> {
     let progress = pl.progress;
     let quiet = pl.opts.quiet;
     let warned = std::cell::Cell::new(false);
+    let mut ignored_paths = Vec::new();
     let res = src.scan(
         root,
         follow_root,
         ignore,
-        false,
+        report_ignored,
         &mut |batch| f(pl, batch),
-        &mut |_| Ok(()),
+        &mut |paths| {
+            ignored_paths.extend(paths);
+            Ok(())
+        },
         &mut |w| {
             // "skipping …" is a notice (nothing the copy owes is missing);
             // anything else from the scanner means an entry was lost.
@@ -1068,7 +1074,8 @@ fn scan_into_planner(
     if warned.get() {
         pl.scan_warned = true;
     }
-    res
+    res?;
+    Ok(ignored_paths)
 }
 
 /// If `entry` is a symlink whose (possibly chained) target is a directory,
@@ -1178,6 +1185,9 @@ struct Planner<'a> {
     /// (destination directory, its path relative to the transfer root) for every
     /// directory source; --delete removes extras inside these.
     delete_roots: Vec<(PathBytes, String)>,
+    /// Source directories excluded specifically as directories, mapped onto
+    /// their destination names. They protect a same-named destination leaf.
+    source_ignored_dirs: std::collections::HashSet<PathBytes>,
     deletes: Deletes,
 }
 
@@ -1250,33 +1260,53 @@ impl Planner<'_> {
         let mut sub = sub.to_string();
         let mut skip_all = false;
         let ignore = self.opts.ignore.clone();
-        scan_into_planner(self, src, src_root, follow, &ignore, |pl, batch| {
-            if skip_all {
-                return Ok(());
-            }
-            if first {
-                first = false;
-                if let Some(root) = batch.first() {
-                    if root.kind != Kind::Dir && !dst_is_dir {
-                        sub = String::new();
-                    }
-                    if root.kind == Kind::Dir && !pl.opts.recursive {
-                        if !pl.opts.quiet {
-                            pl.progress
-                                .eprintln(&format!("skipping directory {}", display(src_root)));
+        let report_ignored = if self.opts.delete && !self.opts.delete_excluded {
+            IgnoredReport::TypeSensitiveDirs
+        } else {
+            IgnoredReport::None
+        };
+        let ignored_dirs = scan_into_planner(
+            self,
+            src,
+            src_root,
+            follow,
+            &ignore,
+            report_ignored,
+            |pl, batch| {
+                if skip_all {
+                    return Ok(());
+                }
+                if first {
+                    first = false;
+                    if let Some(root) = batch.first() {
+                        if root.kind != Kind::Dir && !dst_is_dir {
+                            sub = String::new();
                         }
-                        skip_all = true;
-                        return Ok(());
-                    }
-                    if root.kind == Kind::Dir {
-                        pl.delete_roots
-                            .push((join(dst_root, sub.as_bytes()), sub.clone()));
+                        if root.kind == Kind::Dir && !pl.opts.recursive {
+                            if !pl.opts.quiet {
+                                pl.progress
+                                    .eprintln(&format!("skipping directory {}", display(src_root)));
+                            }
+                            skip_all = true;
+                            return Ok(());
+                        }
+                        if root.kind == Kind::Dir {
+                            pl.delete_roots
+                                .push((join(dst_root, sub.as_bytes()), sub.clone()));
+                        }
                     }
                 }
-            }
-            pl.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
-            pl.handle_batch(batch, src_root, &sub, dst_root)
-        })
+                pl.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
+                pl.handle_batch(batch, src_root, &sub, dst_root)
+            },
+        )?;
+        let protection_root = join(dst_root, sub.as_bytes());
+        self.source_ignored_dirs.extend(
+            ignored_dirs
+                .into_iter()
+                .map(|path| join(&protection_root, &path)),
+        );
+        Ok(())
     }
 
     /// --files-from: instead of walking the source, stat each listed path (and
@@ -1466,26 +1496,35 @@ impl Planner<'_> {
         dst_root: &[u8],
         emitted: &mut std::collections::HashMap<PathBytes, Kind>,
     ) -> Result<()> {
-        scan_into_planner(self, src, &join(src_root, rel), false, &[], |pl, batch| {
-            let batch: Vec<Entry> = batch
-                .into_iter()
-                .filter(|e| !e.path.is_empty())
-                .map(|mut e| {
-                    e.path = join(rel, &e.path);
-                    e
-                })
-                .filter(|e| {
-                    if emitted.contains_key(&e.path) {
-                        false
-                    } else {
-                        emitted.insert(e.path.clone(), e.kind);
-                        true
-                    }
-                })
-                .collect();
-            pl.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
-            pl.handle_batch(batch, src_root, "", dst_root)
-        })
+        scan_into_planner(
+            self,
+            src,
+            &join(src_root, rel),
+            false,
+            &[],
+            IgnoredReport::None,
+            |pl, batch| {
+                let batch: Vec<Entry> = batch
+                    .into_iter()
+                    .filter(|e| !e.path.is_empty())
+                    .map(|mut e| {
+                        e.path = join(rel, &e.path);
+                        e
+                    })
+                    .filter(|e| {
+                        if emitted.contains_key(&e.path) {
+                            false
+                        } else {
+                            emitted.insert(e.path.clone(), e.kind);
+                            true
+                        }
+                    })
+                    .collect();
+                pl.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
+                pl.handle_batch(batch, src_root, "", dst_root)
+            },
+        )?;
+        Ok(())
     }
 
     fn handle_batch(
@@ -2367,6 +2406,7 @@ impl Planner<'_> {
             let mut protected: std::collections::HashSet<PathBytes> =
                 std::collections::HashSet::new();
             let seen = &self.dst_seen;
+            let source_ignored_dirs = &self.source_ignored_dirs;
             let live_sidecars = &self.live_sidecars;
             // Destination directories whose path the source claims as a
             // non-directory (a file we chose not to send, a symlink skipped
@@ -2378,7 +2418,7 @@ impl Planner<'_> {
                 &root,
                 false,
                 &ignore,
-                true,
+                IgnoredReport::All,
                 &mut |batch: Vec<Entry>| {
                     for e in batch {
                         if e.path.is_empty() {
@@ -2388,6 +2428,9 @@ impl Planner<'_> {
                         if nested.iter().any(|n| *n == full || inside(&full, n))
                             || Planner::under_any(&shielded, &full, &root)
                         {
+                            continue;
+                        }
+                        if source_ignored_dirs.contains(&full) {
                             continue;
                         }
                         match seen.get(&full) {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1805,6 +1805,44 @@ fn delete_removes_extras_and_protects_ignored() {
     assert!(se.contains("not deleting keep/"), "{se}");
 }
 
+#[test]
+fn delete_protects_an_ignored_source_directory_across_a_type_change() {
+    let t = Tmp::new();
+    fs::create_dir_all(t.path("src/x")).unwrap();
+    write(&t.path("dst/x"), b"precious");
+    write(&t.path("dst/destination-only"), b"extra");
+
+    run_ok(&[
+        "-a",
+        "--delete",
+        "-i",
+        "x/",
+        "-i",
+        "destination-only/",
+        &t.s("src/"),
+        &t.s("dst"),
+    ]);
+    assert_eq!(read(&t.path("dst/x")), b"precious");
+    assert!(
+        !t.path("dst/destination-only").exists(),
+        "a directory-only rule does not blanket-protect a destination-only file"
+    );
+
+    run_ok(&[
+        "-a",
+        "--delete",
+        "--delete-excluded",
+        "-i",
+        "x/",
+        &t.s("src/"),
+        &t.s("dst"),
+    ]);
+    assert!(
+        !t.path("dst/x").exists(),
+        "--delete-excluded deliberately drops ignored-path protection"
+    );
+}
+
 #[cfg(debug_assertions)]
 #[test]
 fn delete_removes_only_this_jobs_orphaned_sidecars() {


### PR DESCRIPTION
## Summary

- preserve a same-named destination leaf when its mapped source directory is ignored
- report only type-sensitive ignored source directories, avoiding blanket protection for destination-only files
- keep --delete-excluded as the explicit override and document the intentional rsync safety difference

## Tests

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets