### PR TITLE
Document directory-only ignore behavior under --delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,10 +623,15 @@ have is removed. The rules are simpler than rsync's, deliberately:
   dst/` cleans `dst/a` and `dst/b`, never `dst/c`. A single-file source deletes
   nothing.
 - **Ignored means out of scope, on both sides.** The `-i` patterns are applied
-  to the destination walk from the same roots, so an ignored path is neither
+  to the destination walk from the same roots, so an ignored entry is neither
   copied nor deleted, and a directory that holds one is kept (`not deleting
-  keep/: it holds ignored paths`, on stderr, not an error). `--delete-excluded`
-  drops that protection: ignored paths on the destination are extras too.
+  keep/: it holds ignored paths`, on stderr, not an error). Patterns are
+  matched against each side's actual entry, with gitignore's one type
+  distinction: `cache/` matches only directories, so it protects a destination
+  directory named `cache` but not a destination *file* of that name, which is
+  an ordinary extra (rsync behaves the same). Write `cache` without the slash
+  to cover both. `--delete-excluded` drops that protection: ignored paths on
+  the destination are extras too.
 - **Anything the source has is safe.** A file skipped by `-u`, `--existing`,
   `--ignore-existing`, `--max-size` or `--min-size` — or a symlink or special
   file skipped for lack of `-l`/`-D` — still exists in the source, so its


### PR DESCRIPTION
A trailing-slash pattern such as `cache/` matches only directories, so under `--delete` a destination *file* named `cache` is an ordinary extra when the source has an ignored directory of that name. That is gitignore's semantics and matches rsync. The README's "an ignored path is neither copied nor deleted" read as a per-pathname promise; this states the entry-type rule and the no-slash alternative instead of changing behavior (supersedes #38, closed).

Doc-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)