### PR TITLE
Enable transport compression by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ syq [OPTIONS] SRC... [USER@]HOST:DEST
 ```
 
 ```sh
-syq -avz project/ server:backup/project/      # push
-syq -avz server:data/ ./data/                 # pull
+syq -av project/ server:backup/project/       # push
+syq -av server:data/ ./data/                  # pull
 syq -a /mnt/nfs/tree /local/tree              # local → local (parallel scan and copy)
 syq -a hostA:big/ hostB:big/                  # remote → remote: runs on hostA, data goes A → B directly
 syq -a --relay hostA:big/ hostB:big/          # ...or relay through this machine if A can't reach B
-syq -avz -j 16 bigdir server:dest             # 16 parallel connections
+syq -av -j 16 bigdir server:dest              # 16 parallel connections
 syq -a --bwlimit 50M src server:dst            # cap all connections at 50 MiB/s total
 syq -a -e 'ssh -p 2222 -i ~/.ssh/other' src host:dst
 syq -a --dry-run -v src host:dst              # show what would be copied
@@ -140,7 +140,7 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `-r` `-l` `-p` `-t` `-g` `-o` `-D` | Recursive; symlinks as symlinks; perms; mtimes; group; owner; devices and specials |
 | `-v` | List files as they complete (also new dirs, symlinks) |
 | `-q` | Errors only |
-| `-z`, `--compress` | zstd-compress data in transit (inside syq's protocol, not `ssh -C`) |
+| `-z`, `--compress` / `--no-compress` | Enable (the default) or disable zstd compression in syq's protocol; this is not `ssh -C` |
 | `-n`, `--dry-run` | Scan and report; change nothing |
 | `-j N`, `--connections N` | Parallel data connections (default: auto-tuned, see below) |
 | `--bwlimit RATE` | Limit aggregate file-data throughput (bare rate is KiB/s; `0` disables) |
@@ -188,8 +188,15 @@ stderr and reflected in the exit status.
 per-connection limit. As in rsync, a bare rate is KiB/s, suffixes such as `K`,
 `M`, `G`, and `MiB` use powers of 1024, a final `+1` or `-1` adjusts the scaled
 value by one byte, and `0` means unlimited. SYQ counts uncompressed file bytes;
-protocol overhead is not counted, and `-z` may make the actual network rate
-lower. Scanning, hashing, and metadata operations are not limited.
+protocol overhead is not counted, and transport compression may make the actual
+network rate lower. Scanning, hashing, and metadata operations are not limited.
+
+Remote transfers use fast zstd level-1 compression by default. Each protocol
+frame is sent compressed only when that representation is smaller, so archives,
+media, and encrypted data do not expand on the wire. They still cost a fast
+compression attempt; use `--no-compress` when CPU is scarcer than network
+bandwidth, particularly on a very fast LAN. Compression is transport-only and
+does not change file contents, hashes, resume offsets, or `--bwlimit` accounting.
 
 ### Remote-to-remote
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,9 +52,17 @@ pub struct Args {
     /// Suppress non-error messages
     #[arg(short = 'q', long)]
     pub quiet: bool,
-    /// Compress data in transit (zstd)
-    #[arg(short = 'z', long)]
+    /// Compress remote data in transit with zstd (default)
+    #[arg(
+        short = 'z',
+        long,
+        default_value_t = true,
+        overrides_with = "no_compress"
+    )]
     pub compress: bool,
+    /// Disable transport compression
+    #[arg(long, overrides_with = "compress")]
+    pub no_compress: bool,
     /// Show what would be transferred without doing it
     #[arg(short = 'n', long)]
     pub dry_run: bool,
@@ -305,6 +313,9 @@ impl Args {
     }
 
     pub fn normalize(&mut self) {
+        if self.no_compress {
+            self.compress = false;
+        }
         self.recursive_explicit = self.recursive;
         if self.archive {
             self.recursive = true;
@@ -539,8 +550,29 @@ pub fn parse_size(s: &str) -> Result<u64> {
 }
 
 #[cfg(test)]
-mod size_tests {
-    use super::parse_size;
+mod tests {
+    use super::{parse_size, Args};
+    use clap::Parser;
+
+    fn args(options: &[&str]) -> Args {
+        let mut argv = vec!["syq"];
+        argv.extend_from_slice(options);
+        argv.extend_from_slice(&["src", "dst"]);
+        let mut args = Args::try_parse_from(argv).unwrap();
+        args.normalize();
+        args
+    }
+
+    #[test]
+    fn compression_defaults_on_and_can_be_disabled() {
+        assert!(args(&[]).compress);
+        assert!(args(&["-z"]).compress);
+        assert!(!args(&["--no-compress"]).compress);
+
+        // As with other clap overrides, the last spelling wins.
+        assert!(!args(&["-z", "--no-compress"]).compress);
+        assert!(args(&["--no-compress", "-z"]).compress);
+    }
 
     #[test]
     fn size_parser_checks_sign_and_range() {

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -63,7 +63,6 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         ('g', args.group && !args.archive),
         ('o', args.owner && !args.archive),
         ('D', args.devices && !args.archive),
-        ('z', args.compress),
         ('n', args.dry_run),
         ('q', args.quiet),
         ('c', args.checksum),
@@ -77,6 +76,9 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     }
     if !short.is_empty() {
         remote.push(format!("-{short}"));
+    }
+    if !args.compress {
+        remote.push("--no-compress".into());
     }
     if let Some(j) = args.connections_opt {
         remote.push("-j".into());

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -10,6 +10,7 @@ use std::io::{self, BufReader, BufWriter, Read, Write};
 
 pub const MAX_FRAME: usize = 256 * 1024 * 1024;
 const COMPRESS_MIN: usize = 512;
+const COMPRESS_LEVEL: i32 = 1;
 
 /// Path bytes, as given by the user (absolute, or relative to the server's cwd).
 pub type PathBytes = Vec<u8>;
@@ -354,7 +355,7 @@ impl<W: Write> FrameWriter<W> {
         let mut flag = 0u8;
         let mut body = payload;
         if self.compress && body.len() > COMPRESS_MIN {
-            if let Ok(c) = zstd::bulk::compress(&body, 3) {
+            if let Ok(c) = zstd::bulk::compress(&body, COMPRESS_LEVEL) {
                 if c.len() < body.len() {
                     body = c;
                     flag = 1;
@@ -414,5 +415,61 @@ impl<R: Read> FrameReader<R> {
             body
         };
         postcard::from_bytes(&payload).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block_frame(data: Vec<u8>, compress: bool) -> Vec<u8> {
+        let mut frame = Vec::new();
+        FrameWriter::new(&mut frame, compress)
+            .write_msg(&Response::Block {
+                off: 7,
+                hash: 11,
+                data,
+            })
+            .unwrap();
+        frame
+    }
+
+    #[test]
+    fn compression_is_per_frame_and_never_expands_the_wire_payload() {
+        let data = vec![b'a'; 64 * 1024];
+        let compressed = block_frame(data.clone(), true);
+        assert_eq!(compressed[4], 1, "compressible frame was not compressed");
+
+        let decoded = FrameReader::new(compressed.as_slice())
+            .read_msg::<Response>()
+            .unwrap();
+        match decoded {
+            Response::Block {
+                off,
+                hash,
+                data: decoded,
+            } => {
+                assert_eq!((off, hash), (7, 11));
+                assert_eq!(decoded, data);
+            }
+            other => panic!("unexpected response {other:?}"),
+        }
+
+        let disabled = block_frame(data, false);
+        assert_eq!(disabled[4], 0, "disabled compression changed the frame");
+
+        let mut random = vec![0u8; 64 * 1024];
+        let mut state = 0x9e37_79b9_7f4a_7c15u64;
+        for byte in &mut random {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            *byte = state as u8;
+        }
+        let incompressible = block_frame(random, true);
+        assert_eq!(
+            incompressible[4], 0,
+            "an expanded compressed representation was selected"
+        );
     }
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -5061,6 +5061,31 @@ fn direct_remote_to_remote_passes_through_defined_exit_codes() {
     );
 }
 
+#[test]
+fn direct_remote_to_remote_forwards_compression_opt_out() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    write(&t.path("src"), b"payload");
+    let src = format!("fake:{}", t.s("src"));
+    let dst = format!("fake:{}", t.s("dst"));
+
+    let out = remote_syq(
+        &t,
+        &rsh,
+        &["-a", "--no-bootstrap", "--no-compress", &src, &dst],
+    );
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"payload");
+    assert!(
+        fs::read_to_string(t.path("rsh.log"))
+            .unwrap()
+            .contains("--no-compress"),
+        "the source-side orchestrator silently reverted to default compression"
+    );
+}
+
 // ----------------------------------------------------------- review round 13
 
 #[test]


### PR DESCRIPTION
## Summary

- enable zstd transport compression by default for remote transfers
- use level 1 to keep the default-on CPU cost low, while retaining `-z` and `--compress` as explicit compatibility spellings
- add `--no-compress` and forward it to source-side orchestrators for direct remote-to-remote copies
- document that compression is per protocol frame, transport-only, and selected only when the encoded result is smaller
- cover CLI precedence, compressed/raw frame selection and round trips, and remote-to-remote opt-out forwarding

Local probes on an AMD EPYC 9454P supported level 1 as the default tradeoff. Independently framed repository text compressed to 31.3% at 341 MiB/s with level 1 versus 30.0% at 265 MiB/s with level 3. ELF executables and libraries compressed to 39.5-41.9% at 411-461 MiB/s with level 1 versus 36.2-38.2% at 252-260 MiB/s with level 3. For already-compressed formats, almost every frame retained its original representation.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (239 tests passed)
