### PR TITLE
Add verified SSH fallback for remote helper bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,6 +153,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -343,7 +349,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core",
 ]
@@ -451,7 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -474,6 +480,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -540,6 +557,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,7 +624,7 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -649,10 +682,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pkg-config"
@@ -752,6 +797,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,7 +829,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -958,7 +1052,7 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "flate2",
- "getrandom",
+ "getrandom 0.4.3",
  "ignore",
  "jwalk",
  "libc",
@@ -970,6 +1064,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2",
  "shell-words",
+ "ureq",
  "xxhash-rust",
  "zstd",
 ]
@@ -981,7 +1076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1027,6 +1122,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,12 +1178,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1059,12 +1209,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ ed25519-dalek = "3"
 flate2 = "1"
 semver = "1"
 sha2 = "0.11"
+ureq = { version = "3", default-features = false, features = ["rustls"] }
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ macOS binary in `~/.local/bin`:
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/greaber/syq/releases/latest/download/install.sh | sh
 ```
 
+That initial shell installer necessarily needs `curl` or `wget` to obtain syq
+before syq exists. The installed application and its managed remote bootstrap
+do not depend on either command.
+
 To inspect it first, download the same URL without piping it to `sh`. Every
 release also has an immutable versioned installer, for example
 `https://github.com/greaber/syq/releases/download/v0.1.0/install.sh`. To choose
@@ -87,9 +91,10 @@ connection.
 
 If the remote toolchain is unavailable, a tool fails, or the download times
 out or otherwise fails, the local client downloads the target-specific archive
-instead. It verifies both the archive and decompressed binary, caches the
-verified binary under `$XDG_CACHE_HOME/syq/helpers/` (normally
-`~/.cache/syq/helpers/`), and uploads it through the configured SSH command.
+with its built-in rustls HTTP client instead. It verifies both the archive and
+decompressed binary, caches the verified binary under
+`$XDG_CACHE_HOME/syq/helpers/` (normally `~/.cache/syq/helpers/`), and uploads it
+through the configured SSH command.
 This fallback does not require a remote downloader, hasher, or decompressor.
 Remote filesystem and installation errors fail immediately because uploading
 the same helper cannot fix them. A completed download with the wrong digest is

--- a/README.md
+++ b/README.md
@@ -75,26 +75,41 @@ notarization in addition to this terminal-first path.
 The remote side runs `syq --server`, but it does not need to be installed or
 configured first. An official syq uses its exact release helper under
 `~/.cache/syq/helpers/`. On first use of a version it detects the remote
-platform, downloads the matching compressed binary from that version's GitHub
-release, verifies its SHA-256 against the separately signed release manifest,
-and installs it atomically. Later runs execute that exact path without an extra
-probe connection.
+platform and checks for a downloader, SHA-256 implementation, and `gzip`. When
+that complete toolchain is available, the remote downloads the matching
+compressed binary and signed manifest from that version's GitHub release. It
+relays the manifest and computed digest over SSH, then waits while the local
+client verifies the manifest signature and compares its expected digest. Only
+an explicit approval from the client lets the remote install the helper
+atomically. This path therefore works even when the local machine cannot reach
+the release host. Later runs execute that exact path without an extra probe
+connection.
 
-The managed cache accepts only the downloaded, verified release binary. If the
-remote cannot download it, bootstrapping fails visibly; install a compatible
-binary yourself and pass `--syq-path /path/to/syq`, or put it on the
-non-interactive remote `PATH` and use `--no-bootstrap`. Helpers cached under an
-older identity or cache layout are never executed; they may be removed with the
-rest of the disposable helper cache.
+If the remote toolchain is unavailable, a tool fails, or the download times
+out or otherwise fails, the local client downloads the target-specific archive
+instead. It verifies both the archive and decompressed binary, caches the
+verified binary under `$XDG_CACHE_HOME/syq/helpers/` (normally
+`~/.cache/syq/helpers/`), and uploads it through the configured SSH command.
+This fallback does not require a remote downloader, hasher, or decompressor.
+Remote filesystem and installation errors fail immediately because uploading
+the same helper cannot fix them. A completed download with the wrong digest is
+discarded and produces an integrity warning even if the verified upload then
+succeeds.
+
+The managed cache accepts only a verified release binary. Helpers cached under
+an older identity or cache layout are never executed; they may be removed with
+the rest of the disposable helper cache. To opt out of managed bootstrap,
+install a compatible binary yourself and pass `--syq-path /path/to/syq`, or put
+it on the non-interactive remote `PATH` and use `--no-bootstrap`.
 
 The local client verifies the manifest's embedded Ed25519 signature over its
-RFC 8785 canonical JSON and passes its trusted hash to the remote install
-script. The remote uses `curl` or `wget`, `gzip`, and one of `sha256sum`,
-`shasum`, or `openssl`. Version directories coexist and the helper cache can be
-removed at any time; syq recreates the helper it needs on the next connection.
-After launch, both peers require the same build identity: the release tag for
-official binaries, or the Git-derived identity when an explicit source-built
-helper is used.
+RFC 8785 canonical JSON. Direct remote download uses `curl` or `wget`, `gzip`,
+and one of `sha256sum`, `shasum`, or `openssl`; those programs are optional
+because missing or unusable tools select verified SSH upload instead. Version
+directories coexist and either helper cache can be removed at any time; syq
+recreates the helper it needs on the next connection. After launch, both peers
+require the same build identity: the release tag for official binaries, or the
+Git-derived identity when an explicit source-built helper is used.
 
 - **macOS (Apple Silicon / Intel):** build natively on the Mac with
   `cargo build --release` (needs the Xcode command-line tools, `xcode-select

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,8 @@ allow = [
   "Apache-2.0 WITH LLVM-exception",
   "BSD-3-Clause",
   "BSL-1.0",
+  "CDLA-Permissive-2.0",
+  "ISC",
   "MIT",
   "Unicode-3.0",
   "Zlib",

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -8,7 +8,7 @@ use crate::proto::*;
 use crate::remote_helper::{self, Target};
 use anyhow::{anyhow, bail, Context, Result};
 use std::collections::VecDeque;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::process::{Child, Command, Stdio};
 
@@ -829,7 +829,8 @@ impl RemoteSpec {
             return Ok(());
         }
 
-        let target = self.remote_target()?;
+        let bootstrap = self.remote_bootstrap()?;
+        let target = bootstrap.target;
         if !self.quiet {
             eprintln!(
                 "syq: {}: installing {} helper for {}",
@@ -838,7 +839,7 @@ impl RemoteSpec {
                 target.key
             );
         }
-        self.download_helper(target).with_context(|| {
+        self.bootstrap_helper(bootstrap).with_context(|| {
             format!(
                 "could not install the authorized {} helper on {} ({}); install a compatible syq and pass --syq-path",
                 remote_helper::helper_identity(),
@@ -850,7 +851,7 @@ impl RemoteSpec {
         Ok(())
     }
 
-    fn remote_target(&self) -> Result<Target> {
+    fn remote_bootstrap(&self) -> Result<RemoteBootstrap> {
         let mut cmd = self.ssh_command();
         cmd.arg(remote_helper::probe_command())
             .stdin(Stdio::null())
@@ -875,45 +876,335 @@ impl RemoteSpec {
         let (os, arch) = value
             .split_once(':')
             .ok_or_else(|| anyhow!("{}: malformed platform response {value:?}", self.label()))?;
-        Target::from_uname(os, arch).ok_or_else(|| {
+        let target = Target::from_uname(os, arch).ok_or_else(|| {
             anyhow!(
                 "{}: automatic remote helpers do not support {os} {arch}; install syq there and pass --syq-path",
                 self.label()
             )
+        })?;
+        let direct_download = text
+            .lines()
+            .find_map(|line| line.strip_prefix("syq-helper-tools:"))
+            .is_some_and(|tools| {
+                let mut tools = tools.split(':');
+                tools.next().is_some_and(|tool| !tool.is_empty())
+                    && tools.next().is_some_and(|tool| !tool.is_empty())
+                    && tools.next().is_some_and(|tool| !tool.is_empty())
+                    && tools.next().is_none()
+            });
+        Ok(RemoteBootstrap {
+            target,
+            direct_download,
         })
     }
 
-    fn download_helper(&self, target: Target) -> Result<()> {
-        let expected_sha256 = crate::update::trusted_current_archive_hash(target)
-            .context("verify the signed release manifest")?;
-        let script = remote_helper::download_script(target, &expected_sha256);
+    fn bootstrap_helper(&self, bootstrap: RemoteBootstrap) -> Result<()> {
+        let mut trusted = None;
+        if bootstrap.direct_download {
+            match self.try_direct_helper(bootstrap.target)? {
+                DirectHelper::Installed => return Ok(()),
+                DirectHelper::Fallback { detail, helper } => {
+                    trusted = helper;
+                    if !self.quiet {
+                        eprintln!(
+                            "syq: {}: remote download unavailable{}; uploading the verified helper over SSH",
+                            self.label(),
+                            parenthesized_detail(&detail)
+                        );
+                    }
+                }
+                DirectHelper::Integrity { warning, helper } => {
+                    trusted = helper;
+                    eprintln!(
+                        "syq: warning: {}: {}; the remote download was discarded; uploading the verified helper over SSH",
+                        self.label(),
+                        warning
+                    );
+                }
+            }
+        } else if !self.quiet {
+            eprintln!(
+                "syq: {}: remote download prerequisites unavailable; uploading the verified helper over SSH",
+                self.label()
+            );
+        }
+
+        let helper = match trusted {
+            Some(helper) => helper,
+            None => crate::update::trusted_current_helper(bootstrap.target)
+                .context("download and verify the signed release manifest")?,
+        };
+        let binary = crate::update::verified_current_helper(&helper)
+            .context("download and verify the helper for SSH upload")?;
+        self.upload_helper(bootstrap.target, &binary)
+    }
+
+    fn try_direct_helper(&self, target: Target) -> Result<DirectHelper> {
+        let script = remote_helper::download_script(target);
         let mut cmd = self.ssh_command();
         cmd.arg(format!("sh -c {}", shell_words::quote(&script)))
-            .stdin(Stdio::null())
+            .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        let out = cmd
-            .output()
-            .with_context(|| format!("download helper on {}", self.label()))?;
+        let mut child = cmd
+            .spawn()
+            .with_context(|| format!("start helper download on {}", self.label()))?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("remote helper download stdin was not piped"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("remote helper download stdout was not piped"))?;
+        let mut stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("remote helper download stderr was not piped"))?;
+        let stderr_reader = std::thread::spawn(move || {
+            let mut bytes = Vec::new();
+            let _ = stderr.read_to_end(&mut bytes);
+            bytes
+        });
+
+        let report = read_direct_report(&mut BufReader::new(stdout));
+        let mut helper = None;
+        let mut integrity_warning = None;
+        let mut protocol_detail = None;
+        let mut authorized = false;
+        match report {
+            Ok(Some(report)) if valid_sha256(&report.sha256) => {
+                match crate::update::trusted_current_helper_from_manifest(target, &report.manifest)
+                {
+                    Ok(trusted) => {
+                        if report.sha256 == trusted.archive_sha256() {
+                            authorized = true;
+                        } else {
+                            integrity_warning = Some(format!(
+                                "remote helper download failed integrity verification (expected SHA-256 {}, got {})",
+                                trusted.archive_sha256(),
+                                report.sha256
+                            ));
+                        }
+                        helper = Some(trusted);
+                    }
+                    Err(error) => {
+                        integrity_warning = Some(format!(
+                            "remote release manifest failed integrity verification or validation ({error})"
+                        ));
+                    }
+                }
+            }
+            Ok(Some(_)) => {
+                protocol_detail = Some("the remote hasher returned no valid digest".into());
+            }
+            Ok(None) => {
+                protocol_detail =
+                    Some("the remote returned no download verification report".into());
+            }
+            Err(error) => {
+                protocol_detail = Some(format!(
+                    "could not read the remote verification report: {error}"
+                ));
+            }
+        }
+        let decision = if authorized {
+            b"install\n"
+        } else {
+            b"discard\n"
+        };
+        let write_result = stdin.write_all(decision);
+        drop(stdin);
+
+        let status = child
+            .wait()
+            .with_context(|| format!("wait for helper download on {}", self.label()))?;
+        let stderr = stderr_reader
+            .join()
+            .map_err(|_| anyhow!("remote helper stderr reader panicked"))?;
+        let detail = output_message(&stderr);
+        if status.success() {
+            write_result.context("authorize the verified remote helper")?;
+            return if authorized {
+                Ok(DirectHelper::Installed)
+            } else {
+                Ok(DirectHelper::Fallback {
+                    detail: protocol_detail
+                        .unwrap_or_else(|| "the remote ignored a discard decision".into()),
+                    helper,
+                })
+            };
+        }
+        match status.code() {
+            Some(remote_helper::DIRECT_FALLBACK_EXIT) => Ok(DirectHelper::Fallback {
+                detail: if detail.is_empty() {
+                    protocol_detail.unwrap_or_default()
+                } else {
+                    detail
+                },
+                helper,
+            }),
+            Some(remote_helper::DIRECT_INTEGRITY_EXIT) => match integrity_warning {
+                Some(warning) => Ok(DirectHelper::Integrity { warning, helper }),
+                None => Ok(DirectHelper::Fallback {
+                    detail: protocol_detail.unwrap_or(detail),
+                    helper,
+                }),
+            },
+            _ => {
+                bail!(
+                    "remote download exited {}{}",
+                    status,
+                    output_suffix(&stderr)
+                );
+            }
+        }
+    }
+
+    fn upload_helper(&self, target: Target, binary: &[u8]) -> Result<()> {
+        let script = remote_helper::upload_script(target);
+        let mut cmd = self.ssh_command();
+        cmd.arg(format!("sh -c {}", shell_words::quote(&script)))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = cmd
+            .spawn()
+            .with_context(|| format!("start helper upload to {}", self.label()))?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("helper upload stdin was not piped"))?;
+        let write_result = stdin.write_all(binary);
+        drop(stdin);
+        let out = child
+            .wait_with_output()
+            .with_context(|| format!("wait for helper upload to {}", self.label()))?;
         if !out.status.success() {
             bail!(
-                "remote download exited {}{}",
+                "remote helper upload exited {}{}",
                 out.status,
                 output_suffix(&out.stderr)
             );
         }
-        Ok(())
+        write_result.with_context(|| format!("upload helper to {}", self.label()))
     }
 }
 
+#[derive(Clone, Copy)]
+struct RemoteBootstrap {
+    target: Target,
+    direct_download: bool,
+}
+
+enum DirectHelper {
+    Installed,
+    Fallback {
+        detail: String,
+        helper: Option<crate::update::TrustedCurrentHelper>,
+    },
+    Integrity {
+        warning: String,
+        helper: Option<crate::update::TrustedCurrentHelper>,
+    },
+}
+
+#[derive(Debug)]
+struct DirectReport {
+    manifest: Vec<u8>,
+    sha256: String,
+}
+
+fn read_direct_report(reader: &mut impl BufRead) -> std::io::Result<Option<DirectReport>> {
+    const MAX_MANIFEST_SIZE: usize = 1024 * 1024;
+    let mut line = Vec::new();
+    if reader.read_until(b'\n', &mut line)? == 0 {
+        return Ok(None);
+    }
+    if protocol_line(&line) != b"syq-helper-manifest-begin" {
+        return Ok(None);
+    }
+
+    let mut manifest = Vec::new();
+    loop {
+        line.clear();
+        if reader.read_until(b'\n', &mut line)? == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "remote manifest was not terminated",
+            ));
+        }
+        if protocol_line(&line) == b"syq-helper-manifest-end" {
+            break;
+        }
+        if manifest.len().saturating_add(line.len()) > MAX_MANIFEST_SIZE {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "remote manifest exceeded 1 MiB",
+            ));
+        }
+        manifest.extend_from_slice(&line);
+    }
+
+    line.clear();
+    if reader.read_until(b'\n', &mut line)? == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "remote helper digest was missing",
+        ));
+    }
+    let digest = protocol_line(&line)
+        .strip_prefix(b"syq-helper-sha256:")
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "remote helper digest marker was missing",
+            )
+        })?;
+    Ok(Some(DirectReport {
+        manifest,
+        sha256: String::from_utf8_lossy(digest).into_owned(),
+    }))
+}
+
+fn protocol_line(mut line: &[u8]) -> &[u8] {
+    if let Some(value) = line.strip_suffix(b"\n") {
+        line = value;
+    }
+    line.strip_suffix(b"\r").unwrap_or(line)
+}
+
 fn output_suffix(stderr: &[u8]) -> String {
-    let message = String::from_utf8_lossy(stderr);
-    let message = message.trim();
+    let message = output_message(stderr);
     if message.is_empty() {
         String::new()
     } else {
         format!(": {message}")
     }
+}
+
+fn output_message(stderr: &[u8]) -> String {
+    let message = String::from_utf8_lossy(stderr);
+    message
+        .trim()
+        .strip_prefix("syq: ")
+        .unwrap_or_else(|| message.trim())
+        .to_owned()
+}
+
+fn parenthesized_detail(detail: &str) -> String {
+    if detail.is_empty() {
+        String::new()
+    } else {
+        format!(" ({detail})")
+    }
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
 }
 
 #[derive(Clone, Debug)]
@@ -1004,6 +1295,25 @@ mod tests {
 
         let mut saw_root = true;
         assert!(validate_remote_scan_batch(&[entry(b"")], &mut saw_root).is_err());
+    }
+
+    #[test]
+    fn direct_download_report_frames_manifest_and_digest() {
+        let digest = "a".repeat(64);
+        let bytes = format!(
+            "syq-helper-manifest-begin\n{{\n  \"schema\": 1\n}}\nsyq-helper-manifest-end\nsyq-helper-sha256:{digest}\n"
+        );
+        let report = read_direct_report(&mut bytes.as_bytes()).unwrap().unwrap();
+        assert_eq!(report.manifest, b"{\n  \"schema\": 1\n}\n");
+        assert_eq!(report.sha256, digest);
+    }
+
+    #[test]
+    fn direct_download_report_rejects_unterminated_manifest() {
+        let error =
+            read_direct_report(&mut b"syq-helper-manifest-begin\n{\"schema\":1}\n".as_slice())
+                .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1134,16 +1134,26 @@ fn read_direct_report(reader: &mut impl BufRead) -> std::io::Result<Option<Direc
                 "remote manifest was not terminated",
             ));
         }
-        if protocol_line(&line) == b"syq-helper-manifest-end" {
+        let framed = protocol_line(&line);
+        if framed == b"syq-helper-manifest-end" {
             break;
         }
-        if manifest.len().saturating_add(line.len()) > MAX_MANIFEST_SIZE {
+        let data = framed
+            .strip_prefix(b"syq-helper-manifest-data:")
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "remote manifest contained unframed protocol data",
+                )
+            })?;
+        if manifest.len().saturating_add(data.len() + 1) > MAX_MANIFEST_SIZE {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "remote manifest exceeded 1 MiB",
             ));
         }
-        manifest.extend_from_slice(&line);
+        manifest.extend_from_slice(data);
+        manifest.push(b'\n');
     }
 
     line.clear();
@@ -1161,10 +1171,21 @@ fn read_direct_report(reader: &mut impl BufRead) -> std::io::Result<Option<Direc
                 "remote helper digest marker was missing",
             )
         })?;
-    Ok(Some(DirectReport {
-        manifest,
-        sha256: String::from_utf8_lossy(digest).into_owned(),
-    }))
+    let sha256 = String::from_utf8_lossy(digest).into_owned();
+    line.clear();
+    if reader.read_until(b'\n', &mut line)? == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "remote helper report was not terminated",
+        ));
+    }
+    if protocol_line(&line) != b"syq-helper-report-end" {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "remote helper report contained trailing or malformed protocol data",
+        ));
+    }
+    Ok(Some(DirectReport { manifest, sha256 }))
 }
 
 fn protocol_line(mut line: &[u8]) -> &[u8] {
@@ -1301,7 +1322,7 @@ mod tests {
     fn direct_download_report_frames_manifest_and_digest() {
         let digest = "a".repeat(64);
         let bytes = format!(
-            "syq-helper-manifest-begin\n{{\n  \"schema\": 1\n}}\nsyq-helper-manifest-end\nsyq-helper-sha256:{digest}\n"
+            "syq-helper-manifest-begin\nsyq-helper-manifest-data:{{\nsyq-helper-manifest-data:  \"schema\": 1\nsyq-helper-manifest-data:}}\nsyq-helper-manifest-end\nsyq-helper-sha256:{digest}\nsyq-helper-report-end\n"
         );
         let report = read_direct_report(&mut bytes.as_bytes()).unwrap().unwrap();
         assert_eq!(report.manifest, b"{\n  \"schema\": 1\n}\n");
@@ -1310,10 +1331,40 @@ mod tests {
 
     #[test]
     fn direct_download_report_rejects_unterminated_manifest() {
-        let error =
-            read_direct_report(&mut b"syq-helper-manifest-begin\n{\"schema\":1}\n".as_slice())
-                .unwrap_err();
+        let error = read_direct_report(
+            &mut b"syq-helper-manifest-begin\nsyq-helper-manifest-data:{\"schema\":1}\n".as_slice(),
+        )
+        .unwrap_err();
         assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn direct_download_report_keeps_injected_markers_inside_the_manifest() {
+        let spoofed = "a".repeat(64);
+        let actual = "b".repeat(64);
+        let bytes = format!(
+            "syq-helper-manifest-begin\nsyq-helper-manifest-data:{{\"schema\":1}}\nsyq-helper-manifest-data:syq-helper-manifest-end\nsyq-helper-manifest-data:syq-helper-sha256:{spoofed}\nsyq-helper-manifest-end\nsyq-helper-sha256:{actual}\nsyq-helper-report-end\n"
+        );
+        let report = read_direct_report(&mut bytes.as_bytes()).unwrap().unwrap();
+        assert_eq!(report.sha256, actual);
+        assert!(report
+            .manifest
+            .windows(b"syq-helper-manifest-end".len())
+            .any(|window| window == b"syq-helper-manifest-end"));
+        assert!(report
+            .manifest
+            .windows(spoofed.len())
+            .any(|window| { window == spoofed.as_bytes() }));
+    }
+
+    #[test]
+    fn direct_download_report_rejects_data_after_the_digest() {
+        let digest = "a".repeat(64);
+        let bytes = format!(
+            "syq-helper-manifest-begin\nsyq-helper-manifest-data:{{}}\nsyq-helper-manifest-end\nsyq-helper-sha256:{digest}\nunexpected\nsyq-helper-report-end\n"
+        );
+        let error = read_direct_report(&mut bytes.as_bytes()).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/src/remote_helper.rs
+++ b/src/remote_helper.rs
@@ -202,10 +202,11 @@ if [ "${{#actual}}" -ne 64 ]; then
 fi
 printf 'syq-helper-manifest-begin\n'
 while IFS= read -r line || [ -n "$line" ]; do
-    printf '%s\n' "$line"
+    printf 'syq-helper-manifest-data:%s\n' "$line"
 done < "$manifest"
 printf 'syq-helper-manifest-end\n'
 printf 'syq-helper-sha256:%s\n' "$actual"
+printf 'syq-helper-report-end\n'
 if ! IFS= read -r decision; then
     echo "syq: local client did not authorize the remote helper download" >&2
     exit {direct_fallback_exit}
@@ -355,7 +356,9 @@ mod tests {
         assert!(script.contains("sha256sum"));
         assert!(script.contains("local integrity verification"));
         assert!(script.contains("syq-helper-manifest-begin"));
+        assert!(script.contains("syq-helper-manifest-data:%s"));
         assert!(script.contains("syq-helper-sha256:"));
+        assert!(script.contains("syq-helper-report-end"));
         assert!(script.contains("read -r decision"));
         assert!(!script.contains(".sha256"));
         assert!(script.contains(helper_identity()));

--- a/src/remote_helper.rs
+++ b/src/remote_helper.rs
@@ -3,12 +3,18 @@
 //! Official clients name their exact release; development clients carry a Git
 //! identity but may not populate the managed cache. A cache hit adds no extra
 //! ssh round trip: the normal remote command computes the target name and execs
-//! the cached binary directly. On a miss, `conn` probes the target and downloads
-//! the matching authorized release asset.
+//! the cached binary directly. On a miss, `conn` probes the target and either
+//! authorizes a direct download or uploads a locally verified matching asset.
 
 pub const RELEASE_BASE_URL: &str = "https://github.com/greaber/syq/releases/download";
 pub const HELPER_MISSING_EXIT: i32 = 125;
 pub const HELPER_NOT_EXECUTABLE_EXIT: i32 = 126;
+/// Direct download could not be used, but installing an uploaded helper may work.
+pub const DIRECT_FALLBACK_EXIT: i32 = 75;
+/// Direct download completed, but its digest did not match the signed manifest.
+pub const DIRECT_INTEGRITY_EXIT: i32 = 76;
+/// The remote cache itself could not be written or finalized; upload cannot fix it.
+pub const INSTALL_FAILED_EXIT: i32 = 77;
 const DOWNLOAD_CACHE_GENERATION: &str = "release-v1";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -64,7 +70,19 @@ fn cache_key() -> String {
 }
 
 pub fn probe_command() -> &'static str {
-    "sh -c 'printf \"syq-helper-target:%s:%s\\n\" \"$(uname -s)\" \"$(uname -m)\"'"
+    r#"sh -c 'downloader=
+if command -v curl >/dev/null 2>&1; then downloader=curl
+elif command -v wget >/dev/null 2>&1; then downloader=wget
+fi
+hasher=
+if command -v sha256sum >/dev/null 2>&1; then hasher=sha256sum
+elif command -v shasum >/dev/null 2>&1; then hasher=shasum
+elif command -v openssl >/dev/null 2>&1; then hasher=openssl
+fi
+decompressor=
+if command -v gzip >/dev/null 2>&1; then decompressor=gzip; fi
+printf "syq-helper-target:%s:%s\n" "$(uname -s)" "$(uname -m)"
+printf "syq-helper-tools:%s:%s:%s\n" "$downloader" "$hasher" "$decompressor"'"#
 }
 
 /// Run this release's helper from its deterministic cache path.  The target
@@ -91,80 +109,204 @@ exec "$program" "$@""#,
     )
 }
 
-pub fn download_script(target: Target, expected_sha256: &str) -> String {
-    assert!(
-        expected_sha256.len() == 64
-            && expected_sha256
-                .bytes()
-                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()),
-        "trusted release hash must be lowercase SHA-256"
-    );
+pub fn download_script(target: Target) -> String {
     let release = cache_key();
     let tag = format!("v{}", env!("CARGO_PKG_VERSION"));
-    let url = format!("{RELEASE_BASE_URL}/{tag}/{}.gz", target.asset);
+    let archive_url = format!("{RELEASE_BASE_URL}/{tag}/{}.gz", target.asset);
+    let manifest_url = format!("{RELEASE_BASE_URL}/{tag}/syq-release-manifest.json");
     let expected_version = format!("syq {}", env!("CARGO_PKG_VERSION"));
     let expected_identity = helper_identity();
     format!(
-        r#"set -eu
+        r#"set -u
 dir="$HOME/.cache/syq/helpers/{release}/{target_key}"
 program="$dir/syq"
 tmp="$dir/.syq.$$.tmp"
 archive="$tmp.gz"
-mkdir -p "$dir"
-cleanup() {{ rm -f "$tmp" "$archive"; }}
+manifest="$tmp.json"
+if ! mkdir -p "$dir"; then
+    echo "syq: cannot create the remote helper cache" >&2
+    exit {install_failed_exit}
+fi
+cleanup() {{ rm -f "$tmp" "$archive" "$manifest"; }}
 trap cleanup EXIT HUP INT TERM
-fetch() {{
+download() {{
+    source=$1
+    destination=$2
+    if ! : > "$destination"; then
+        echo "syq: cannot write the remote helper cache" >&2
+        exit {install_failed_exit}
+    fi
     if command -v curl >/dev/null 2>&1; then
-        curl --fail --silent --show-error --location --retry 2 --connect-timeout 10 --proto '=https' --proto-redir '=https' --output "$2" "$1"
+        curl --fail --silent --show-error --location --connect-timeout 5 --max-time 30 --speed-limit 1024 --speed-time 10 --proto '=https' --proto-redir '=https' --output "$destination" "$source"
+        status=$?
+        if [ "$status" -ne 0 ]; then
+            if [ "$status" -eq 23 ]; then
+                echo "syq: remote helper download could not write its temporary file" >&2
+                exit {install_failed_exit}
+            fi
+            echo "syq: remote helper download with curl failed" >&2
+            exit {direct_fallback_exit}
+        fi
     elif command -v wget >/dev/null 2>&1; then
-        wget -q -O "$2" "$1"
+        wget -q --timeout=10 --tries=1 -O "$destination" "$source"
+        status=$?
+        if [ "$status" -ne 0 ]; then
+            if [ "$status" -eq 3 ]; then
+                echo "syq: remote helper download could not write its temporary file" >&2
+                exit {install_failed_exit}
+            fi
+            echo "syq: remote helper download with wget failed" >&2
+            exit {direct_fallback_exit}
+        fi
     else
         echo "syq: remote helper download needs curl or wget" >&2
-        return 1
+        exit {direct_fallback_exit}
     fi
 }}
-fetch {url} "$archive"
-expected={expected_sha256}
+download {manifest_url} "$manifest"
+download {archive_url} "$archive"
 if command -v sha256sum >/dev/null 2>&1; then
-    actual=$(sha256sum "$archive" | sed 's/[[:space:]].*$//')
+    if output=$(sha256sum "$archive" 2>/dev/null); then
+        actual=${{output%%[[:space:]]*}}
+    else
+        echo "syq: remote helper hashing with sha256sum failed" >&2
+        exit {direct_fallback_exit}
+    fi
 elif command -v shasum >/dev/null 2>&1; then
-    actual=$(shasum -a 256 "$archive" | sed 's/[[:space:]].*$//')
+    if output=$(shasum -a 256 "$archive" 2>/dev/null); then
+        actual=${{output%%[[:space:]]*}}
+    else
+        echo "syq: remote helper hashing with shasum failed" >&2
+        exit {direct_fallback_exit}
+    fi
 elif command -v openssl >/dev/null 2>&1; then
-    actual=$(openssl dgst -sha256 "$archive" | sed 's/^.*= //')
+    if output=$(openssl dgst -sha256 "$archive" 2>/dev/null); then
+        actual=${{output##* }}
+    else
+        echo "syq: remote helper hashing with openssl failed" >&2
+        exit {direct_fallback_exit}
+    fi
 else
     echo "syq: remote helper verification needs sha256sum, shasum, or openssl" >&2
-    exit 1
+    exit {direct_fallback_exit}
 fi
-[ -n "$expected" ] && [ "$actual" = "$expected" ] || {{
-    echo "syq: remote helper checksum mismatch" >&2
-    exit 1
-}}
-gzip -dc "$archive" > "$tmp"
-chmod 700 "$tmp"
+case "$actual" in
+    ''|*[!0-9a-f]*)
+        echo "syq: remote helper hasher returned an invalid SHA-256 digest" >&2
+        exit {direct_fallback_exit}
+        ;;
+esac
+if [ "${{#actual}}" -ne 64 ]; then
+    echo "syq: remote helper hasher returned an invalid SHA-256 digest" >&2
+    exit {direct_fallback_exit}
+fi
+printf 'syq-helper-manifest-begin\n'
+while IFS= read -r line || [ -n "$line" ]; do
+    printf '%s\n' "$line"
+done < "$manifest"
+printf 'syq-helper-manifest-end\n'
+printf 'syq-helper-sha256:%s\n' "$actual"
+if ! IFS= read -r decision; then
+    echo "syq: local client did not authorize the remote helper download" >&2
+    exit {direct_fallback_exit}
+fi
+if [ "$decision" != install ]; then
+    echo "syq: remote helper download was discarded after local integrity verification" >&2
+    exit {direct_integrity_exit}
+fi
+if ! gzip -dc "$archive" > "$tmp"; then
+    echo "syq: remote helper decompression failed" >&2
+    exit {direct_fallback_exit}
+fi
+if ! chmod 700 "$tmp"; then
+    echo "syq: cannot make the remote helper executable" >&2
+    exit {install_failed_exit}
+fi
 got=$("$tmp" --version 2>/dev/null) || {{
     echo "syq: downloaded helper cannot run on this host" >&2
-    exit 1
+    exit {install_failed_exit}
 }}
 [ "$got" = {expected_version} ] || {{
     echo "syq: downloaded helper has unexpected version: $got" >&2
-    exit 1
+    exit {install_failed_exit}
 }}
 got_id=$("$tmp" --build-identity 2>/dev/null) || {{
     echo "syq: downloaded helper does not report a build identity" >&2
-    exit 1
+    exit {install_failed_exit}
 }}
 [ "$got_id" = {expected_identity} ] || {{
     echo "syq: downloaded helper has unexpected identity: $got_id" >&2
-    exit 1
+    exit {install_failed_exit}
 }}
-mv "$tmp" "$program"
+if ! mv "$tmp" "$program"; then
+    echo "syq: cannot install the remote helper" >&2
+    exit {install_failed_exit}
+fi
 cleanup
 trap - EXIT HUP INT TERM"#,
         target_key = target.key,
-        url = shell_words::quote(&url),
-        expected_sha256 = shell_words::quote(expected_sha256),
+        archive_url = shell_words::quote(&archive_url),
+        manifest_url = shell_words::quote(&manifest_url),
         expected_version = shell_words::quote(&expected_version),
         expected_identity = shell_words::quote(expected_identity),
+        direct_fallback_exit = DIRECT_FALLBACK_EXIT,
+        direct_integrity_exit = DIRECT_INTEGRITY_EXIT,
+        install_failed_exit = INSTALL_FAILED_EXIT,
+    )
+}
+
+/// Install a locally verified, uncompressed helper received on standard input.
+/// This path deliberately needs no remote downloader, hasher, or decompressor.
+pub fn upload_script(target: Target) -> String {
+    let release = cache_key();
+    let expected_version = format!("syq {}", env!("CARGO_PKG_VERSION"));
+    let expected_identity = helper_identity();
+    format!(
+        r#"set -u
+umask 077
+dir="$HOME/.cache/syq/helpers/{release}/{target_key}"
+program="$dir/syq"
+tmp="$dir/.syq.$$.upload"
+if ! mkdir -p "$dir"; then
+    echo "syq: cannot create the remote helper cache" >&2
+    exit {install_failed_exit}
+fi
+cleanup() {{ rm -f "$tmp"; }}
+trap cleanup EXIT HUP INT TERM
+if ! cat > "$tmp"; then
+    echo "syq: could not upload the remote helper" >&2
+    exit {install_failed_exit}
+fi
+if ! chmod 700 "$tmp"; then
+    echo "syq: cannot make the uploaded remote helper executable" >&2
+    exit {install_failed_exit}
+fi
+got=$("$tmp" --version 2>/dev/null) || {{
+    echo "syq: uploaded helper cannot run on this host" >&2
+    exit {install_failed_exit}
+}}
+[ "$got" = {expected_version} ] || {{
+    echo "syq: uploaded helper has unexpected version: $got" >&2
+    exit {install_failed_exit}
+}}
+got_id=$("$tmp" --build-identity 2>/dev/null) || {{
+    echo "syq: uploaded helper does not report a build identity" >&2
+    exit {install_failed_exit}
+}}
+[ "$got_id" = {expected_identity} ] || {{
+    echo "syq: uploaded helper has unexpected identity: $got_id" >&2
+    exit {install_failed_exit}
+}}
+if ! mv "$tmp" "$program"; then
+    echo "syq: cannot install the uploaded remote helper" >&2
+    exit {install_failed_exit}
+fi
+cleanup
+trap - EXIT HUP INT TERM"#,
+        target_key = target.key,
+        expected_version = shell_words::quote(&expected_version),
+        expected_identity = shell_words::quote(expected_identity),
+        install_failed_exit = INSTALL_FAILED_EXIT,
     )
 }
 
@@ -201,16 +343,47 @@ mod tests {
     #[test]
     fn release_download_is_pinned_and_verified() {
         let target = Target::from_uname("Linux", "x86_64").unwrap();
-        let script = download_script(target, &"a".repeat(64));
+        let script = download_script(target);
         assert!(script.contains(&format!(
             "/v{}/syq-linux-x86_64.gz",
             env!("CARGO_PKG_VERSION")
         )));
+        assert!(script.contains(&format!(
+            "/v{}/syq-release-manifest.json",
+            env!("CARGO_PKG_VERSION")
+        )));
         assert!(script.contains("sha256sum"));
-        assert!(script.contains("checksum mismatch"));
+        assert!(script.contains("local integrity verification"));
+        assert!(script.contains("syq-helper-manifest-begin"));
+        assert!(script.contains("syq-helper-sha256:"));
+        assert!(script.contains("read -r decision"));
         assert!(!script.contains(".sha256"));
         assert!(script.contains(helper_identity()));
         assert!(script.contains("--build-identity"));
         assert!(!script.contains("--remote-helper-id"));
+    }
+
+    #[test]
+    fn probe_reports_the_complete_direct_download_toolchain() {
+        let command = probe_command();
+        assert!(command.contains("curl"));
+        assert!(command.contains("wget"));
+        assert!(command.contains("sha256sum"));
+        assert!(command.contains("shasum"));
+        assert!(command.contains("openssl"));
+        assert!(command.contains("gzip"));
+        assert!(command.contains("syq-helper-tools:"));
+    }
+
+    #[test]
+    fn upload_needs_no_download_verification_or_decompression_tools() {
+        let target = Target::from_uname("Linux", "x86_64").unwrap();
+        let script = upload_script(target);
+        assert!(script.contains("cat > \"$tmp\""));
+        assert!(script.contains("--build-identity"));
+        assert!(!script.contains("curl"));
+        assert!(!script.contains("wget"));
+        assert!(!script.contains("sha256"));
+        assert!(!script.contains("gzip"));
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,4 +1,4 @@
-//! Signed standalone release updates.
+//! Signed standalone release updates and remote-helper artifact verification.
 //!
 //! Package-manager and source installs deliberately have no install receipt,
 //! so this module will never replace them. Official release builds embed the
@@ -74,6 +74,22 @@ struct ReleaseFile {
 struct VerifiedRelease {
     manifest: ReleaseManifest,
     version: Version,
+}
+
+/// Target-specific release metadata whose manifest signature has been checked
+/// by the running client. It can authorize either a remote download or a
+/// locally downloaded helper uploaded over SSH.
+pub(crate) struct TrustedCurrentHelper {
+    tag: String,
+    target: Target,
+    binary: ReleaseFile,
+    archive: ReleaseFile,
+}
+
+impl TrustedCurrentHelper {
+    pub fn archive_sha256(&self) -> &str {
+        &self.archive.sha256
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -172,16 +188,37 @@ fn should_check_for_updates(quiet: bool, stderr_is_terminal: bool, disabled: boo
     !quiet && stderr_is_terminal && !disabled
 }
 
-/// Return the archive hash for this exact release after verifying its signed
-/// manifest. Remote bootstrap passes this trusted value to the remote shell;
-/// it never trusts a checksum downloaded beside the executable.
-pub fn trusted_current_archive_hash(target: Target) -> Result<String> {
+/// Return the artifact metadata for this exact release after verifying its
+/// signed manifest. Remote bootstrap never trusts metadata downloaded by the
+/// remote host itself.
+pub(crate) fn trusted_current_helper(target: Target) -> Result<TrustedCurrentHelper> {
     crate::identity::require_release_build()?;
     let tag = format!("v{}", env!("CARGO_PKG_VERSION"));
     let release = fetch_verified(
         &format!("{}/{tag}", release_downloads()),
         FetchMode::Interactive,
     )?;
+    current_helper_from_release(target, release)
+}
+
+/// Verify a manifest relayed by the remote host and return its target metadata.
+/// Only the signed contents are trusted; SSH transport does not authorize
+/// release metadata by itself.
+pub(crate) fn trusted_current_helper_from_manifest(
+    target: Target,
+    manifest_bytes: &[u8],
+) -> Result<TrustedCurrentHelper> {
+    crate::identity::require_release_build()?;
+    let key = embedded_public_key()?;
+    let manifest = verified_manifest(manifest_bytes, key.as_ref())?;
+    let version = validate_manifest(&manifest)?;
+    current_helper_from_release(target, VerifiedRelease { manifest, version })
+}
+
+fn current_helper_from_release(
+    target: Target,
+    release: VerifiedRelease,
+) -> Result<TrustedCurrentHelper> {
     if release.version != current_version()? {
         bail!("signed release manifest does not describe this syq build");
     }
@@ -193,7 +230,74 @@ pub fn trusted_current_archive_hash(target: Target) -> Result<String> {
     if artifact.binary.name != target.asset {
         bail!("release artifact name does not match target {}", target.key);
     }
-    Ok(artifact.archive.sha256.clone())
+    Ok(TrustedCurrentHelper {
+        tag: release.manifest.tag,
+        target,
+        binary: artifact.binary.clone(),
+        archive: artifact.archive.clone(),
+    })
+}
+
+/// Return a locally cached, verified, uncompressed helper. The archive and
+/// binary hashes both come from the signed manifest, so this is safe for a
+/// different target from the client and never uploads the running executable.
+pub(crate) fn verified_current_helper(helper: &TrustedCurrentHelper) -> Result<Vec<u8>> {
+    let cache_path = helper_cache_path(helper)?;
+    if cache_path.is_file() {
+        match verify_file_as(&cache_path, &helper.binary, "cached remote helper") {
+            Ok(()) => {
+                return fs::read(&cache_path).with_context(|| {
+                    format!("read cached remote helper {}", cache_path.display())
+                });
+            }
+            Err(error) => {
+                eprintln!(
+                    "syq: warning: cached remote helper failed integrity verification ({error}); discarding it"
+                );
+                fs::remove_file(&cache_path).with_context(|| {
+                    format!("remove invalid cached helper {}", cache_path.display())
+                })?;
+            }
+        }
+    }
+
+    let parent = cache_path
+        .parent()
+        .ok_or_else(|| anyhow!("the remote helper cache path has no parent directory"))?;
+    create_private_dir(parent)?;
+    let archive = TempFile::new(parent, ".gz")?;
+    let binary = TempFile::new(parent, ".bin")?;
+    let url = format!(
+        "{}/{}/{}",
+        release_downloads(),
+        helper.tag,
+        helper.archive.name
+    );
+    fetch(&url, archive.path(), FetchMode::Interactive)?;
+    verify_file(archive.path(), &helper.archive)?;
+
+    let input = File::open(archive.path()).context("open downloaded remote helper archive")?;
+    let mut decoder = GzDecoder::new(BufReader::new(input));
+    let output = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(binary.path())
+        .context("open temporary remote helper")?;
+    let mut output = BufWriter::new(output);
+    std::io::copy(&mut decoder, &mut output).context("decompress the remote helper")?;
+    output.flush().context("flush the remote helper")?;
+    output
+        .get_ref()
+        .sync_all()
+        .context("sync the remote helper")?;
+    drop(output);
+    verify_file_as(binary.path(), &helper.binary, "downloaded remote helper")?;
+    set_executable(binary.path())?;
+    fs::rename(binary.path(), &cache_path)
+        .with_context(|| format!("cache verified remote helper at {}", cache_path.display()))?;
+    sync_parent(parent)?;
+    fs::read(&cache_path)
+        .with_context(|| format!("read cached remote helper {}", cache_path.display()))
 }
 
 fn current_version() -> Result<Version> {
@@ -442,10 +546,14 @@ pub fn write_manifest_signing_payload(path: &Path) -> Result<()> {
 }
 
 fn verify_file(path: &Path, expected: &ReleaseFile) -> Result<()> {
+    verify_file_as(path, expected, "downloaded release archive")
+}
+
+fn verify_file_as(path: &Path, expected: &ReleaseFile, description: &str) -> Result<()> {
     let metadata = fs::metadata(path).context("stat downloaded release archive")?;
     if metadata.len() != expected.size {
         bail!(
-            "downloaded release archive has size {}, expected {}",
+            "{description} has size {}, expected {}",
             metadata.len(),
             expected.size
         );
@@ -466,7 +574,7 @@ fn verify_file(path: &Path, expected: &ReleaseFile) -> Result<()> {
         .map(|byte| format!("{byte:02x}"))
         .collect();
     if actual != expected.sha256 {
-        bail!("downloaded release archive failed SHA-256 verification");
+        bail!("{description} failed SHA-256 verification");
     }
     Ok(())
 }
@@ -606,6 +714,24 @@ fn config_dir() -> Result<PathBuf> {
             anyhow!("HOME is not set, so the standalone install receipt cannot be located")
         })?;
     Ok(PathBuf::from(home).join(".config/syq"))
+}
+
+fn helper_cache_path(helper: &TrustedCurrentHelper) -> Result<PathBuf> {
+    let base = if let Some(base) = std::env::var_os("XDG_CACHE_HOME").filter(|v| !v.is_empty()) {
+        PathBuf::from(base)
+    } else {
+        let home = std::env::var_os("HOME")
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| {
+                anyhow!("HOME is not set, so the remote helper cache cannot be located")
+            })?;
+        PathBuf::from(home).join(".cache")
+    };
+    Ok(base
+        .join("syq/helpers")
+        .join(&helper.tag)
+        .join(helper.target.key)
+        .join("syq"))
 }
 
 fn canonical_current_exe() -> Result<PathBuf> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -274,17 +274,22 @@ pub(crate) fn verified_current_helper(helper: &TrustedCurrentHelper) -> Result<V
         helper.archive.name
     );
     fetch(&url, archive.path(), FetchMode::Interactive)?;
-    verify_file(archive.path(), &helper.archive)?;
+    verify_file_as(
+        archive.path(),
+        &helper.archive,
+        "downloaded remote helper archive",
+    )?;
 
     let input = File::open(archive.path()).context("open downloaded remote helper archive")?;
-    let mut decoder = GzDecoder::new(BufReader::new(input));
+    let decoder = GzDecoder::new(BufReader::new(input));
     let output = OpenOptions::new()
         .write(true)
         .truncate(true)
         .open(binary.path())
         .context("open temporary remote helper")?;
     let mut output = BufWriter::new(output);
-    std::io::copy(&mut decoder, &mut output).context("decompress the remote helper")?;
+    std::io::copy(&mut decoder.take(helper.binary.size + 1), &mut output)
+        .context("decompress the remote helper")?;
     output.flush().context("flush the remote helper")?;
     output
         .get_ref()
@@ -467,29 +472,7 @@ fn install_release(release: &VerifiedRelease, receipt: &mut InstallReceipt) -> R
     let parent = executable
         .parent()
         .ok_or_else(|| anyhow!("the syq executable has no parent directory"))?;
-    let archive = TempFile::new(parent, ".gz")?;
-    let binary = TempFile::new(parent, ".bin")?;
-    let url = format!(
-        "{}/{}/{}",
-        release_downloads(),
-        release.manifest.tag,
-        artifact.archive.name
-    );
-    fetch(&url, archive.path(), FetchMode::Interactive)?;
-    verify_file(archive.path(), &artifact.archive)?;
-
-    let input = File::open(archive.path()).context("open downloaded release archive")?;
-    let mut decoder = GzDecoder::new(BufReader::new(input));
-    let output = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .open(binary.path())
-        .context("open temporary update executable")?;
-    let mut output = BufWriter::new(output);
-    std::io::copy(&mut decoder, &mut output).context("decompress the syq update")?;
-    output.flush().context("flush the syq update")?;
-    output.get_ref().sync_all().context("sync the syq update")?;
-    drop(output);
+    let binary = download_artifact(release, artifact, parent)?;
     set_executable(binary.path())?;
     verify_executable(binary.path(), release)?;
 
@@ -545,12 +528,52 @@ pub fn write_manifest_signing_payload(path: &Path) -> Result<()> {
         .context("write release manifest signing payload")
 }
 
-fn verify_file(path: &Path, expected: &ReleaseFile) -> Result<()> {
-    verify_file_as(path, expected, "downloaded release archive")
+fn download_artifact(
+    release: &VerifiedRelease,
+    artifact: &ReleaseArtifact,
+    parent: &Path,
+) -> Result<TempFile> {
+    let archive = TempFile::new(parent, ".gz")?;
+    let binary = TempFile::new(parent, ".bin")?;
+    let url = format!(
+        "{}/{}/{}",
+        release_downloads(),
+        release.manifest.tag,
+        artifact.archive.name
+    );
+    fetch(&url, archive.path(), FetchMode::Interactive)?;
+    verify_file_as(
+        archive.path(),
+        &artifact.archive,
+        "downloaded release archive",
+    )?;
+
+    let input = File::open(archive.path()).context("open downloaded release archive")?;
+    let decoder = GzDecoder::new(BufReader::new(input));
+    let output = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(binary.path())
+        .context("open temporary release executable")?;
+    let mut output = BufWriter::new(output);
+    std::io::copy(&mut decoder.take(artifact.binary.size + 1), &mut output)
+        .context("decompress the syq release executable")?;
+    output.flush().context("flush the syq release executable")?;
+    output
+        .get_ref()
+        .sync_all()
+        .context("sync the syq release executable")?;
+    drop(output);
+    verify_file_as(
+        binary.path(),
+        &artifact.binary,
+        "downloaded release executable",
+    )?;
+    Ok(binary)
 }
 
 fn verify_file_as(path: &Path, expected: &ReleaseFile, description: &str) -> Result<()> {
-    let metadata = fs::metadata(path).context("stat downloaded release archive")?;
+    let metadata = fs::metadata(path).with_context(|| format!("stat {description}"))?;
     if metadata.len() != expected.size {
         bail!(
             "{description} has size {}, expected {}",
@@ -558,11 +581,15 @@ fn verify_file_as(path: &Path, expected: &ReleaseFile, description: &str) -> Res
             expected.size
         );
     }
-    let mut input = BufReader::new(File::open(path).context("open release archive for hashing")?);
+    let mut input = BufReader::new(
+        File::open(path).with_context(|| format!("open {description} for hashing"))?,
+    );
     let mut hasher = Sha256::new();
     let mut buffer = [0u8; 128 * 1024];
     loop {
-        let count = input.read(&mut buffer).context("hash release archive")?;
+        let count = input
+            .read(&mut buffer)
+            .with_context(|| format!("hash {description}"))?;
         if count == 0 {
             break;
         }
@@ -604,53 +631,66 @@ fn verify_executable(path: &Path, release: &VerifiedRelease) -> Result<()> {
 }
 
 fn fetch(url: &str, destination: &Path, mode: FetchMode) -> Result<()> {
-    let mut curl = Command::new("curl");
-    curl.args([
-        "--fail",
-        "--silent",
-        "--show-error",
-        "--location",
-        "--proto",
-        "=https",
-        "--proto-redir",
-        "=https",
-        "--connect-timeout",
-    ]);
-    match mode {
-        FetchMode::Interactive => {
-            curl.args(["10", "--retry", "2"]);
-        }
-        FetchMode::BackgroundCheck => {
-            curl.args(["2", "--max-time", "5"]);
-        }
-    }
-    curl.arg("--output").arg(destination).arg(url);
-    match curl.stdin(Stdio::null()).status() {
-        Ok(status) if status.success() => return Ok(()),
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => return Err(e).context("run curl"),
+    #[cfg(debug_assertions)]
+    if let Some(root) = std::env::var_os("SYQ_TEST_FIXTURES").filter(|value| !value.is_empty()) {
+        let name = url
+            .rsplit('/')
+            .next()
+            .filter(|name| !name.is_empty() && !matches!(*name, "." | ".."))
+            .ok_or_else(|| anyhow!("test release URL has no fixture name"))?;
+        fs::copy(PathBuf::from(root).join(name), destination)
+            .with_context(|| format!("copy test release fixture {name}"))?;
+        return Ok(());
     }
 
-    let mut wget = Command::new("wget");
-    wget.args(["--quiet", "--https-only"]);
-    match mode {
-        FetchMode::Interactive => {
-            wget.args(["--timeout=10", "--tries=3"]);
-        }
-        FetchMode::BackgroundCheck => {
-            wget.args(["--timeout=5", "--tries=1"]);
+    let (connect_timeout, global_timeout, attempts) = match mode {
+        FetchMode::Interactive => (Duration::from_secs(10), None, 3),
+        FetchMode::BackgroundCheck => (Duration::from_secs(2), Some(Duration::from_secs(5)), 1),
+    };
+    let agent = ureq::Agent::config_builder()
+        .https_only(true)
+        .timeout_connect(Some(connect_timeout))
+        .timeout_global(global_timeout)
+        .user_agent(concat!("syq/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .new_agent();
+
+    let mut last_error = None;
+    for attempt in 0..attempts {
+        let result = (|| -> Result<()> {
+            let mut response = agent
+                .get(url)
+                .call()
+                .with_context(|| format!("request {url}"))?;
+            let file = OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(destination)
+                .with_context(|| format!("open {} for download", destination.display()))?;
+            let mut file = BufWriter::new(file);
+            std::io::copy(&mut response.body_mut().as_reader(), &mut file)
+                .with_context(|| format!("download {url}"))?;
+            file.flush()
+                .with_context(|| format!("flush downloaded file {}", destination.display()))?;
+            Ok(())
+        })();
+        match result {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                let retryable = !matches!(
+                    error.downcast_ref::<ureq::Error>(),
+                    Some(ureq::Error::StatusCode(code))
+                        if *code < 500 && !matches!(*code, 408 | 429)
+                );
+                last_error = Some(error);
+                if !retryable || attempt + 1 == attempts {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(250 * (attempt as u64 + 1)));
+            }
         }
     }
-    wget.arg("-O").arg(destination).arg(url);
-    match wget.stdin(Stdio::null()).status() {
-        Ok(status) if status.success() => Ok(()),
-        Ok(status) => bail!("download {url} failed ({status})"),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            bail!("downloading updates requires curl or wget")
-        }
-        Err(e) => Err(e).context("run wget"),
-    }
+    Err(last_error.unwrap()).with_context(|| format!("download {url}"))
 }
 
 fn managed_receipt() -> Result<(PathBuf, InstallReceipt)> {
@@ -947,5 +987,21 @@ mod tests {
         assert!(!should_check_for_updates(true, true, false));
         assert!(!should_check_for_updates(false, false, false));
         assert!(!should_check_for_updates(false, true, true));
+    }
+
+    #[test]
+    fn release_fetches_reject_plain_http() {
+        let parent = std::env::temp_dir();
+        let destination = TempFile::new(&parent, ".http-test").unwrap();
+        let error = fetch(
+            "http://127.0.0.1:1/release",
+            destination.path(),
+            FetchMode::BackgroundCheck,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error.downcast_ref::<ureq::Error>(),
+            Some(ureq::Error::RequireHttpsOnly(_))
+        ));
     }
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -2,6 +2,7 @@
 
 use base64::Engine as _;
 use ed25519_dalek::{Signer, SigningKey};
+use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -150,7 +151,11 @@ fn fake_rsh(t: &Tmp) -> PathBuf {
         br#"#!/bin/sh
 shift
 HOME="$FAKE_REMOTE_HOME"
-PATH="$FAKE_REMOTE_BIN:/usr/bin:/bin"
+if [ -n "${FAKE_REMOTE_PATH:-}" ]; then
+    PATH="$FAKE_REMOTE_PATH"
+else
+    PATH="$FAKE_REMOTE_BIN:/usr/bin:/bin"
+fi
 export HOME PATH
 printf '%s\n' "$1" >> "$FAKE_RSH_LOG"
 exec /bin/sh -c "$1"
@@ -159,7 +164,7 @@ exec /bin/sh -c "$1"
     path
 }
 
-fn remote_syq(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
+fn remote_syq_command(t: &Tmp, rsh: &Path, args: &[&str]) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_syq"));
     cmd.args(["-e", rsh.to_str().unwrap(), "--no-tcp", "-j", "1"])
         .args(args)
@@ -167,12 +172,18 @@ fn remote_syq(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
         .env("FAKE_REMOTE_HOME", t.path("remote-home"))
         .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
         .env("FAKE_RELEASE_ARCHIVE", t.path("release.gz"))
+        .env("FAKE_REMOTE_RELEASE_ARCHIVE", t.path("release.gz"))
         .env("FAKE_CURL_LOG", t.path("curl.log"))
         .env("FAKE_LOCAL_CURL_LOG", t.path("local-curl.log"))
         .env("FAKE_RELEASE_MANIFEST", t.path("release-manifest.json"))
+        .env(
+            "FAKE_REMOTE_RELEASE_MANIFEST",
+            t.path("release-manifest.json"),
+        )
         .env("FAKE_RSH_LOG", t.path("rsh.log"))
         .env("FAKE_LEGACY_LOG", t.path("legacy.log"))
-        .env("XDG_CONFIG_HOME", t.path("config"));
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_CACHE_HOME", t.path("cache"));
     if let Ok(key) = fs::read_to_string(t.path("release-public-key")) {
         cmd.env("SYQ_TEST_RELEASE_PUBLIC_KEY", key.trim())
             .env("SYQ_TEST_RELEASE_BUILD", "1")
@@ -182,7 +193,13 @@ fn remote_syq(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
             )
             .env("PATH", format!("{}:/usr/bin:/bin", t.s("local-bin")));
     }
-    cmd.output().expect("run syq through fake remote shell")
+    cmd
+}
+
+fn remote_syq(t: &Tmp, rsh: &Path, args: &[&str]) -> Output {
+    remote_syq_command(t, rsh, args)
+        .output()
+        .expect("run syq through fake remote shell")
 }
 
 fn assert_output_ok(out: &Output) {
@@ -204,6 +221,18 @@ fn cached_remote_helper(t: &Tmp) -> PathBuf {
     };
     t.path(&format!(
         "remote-home/.cache/syq/helpers/{identity}-release-v1/{target}/syq"
+    ))
+}
+
+fn cached_local_helper(t: &Tmp) -> PathBuf {
+    let target = match std::env::consts::ARCH {
+        "x86_64" => "linux-x86_64",
+        "aarch64" => "linux-aarch64",
+        arch => panic!("unsupported test architecture {arch}"),
+    };
+    t.path(&format!(
+        "cache/syq/helpers/v{}/{target}/syq",
+        env!("CARGO_PKG_VERSION")
     ))
 }
 
@@ -236,20 +265,15 @@ fn legacy_cached_remote_helpers(t: &Tmp) -> [PathBuf; 2] {
 }
 
 #[cfg(target_os = "linux")]
-#[test]
-fn release_keyed_remote_helper_ignores_legacy_protocol_caches() {
-    let t = Tmp::new();
-    let rsh = fake_rsh(&t);
-    let legacy_helpers = legacy_cached_remote_helpers(&t);
-    for legacy_helper in &legacy_helpers {
-        executable(
-            legacy_helper,
-            br#"#!/bin/sh
-printf 'legacy helper ran\n' >> "$FAKE_LEGACY_LOG"
-exit 99
-"#,
-        );
-    }
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn setup_release_bootstrap(t: &Tmp) {
     let archive = File::create(t.path("release.gz")).unwrap();
     let status = Command::new("gzip")
         .args(["-9", "-n", "-c", env!("CARGO_BIN_EXE_syq")])
@@ -257,18 +281,8 @@ exit 99
         .status()
         .unwrap();
     assert!(status.success());
-    let sum = Command::new("sha256sum")
-        .arg(t.path("release.gz"))
-        .output()
-        .unwrap();
-    assert!(sum.status.success());
-    let digest = String::from_utf8(sum.stdout)
-        .unwrap()
-        .split_whitespace()
-        .next()
-        .unwrap()
-        .to_string();
-    let archive_size = fs::metadata(t.path("release.gz")).unwrap().len();
+    let archive_bytes = fs::read(t.path("release.gz")).unwrap();
+    let binary_bytes = fs::read(env!("CARGO_BIN_EXE_syq")).unwrap();
     let (target, asset) = match std::env::consts::ARCH {
         "x86_64" => ("linux-x86_64", "syq-linux-x86_64"),
         "aarch64" => ("linux-aarch64", "syq-linux-aarch64"),
@@ -282,8 +296,16 @@ exit 99
         "helper_id": format!("v{}-p0", env!("CARGO_PKG_VERSION")),
         "artifacts": {
             (target): {
-                "binary": {"name": asset, "sha256": "0".repeat(64), "size": 1},
-                "archive": {"name": format!("{asset}.gz"), "sha256": digest, "size": archive_size}
+                "binary": {
+                    "name": asset,
+                    "sha256": sha256_hex(&binary_bytes),
+                    "size": binary_bytes.len()
+                },
+                "archive": {
+                    "name": format!("{asset}.gz"),
+                    "sha256": sha256_hex(&archive_bytes),
+                    "size": archive_bytes.len()
+                }
             }
         },
         "installer": {"name": "install.sh", "sha256": "1".repeat(64), "size": 1},
@@ -321,6 +343,7 @@ while [ "$#" -gt 0 ]; do
 done
 case "$url" in
     *.json) cp "$FAKE_RELEASE_MANIFEST" "$out" ;;
+    *.gz) cp "$FAKE_RELEASE_ARCHIVE" "$out" ;;
     *) exit 22 ;;
 esac
 "#,
@@ -331,15 +354,54 @@ esac
         br#"#!/bin/sh
 printf 'fetch\n' >> "$FAKE_CURL_LOG"
 out=
+url=
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --output) out=$2; shift 2 ;;
-        *) shift ;;
+        *) url=$1; shift ;;
     esac
 done
-cp "$FAKE_RELEASE_ARCHIVE" "$out"
+case "$url" in
+    *.json) cp "$FAKE_REMOTE_RELEASE_MANIFEST" "$out" ;;
+    *.gz) cp "$FAKE_REMOTE_RELEASE_ARCHIVE" "$out" ;;
+    *) exit 22 ;;
+esac
 "#,
     );
+}
+
+#[cfg(target_os = "linux")]
+fn add_remote_tool(t: &Tmp, name: &str) {
+    let destination = t.path(&format!("remote-bin/{name}"));
+    if destination.exists() {
+        return;
+    }
+    let source = [
+        Path::new("/usr/bin").join(name),
+        Path::new("/bin").join(name),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+    .unwrap_or_else(|| panic!("test host has no {name}"));
+    std::os::unix::fs::symlink(source, destination).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn release_keyed_remote_helper_ignores_legacy_protocol_caches() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    let legacy_helpers = legacy_cached_remote_helpers(&t);
+    for legacy_helper in &legacy_helpers {
+        executable(
+            legacy_helper,
+            br#"#!/bin/sh
+printf 'legacy helper ran\n' >> "$FAKE_LEGACY_LOG"
+exit 99
+"#,
+        );
+    }
+    setup_release_bootstrap(&t);
 
     write(&t.path("src"), b"first");
     let remote = format!("fake:{}", t.s("dst"));
@@ -349,8 +411,8 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
     assert!(cached_remote_helper(&t).is_file());
     assert!(legacy_helpers.iter().all(|helper| helper.exists()));
     assert!(!t.path("legacy.log").exists(), "legacy helper was executed");
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\n");
-    assert_eq!(read(&t.path("curl.log")), b"fetch\n");
+    assert!(!t.path("local-curl.log").exists());
+    assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
     assert!(!String::from_utf8_lossy(&out.stderr).contains("uploading this executable"));
     assert!(
         String::from_utf8_lossy(&out.stderr).contains(&format!(
@@ -371,8 +433,8 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
     let out = remote_syq(&t, &rsh, &["-avv", &t.s("src"), &remote]);
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"second");
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\n");
-    assert_eq!(read(&t.path("curl.log")), b"fetch\n");
+    assert!(!t.path("local-curl.log").exists());
+    assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
     assert!(
         String::from_utf8_lossy(&out.stderr).contains(&format!(
             "helper: {} (managed helper cache)",
@@ -386,6 +448,268 @@ cp "$FAKE_RELEASE_ARCHIVE" "$out"
         .matches("syq-helper-target:")
         .count();
     assert_eq!(probes, 1, "cache hit should not probe the platform again");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn remote_helper_integrity_mismatch_warns_and_uploads_verified_binary() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    setup_release_bootstrap(&t);
+    let mut corrupt = read(&t.path("release.gz"));
+    let middle = corrupt.len() / 2;
+    corrupt[middle] ^= 1;
+    write(&t.path("corrupt-release.gz"), &corrupt);
+    let corrupt_digest = sha256_hex(&corrupt);
+
+    write(&t.path("src"), b"integrity fallback");
+    let remote = format!("fake:{}", t.s("dst"));
+    let mut cmd = remote_syq_command(&t, &rsh, &["-a", "-q", &t.s("src"), &remote]);
+    let out = cmd
+        .env("FAKE_REMOTE_RELEASE_ARCHIVE", t.path("corrupt-release.gz"))
+        .output()
+        .unwrap();
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"integrity fallback");
+    assert_eq!(
+        read(&cached_remote_helper(&t)),
+        read(Path::new(env!("CARGO_BIN_EXE_syq")))
+    );
+    assert_eq!(
+        read(&cached_local_helper(&t)),
+        read(Path::new(env!("CARGO_BIN_EXE_syq")))
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote helper download failed integrity verification"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("expected SHA-256"), "{stderr}");
+    assert!(stderr.contains(&corrupt_digest), "{stderr}");
+    assert!(
+        stderr.contains("uploading the verified helper over SSH"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("checksum mismatch"), "{stderr}");
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\n");
+    assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
+    let cache_entries: Vec<_> = fs::read_dir(cached_remote_helper(&t).parent().unwrap())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    assert_eq!(cache_entries, ["syq"]);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn remote_manifest_signature_failure_warns_and_uses_local_verified_release() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    setup_release_bootstrap(&t);
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(&read(&t.path("release-manifest.json"))).unwrap();
+    manifest["repository"] = "https://attacker.invalid/syq".into();
+    write(
+        &t.path("tampered-remote-manifest.json"),
+        &serde_json::to_vec_pretty(&manifest).unwrap(),
+    );
+
+    write(&t.path("src"), b"manifest fallback");
+    let remote = format!("fake:{}", t.s("dst"));
+    let mut cmd = remote_syq_command(&t, &rsh, &["-a", "-q", &t.s("src"), &remote]);
+    let out = cmd
+        .env(
+            "FAKE_REMOTE_RELEASE_MANIFEST",
+            t.path("tampered-remote-manifest.json"),
+        )
+        .output()
+        .unwrap();
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"manifest fallback");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote release manifest failed integrity verification or validation"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("signature verification failed"), "{stderr}");
+    assert!(
+        stderr.contains("uploading the verified helper over SSH"),
+        "{stderr}"
+    );
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
+    assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn failed_remote_download_falls_back_to_verified_upload() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    setup_release_bootstrap(&t);
+    executable(
+        &t.path("remote-bin/curl"),
+        br#"#!/bin/sh
+printf 'fetch\n' >> "$FAKE_CURL_LOG"
+exit 22
+"#,
+    );
+
+    write(&t.path("src"), b"download fallback");
+    let remote = format!("fake:{}", t.s("dst"));
+    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"download fallback");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("remote download unavailable"), "{stderr}");
+    assert!(
+        stderr.contains("uploading the verified helper over SSH"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("warning:"), "{stderr}");
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
+    assert_eq!(read(&t.path("curl.log")), b"fetch\n");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn missing_remote_hasher_skips_download_and_uploads_verified_binary() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    setup_release_bootstrap(&t);
+    for tool in ["sh", "uname", "mkdir", "rm", "cat", "chmod", "mv", "gzip"] {
+        add_remote_tool(&t, tool);
+    }
+
+    write(&t.path("src"), b"capability fallback");
+    let remote = format!("fake:{}", t.s("dst"));
+    let mut cmd = remote_syq_command(&t, &rsh, &["-a", &t.s("src"), &remote]);
+    let out = cmd
+        .env("FAKE_REMOTE_PATH", t.path("remote-bin"))
+        .output()
+        .unwrap();
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"capability fallback");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote download prerequisites unavailable"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("uploading the verified helper over SSH"),
+        "{stderr}"
+    );
+    assert!(!t.path("curl.log").exists());
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn broken_remote_hasher_falls_back_to_verified_upload() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    setup_release_bootstrap(&t);
+    executable(
+        &t.path("remote-bin/sha256sum"),
+        br#"#!/bin/sh
+exit 1
+"#,
+    );
+
+    write(&t.path("src"), b"hasher fallback");
+    let remote = format!("fake:{}", t.s("dst"));
+    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"hasher fallback");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote helper hashing with sha256sum failed"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("uploading the verified helper over SSH"),
+        "{stderr}"
+    );
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
+    assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn corrupted_local_helper_cache_is_discarded_and_refetched() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    setup_release_bootstrap(&t);
+    executable(
+        &t.path("remote-bin/curl"),
+        br#"#!/bin/sh
+exit 22
+"#,
+    );
+    let mut corrupt = read(Path::new(env!("CARGO_BIN_EXE_syq")));
+    let middle = corrupt.len() / 2;
+    corrupt[middle] ^= 1;
+    fs::create_dir_all(cached_local_helper(&t).parent().unwrap()).unwrap();
+    write(&cached_local_helper(&t), &corrupt);
+
+    write(&t.path("src"), b"local cache repair");
+    let remote = format!("fake:{}", t.s("dst"));
+    let out = remote_syq(&t, &rsh, &["-a", "-q", &t.s("src"), &remote]);
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"local cache repair");
+    assert_eq!(
+        read(&cached_local_helper(&t)),
+        read(Path::new(env!("CARGO_BIN_EXE_syq")))
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("cached remote helper failed integrity verification"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("discarding it"), "{stderr}");
+    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn remote_download_write_failure_does_not_retry_with_upload() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    setup_release_bootstrap(&t);
+    executable(
+        &t.path("remote-bin/curl"),
+        br#"#!/bin/sh
+printf 'fetch\n' >> "$FAKE_CURL_LOG"
+exit 23
+"#,
+    );
+
+    write(&t.path("src"), b"must fail");
+    let remote = format!("fake:{}", t.s("dst"));
+    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
+
+    assert!(
+        !out.status.success(),
+        "remote write failure unexpectedly succeeded"
+    );
+    assert!(!t.path("dst").exists());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote helper download could not write its temporary file"),
+        "{stderr}"
+    );
+    assert!(
+        !stderr.contains("uploading the verified helper"),
+        "{stderr}"
+    );
+    assert!(!t.path("local-curl.log").exists());
+    assert_eq!(read(&t.path("curl.log")), b"fetch\n");
+    assert!(!cached_local_helper(&t).exists());
 }
 
 #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -2,7 +2,7 @@
 
 use base64::Engine as _;
 use ed25519_dalek::{Signer, SigningKey};
-use flate2::{write::GzEncoder, Compression};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
@@ -473,6 +473,67 @@ fn remote_helper_integrity_mismatch_warns_and_uploads_verified_binary() {
         .map(|entry| entry.unwrap().file_name())
         .collect();
     assert_eq!(cache_entries, ["syq"]);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn remote_manifest_cannot_inject_digest_protocol_framing() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    setup_release_bootstrap(&t);
+
+    let archive = read(&t.path("release.gz"));
+    let expected_digest = sha256_hex(&archive);
+    let mut alternate_archive = archive;
+    alternate_archive[4] ^= 1;
+    let mut decoded = Vec::new();
+    GzDecoder::new(alternate_archive.as_slice())
+        .read_to_end(&mut decoded)
+        .unwrap();
+    assert_eq!(decoded, read(Path::new(env!("CARGO_BIN_EXE_syq"))));
+    write(&t.path("alternate-release.gz"), &alternate_archive);
+
+    let mut injected_manifest = read(&t.path("release-manifest.json"));
+    injected_manifest.extend_from_slice(
+        format!("\nsyq-helper-manifest-end\nsyq-helper-sha256:{expected_digest}\n").as_bytes(),
+    );
+    write(&t.path("injected-manifest.json"), &injected_manifest);
+
+    write(&t.path("src"), b"framing fallback");
+    let remote = format!("fake:{}", t.s("dst"));
+    let mut cmd = remote_syq_command(&t, &rsh, &["-a", "-q", &t.s("src"), &remote]);
+    let out = cmd
+        .env(
+            "FAKE_REMOTE_RELEASE_MANIFEST",
+            t.path("injected-manifest.json"),
+        )
+        .env(
+            "FAKE_REMOTE_RELEASE_ARCHIVE",
+            t.path("alternate-release.gz"),
+        )
+        .output()
+        .unwrap();
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"framing fallback");
+    assert_eq!(
+        read(&cached_remote_helper(&t)),
+        read(Path::new(env!("CARGO_BIN_EXE_syq")))
+    );
+    assert_eq!(
+        read(&cached_local_helper(&t)),
+        read(Path::new(env!("CARGO_BIN_EXE_syq")))
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote release manifest failed integrity verification or validation"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains("uploading the verified helper over SSH"),
+        "{stderr}"
+    );
+    assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
 }
 
 #[cfg(target_os = "linux")]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -2,6 +2,7 @@
 
 use base64::Engine as _;
 use ed25519_dalek::{Signer, SigningKey};
+use flate2::{write::GzEncoder, Compression};
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
@@ -171,11 +172,8 @@ fn remote_syq_command(t: &Tmp, rsh: &Path, args: &[&str]) -> Command {
         .arg("--no-progress")
         .env("FAKE_REMOTE_HOME", t.path("remote-home"))
         .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
-        .env("FAKE_RELEASE_ARCHIVE", t.path("release.gz"))
         .env("FAKE_REMOTE_RELEASE_ARCHIVE", t.path("release.gz"))
         .env("FAKE_CURL_LOG", t.path("curl.log"))
-        .env("FAKE_LOCAL_CURL_LOG", t.path("local-curl.log"))
-        .env("FAKE_RELEASE_MANIFEST", t.path("release-manifest.json"))
         .env(
             "FAKE_REMOTE_RELEASE_MANIFEST",
             t.path("release-manifest.json"),
@@ -191,7 +189,7 @@ fn remote_syq_command(t: &Tmp, rsh: &Path, args: &[&str]) -> Command {
                 "SYQ_TEST_RELEASE_DOWNLOADS",
                 "https://release.invalid/download",
             )
-            .env("PATH", format!("{}:/usr/bin:/bin", t.s("local-bin")));
+            .env("SYQ_TEST_FIXTURES", &t.0);
     }
     cmd
 }
@@ -274,15 +272,14 @@ fn sha256_hex(bytes: &[u8]) -> String {
 
 #[cfg(target_os = "linux")]
 fn setup_release_bootstrap(t: &Tmp) {
-    let archive = File::create(t.path("release.gz")).unwrap();
-    let status = Command::new("gzip")
-        .args(["-9", "-n", "-c", env!("CARGO_BIN_EXE_syq")])
-        .stdout(Stdio::from(archive))
-        .status()
-        .unwrap();
-    assert!(status.success());
-    let archive_bytes = fs::read(t.path("release.gz")).unwrap();
     let binary_bytes = fs::read(env!("CARGO_BIN_EXE_syq")).unwrap();
+    let mut encoder = GzEncoder::new(
+        File::create(t.path("release.gz")).unwrap(),
+        Compression::best(),
+    );
+    encoder.write_all(&binary_bytes).unwrap();
+    encoder.finish().unwrap();
+    let archive_bytes = fs::read(t.path("release.gz")).unwrap();
     let (target, asset) = match std::env::consts::ARCH {
         "x86_64" => ("linux-x86_64", "syq-linux-x86_64"),
         "aarch64" => ("linux-aarch64", "syq-linux-aarch64"),
@@ -318,36 +315,16 @@ fn setup_release_bootstrap(t: &Tmp) {
         base64::engine::general_purpose::STANDARD.encode(signing.sign(&canonical).to_bytes());
     let mut manifest = manifest;
     manifest["signature"] = signature.into();
-    write(
-        &t.path("release-manifest.json"),
-        &serde_json::to_vec_pretty(&manifest).unwrap(),
-    );
+    let manifest_bytes = serde_json::to_vec_pretty(&manifest).unwrap();
+    write(&t.path("syq-release-manifest.json"), &manifest_bytes);
+    write(&t.path("release-manifest.json"), &manifest_bytes);
     write(
         &t.path("release-public-key"),
         base64::engine::general_purpose::STANDARD
             .encode(signing.verifying_key().to_bytes())
             .as_bytes(),
     );
-
-    executable(
-        &t.path("local-bin/curl"),
-        br#"#!/bin/sh
-printf 'fetch\n' >> "$FAKE_LOCAL_CURL_LOG"
-out=
-url=
-while [ "$#" -gt 0 ]; do
-    case "$1" in
-        --output) out=$2; shift 2 ;;
-        *) url=$1; shift ;;
-    esac
-done
-case "$url" in
-    *.json) cp "$FAKE_RELEASE_MANIFEST" "$out" ;;
-    *.gz) cp "$FAKE_RELEASE_ARCHIVE" "$out" ;;
-    *) exit 22 ;;
-esac
-"#,
-    );
+    fs::copy(t.path("release.gz"), t.path(&format!("{asset}.gz"))).unwrap();
 
     executable(
         &t.path("remote-bin/curl"),
@@ -411,7 +388,6 @@ exit 99
     assert!(cached_remote_helper(&t).is_file());
     assert!(legacy_helpers.iter().all(|helper| helper.exists()));
     assert!(!t.path("legacy.log").exists(), "legacy helper was executed");
-    assert!(!t.path("local-curl.log").exists());
     assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
     assert!(!String::from_utf8_lossy(&out.stderr).contains("uploading this executable"));
     assert!(
@@ -433,7 +409,6 @@ exit 99
     let out = remote_syq(&t, &rsh, &["-avv", &t.s("src"), &remote]);
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"second");
-    assert!(!t.path("local-curl.log").exists());
     assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
     assert!(
         String::from_utf8_lossy(&out.stderr).contains(&format!(
@@ -492,7 +467,6 @@ fn remote_helper_integrity_mismatch_warns_and_uploads_verified_binary() {
         "{stderr}"
     );
     assert!(!stderr.contains("checksum mismatch"), "{stderr}");
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\n");
     assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
     let cache_entries: Vec<_> = fs::read_dir(cached_remote_helper(&t).parent().unwrap())
         .unwrap()
@@ -538,7 +512,6 @@ fn remote_manifest_signature_failure_warns_and_uses_local_verified_release() {
         stderr.contains("uploading the verified helper over SSH"),
         "{stderr}"
     );
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
     assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
 }
 
@@ -569,7 +542,6 @@ exit 22
         "{stderr}"
     );
     assert!(!stderr.contains("warning:"), "{stderr}");
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
     assert_eq!(read(&t.path("curl.log")), b"fetch\n");
 }
 
@@ -603,7 +575,6 @@ fn missing_remote_hasher_skips_download_and_uploads_verified_binary() {
         "{stderr}"
     );
     assert!(!t.path("curl.log").exists());
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
 }
 
 #[cfg(target_os = "linux")]
@@ -634,7 +605,6 @@ exit 1
         stderr.contains("uploading the verified helper over SSH"),
         "{stderr}"
     );
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
     assert_eq!(read(&t.path("curl.log")), b"fetch\nfetch\n");
 }
 
@@ -672,7 +642,6 @@ exit 22
         "{stderr}"
     );
     assert!(stderr.contains("discarding it"), "{stderr}");
-    assert_eq!(read(&t.path("local-curl.log")), b"fetch\nfetch\n");
 }
 
 #[cfg(target_os = "linux")]
@@ -707,7 +676,6 @@ exit 23
         !stderr.contains("uploading the verified helper"),
         "{stderr}"
     );
-    assert!(!t.path("local-curl.log").exists());
     assert_eq!(read(&t.path("curl.log")), b"fetch\n");
     assert!(!cached_local_helper(&t).exists());
 }
@@ -731,7 +699,6 @@ fn development_build_refuses_managed_remote_bootstrap() {
         "{stderr}"
     );
     assert!(!stderr.contains("uploading"), "{stderr}");
-    assert!(!t.path("curl.log").exists());
 }
 
 #[test]

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -38,14 +38,6 @@ impl Drop for TempDir {
     }
 }
 
-fn write_executable(path: &Path, bytes: &[u8]) {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).unwrap();
-    }
-    fs::write(path, bytes).unwrap();
-    fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
-}
-
 #[cfg(target_os = "linux")]
 struct UpdateFixture {
     temp: TempDir,
@@ -126,21 +118,6 @@ impl UpdateFixture {
         let public_key =
             base64::engine::general_purpose::STANDARD.encode(signing.verifying_key().to_bytes());
 
-        write_executable(
-            &temp.path("fake-bin/curl"),
-            br#"#!/bin/sh
-out=
-url=
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --output) out=$2; shift 2 ;;
-    *) url=$1; shift ;;
-  esac
-done
-cp "$SYQ_TEST_FIXTURES/${url##*/}" "$out"
-"#,
-        );
-
         Self {
             config: temp.path("config"),
             temp,
@@ -164,10 +141,6 @@ cp "$SYQ_TEST_FIXTURES/${url##*/}" "$out"
                 "https://release.invalid/download",
             )
             .env("SYQ_TEST_FIXTURES", self.temp.path("fixtures"))
-            .env(
-                "PATH",
-                format!("{}:/usr/bin:/bin", self.temp.path("fake-bin").display()),
-            )
             .output()
             .unwrap()
     }


### PR DESCRIPTION
## Summary

- probe the remote for a downloader, SHA-256 implementation, and gzip, then use a tightly bounded direct download when the complete toolchain works
- encode every downloaded manifest line as protocol data, relay the actual digest in a terminated report, and verify the signed manifest locally before authorizing installation
- fall back on any remote download/tool/verification failure to a target-specific helper downloaded with the built-in rustls client, verified, cached locally, and uploaded over the configured SSH transport
- keep remote filesystem/install failures fatal and emit an explicit integrity warning when a completed remote download has the wrong digest
- remove the installed client runtime dependency on curl and wget, and document and test the combined policy

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets (258 tests)