### PR TITLE
Make connection auto-tuning adaptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,9 @@ differs and why, what's missing, and the open issues. The short version:
 - rsync daemon mode / `rsync://`. syq speaks its own protocol; it cannot talk
   to an rsync server.
 - Rolling-checksum delta transfer (see Resume above).
+- UDP or forward-error-correcting data transport. TCP retransmission/RTT
+  counters are collected for diagnosis, but a loss-tolerant transport would be
+  a separate protocol and security design.
 - Preserving existing partial files from `rsync --partial`; only SYQ's own
   `.name.syq-part.<job-id>` sidecars for the same logical command are
   recognised.
@@ -583,26 +586,51 @@ differs and why, what's missing, and the open issues. The short version:
 
 Without `-j`, syq tunes the number of workers while a copy runs instead of
 guessing (`--rm` keeps a fixed 8, or 32 locally: removal is metadata-bound
-and short). It starts with 16 when every remote endpoint has a reachable TCP
-data path, 8 over ssh, or 32 when both ends are local (threads are free,
-connections are not), and measures: progress (bytes, plus a small credit per
-completed file so small-file trees count) is sampled every 2.5 s, and a count
-has been *measured* only once two consecutive samples agree within 10 % — so a
-burst that gets throttled, or a link still ramping up, is waited out (up to 20
-s) rather than credited to the last change. Each measured count is compared
-with the previous one: it doubles while a doubling gains at least a third of
-what linear scaling would (up to 64); when a doubling doesn't, it goes back to
-the last good count and refines upward in 1.3× steps; when even that buys
-nothing it shrinks by 1.3× as long as that costs less than 5 % (down to 2);
-then it holds. It never stops watching: after every 6 measurements it probes
-one step down (kept if throughput doesn't drop — this is what saves a spinning
-disk from seek thrash) or one step up (the route or a shared NAS may have freed
-up), and a direction that keeps failing is tried progressively less often.
-Surplus workers are parked, not closed: they keep their connections and stop
-taking work, handing back the rest of their range, so un-parking is instant.
-Transfers shorter than a measurement or two just run with the starting count.
-The progress line shows the current count (`16 conn`), and `--stats` reports
-the path it took (`connections: auto: settled at 16 (path 16, peak 16)`).
+and short). On a data path it has measured before, it starts at that path's last
+settled count; otherwise it starts with 16 when every remote endpoint has a
+reachable TCP data path, 8 over ssh, or 32 when both ends are local (threads
+are free, connections are not). Remembered results are keyed only by the
+directional endpoint path and transport (TCP and ssh learn separately), not by
+RTT, workload, filesystem or other volatile telemetry. A stale hint only costs
+the tuner a probe or two. The cache is
+`$XDG_CACHE_HOME/syq/tuning-v1.json` (normally
+`~/.cache/syq/tuning-v1.json`; set `SYQ_TUNING_CACHE` to override it or to an
+empty value to disable it). Explicit `-j`, dry runs, verification, short runs
+that compare no counts, and failed/aborted copies do not update it.
+
+Progress (bytes, plus a small credit per completed file so small-file trees
+count) is sampled every 2.5 s. A count has been *measured* only once two
+consecutive samples agree within 10 %, so a burst that gets throttled or a link
+still ramping up is waited out (up to 20 s) rather than credited to the last
+change. The first probe is a 1.3× step up — 8→10, not 8→16. A step up is kept
+when it gains at least a third of proportional scaling; a step down is kept
+when it stays within 5 % of the best recent measurement. A successful move
+keeps exploring in the same direction. A failed move returns to the last good
+count and records a bound, so later probes refine untested integers: if 10→13
+helps and 13→17 is flat, syq stays at 13 and can later try 11 rather than
+immediately falling back to 10. The objective is the smallest count within 5 %
+of the best observed speed, from 1 through 64.
+
+In steady state, evidence in the upward and downward directions ages and backs
+off independently. A direction is first eligible again after 6 stable
+measurements (about 30 seconds at minimum); repeated failures double only that
+direction's delay, up to 4 minutes at the minimum sampling rate. When both
+directions are equally informative, syq deterministically probes up first:
+most connection/throughput curves are concave or saturating, so an extra
+connection usually loses less transfer speed than removing a useful one. This
+is a prior, not a rule — measured collapse aborts a probe early, and independent
+backoff lets downward evidence win.
+
+Upward candidates connect in the background while the settled workers keep
+copying; connection setup time is not scored as throughput. After a decision,
+surplus connections are closed instead of retaining the largest pool ever
+tried. At one active connection syq keeps exactly one ready spare so the
+important 1→2 probe remains cheap. A dropped data connection is reopened with
+bounded exponential backoff; ranges with uncertain acknowledgements and final
+publication are safely requeued. Transfers shorter than a measurement or two
+just run with the starting count. The progress line shows the current count
+(`16 conn`), and `--stats` reports the path it took
+(`connections: auto: settled at 16 (path 16, peak 16)`).
 
 Measured from a 1 Gbit box in Germany to a host in Japan (265 ms): over TCP
 data connections it settles around 8–13 at line rate; over ssh data
@@ -626,6 +654,14 @@ AES-256-GCM records keyed by a secret exchanged over the ssh session
 (`--tcp-plain` skips the encryption on trusted networks; `--no-tcp` sends data over the ssh connection instead). If the port can't be
 reached — a firewall, typically — syq says so once and falls back to ssh data
 connections, so the default is always safe.
+
+With `--stats`, direct TCP copies also report the kernel counters available on
+both socket ends: retransmitted packets and bytes (a packet-loss signal),
+current/minimum RTT, congestion window and delivery rate, receive-window and
+send-buffer limited time, and ECN CE deliveries. These are diagnostic telemetry
+only and do not change the tuning cache key. SSH does not expose
+per-data-connection TCP counters to syq, so the statistics say they are
+unavailable when the data transport is SSH.
 
 The remote advertises every address it has (the one your ssh session arrived
 on first, then private LAN, then public, then CGNAT/Tailscale); the client

--- a/README.md
+++ b/README.md
@@ -600,8 +600,10 @@ that compare no counts, failed/aborted copies, and runs whose TCP path falls
 back to ssh after workers start do not update it; the last case may contain
 mixed-transport measurements that are not representative of either pure path.
 
-Progress (bytes, plus a small credit per completed file so small-file trees
-count) is sampled every 2.5 s. A count has been *measured* only once two
+Useful progress (the high-water mark of logically completed bytes, plus a small
+credit per completed file so small-file trees count) is sampled every 2.5 s.
+Recovery can retract uncertain bytes, and retransmitting those same bytes does
+not inflate the tuning rate. A count has been *measured* only once two
 consecutive samples agree within 10 %, so a burst that gets throttled or a link
 still ramping up is waited out (up to 20 s) rather than credited to the last
 change. The first probe is a 1.3× step up — 8→10, not 8→16. A step up is kept
@@ -624,13 +626,17 @@ is a prior, not a rule — measured collapse aborts a probe early, and independe
 backoff lets downward evidence win.
 
 Upward candidates connect in the background while the settled workers keep
-copying; connection setup time is not scored as throughput. After a decision,
-surplus connections are closed instead of retaining the largest pool ever
-tried. At one active connection syq keeps exactly one ready spare so the
-important 1→2 probe remains cheap. A dropped data connection is reopened with
-bounded exponential backoff; ranges with uncertain acknowledgements and final
-publication are safely requeued. Transfers shorter than a measurement or two
-just run with the starting count. The progress line shows the current count
+copying; their stable rate refreshes the comparison baseline, while connection
+setup time itself is not scored. A probe starts only when the activity remaining
+at the observed rate is estimated to last through a complete measurement, so a
+slow path is not rejected by a fixed byte threshold and a very fast tail is not
+mistaken for evidence. After a decision, surplus connections and their reader
+threads are closed instead of retaining the largest pool ever tried. At one
+active connection syq keeps exactly one ready spare so the important 1→2 probe
+remains cheap. A dropped data connection is reopened with bounded exponential
+backoff; ranges with uncertain acknowledgements and final publication are
+safely requeued. Transfers shorter than a measurement or two just run with the
+starting count. The progress line shows the current count
 (`16 conn`), and `--stats` reports the path it took
 (`connections: auto: settled at 16 (path 16, peak 16)`).
 

--- a/README.md
+++ b/README.md
@@ -596,20 +596,22 @@ the tuner a probe or two. The cache is
 `$XDG_CACHE_HOME/syq/tuning-v1.json` (normally
 `~/.cache/syq/tuning-v1.json`; set `SYQ_TUNING_CACHE` to override it or to an
 empty value to disable it). Explicit `-j`, dry runs, verification, short runs
-that compare no counts, and failed/aborted copies do not update it.
+that compare no counts, failed/aborted copies, and runs whose TCP path falls
+back to ssh after workers start do not update it; the last case may contain
+mixed-transport measurements that are not representative of either pure path.
 
 Progress (bytes, plus a small credit per completed file so small-file trees
 count) is sampled every 2.5 s. A count has been *measured* only once two
 consecutive samples agree within 10 %, so a burst that gets throttled or a link
 still ramping up is waited out (up to 20 s) rather than credited to the last
 change. The first probe is a 1.3× step up — 8→10, not 8→16. A step up is kept
-when it gains at least a third of proportional scaling; a step down is kept
-when it stays within 5 % of the best recent measurement. A successful move
-keeps exploring in the same direction. A failed move returns to the last good
-count and records a bound, so later probes refine untested integers: if 10→13
-helps and 13→17 is flat, syq stays at 13 and can later try 11 rather than
-immediately falling back to 10. The objective is the smallest count within 5 %
-of the best observed speed, from 1 through 64.
+only when the smaller count is more than 5 % below the best recent measurement;
+a step down is kept when it stays within 5 %. Thus acceptance directly follows
+the objective: the smallest measured count within 5 % of the best observed
+speed, from 1 through 64. A successful move keeps exploring in the same
+direction. A failed move returns to the last good count and records a bound, so
+later probes refine untested integers: if 10→13 helps and 13→17 is flat, syq
+stays at 13 and can later try 11 rather than immediately falling back to 10.
 
 In steady state, evidence in the upward and downward directions ages and backs
 off independently. A direction is first eligible again after 6 stable
@@ -659,9 +661,10 @@ With `--stats`, direct TCP copies also report the kernel counters available on
 both socket ends: retransmitted packets and bytes (a packet-loss signal),
 current/minimum RTT, congestion window and delivery rate, receive-window and
 send-buffer limited time, and ECN CE deliveries. These are diagnostic telemetry
-only and do not change the tuning cache key. SSH does not expose
-per-data-connection TCP counters to syq, so the statistics say they are
-unavailable when the data transport is SSH.
+only and do not change the tuning cache key. Unsupported fields are labeled
+unavailable rather than displayed as zero. SSH does not expose per-data-
+connection TCP counters to syq, so the statistics say they are unavailable
+when the data transport is SSH.
 
 The remote advertises every address it has (the one your ssh session arrived
 on first, then private LAN, then public, then CGNAT/Tailscale); the client

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,9 +74,10 @@ pub struct Args {
     #[arg(long)]
     pub numeric_ids: bool,
 
-    /// Parallel connections/workers. Default for copies: auto-tuned — starts at 16
-    /// over TCP, 8 over ssh, or 32 when local; grows while throughput improves and
-    /// shrinks when that costs nothing. Give a number to fix it. --rm uses a fixed
+    /// Parallel connections/workers. Default for copies: auto-tuned — starts at
+    /// the last settled count remembered for this host path and transport, or 16
+    /// over TCP, 8 over ssh, or 32 when local. It probes from 1 to 64 while the
+    /// copy has enough work to measure. Give a number to fix it. --rm uses a fixed
     /// 8 (32 when local).
     #[arg(short = 'j', long = "connections", value_name = "N")]
     pub connections_opt: Option<usize>,

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -209,7 +209,8 @@ pub struct RemoteConn {
     w: FrameWriter<Box<dyn Write + Send>>,
     /// Responses are parsed on a reader thread so the network keeps flowing
     /// while the caller processes the previous one.
-    rx: std::sync::mpsc::Receiver<std::io::Result<Response>>,
+    rx: Option<std::sync::mpsc::Receiver<std::io::Result<Response>>>,
+    reader: Option<std::thread::JoinHandle<()>>,
     label: String,
     dead: bool,
     peer: Option<PeerInfo>,
@@ -221,9 +222,12 @@ const TRANSPORT_STATS_TIMEOUT: std::time::Duration = std::time::Duration::from_s
 
 fn spawn_reader(
     input: Box<dyn Read + Send>,
-) -> std::sync::mpsc::Receiver<std::io::Result<Response>> {
+) -> (
+    std::sync::mpsc::Receiver<std::io::Result<Response>>,
+    std::thread::JoinHandle<()>,
+) {
     let (tx, rx) = std::sync::mpsc::sync_channel(READ_AHEAD);
-    std::thread::spawn(move || {
+    let reader = std::thread::spawn(move || {
         let mut r = FrameReader::new(input);
         loop {
             let msg = r.read_msg::<Response>();
@@ -233,7 +237,7 @@ fn spawn_reader(
             }
         }
     });
-    rx
+    (rx, reader)
 }
 
 fn receive_transport_stats(
@@ -275,6 +279,28 @@ fn validate_remote_scan_batch(batch: &[Entry], saw_root: &mut bool) -> Result<()
 }
 
 impl RemoteConn {
+    fn transport_stats_with_timeout(
+        &mut self,
+        timeout: std::time::Duration,
+    ) -> Option<TcpPairStats> {
+        let socket = self.tcp_socket.as_ref()?.try_clone().ok()?;
+        let local = tcp_socket_stats(&socket);
+        // Changing SO_RCVTIMEO cannot wake a reader already blocked on another
+        // clone. Bound the actual response wait instead. This connection is
+        // retired immediately after collection, so a late reply cannot become
+        // a response to a later request.
+        let peer = if self.dead || self.send(Request::TransportStats).is_err() {
+            None
+        } else {
+            receive_transport_stats(self.rx.as_ref().expect("reader receiver present"), timeout)
+        };
+        (local.is_some() || peer.is_some()).then(|| TcpPairStats {
+            label: self.label.clone(),
+            local,
+            peer,
+        })
+    }
+
     fn io_err(&mut self, e: anyhow::Error) -> anyhow::Error {
         self.dead = true;
         // If the child has exited (or does so shortly), that's the more useful error.
@@ -303,7 +329,7 @@ impl Conn for RemoteConn {
         self.w.write_msg(&req).map_err(|e| self.io_err(e.into()))
     }
     fn recv(&mut self) -> Result<Response> {
-        match self.rx.recv() {
+        match self.rx.as_ref().expect("reader receiver present").recv() {
             Ok(Ok(r)) => Ok(r),
             Ok(Err(e)) => Err(self.io_err(e.into())),
             Err(_) => Err(self.io_err(
@@ -315,22 +341,7 @@ impl Conn for RemoteConn {
         self.dead
     }
     fn transport_stats(&mut self) -> Option<TcpPairStats> {
-        let socket = self.tcp_socket.as_ref()?.try_clone().ok()?;
-        let local = tcp_socket_stats(&socket);
-        // Changing SO_RCVTIMEO cannot wake a reader already blocked on another
-        // clone. Bound the actual response wait instead. This connection is
-        // retired immediately after collection, so a late reply cannot become
-        // a response to a later request.
-        let peer = if self.dead || self.send(Request::TransportStats).is_err() {
-            None
-        } else {
-            receive_transport_stats(&self.rx, TRANSPORT_STATS_TIMEOUT)
-        };
-        (local.is_some() || peer.is_some()).then(|| TcpPairStats {
-            label: self.label.clone(),
-            local,
-            peer,
-        })
+        self.transport_stats_with_timeout(TRANSPORT_STATS_TIMEOUT)
     }
     fn scan(
         &mut self,
@@ -372,8 +383,20 @@ impl Drop for RemoteConn {
         if !self.dead {
             let _ = self.w.write_msg(&Request::Shutdown);
         }
+        // Sending Shutdown asks for an orderly peer exit; shutting down the
+        // retained TCP descriptor also wakes our reader clone and the peer's
+        // request reader if either side is wedged or the diagnostic reply
+        // timed out. Drop the receiver before joining so a reader blocked on a
+        // full response channel can exit as well.
+        if let Some(socket) = &self.tcp_socket {
+            let _ = socket.shutdown(std::net::Shutdown::Both);
+        }
+        self.rx.take();
         if let Some(child) = &mut self.child {
             let _ = child.wait();
+        }
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
         }
     }
 }
@@ -638,10 +661,12 @@ impl RemoteSpec {
             .with_context(|| format!("spawn {:?}", self.rsh[0]))?;
         let stdin = child.stdin.take().unwrap();
         let stdout = child.stdout.take().unwrap();
+        let (rx, reader) = spawn_reader(Box::new(stdout));
         let conn = RemoteConn {
             child: Some(child),
             w: FrameWriter::new(Box::new(stdin), compress),
-            rx: spawn_reader(Box::new(stdout)),
+            rx: Some(rx),
+            reader: Some(reader),
             label: self.label(),
             dead: false,
             peer: None,
@@ -846,10 +871,12 @@ impl RemoteSpec {
             let writer = RecordWriter::new(stream.try_clone()?, wc);
             let tcp_socket = stream.try_clone()?;
             let reader = RecordReader::new(stream, rc);
+            let (rx, reader) = spawn_reader(Box::new(reader));
             let conn = RemoteConn {
                 child: None,
                 w: FrameWriter::new(Box::new(writer), compress),
-                rx: spawn_reader(Box::new(reader)),
+                rx: Some(rx),
+                reader: Some(reader),
                 label: format!("{} (tcp {addr_s})", self.label()),
                 dead: false,
                 peer: None,
@@ -1410,6 +1437,24 @@ mod tests {
     use super::*;
     use std::ffi::OsStr;
 
+    struct ExitObserved<R> {
+        inner: R,
+        dropped: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl<R: Read> Read for ExitObserved<R> {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            self.inner.read(buffer)
+        }
+    }
+
+    impl<R> Drop for ExitObserved<R> {
+        fn drop(&mut self) {
+            self.dropped
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[test]
     fn kernel_tcp_stats_are_available_for_a_live_socket() {
@@ -1447,6 +1492,51 @@ mod tests {
         assert!(receive_transport_stats(&receiver, timeout).is_none());
         assert!(start.elapsed() >= timeout);
         assert!(start.elapsed() < std::time::Duration::from_secs(1));
+    }
+
+    #[test]
+    fn repeatedly_retiring_timed_out_tcp_connections_joins_their_readers() {
+        const CONNECTIONS: usize = 32;
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            for _ in 0..CONNECTIONS {
+                let (mut socket, _) = listener.accept().unwrap();
+                let mut request_bytes = Vec::new();
+                socket.read_to_end(&mut request_bytes).unwrap();
+                assert!(!request_bytes.is_empty());
+            }
+        });
+
+        for _ in 0..CONNECTIONS {
+            let socket = TcpStream::connect(address).unwrap();
+            let writer = socket.try_clone().unwrap();
+            let tcp_socket = socket.try_clone().unwrap();
+            let dropped = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let input = ExitObserved {
+                inner: socket,
+                dropped: dropped.clone(),
+            };
+            let (rx, reader) = spawn_reader(Box::new(input));
+            let mut connection = RemoteConn {
+                child: None,
+                w: FrameWriter::new(Box::new(writer), false),
+                rx: Some(rx),
+                reader: Some(reader),
+                label: "test tcp".into(),
+                dead: false,
+                peer: None,
+                tcp_socket: Some(tcp_socket),
+            };
+            let timeout = std::time::Duration::from_millis(5);
+            let start = std::time::Instant::now();
+            let _ = connection.transport_stats_with_timeout(timeout);
+            assert!(start.elapsed() >= timeout);
+            drop(connection);
+            assert!(dropped.load(std::sync::atomic::Ordering::SeqCst));
+            assert_eq!(std::sync::Arc::strong_count(&dropped), 1);
+        }
+        server.join().unwrap();
     }
 
     fn entry(path: &[u8]) -> Entry {

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
+use std::os::fd::AsRawFd;
 use std::process::{Child, Command, Stdio};
 
 pub trait Conn: Send {
@@ -22,6 +23,11 @@ pub trait Conn: Send {
     /// True once the transport has failed (remote process gone).
     fn is_dead(&self) -> bool {
         false
+    }
+    /// Best-effort counters for a direct TCP data connection. Collection is
+    /// deliberately observational: unavailable kernels and SSH return None.
+    fn transport_stats(&mut self) -> Option<TcpPairStats> {
+        None
     }
     /// Streamed scan; `sink` gets batches, `warn` gets non-fatal messages,
     /// `ignored` gets the paths the patterns pruned (only if `report_ignored`).
@@ -42,6 +48,81 @@ pub trait Conn: Send {
 pub struct PeerInfo {
     pub identity: String,
     pub platform: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct TcpPairStats {
+    pub label: String,
+    pub local: Option<TcpSocketStats>,
+    pub peer: Option<TcpSocketStats>,
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn tcp_socket_stats(stream: &TcpStream) -> Option<TcpSocketStats> {
+    let mut info: libc::tcp_info = unsafe { std::mem::zeroed() };
+    let mut len = std::mem::size_of::<libc::tcp_info>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::IPPROTO_TCP,
+            libc::TCP_INFO,
+            &mut info as *mut _ as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    (result == 0).then_some(TcpSocketStats {
+        bytes_sent: info.tcpi_bytes_sent,
+        bytes_retransmitted: info.tcpi_bytes_retrans,
+        segments_sent: info.tcpi_segs_out.into(),
+        segments_received: info.tcpi_segs_in.into(),
+        retransmissions: info.tcpi_total_retrans.into(),
+        rtt_us: info.tcpi_rtt.into(),
+        rtt_variance_us: info.tcpi_rttvar.into(),
+        min_rtt_us: info.tcpi_min_rtt.into(),
+        send_cwnd_bytes: u64::from(info.tcpi_snd_cwnd) * u64::from(info.tcpi_snd_mss),
+        delivery_rate: info.tcpi_delivery_rate,
+        busy_time_us: info.tcpi_busy_time,
+        receive_window_limited_us: info.tcpi_rwnd_limited,
+        send_buffer_limited_us: info.tcpi_sndbuf_limited,
+        ecn_ce_delivered: info.tcpi_delivered_ce.into(),
+    })
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn tcp_socket_stats(stream: &TcpStream) -> Option<TcpSocketStats> {
+    let mut info: libc::tcp_connection_info = unsafe { std::mem::zeroed() };
+    let mut len = std::mem::size_of::<libc::tcp_connection_info>() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::IPPROTO_TCP,
+            libc::TCP_CONNECTION_INFO,
+            &mut info as *mut _ as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    (result == 0).then_some(TcpSocketStats {
+        bytes_sent: info.tcpi_txbytes,
+        bytes_retransmitted: info.tcpi_txretransmitbytes,
+        segments_sent: info.tcpi_txpackets,
+        segments_received: info.tcpi_rxpackets,
+        retransmissions: 0,
+        // Darwin reports these fields in milliseconds.
+        rtt_us: u64::from(info.tcpi_srtt) * 1000,
+        rtt_variance_us: u64::from(info.tcpi_rttvar) * 1000,
+        min_rtt_us: 0,
+        send_cwnd_bytes: info.tcpi_snd_cwnd.into(),
+        delivery_rate: 0,
+        busy_time_us: 0,
+        receive_window_limited_us: 0,
+        send_buffer_limited_us: 0,
+        ecn_ce_delivered: 0,
+    })
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub(crate) fn tcp_socket_stats(_stream: &TcpStream) -> Option<TcpSocketStats> {
+    None
 }
 
 /// Turn an `Err` response into an error, otherwise pass through.
@@ -108,6 +189,7 @@ pub struct RemoteConn {
     label: String,
     dead: bool,
     peer: Option<PeerInfo>,
+    tcp_socket: Option<TcpStream>,
 }
 
 const READ_AHEAD: usize = 4;
@@ -196,6 +278,27 @@ impl Conn for RemoteConn {
     }
     fn is_dead(&self) -> bool {
         self.dead
+    }
+    fn transport_stats(&mut self) -> Option<TcpPairStats> {
+        let socket = self.tcp_socket.as_ref()?.try_clone().ok()?;
+        let local = tcp_socket_stats(&socket);
+        // Diagnostics must not make a completed copy wait forever for a
+        // wedged peer. The option is socket-wide, including the reader clone.
+        let _ = socket.set_read_timeout(Some(std::time::Duration::from_secs(2)));
+        let peer = if self.dead {
+            None
+        } else {
+            match self.call(Request::TransportStats) {
+                Ok(Response::TransportStats(stats)) => stats,
+                _ => None,
+            }
+        };
+        let _ = socket.set_read_timeout(None);
+        (local.is_some() || peer.is_some()).then(|| TcpPairStats {
+            label: self.label.clone(),
+            local,
+            peer,
+        })
     }
     fn scan(
         &mut self,
@@ -510,6 +613,7 @@ impl RemoteSpec {
             label: self.label(),
             dead: false,
             peer: None,
+            tcp_socket: None,
         };
         let conn = hello(conn, compress, Vec::new())?;
         self.record_peer(&conn);
@@ -708,6 +812,7 @@ impl RemoteSpec {
                 None => (None, None),
             };
             let writer = RecordWriter::new(stream.try_clone()?, wc);
+            let tcp_socket = stream.try_clone()?;
             let reader = RecordReader::new(stream, rc);
             let conn = RemoteConn {
                 child: None,
@@ -716,6 +821,7 @@ impl RemoteSpec {
                 label: format!("{} (tcp {addr_s})", self.label()),
                 dead: false,
                 peer: None,
+                tcp_socket: Some(tcp_socket),
             };
             let conn = hello(conn, compress, info.token.clone())?;
             self.record_peer(&conn);
@@ -1271,6 +1377,29 @@ impl Endpoint {
 mod tests {
     use super::*;
     use std::ffi::OsStr;
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn kernel_tcp_stats_are_available_for_a_live_socket() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut socket, _) = listener.accept().unwrap();
+            let mut byte = [0u8; 1];
+            socket.read_exact(&mut byte).unwrap();
+            socket.write_all(&byte).unwrap();
+            tcp_socket_stats(&socket).unwrap()
+        });
+        let mut client = TcpStream::connect(address).unwrap();
+        client.write_all(&[7]).unwrap();
+        let mut byte = [0u8; 1];
+        client.read_exact(&mut byte).unwrap();
+        let client_stats = tcp_socket_stats(&client).unwrap();
+        let server_stats = server.join().unwrap();
+        assert_eq!(byte, [7]);
+        assert!(client_stats.segments_sent > 0 || client_stats.bytes_sent > 0);
+        assert!(server_stats.segments_sent > 0 || server_stats.bytes_sent > 0);
+    }
 
     fn entry(path: &[u8]) -> Entry {
         Entry {

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -70,21 +70,34 @@ pub(crate) fn tcp_socket_stats(stream: &TcpStream) -> Option<TcpSocketStats> {
             &mut len,
         )
     };
-    (result == 0).then_some(TcpSocketStats {
-        bytes_sent: info.tcpi_bytes_sent,
-        bytes_retransmitted: info.tcpi_bytes_retrans,
-        segments_sent: info.tcpi_segs_out.into(),
-        segments_received: info.tcpi_segs_in.into(),
-        retransmissions: info.tcpi_total_retrans.into(),
-        rtt_us: info.tcpi_rtt.into(),
-        rtt_variance_us: info.tcpi_rttvar.into(),
-        min_rtt_us: info.tcpi_min_rtt.into(),
-        send_cwnd_bytes: u64::from(info.tcpi_snd_cwnd) * u64::from(info.tcpi_snd_mss),
-        delivery_rate: info.tcpi_delivery_rate,
-        busy_time_us: info.tcpi_busy_time,
-        receive_window_limited_us: info.tcpi_rwnd_limited,
-        send_buffer_limited_us: info.tcpi_sndbuf_limited,
-        ecn_ce_delivered: info.tcpi_delivered_ce.into(),
+    if result != 0 {
+        return None;
+    }
+    macro_rules! field {
+        ($name:ident, $value:expr) => {
+            ((len as usize)
+                >= std::mem::offset_of!(libc::tcp_info, $name) + std::mem::size_of_val(&info.$name))
+            .then(|| $value)
+        };
+    }
+    Some(TcpSocketStats {
+        bytes_sent: field!(tcpi_bytes_sent, info.tcpi_bytes_sent),
+        bytes_retransmitted: field!(tcpi_bytes_retrans, info.tcpi_bytes_retrans),
+        segments_sent: field!(tcpi_segs_out, info.tcpi_segs_out.into()),
+        segments_received: field!(tcpi_segs_in, info.tcpi_segs_in.into()),
+        retransmissions: field!(tcpi_total_retrans, info.tcpi_total_retrans.into()),
+        rtt_us: field!(tcpi_rtt, info.tcpi_rtt.into()),
+        rtt_variance_us: field!(tcpi_rttvar, info.tcpi_rttvar.into()),
+        min_rtt_us: field!(tcpi_min_rtt, info.tcpi_min_rtt.into()),
+        send_cwnd_bytes: field!(
+            tcpi_snd_cwnd,
+            u64::from(info.tcpi_snd_cwnd) * u64::from(info.tcpi_snd_mss)
+        ),
+        delivery_rate: field!(tcpi_delivery_rate, info.tcpi_delivery_rate),
+        busy_time_us: field!(tcpi_busy_time, info.tcpi_busy_time),
+        receive_window_limited_us: field!(tcpi_rwnd_limited, info.tcpi_rwnd_limited),
+        send_buffer_limited_us: field!(tcpi_sndbuf_limited, info.tcpi_sndbuf_limited),
+        ecn_ce_delivered: field!(tcpi_delivered_ce, info.tcpi_delivered_ce.into()),
     })
 }
 
@@ -101,22 +114,33 @@ pub(crate) fn tcp_socket_stats(stream: &TcpStream) -> Option<TcpSocketStats> {
             &mut len,
         )
     };
-    (result == 0).then_some(TcpSocketStats {
-        bytes_sent: info.tcpi_txbytes,
-        bytes_retransmitted: info.tcpi_txretransmitbytes,
-        segments_sent: info.tcpi_txpackets,
-        segments_received: info.tcpi_rxpackets,
-        retransmissions: 0,
+    if result != 0 {
+        return None;
+    }
+    macro_rules! field {
+        ($name:ident, $value:expr) => {
+            ((len as usize)
+                >= std::mem::offset_of!(libc::tcp_connection_info, $name)
+                    + std::mem::size_of_val(&info.$name))
+            .then(|| $value)
+        };
+    }
+    Some(TcpSocketStats {
+        bytes_sent: field!(tcpi_txbytes, info.tcpi_txbytes),
+        bytes_retransmitted: field!(tcpi_txretransmitbytes, info.tcpi_txretransmitbytes),
+        segments_sent: field!(tcpi_txpackets, info.tcpi_txpackets),
+        segments_received: field!(tcpi_rxpackets, info.tcpi_rxpackets),
+        retransmissions: None,
         // Darwin reports these fields in milliseconds.
-        rtt_us: u64::from(info.tcpi_srtt) * 1000,
-        rtt_variance_us: u64::from(info.tcpi_rttvar) * 1000,
-        min_rtt_us: 0,
-        send_cwnd_bytes: info.tcpi_snd_cwnd.into(),
-        delivery_rate: 0,
-        busy_time_us: 0,
-        receive_window_limited_us: 0,
-        send_buffer_limited_us: 0,
-        ecn_ce_delivered: 0,
+        rtt_us: field!(tcpi_srtt, u64::from(info.tcpi_srtt) * 1000),
+        rtt_variance_us: field!(tcpi_rttvar, u64::from(info.tcpi_rttvar) * 1000),
+        min_rtt_us: None,
+        send_cwnd_bytes: field!(tcpi_snd_cwnd, info.tcpi_snd_cwnd.into()),
+        delivery_rate: None,
+        busy_time_us: None,
+        receive_window_limited_us: None,
+        send_buffer_limited_us: None,
+        ecn_ce_delivered: None,
     })
 }
 
@@ -193,6 +217,7 @@ pub struct RemoteConn {
 }
 
 const READ_AHEAD: usize = 4;
+const TRANSPORT_STATS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 fn spawn_reader(
     input: Box<dyn Read + Send>,
@@ -209,6 +234,16 @@ fn spawn_reader(
         }
     });
     rx
+}
+
+fn receive_transport_stats(
+    rx: &std::sync::mpsc::Receiver<std::io::Result<Response>>,
+    timeout: std::time::Duration,
+) -> Option<TcpSocketStats> {
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(Response::TransportStats(stats))) => stats,
+        _ => None,
+    }
 }
 
 fn validate_remote_scan_batch(batch: &[Entry], saw_root: &mut bool) -> Result<()> {
@@ -282,18 +317,15 @@ impl Conn for RemoteConn {
     fn transport_stats(&mut self) -> Option<TcpPairStats> {
         let socket = self.tcp_socket.as_ref()?.try_clone().ok()?;
         let local = tcp_socket_stats(&socket);
-        // Diagnostics must not make a completed copy wait forever for a
-        // wedged peer. The option is socket-wide, including the reader clone.
-        let _ = socket.set_read_timeout(Some(std::time::Duration::from_secs(2)));
-        let peer = if self.dead {
+        // Changing SO_RCVTIMEO cannot wake a reader already blocked on another
+        // clone. Bound the actual response wait instead. This connection is
+        // retired immediately after collection, so a late reply cannot become
+        // a response to a later request.
+        let peer = if self.dead || self.send(Request::TransportStats).is_err() {
             None
         } else {
-            match self.call(Request::TransportStats) {
-                Ok(Response::TransportStats(stats)) => stats,
-                _ => None,
-            }
+            receive_transport_stats(&self.rx, TRANSPORT_STATS_TIMEOUT)
         };
-        let _ = socket.set_read_timeout(None);
         (local.is_some() || peer.is_some()).then(|| TcpPairStats {
             label: self.label.clone(),
             local,
@@ -1397,8 +1429,24 @@ mod tests {
         let client_stats = tcp_socket_stats(&client).unwrap();
         let server_stats = server.join().unwrap();
         assert_eq!(byte, [7]);
-        assert!(client_stats.segments_sent > 0 || client_stats.bytes_sent > 0);
-        assert!(server_stats.segments_sent > 0 || server_stats.bytes_sent > 0);
+        assert!(
+            client_stats.segments_sent.is_some_and(|value| value > 0)
+                || client_stats.bytes_sent.is_some_and(|value| value > 0)
+        );
+        assert!(
+            server_stats.segments_sent.is_some_and(|value| value > 0)
+                || server_stats.bytes_sent.is_some_and(|value| value > 0)
+        );
+    }
+
+    #[test]
+    fn transport_stats_response_wait_has_a_deadline() {
+        let (_sender, receiver) = std::sync::mpsc::sync_channel(1);
+        let timeout = std::time::Duration::from_millis(20);
+        let start = std::time::Instant::now();
+        assert!(receive_transport_stats(&receiver, timeout).is_none());
+        assert!(start.elapsed() >= timeout);
+        assert!(start.elapsed() < std::time::Duration::from_secs(1));
     }
 
     fn entry(path: &[u8]) -> Entry {

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1453,6 +1453,7 @@ impl FsOps {
             }
             Request::Hello { .. }
             | Request::Scan { .. }
+            | Request::TransportStats
             | Request::Shutdown
             | Request::TcpListen { .. } => Err(anyhow!("unexpected request")),
         };

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -21,9 +21,10 @@ pub struct Progress {
     pub rm: bool,
     pub bytes_total: AtomicU64,
     pub bytes_done: AtomicU64,
-    /// Monotonic bytes moved, including work later retried after a dropped
-    /// connection. Logical completion may roll back; tuning activity may not.
-    tuning_bytes: AtomicU64,
+    /// Monotonic high-water mark of logical completion. Recovery may roll
+    /// `bytes_done` back, but retransmitting the same range is not fresh useful
+    /// throughput and cannot advance this meter until progress passes the mark.
+    tuning_high_water: AtomicU64,
     pub bytes_skipped: AtomicU64,
     pub files_total: AtomicU64,
     pub files_done: AtomicU64,
@@ -67,7 +68,7 @@ impl Progress {
             rm: false,
             bytes_total: AtomicU64::new(0),
             bytes_done: AtomicU64::new(0),
-            tuning_bytes: AtomicU64::new(0),
+            tuning_high_water: AtomicU64::new(0),
             bytes_skipped: AtomicU64::new(0),
             files_total: AtomicU64::new(0),
             files_done: AtomicU64::new(0),
@@ -98,8 +99,8 @@ impl Progress {
     }
 
     pub fn add_bytes(&self, n: u64) {
-        self.bytes_done.fetch_add(n, Relaxed);
-        self.tuning_bytes.fetch_add(n, Relaxed);
+        let done = self.bytes_done.fetch_add(n, Relaxed).saturating_add(n);
+        self.tuning_high_water.fetch_max(done, Relaxed);
     }
 
     /// Print a line to stdout, keeping the progress area intact.
@@ -362,7 +363,7 @@ pub fn commas(n: u64) -> String {
 
 impl crate::tune::Meter for Progress {
     fn bytes(&self) -> u64 {
-        self.tuning_bytes.load(Relaxed)
+        self.tuning_high_water.load(Relaxed)
     }
     fn files(&self) -> u64 {
         self.files_done.load(Relaxed)
@@ -378,7 +379,7 @@ mod tests {
     use crate::tune::Meter;
 
     #[test]
-    fn rollback_resets_display_rate_but_not_tuning_activity() {
+    fn rollback_resets_display_rate_and_retries_do_not_inflate_tuning_progress() {
         let progress = Progress::new(1, false, false, None, false);
         progress.add_bytes(1_000);
         let mut term = progress.term.lock().unwrap();
@@ -391,6 +392,8 @@ mod tests {
         assert_eq!(Meter::bytes(&*progress), 1_000);
 
         progress.add_bytes(600);
-        assert_eq!(Meter::bytes(&*progress), 1_600);
+        assert_eq!(Meter::bytes(&*progress), 1_000);
+        progress.add_bytes(100);
+        assert_eq!(Meter::bytes(&*progress), 1_100);
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -21,6 +21,9 @@ pub struct Progress {
     pub rm: bool,
     pub bytes_total: AtomicU64,
     pub bytes_done: AtomicU64,
+    /// Monotonic bytes moved, including work later retried after a dropped
+    /// connection. Logical completion may roll back; tuning activity may not.
+    tuning_bytes: AtomicU64,
     pub bytes_skipped: AtomicU64,
     pub files_total: AtomicU64,
     pub files_done: AtomicU64,
@@ -64,6 +67,7 @@ impl Progress {
             rm: false,
             bytes_total: AtomicU64::new(0),
             bytes_done: AtomicU64::new(0),
+            tuning_bytes: AtomicU64::new(0),
             bytes_skipped: AtomicU64::new(0),
             files_total: AtomicU64::new(0),
             files_done: AtomicU64::new(0),
@@ -95,6 +99,7 @@ impl Progress {
 
     pub fn add_bytes(&self, n: u64) {
         self.bytes_done.fetch_add(n, Relaxed);
+        self.tuning_bytes.fetch_add(n, Relaxed);
     }
 
     /// Print a line to stdout, keeping the progress area intact.
@@ -146,6 +151,14 @@ impl Progress {
     fn rate(&self, t: &mut TermState) -> f64 {
         let now = Instant::now();
         let done = self.bytes_done.load(Relaxed);
+        if t.samples
+            .back()
+            .is_some_and(|&(_, previous)| done < previous)
+        {
+            // Recovery can retract bytes whose acknowledgement is uncertain.
+            // A window spanning that rollback is not a meaningful rate.
+            t.samples.clear();
+        }
         t.samples.push_back((now, done));
         while t.samples.len() > 2 && now - t.samples[0].0 > Duration::from_secs(5) {
             t.samples.pop_front();
@@ -349,12 +362,35 @@ pub fn commas(n: u64) -> String {
 
 impl crate::tune::Meter for Progress {
     fn bytes(&self) -> u64 {
-        self.bytes_done.load(Relaxed)
+        self.tuning_bytes.load(Relaxed)
     }
     fn files(&self) -> u64 {
         self.files_done.load(Relaxed)
     }
     fn set_active(&self, n: usize) {
         self.active_workers.store(n as u64, Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tune::Meter;
+
+    #[test]
+    fn rollback_resets_display_rate_but_not_tuning_activity() {
+        let progress = Progress::new(1, false, false, None, false);
+        progress.add_bytes(1_000);
+        let mut term = progress.term.lock().unwrap();
+        term.samples
+            .push_back((Instant::now() - Duration::from_secs(1), 1_000));
+
+        progress.bytes_done.fetch_sub(600, Relaxed);
+        assert_eq!(progress.rate(&mut term), 0.0);
+        assert_eq!(term.samples.len(), 1);
+        assert_eq!(Meter::bytes(&*progress), 1_000);
+
+        progress.add_bytes(600);
+        assert_eq!(Meter::bytes(&*progress), 1_600);
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -78,25 +78,25 @@ pub mod flags {
     pub const TIMES: u8 = 8;
 }
 
-/// Best-effort kernel counters for one end of a TCP data socket. Zero means
-/// either zero or not exposed by that platform/kernel version; availability of
-/// the structure itself is reported separately by the caller.
+/// Best-effort kernel counters for one end of a TCP data socket. `None` means
+/// the platform or returned kernel structure does not expose that field; a
+/// reported zero is therefore a genuine measurement.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Default)]
 pub struct TcpSocketStats {
-    pub bytes_sent: u64,
-    pub bytes_retransmitted: u64,
-    pub segments_sent: u64,
-    pub segments_received: u64,
-    pub retransmissions: u64,
-    pub rtt_us: u64,
-    pub rtt_variance_us: u64,
-    pub min_rtt_us: u64,
-    pub send_cwnd_bytes: u64,
-    pub delivery_rate: u64,
-    pub busy_time_us: u64,
-    pub receive_window_limited_us: u64,
-    pub send_buffer_limited_us: u64,
-    pub ecn_ce_delivered: u64,
+    pub bytes_sent: Option<u64>,
+    pub bytes_retransmitted: Option<u64>,
+    pub segments_sent: Option<u64>,
+    pub segments_received: Option<u64>,
+    pub retransmissions: Option<u64>,
+    pub rtt_us: Option<u64>,
+    pub rtt_variance_us: Option<u64>,
+    pub min_rtt_us: Option<u64>,
+    pub send_cwnd_bytes: Option<u64>,
+    pub delivery_rate: Option<u64>,
+    pub busy_time_us: Option<u64>,
+    pub receive_window_limited_us: Option<u64>,
+    pub send_buffer_limited_us: Option<u64>,
+    pub ecn_ce_delivered: Option<u64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -78,6 +78,27 @@ pub mod flags {
     pub const TIMES: u8 = 8;
 }
 
+/// Best-effort kernel counters for one end of a TCP data socket. Zero means
+/// either zero or not exposed by that platform/kernel version; availability of
+/// the structure itself is reported separately by the caller.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default)]
+pub struct TcpSocketStats {
+    pub bytes_sent: u64,
+    pub bytes_retransmitted: u64,
+    pub segments_sent: u64,
+    pub segments_received: u64,
+    pub retransmissions: u64,
+    pub rtt_us: u64,
+    pub rtt_variance_us: u64,
+    pub min_rtt_us: u64,
+    pub send_cwnd_bytes: u64,
+    pub delivery_rate: u64,
+    pub busy_time_us: u64,
+    pub receive_window_limited_us: u64,
+    pub send_buffer_limited_us: u64,
+    pub ecn_ce_delivered: u64,
+}
+
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Which {
     Final,
@@ -262,6 +283,10 @@ pub enum Request {
     Canonicalize {
         path: PathBytes,
     },
+    /// Kernel TCP_INFO/TCP_CONNECTION_INFO for this end of a direct data
+    /// socket. SSH data transports report None at the orchestrator instead of
+    /// sending this request.
+    TransportStats,
     Shutdown,
 }
 
@@ -302,6 +327,7 @@ pub enum Response {
         hash: u128,
     },
     Path(PathBytes),
+    TransportStats(Option<TcpSocketStats>),
     Ok,
     Err(String),
 }

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -131,19 +131,14 @@ impl Sched {
             && g.finishes.is_empty()
     }
 
-    /// Whether enough work is left for `n` workers to be measurable: the
-    /// namespace preflight has finished and at least `n` files are queued, or
-    /// the bytes left (queued files and ranges, plus what in-flight ranges
-    /// have not read yet) would keep `n` workers busy past the next window.
-    /// When this is false the transfer is not moving yet or is in its tail,
-    /// so throughput says nothing about the worker count.
-    pub fn work_left_for(&self, n: usize, bytes_per_worker: u64) -> bool {
+    /// Whether enough splittable activity remains to measure `n` workers.
+    /// `minimum_activity` is derived from the observed aggregate rate and the
+    /// time needed for a complete sampling window; queued files add the same
+    /// completion credit the tuner uses for small-file workloads.
+    pub fn work_left_for(&self, n: usize, minimum_activity: u64, file_credit: u64) -> bool {
         let g = self.inner.lock().unwrap();
         if !g.scan_done {
             return false;
-        }
-        if g.files.len() >= n {
-            return true;
         }
         let mut bytes: u64 = g.files.iter().map(|(s, _)| *s).sum();
         bytes += g.ranges.iter().map(|(_, o, e)| e - o).sum::<u64>();
@@ -155,7 +150,10 @@ impl Sched {
                 r.end.saturating_sub(r.pos)
             })
             .sum::<u64>();
-        bytes >= n as u64 * bytes_per_worker
+        let activity = bytes.saturating_add((g.files.len() as u64).saturating_mul(file_credit));
+        let work_units = g.files.len() + g.ranges.len() + g.inflight.len();
+        let parallel = work_units >= n || bytes >= (n as u64).saturating_mul(self.min_split);
+        parallel && activity >= minimum_activity
     }
 
     /// Hand the unread remainder of an in-flight range back to the queue (a
@@ -327,6 +325,20 @@ impl Sched {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tail_gate_combines_bytes_file_credit_and_duration_requirement() {
+        let sched = Sched::new(64, 128);
+        {
+            let mut inner = sched.inner.lock().unwrap();
+            inner.scan_done = true;
+            inner.files.push((100, Reverse(0)));
+            inner.files.push((100, Reverse(1)));
+        }
+        assert!(sched.work_left_for(2, 1_200, 512));
+        assert!(!sched.work_left_for(2, 1_300, 512));
+        assert!(!sched.work_left_for(3, 1_000, 512));
+    }
 
     #[test]
     fn retry_range_replaces_the_failed_inflight_share() {

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -35,12 +35,14 @@ pub type RangeHandle = Arc<Mutex<RangeState>>;
 pub enum Item {
     File(usize),
     Range(RangeHandle),
+    Finish { idx: usize, matched: bool },
     Exit,
 }
 
 struct Inner {
     files: BinaryHeap<(u64, Reverse<usize>)>,
     ranges: Vec<(usize, u64, u64)>,
+    finishes: Vec<(usize, bool)>,
     inflight: Vec<RangeHandle>,
     outstanding: HashMap<usize, u32>,
     failed: HashSet<usize>,
@@ -63,6 +65,7 @@ impl Sched {
             inner: Mutex::new(Inner {
                 files: BinaryHeap::new(),
                 ranges: Vec::new(),
+                finishes: Vec::new(),
                 inflight: Vec::new(),
                 outstanding: HashMap::new(),
                 failed: HashSet::new(),
@@ -125,6 +128,7 @@ impl Sched {
             && g.inflight.is_empty()
             && g.files.is_empty()
             && g.ranges.is_empty()
+            && g.finishes.is_empty()
     }
 
     /// Whether enough work is left for `n` workers to be measurable: the
@@ -183,6 +187,9 @@ impl Sched {
                     let h = Arc::new(Mutex::new(RangeState { idx, pos: off, end }));
                     g.inflight.push(h.clone());
                     return Item::Range(h);
+                }
+                if let Some((idx, matched)) = g.finishes.pop() {
+                    return Item::Finish { idx, matched };
                 }
                 if let Some((_, Reverse(idx))) = g.files.pop() {
                     g.probing += 1;
@@ -286,5 +293,77 @@ impl Sched {
         }
         self.cv.notify_all();
         done
+    }
+
+    /// A connection died with this range's acknowledgements uncertain. Put
+    /// its whole claimed interval back without changing `outstanding`: the
+    /// replacement carries the failed handle's existing share.
+    pub fn retry_range(&self, h: &RangeHandle, start: u64) {
+        let mut g = self.inner.lock().unwrap();
+        g.inflight.retain(|candidate| !Arc::ptr_eq(candidate, h));
+        let range = h.lock().unwrap();
+        if start < range.end {
+            g.ranges.push((range.idx, start, range.end));
+            g.ranges.sort_by_key(|(_, off, end)| end - off);
+        } else {
+            let n = g.outstanding.get_mut(&range.idx).expect("outstanding");
+            *n -= 1;
+            if *n == 0 {
+                g.outstanding.remove(&range.idx);
+                g.finishes.push((range.idx, false));
+            }
+        }
+        self.cv.notify_all();
+    }
+
+    /// Final publication is separate from range accounting so a lost
+    /// Finalize response can be retried on a fresh connection.
+    pub fn requeue_finish(&self, idx: usize, matched: bool) {
+        self.inner.lock().unwrap().finishes.push((idx, matched));
+        self.cv.notify_one();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retry_range_replaces_the_failed_inflight_share() {
+        let sched = Sched::new(64, 128);
+        let range = Arc::new(Mutex::new(RangeState {
+            idx: 4,
+            pos: 192,
+            end: 256,
+        }));
+        {
+            let mut inner = sched.inner.lock().unwrap();
+            inner.inflight.push(range.clone());
+            inner.outstanding.insert(4, 1);
+        }
+        sched.retry_range(&range, 128);
+        let inner = sched.inner.lock().unwrap();
+        assert!(inner.inflight.is_empty());
+        assert_eq!(inner.ranges, vec![(4, 128, 256)]);
+        assert_eq!(inner.outstanding.get(&4), Some(&1));
+    }
+
+    #[test]
+    fn retry_of_an_empty_claim_preserves_finalization() {
+        let sched = Sched::new(64, 128);
+        let range = Arc::new(Mutex::new(RangeState {
+            idx: 5,
+            pos: 256,
+            end: 256,
+        }));
+        {
+            let mut inner = sched.inner.lock().unwrap();
+            inner.inflight.push(range.clone());
+            inner.outstanding.insert(5, 1);
+        }
+        sched.retry_range(&range, 256);
+        let inner = sched.inner.lock().unwrap();
+        assert!(!inner.outstanding.contains_key(&5));
+        assert_eq!(inner.finishes, vec![(5, false)]);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 pub fn run() -> Result<()> {
-    serve(io::stdin(), io::stdout().lock(), true, None, None)
+    serve(io::stdin(), io::stdout().lock(), true, None, None, None)
 }
 
 /// Serve one connection. `over_ssh` connections may set up a TCP listener;
@@ -23,6 +23,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
     over_ssh: bool,
     expect_token: Option<Vec<u8>>,
     authed: Option<&std::sync::atomic::AtomicBool>,
+    tcp_socket: Option<TcpStream>,
 ) -> Result<()> {
     let mut r = FrameReader::new(r);
     let mut w = FrameWriter::new(w, false);
@@ -153,10 +154,18 @@ fn serve<R: Read + Send + 'static, W: Write>(
                     Err(e) => w.write_msg(&Response::Err(format!("{e:#}")))?,
                 }
             }
+            Request::TransportStats => {
+                w.write_msg(&Response::TransportStats(
+                    tcp_socket.as_ref().and_then(crate::conn::tcp_socket_stats),
+                ))?;
+            }
             other => {
                 let t0 = std::time::Instant::now();
                 let resp = ops.handle(&other);
                 t[1] += t0.elapsed().as_secs_f64();
+                if drop_after_handling_for_test(&other) {
+                    return Ok(());
+                }
                 let t0 = std::time::Instant::now();
                 w.write_msg(&resp)?;
                 t[2] += t0.elapsed().as_secs_f64();
@@ -340,11 +349,40 @@ fn serve_tcp(
         false,
         Some(token),
         Some(&authed),
+        Some(stream.try_clone()?),
     );
     if res.is_err() && !authed.load(std::sync::atomic::Ordering::SeqCst) {
         seen.lock().unwrap().remove(&conn_id);
     }
     res
+}
+
+#[cfg(debug_assertions)]
+fn drop_after_handling_for_test(request: &Request) -> bool {
+    let Some(kind) = std::env::var_os("SYQ_TEST_DROP_AFTER_REQUEST") else {
+        return false;
+    };
+    let matches = match kind.to_string_lossy().as_ref() {
+        "write" => matches!(request, Request::WriteRange { .. }),
+        "finalize" => matches!(request, Request::Finalize { .. }),
+        _ => false,
+    };
+    if !matches {
+        return false;
+    }
+    let Some(marker) = std::env::var_os("SYQ_TEST_DROP_MARKER") else {
+        return false;
+    };
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(marker)
+        .is_ok()
+}
+
+#[cfg(not(debug_assertions))]
+fn drop_after_handling_for_test(_request: &Request) -> bool {
+    false
 }
 
 /// Clears the socket read timeout after the first successful read.

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,62 @@ use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
 use std::sync::Arc;
 use std::time::Duration;
 
+struct RequestReader {
+    rx: Option<std::sync::mpsc::Receiver<io::Result<Request>>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+    tcp_socket: Option<TcpStream>,
+}
+
+impl RequestReader {
+    fn spawn<R: Read + Send + 'static>(
+        mut reader: FrameReader<R>,
+        tcp_socket: Option<TcpStream>,
+    ) -> Self {
+        let (tx, rx) = std::sync::mpsc::sync_channel(4);
+        let thread = std::thread::spawn(move || loop {
+            let msg = reader.read_msg::<Request>();
+            let failed = msg.is_err();
+            if tx.send(msg).is_err() || failed {
+                break;
+            }
+        });
+        Self {
+            rx: Some(rx),
+            thread: Some(thread),
+            tcp_socket,
+        }
+    }
+
+    fn recv(&self) -> std::result::Result<io::Result<Request>, std::sync::mpsc::RecvError> {
+        self.rx.as_ref().expect("request receiver present").recv()
+    }
+
+    fn tcp_stats(&self) -> Option<TcpSocketStats> {
+        self.tcp_socket
+            .as_ref()
+            .and_then(crate::conn::tcp_socket_stats)
+    }
+}
+
+impl Drop for RequestReader {
+    fn drop(&mut self) {
+        let tcp = self.tcp_socket.is_some();
+        if let Some(socket) = &self.tcp_socket {
+            let _ = socket.shutdown(std::net::Shutdown::Both);
+        }
+        self.rx.take();
+        // An ssh server process exits immediately after `serve`; joining its
+        // stdin reader here would deadlock while the client waits for process
+        // exit before closing stdin. A TCP socket can be woken explicitly, so
+        // its reader is joined deterministically on every return path.
+        if tcp {
+            if let Some(thread) = self.thread.take() {
+                let _ = thread.join();
+            }
+        }
+    }
+}
+
 pub fn run() -> Result<()> {
     serve(io::stdin(), io::stdout().lock(), true, None, None, None)
 }
@@ -65,22 +121,16 @@ fn serve<R: Read + Send + 'static, W: Write>(
     }
 
     // Requests are parsed on a reader thread so incoming data keeps flowing
-    // while a block is being hashed and written.
-    let (tx, rx) = std::sync::mpsc::sync_channel::<io::Result<Request>>(4);
-    std::thread::spawn(move || loop {
-        let msg = r.read_msg::<Request>();
-        let failed = msg.is_err();
-        if tx.send(msg).is_err() || failed {
-            break;
-        }
-    });
+    // while a block is being hashed and written. TCP readers are shut down and
+    // joined by the guard on every exit path.
+    let reader = RequestReader::spawn(r, tcp_socket);
 
     let mut ops = FsOps::new();
     let mut t = [0f64; 3];
     let (mut blocks, mut bytes) = (0u64, 0u64);
     loop {
         let t0 = std::time::Instant::now();
-        let req: Request = match rx.recv() {
+        let req: Request = match reader.recv() {
             Ok(Ok(req)) => req,
             Ok(Err(e)) if e.kind() == ErrorKind::UnexpectedEof => break,
             Ok(Err(e)) => return Err(e.into()),
@@ -155,9 +205,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 }
             }
             Request::TransportStats => {
-                w.write_msg(&Response::TransportStats(
-                    tcp_socket.as_ref().and_then(crate::conn::tcp_socket_stats),
-                ))?;
+                w.write_msg(&Response::TransportStats(reader.tcp_stats()))?;
             }
             other => {
                 let t0 = std::time::Instant::now();
@@ -358,6 +406,9 @@ fn serve_tcp(
 }
 
 #[cfg(debug_assertions)]
+static TEST_DROP_MATCHES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(debug_assertions)]
 fn drop_after_handling_for_test(request: &Request) -> bool {
     let Some(kind) = std::env::var_os("SYQ_TEST_DROP_AFTER_REQUEST") else {
         return false;
@@ -368,6 +419,13 @@ fn drop_after_handling_for_test(request: &Request) -> bool {
         _ => false,
     };
     if !matches {
+        return false;
+    }
+    let target = std::env::var_os("SYQ_TEST_DROP_AFTER_N_REQUESTS")
+        .and_then(|value| value.to_string_lossy().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(1);
+    if TEST_DROP_MATCHES.fetch_add(1, Relaxed) + 1 < target {
         return false;
     }
     let Some(marker) = std::env::var_os("SYQ_TEST_DROP_MARKER") else {
@@ -400,5 +458,71 @@ impl<R: Read> Read for TimeoutOnce<R> {
             let _ = self.stream.set_read_timeout(None);
         }
         Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ExitObserved<R> {
+        inner: R,
+        dropped: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl<R: Read> Read for ExitObserved<R> {
+        fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+            self.inner.read(buffer)
+        }
+    }
+
+    impl<R> Drop for ExitObserved<R> {
+        fn drop(&mut self) {
+            self.dropped
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn tcp_server_joins_request_reader_on_shutdown() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed = dropped.clone();
+        let server = std::thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            serve(
+                ExitObserved {
+                    inner: socket.try_clone().unwrap(),
+                    dropped: observed,
+                },
+                socket.try_clone().unwrap(),
+                false,
+                None,
+                None,
+                Some(socket),
+            )
+            .unwrap();
+        });
+
+        let socket = TcpStream::connect(address).unwrap();
+        let mut writer = FrameWriter::new(socket.try_clone().unwrap(), false);
+        let mut reader = FrameReader::new(socket);
+        writer
+            .write_msg(&Request::Hello {
+                identity: crate::identity::build().to_string(),
+                compress: false,
+                debug: false,
+                token: Vec::new(),
+            })
+            .unwrap();
+        assert!(matches!(
+            reader.read_msg::<Response>().unwrap(),
+            Response::HelloOk { .. }
+        ));
+        writer.write_msg(&Request::Shutdown).unwrap();
+        server.join().unwrap();
+        assert!(dropped.load(std::sync::atomic::Ordering::SeqCst));
+        assert_eq!(Arc::strong_count(&dropped), 1);
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -2,7 +2,9 @@
 
 use crate::bwlimit::BandwidthLimit;
 use crate::cli::{parse_rsh, parse_size, Args, Location};
-use crate::conn::{ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, TcpCandidate};
+use crate::conn::{
+    ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, TcpCandidate, TcpPairStats,
+};
 use crate::fsops::{is_partial_name, join};
 use crate::progress::{commas, human, Progress, WorkerStatus};
 use crate::proto::*;
@@ -21,6 +23,7 @@ const MAX_ATTEMPTS: u32 = 3;
 pub const LOCAL_DEFAULT_CONNECTIONS: usize = 32;
 const FAST_BATCH_FILES: usize = 64;
 const FAST_BATCH_BYTES: u64 = 16 << 20;
+const CONNECTION_RECOVERY_ATTEMPTS: u32 = 3;
 
 pub struct Opts {
     pub block: u64,
@@ -262,6 +265,92 @@ fn print_transport_diagnostics(args: &Args, src: &Endpoint, dst: &Endpoint) {
             args.connections
         );
     }
+}
+
+fn format_tcp_stats(pairs: &[TcpPairStats], has_ssh_data: bool) -> String {
+    let sockets: Vec<TcpSocketStats> = pairs
+        .iter()
+        .flat_map(|pair| [pair.local, pair.peer].into_iter().flatten())
+        .collect();
+    if sockets.is_empty() {
+        return if has_ssh_data {
+            "\n  tcp statistics: unavailable (data used SSH)".into()
+        } else {
+            "\n  tcp statistics: unavailable on this platform/kernel".into()
+        };
+    }
+    let sum = |field: fn(&TcpSocketStats) -> u64| sockets.iter().map(field).sum::<u64>();
+    let bytes_sent = sum(|stats| stats.bytes_sent);
+    let bytes_retransmitted = sum(|stats| stats.bytes_retransmitted);
+    let segments_sent = sum(|stats| stats.segments_sent);
+    let retransmissions = sum(|stats| stats.retransmissions);
+    let rtts: Vec<u64> = sockets
+        .iter()
+        .map(|stats| stats.rtt_us)
+        .filter(|rtt| *rtt > 0)
+        .collect();
+    let average_rtt = (!rtts.is_empty()).then(|| rtts.iter().sum::<u64>() / rtts.len() as u64);
+    let min_rtt = sockets
+        .iter()
+        .map(|stats| stats.min_rtt_us)
+        .filter(|rtt| *rtt > 0)
+        .min();
+    let retransmit_percent = if bytes_sent > 0 {
+        bytes_retransmitted as f64 * 100.0 / bytes_sent as f64
+    } else {
+        0.0
+    };
+    let retransmit_packet_percent = if segments_sent > 0 {
+        retransmissions as f64 * 100.0 / segments_sent as f64
+    } else {
+        0.0
+    };
+    let congestion_windows: Vec<u64> = sockets
+        .iter()
+        .map(|stats| stats.send_cwnd_bytes)
+        .filter(|window| *window > 0)
+        .collect();
+    let average_congestion_window = (!congestion_windows.is_empty())
+        .then(|| congestion_windows.iter().sum::<u64>() / congestion_windows.len() as u64);
+    let delivery_rate = sum(|stats| stats.delivery_rate);
+    let busy = sum(|stats| stats.busy_time_us);
+    let receive_limited = sum(|stats| stats.receive_window_limited_us);
+    let send_limited = sum(|stats| stats.send_buffer_limited_us);
+    let limited_percent = |limited: u64| {
+        if busy > 0 {
+            limited as f64 * 100.0 / busy as f64
+        } else {
+            0.0
+        }
+    };
+    let paths = pairs
+        .iter()
+        .map(|pair| pair.label.as_str())
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
+    let mut output = format!(
+        "\n  tcp connection lifetimes sampled: {} across {} path(s) ({} socket ends)\n  tcp retransmissions (loss signal): {} packets ({retransmit_packet_percent:.3}% of sent), {} bytes ({retransmit_percent:.3}% of sent)\n  tcp RTT: current average {}, minimum {}\n  tcp congestion: average send window {}, aggregate delivery rate {}\n  tcp window-limited time: receive {:.1}%, send-buffer {:.1}%\n  tcp ECN CE deliveries: {}",
+        pairs.len(),
+        paths,
+        sockets.len(),
+        commas(retransmissions),
+        commas(bytes_retransmitted),
+        average_rtt.map_or_else(|| "unavailable".into(), |value| format!("{:.2} ms", value as f64 / 1000.0)),
+        min_rtt.map_or_else(|| "unavailable".into(), |value| format!("{:.2} ms", value as f64 / 1000.0)),
+        average_congestion_window.map_or_else(|| "unavailable".into(), human),
+        if delivery_rate > 0 {
+            format!("{}/s", human(delivery_rate))
+        } else {
+            "unavailable".into()
+        },
+        limited_percent(receive_limited),
+        limited_percent(send_limited),
+        commas(sum(|stats| stats.ecn_ce_delivered)),
+    );
+    if has_ssh_data {
+        output.push_str("\n  ssh data connections: kernel TCP loss statistics unavailable");
+    }
+    output
 }
 
 /// The canonical form of a path (symlinks and `..` resolved the way the kernel
@@ -586,8 +675,20 @@ pub fn run(args: Args) -> Result<i32> {
     let checkpoint_slot: CheckpointSlot = std::sync::Arc::new(std::sync::OnceLock::new());
     let workers: Arc<Mutex<Vec<std::thread::JoinHandle<Result<()>>>>> =
         Arc::new(Mutex::new(Vec::new()));
+    let transport_stats: Arc<Mutex<Vec<TcpPairStats>>> = Arc::new(Mutex::new(Vec::new()));
     let spawn_worker: Arc<dyn Fn(usize) + Send + Sync> = {
-        let (src_ep, dst_ep, sched, progress, opts, gate, workers, checkpoint_slot, bwlimit) = (
+        let (
+            src_ep,
+            dst_ep,
+            sched,
+            progress,
+            opts,
+            gate,
+            workers,
+            checkpoint_slot,
+            bwlimit,
+            transport_stats,
+        ) = (
             src_ep.clone(),
             dst_ep.clone(),
             sched.clone(),
@@ -597,10 +698,12 @@ pub fn run(args: Args) -> Result<i32> {
             workers.clone(),
             checkpoint_slot.clone(),
             bwlimit.clone(),
+            transport_stats.clone(),
         );
         let compress = args.compress;
+        let collect_tcp_stats = args.stats;
         Arc::new(move |id: usize| {
-            let (src_ep, dst_ep, sched, progress, opts, gate, checkpoint, bwlimit) = (
+            let (src_ep, dst_ep, sched, progress, opts, gate, checkpoint, bwlimit, transport_stats) = (
                 src_ep.clone(),
                 dst_ep.clone(),
                 sched.clone(),
@@ -609,43 +712,99 @@ pub fn run(args: Args) -> Result<i32> {
                 gate.clone(),
                 checkpoint_slot.clone(),
                 bwlimit.clone(),
+                transport_stats.clone(),
             );
             let h = std::thread::spawn(move || -> Result<()> {
-                let t0 = std::time::Instant::now();
-                let conns = src_ep
-                    .connect(compress)
-                    .and_then(|s| Ok((s, dst_ep.connect(compress)?)));
-                // Counted whether or not it worked: the tuner waits for every
-                // requested worker to arrive before judging, and a failed one
-                // must not stall it.
-                gate.connected.fetch_add(1, Relaxed);
-                let (src, dst) = conns?;
-                let mut w = Worker {
-                    id,
-                    src,
-                    dst,
-                    sched,
-                    progress,
-                    opts,
-                    checkpoint,
-                    bwlimit,
-                    gate,
-                    t: [0.0; 4],
-                };
-                if debug() {
-                    eprintln!(
-                        "syq: worker {id} connected in {:.2}s",
-                        t0.elapsed().as_secs_f64()
-                    );
+                let mut failures = 0u32;
+                loop {
+                    if !gate.retained(id) {
+                        gate.mark_absent(id);
+                        return Ok(());
+                    }
+                    let t0 = std::time::Instant::now();
+                    let conns = src_ep
+                        .connect(compress)
+                        .and_then(|src| Ok((src, dst_ep.connect(compress)?)));
+                    let (src, dst) = match conns {
+                        Ok(conns) => conns,
+                        Err(error) => {
+                            failures += 1;
+                            if failures >= CONNECTION_RECOVERY_ATTEMPTS {
+                                gate.mark_failed(id);
+                                return if gate.allowed(id) { Err(error) } else { Ok(()) };
+                            }
+                            gate.mark_warming(id);
+                            if !opts.quiet {
+                                eprintln!(
+                                    "syq: worker {id}: connection setup failed; retrying in {}s ({error:#})",
+                                    1 << (failures - 1)
+                                );
+                            }
+                            std::thread::sleep(std::time::Duration::from_secs(1 << (failures - 1)));
+                            continue;
+                        }
+                    };
+                    gate.mark_ready(id);
+                    let mut worker = Worker {
+                        id,
+                        src,
+                        dst,
+                        sched: sched.clone(),
+                        progress: progress.clone(),
+                        opts: opts.clone(),
+                        checkpoint: checkpoint.clone(),
+                        bwlimit: bwlimit.clone(),
+                        gate: gate.clone(),
+                        t: [0.0; 4],
+                    };
+                    if debug() {
+                        eprintln!(
+                            "syq: worker {id} connected in {:.2}s",
+                            t0.elapsed().as_secs_f64()
+                        );
+                    }
+                    let result = worker.run();
+                    if collect_tcp_stats {
+                        transport_stats
+                            .lock()
+                            .unwrap()
+                            .extend(worker.collect_transport_stats());
+                    }
+                    let dropped = result.is_err() && worker.transport_dead();
+                    match result {
+                        Ok(()) => {
+                            gate.mark_absent(id);
+                            return Ok(());
+                        }
+                        Err(error) if dropped => {
+                            failures += 1;
+                            progress.set_worker(id, None);
+                            if failures >= CONNECTION_RECOVERY_ATTEMPTS {
+                                gate.mark_failed(id);
+                                return Err(error);
+                            }
+                            gate.mark_warming(id);
+                            if !opts.quiet {
+                                eprintln!(
+                                    "syq: worker {id}: connection dropped; reopening in {}s ({error:#})",
+                                    1 << (failures - 1)
+                                );
+                            }
+                            std::thread::sleep(std::time::Duration::from_secs(1 << (failures - 1)));
+                        }
+                        Err(error) => {
+                            gate.mark_failed(id);
+                            return Err(error);
+                        }
+                    }
                 }
-                w.run()
             });
             workers.lock().unwrap().push(h);
         })
     };
     let tuner: Mutex<Option<std::thread::JoinHandle<tune::Policy>>> = Mutex::new(None);
     let spawn_workers = |initial: usize| {
-        for id in 0..initial {
+        for id in gate.begin_warming(initial) {
             spawn_worker(id);
         }
         if autotune {
@@ -658,7 +817,7 @@ pub fn run(args: Args) -> Result<i32> {
             let n0 = initial;
             let policy = tune::Policy::new(n0, tune::MIN, tune::MAX);
             *tuner.lock().unwrap() = Some(std::thread::spawn(move || {
-                tune::run(policy, gate, sched, progress, |id| spawn_worker(id), n0)
+                tune::run(policy, gate, sched, progress, |id| spawn_worker(id))
             }));
         }
     };
@@ -726,9 +885,22 @@ pub fn run(args: Args) -> Result<i32> {
         });
     if autotune && all_remote_endpoints_use_tcp {
         args.connections = tune::START_TCP;
-        gate.set_limit(args.connections);
+        gate.set_active(args.connections);
+    }
+    let tuning_key = autotune.then(|| tune::path_key(&src_ep, &dst_ep)).flatten();
+    let remembered_start = tuning_key.as_deref().and_then(tune::cached);
+    if let Some(remembered) = remembered_start {
+        args.connections = remembered;
+        gate.set_active(remembered);
     }
     print_transport_diagnostics(&args, &src_ep, &dst_ep);
+    if args.verbose >= 2 {
+        if let Some(remembered) = remembered_start {
+            eprintln!(
+                "syq: auto-tuning: starting with {remembered} connections remembered for this path"
+            );
+        }
+    }
     if !opts.dry_run {
         spawn_workers(args.connections);
     }
@@ -1054,6 +1226,22 @@ pub fn run(args: Args) -> Result<i32> {
 
     let errors = progress.errors.load(Relaxed);
 
+    if !aborted
+        && errors == 0
+        && !opts.dry_run
+        && !opts.verify_only
+        && scan_err.is_none()
+        && !collision
+    {
+        if let Some(policy) = tuned.as_ref().filter(|policy| policy.measured()) {
+            // Recompute after the copy: a failed direct TCP path may have
+            // fallen back to ssh, and the two transports must learn separately.
+            if let Some(key) = tune::path_key(&src_ep, &dst_ep).or(tuning_key) {
+                tune::remember(&key, policy.settled());
+            }
+        }
+    }
+
     // Settle an explicit checkpoint. A recording failure only makes a retry
     // recheck more files. The user-selected state persists until they remove it.
     if let Some(state) = &checkpoint_state {
@@ -1147,8 +1335,12 @@ pub fn run(args: Args) -> Result<i32> {
                     done,
                 )
             };
+            let has_ssh_data = [&src_ep, &dst_ep].into_iter().any(|endpoint| {
+                matches!(endpoint, Endpoint::Remote(spec) if spec.data_transport() == DataTransport::Ssh)
+            });
+            let tcp_stats = format_tcp_stats(&transport_stats.lock().unwrap(), has_ssh_data);
             println!(
-                "  scanned entries: {}\n  {files_label}: {}\n  {unchanged_files_label}: {}\n  files excluded: {}\n  {bytes_label}: {}\n  {unchanged_bytes_label}: {}\n  elapsed: {:.2}s\n  connections: {}",
+                "  scanned entries: {}\n  {files_label}: {}\n  {unchanged_files_label}: {}\n  files excluded: {}\n  {bytes_label}: {}\n  {unchanged_bytes_label}: {}\n  elapsed: {:.2}s\n  connections: {}{}",
                 commas(progress.scanned.load(Relaxed)),
                 commas(progress.files_total.load(Relaxed)),
                 commas(progress.files_skipped.load(Relaxed)),
@@ -1168,7 +1360,8 @@ pub fn run(args: Args) -> Result<i32> {
                         p.peak
                     ),
                     None => args.connections.to_string(),
-                }
+                },
+                tcp_stats,
             );
         }
     }
@@ -3410,12 +3603,27 @@ struct BlockDiff {
 impl Worker {
     fn run(&mut self) -> Result<()> {
         let r = self.run_inner();
-        if r.is_err() {
-            // A dead connection here would otherwise leave peers blocked in
-            // sched.next(); wake them so the whole transfer unwinds.
+        if r.is_err() && !self.transport_dead() {
+            // Fatal local/protocol failures cannot be healed by reopening a
+            // transport. Wake peers so the whole transfer unwinds.
             self.sched.abort();
         }
         r
+    }
+
+    fn transport_dead(&self) -> bool {
+        self.src.is_dead() || self.dst.is_dead()
+    }
+
+    fn collect_transport_stats(&mut self) -> Vec<TcpPairStats> {
+        let mut stats = Vec::new();
+        if let Some(value) = self.src.transport_stats() {
+            stats.push(value);
+        }
+        if let Some(value) = self.dst.transport_stats() {
+            stats.push(value);
+        }
+        stats
     }
 
     fn run_inner(&mut self) -> Result<()> {
@@ -3459,14 +3667,31 @@ impl Worker {
                         let (fast, slow): (Vec<usize>, Vec<usize>) =
                             batch.into_iter().partition(|&i| self.fast_eligible(i));
                         if let Err(e) = self.fast_batch(&fast) {
-                            // Transport-level failure: every file in the batch is affected.
                             for &i in &fast {
                                 self.sched.ranges_ready(i, vec![]);
                             }
-                            self.file_error(fast[0], e)?;
+                            if self.transport_dead() {
+                                for &i in &slow {
+                                    self.sched.ranges_ready(i, vec![]);
+                                }
+                                for &i in fast.iter().chain(&slow) {
+                                    self.sched.requeue(i);
+                                }
+                                return Err(e);
+                            }
+                            let message = format!("{e:#}");
+                            for &i in &fast {
+                                self.file_error(i, anyhow::anyhow!(message.clone()))?;
+                            }
                         }
-                        for i in slow {
+                        for (position, &i) in slow.iter().enumerate() {
                             if let Err(e) = self.handle_file(i) {
+                                if self.transport_dead() {
+                                    for &pending in &slow[position + 1..] {
+                                        self.sched.ranges_ready(pending, vec![]);
+                                        self.sched.requeue(pending);
+                                    }
+                                }
                                 self.file_error(i, e)?;
                             }
                         }
@@ -3482,18 +3707,43 @@ impl Worker {
                     }
                 }
                 Item::Range(h) => {
-                    let idx = h.lock().unwrap().idx;
-                    let res = self.transfer_range(&h);
-                    // Remove the handle from the scheduler's in-flight set FIRST,
-                    // so a propagating error can't strand it and deadlock peers.
-                    let done = self.sched.range_done(&h);
+                    let (idx, start) = {
+                        let range = h.lock().unwrap();
+                        (range.idx, range.pos)
+                    };
+                    let mut credited = 0;
+                    let res = self.transfer_range(&h, &mut credited);
                     if let Err(e) = res {
+                        if self.transport_dead() {
+                            self.undo_progress(idx, credited);
+                            self.sched.retry_range(&h, start);
+                            return Err(e);
+                        }
+                        self.sched.range_done(&h);
                         self.file_error(idx, e)?;
+                        continue;
                     }
+                    let done = self.sched.range_done(&h);
                     if done {
                         if let Err(e) = self.finish_file(idx) {
+                            if self.transport_dead() {
+                                self.sched.requeue_finish(idx, false);
+                            }
                             self.file_error(idx, e)?;
                         }
+                    }
+                }
+                Item::Finish { idx, matched } => {
+                    let result = if matched {
+                        self.finish_matched_file(idx)
+                    } else {
+                        self.finish_file(idx)
+                    };
+                    if let Err(e) = result {
+                        if self.transport_dead() {
+                            self.sched.requeue_finish(idx, matched);
+                        }
+                        self.file_error(idx, e)?;
                     }
                 }
             }
@@ -3707,6 +3957,9 @@ impl Worker {
                 Ok(size) => size,
                 Err(error) => {
                     self.sched.ranges_ready(idx, vec![]);
+                    if self.transport_dead() {
+                        self.sched.requeue(idx);
+                    }
                     return Err(error);
                 }
             }
@@ -3729,6 +3982,14 @@ impl Worker {
                 Ok(false) => {} // not offloadable — fall through to streaming
                 Err(e) => {
                     self.sched.ranges_ready(idx, vec![]);
+                    if self.transport_dead() {
+                        // try_copy_local queues publication recovery after it
+                        // has credited the completed kernel copy. Earlier
+                        // connection failures still need the whole probe.
+                        if job.done.load(Relaxed) < job.entry.size {
+                            self.sched.requeue(idx);
+                        }
+                    }
                     return Err(e);
                 }
             }
@@ -3824,6 +4085,9 @@ impl Worker {
             Ok(result) => result,
             Err(e) => {
                 self.sched.ranges_ready(idx, vec![]);
+                if self.transport_dead() {
+                    self.sched.requeue(idx);
+                }
                 return Err(e);
             }
         };
@@ -3835,16 +4099,43 @@ impl Worker {
         self.progress.bytes_total.fetch_sub(size - to_send, Relaxed);
         match self.sched.ranges_ready(idx, ranges) {
             Some(h) => {
-                let res = self.transfer_range(&h);
+                let start = h.lock().unwrap().pos;
+                let mut credited = 0;
+                let res = self.transfer_range(&h, &mut credited);
                 if let Err(e) = res {
-                    self.file_error(idx, e)?;
+                    if self.transport_dead() {
+                        self.undo_progress(idx, credited);
+                        self.sched.retry_range(&h, start);
+                        return Err(e);
+                    }
+                    self.sched.range_done(&h);
+                    return Err(e);
                 }
                 if self.sched.range_done(&h) {
-                    self.finish_file(idx)?;
+                    if let Err(e) = self.finish_file(idx) {
+                        if self.transport_dead() {
+                            self.sched.requeue_finish(idx, false);
+                        }
+                        return Err(e);
+                    }
                 }
             }
-            None if needs_finalize => self.finish_file(idx)?,
-            None => self.finish_matched_file(idx)?,
+            None if needs_finalize => {
+                if let Err(e) = self.finish_file(idx) {
+                    if self.transport_dead() {
+                        self.sched.requeue_finish(idx, false);
+                    }
+                    return Err(e);
+                }
+            }
+            None => {
+                if let Err(e) = self.finish_matched_file(idx) {
+                    if self.transport_dead() {
+                        self.sched.requeue_finish(idx, true);
+                    }
+                    return Err(e);
+                }
+            }
         }
         Ok(())
     }
@@ -3885,7 +4176,12 @@ impl Worker {
                 );
                 self.progress.add_bytes(job.entry.size);
                 job.done.store(job.entry.size, Relaxed);
-                self.finish_file(idx)?;
+                if let Err(e) = self.finish_file(idx) {
+                    if self.transport_dead() {
+                        self.sched.requeue_finish(idx, false);
+                    }
+                    return Err(e);
+                }
                 Ok(true)
             }
             Response::Err(e) if e.contains("EXDEV") => Ok(false),
@@ -4030,16 +4326,15 @@ impl Worker {
         ranges
     }
 
-    fn transfer_range(&mut self, h: &RangeHandle) -> Result<()> {
-        let (idx, start, end0) = {
+    fn transfer_range(&mut self, h: &RangeHandle, credited: &mut u64) -> Result<()> {
+        let idx = {
             let g = h.lock().unwrap();
-            (g.idx, g.pos, g.end)
+            g.idx
         };
         let job = self.job(idx);
         if self.sched.is_failed(idx) {
             return Ok(());
         }
-        let _ = (start, end0);
         self.progress.set_worker(
             self.id,
             Some(WorkerStatus {
@@ -4112,12 +4407,23 @@ impl Worker {
             }
             self.progress.add_bytes(n);
             job.done.fetch_add(n, Relaxed);
+            *credited += n;
         }
         while writes_out > 0 {
             ok(self.dst.recv()?, "write")?;
             writes_out -= 1;
         }
         Ok(())
+    }
+
+    fn undo_progress(&self, idx: usize, credited: u64) {
+        if credited == 0 {
+            return;
+        }
+        self.progress.bytes_done.fetch_sub(credited, Relaxed);
+        self.sched.jobs.lock().unwrap()[idx]
+            .done
+            .fetch_sub(credited, Relaxed);
     }
 
     fn transfer_block(&self) -> u64 {
@@ -4149,7 +4455,7 @@ impl Worker {
         let mut meta = job.entry.meta();
         meta.mode = self.create_mode(&job);
         let flags = self.opts.flags | flags::MODE; // set the computed mode explicitly
-        ok(
+        let finalized = ok(
             self.dst.call(Request::Finalize {
                 path: job.dst.clone(),
                 inplace: job.inplace,
@@ -4158,7 +4464,29 @@ impl Worker {
                 flags,
             })?,
             "finalize destination",
-        )?;
+        );
+        if let Err(error) = finalized {
+            if self.transport_dead() || job.inplace {
+                return Err(error);
+            }
+            // If the response to a previous Finalize was lost, its sidecar is
+            // gone because publication already happened. Verify the final
+            // bytes before treating the retry as successful; if a sidecar is
+            // still present, preserve the real metadata/publication error.
+            let partial_missing = match ok(
+                self.dst.call(Request::ProbePartial {
+                    path: job.dst.clone(),
+                    partial_id: self.partial_id(),
+                })?,
+                "probe partial after finalize",
+            )? {
+                Response::PartialSize(size) => size.is_none(),
+                other => bail!("unexpected response {other:?}"),
+            };
+            if !partial_missing || !self.contents_match(&job)? {
+                return Err(error);
+            }
+        }
         #[cfg(debug_assertions)]
         if let Some(ms) = std::env::var_os("SYQ_TEST_HOLD_AFTER_FINALIZE_MS") {
             if let Ok(ms) = ms.to_string_lossy().parse::<u64>() {
@@ -4166,6 +4494,34 @@ impl Worker {
             }
         }
         self.complete_file(idx, job, false)
+    }
+
+    fn contents_match(&mut self, job: &FileJob) -> Result<bool> {
+        self.src.send(Request::FileHash {
+            path: job.src.clone(),
+        })?;
+        self.dst.send(Request::FileHash {
+            path: job.dst.clone(),
+        })?;
+        let source = self.src.recv();
+        let destination = self.dst.recv();
+        let source = ok(source?, "hash source after finalize")?;
+        let destination = ok(destination?, "hash destination after finalize")?;
+        match (source, destination) {
+            (
+                Response::FileHash {
+                    size: source_size,
+                    hash: source_hash,
+                },
+                Response::FileHash {
+                    size: destination_size,
+                    hash: destination_hash,
+                },
+            ) => Ok(source_size == destination_size && source_hash == destination_hash),
+            (source, destination) => {
+                bail!("unexpected responses {source:?} {destination:?}")
+            }
+        }
     }
 
     fn finish_matched_file(&mut self, idx: usize) -> Result<()> {
@@ -4262,20 +4618,27 @@ impl Worker {
             }
         })();
         self.sched.ranges_ready(idx, vec![]);
-        self.progress.add_bytes(job.entry.size);
-        job.done.store(job.entry.size, Relaxed);
         match r {
             Ok(true) => {
+                self.progress.add_bytes(job.entry.size);
+                job.done.store(job.entry.size, Relaxed);
                 self.progress.files_done.fetch_add(1, Relaxed);
                 if self.opts.verbose > 0 {
                     self.progress.println(&format!("ok      {}", job.rel));
                 }
             }
             Ok(false) => {
+                self.progress.add_bytes(job.entry.size);
+                job.done.store(job.entry.size, Relaxed);
                 self.progress.error(&format!("DIFFERS {}", job.rel));
                 self.sched.fail_file(idx);
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                if self.transport_dead() {
+                    self.sched.requeue(idx);
+                }
+                return Err(e);
+            }
         }
         Ok(())
     }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -279,49 +279,42 @@ fn format_tcp_stats(pairs: &[TcpPairStats], has_ssh_data: bool) -> String {
             "\n  tcp statistics: unavailable on this platform/kernel".into()
         };
     }
-    let sum = |field: fn(&TcpSocketStats) -> u64| sockets.iter().map(field).sum::<u64>();
+    // Aggregates are meaningful only when every sampled socket exposes the
+    // field. Do not turn an unsupported end into a genuine zero.
+    let sum =
+        |field: fn(&TcpSocketStats) -> Option<u64>| sockets.iter().map(field).sum::<Option<u64>>();
+    let values = |field: fn(&TcpSocketStats) -> Option<u64>| {
+        sockets.iter().map(field).collect::<Option<Vec<u64>>>()
+    };
     let bytes_sent = sum(|stats| stats.bytes_sent);
     let bytes_retransmitted = sum(|stats| stats.bytes_retransmitted);
     let segments_sent = sum(|stats| stats.segments_sent);
     let retransmissions = sum(|stats| stats.retransmissions);
-    let rtts: Vec<u64> = sockets
-        .iter()
-        .map(|stats| stats.rtt_us)
-        .filter(|rtt| *rtt > 0)
-        .collect();
-    let average_rtt = (!rtts.is_empty()).then(|| rtts.iter().sum::<u64>() / rtts.len() as u64);
-    let min_rtt = sockets
-        .iter()
-        .map(|stats| stats.min_rtt_us)
-        .filter(|rtt| *rtt > 0)
-        .min();
-    let retransmit_percent = if bytes_sent > 0 {
-        bytes_retransmitted as f64 * 100.0 / bytes_sent as f64
-    } else {
-        0.0
+    let average_rtt =
+        values(|stats| stats.rtt_us).map(|rtts| rtts.iter().sum::<u64>() / rtts.len() as u64);
+    let min_rtt = values(|stats| stats.min_rtt_us).and_then(|rtts| rtts.into_iter().min());
+    let loss = |amount: Option<u64>, sent: Option<u64>| match amount {
+        None => "unavailable".into(),
+        Some(amount) => match sent {
+            Some(sent) if sent > 0 => format!(
+                "{} ({:.3}% of sent)",
+                commas(amount),
+                amount as f64 * 100.0 / sent as f64
+            ),
+            _ => format!("{} (percentage unavailable)", commas(amount)),
+        },
     };
-    let retransmit_packet_percent = if segments_sent > 0 {
-        retransmissions as f64 * 100.0 / segments_sent as f64
-    } else {
-        0.0
-    };
-    let congestion_windows: Vec<u64> = sockets
-        .iter()
-        .map(|stats| stats.send_cwnd_bytes)
-        .filter(|window| *window > 0)
-        .collect();
-    let average_congestion_window = (!congestion_windows.is_empty())
-        .then(|| congestion_windows.iter().sum::<u64>() / congestion_windows.len() as u64);
+    let average_congestion_window = values(|stats| stats.send_cwnd_bytes)
+        .map(|windows| windows.iter().sum::<u64>() / windows.len() as u64);
     let delivery_rate = sum(|stats| stats.delivery_rate);
     let busy = sum(|stats| stats.busy_time_us);
     let receive_limited = sum(|stats| stats.receive_window_limited_us);
     let send_limited = sum(|stats| stats.send_buffer_limited_us);
-    let limited_percent = |limited: u64| {
-        if busy > 0 {
-            limited as f64 * 100.0 / busy as f64
-        } else {
-            0.0
+    let limited_percent = |limited: Option<u64>| match (limited, busy) {
+        (Some(limited), Some(busy)) if busy > 0 => {
+            format!("{:.1}%", limited as f64 * 100.0 / busy as f64)
         }
+        _ => "unavailable".into(),
     };
     let paths = pairs
         .iter()
@@ -329,23 +322,20 @@ fn format_tcp_stats(pairs: &[TcpPairStats], has_ssh_data: bool) -> String {
         .collect::<std::collections::BTreeSet<_>>()
         .len();
     let mut output = format!(
-        "\n  tcp connection lifetimes sampled: {} across {} path(s) ({} socket ends)\n  tcp retransmissions (loss signal): {} packets ({retransmit_packet_percent:.3}% of sent), {} bytes ({retransmit_percent:.3}% of sent)\n  tcp RTT: current average {}, minimum {}\n  tcp congestion: average send window {}, aggregate delivery rate {}\n  tcp window-limited time: receive {:.1}%, send-buffer {:.1}%\n  tcp ECN CE deliveries: {}",
+        "\n  tcp connection lifetimes sampled: {} across {} path(s) ({} socket ends)\n  tcp retransmissions (loss signal): {} packets, {} bytes\n  tcp RTT: current average {}, minimum {}\n  tcp congestion: average send window {}, aggregate delivery rate {}\n  tcp window-limited time: receive {}, send-buffer {}\n  tcp ECN CE deliveries: {}",
         pairs.len(),
         paths,
         sockets.len(),
-        commas(retransmissions),
-        commas(bytes_retransmitted),
+        loss(retransmissions, segments_sent),
+        loss(bytes_retransmitted, bytes_sent),
         average_rtt.map_or_else(|| "unavailable".into(), |value| format!("{:.2} ms", value as f64 / 1000.0)),
         min_rtt.map_or_else(|| "unavailable".into(), |value| format!("{:.2} ms", value as f64 / 1000.0)),
         average_congestion_window.map_or_else(|| "unavailable".into(), human),
-        if delivery_rate > 0 {
-            format!("{}/s", human(delivery_rate))
-        } else {
-            "unavailable".into()
-        },
+        delivery_rate.map_or_else(|| "unavailable".into(), |value| format!("{}/s", human(value))),
         limited_percent(receive_limited),
         limited_percent(send_limited),
-        commas(sum(|stats| stats.ecn_ce_delivered)),
+        sum(|stats| stats.ecn_ce_delivered)
+            .map_or_else(|| "unavailable".into(), commas),
     );
     if has_ssh_data {
         output.push_str("\n  ssh data connections: kernel TCP loss statistics unavailable");
@@ -1176,7 +1166,17 @@ pub fn run(args: Args) -> Result<i32> {
             }
         }
     }
-    let tuned = tuner.lock().unwrap().take().and_then(|t| t.join().ok());
+    let tuned = match tuner.lock().unwrap().take() {
+        Some(thread) => match thread.join() {
+            Ok(policy) => Some(policy),
+            Err(_) => {
+                progress.error("syq: auto-tuning thread panicked");
+                sched.abort();
+                None
+            }
+        },
+        None => None,
+    };
 
     let aborted = sched.is_aborted();
     let mut deleted = 0u64;
@@ -1234,10 +1234,19 @@ pub fn run(args: Args) -> Result<i32> {
         && !collision
     {
         if let Some(policy) = tuned.as_ref().filter(|policy| policy.measured()) {
-            // Recompute after the copy: a failed direct TCP path may have
-            // fallen back to ssh, and the two transports must learn separately.
-            if let Some(key) = tune::path_key(&src_ep, &dst_ep).or(tuning_key) {
-                tune::remember(&key, policy.settled());
+            // A TCP failure affects later connections but leaves earlier TCP
+            // workers alive, so a changed key means the measurements may mix
+            // transports. Such a run is useful live evidence but not a safe
+            // hint for either future pure path.
+            if let Some(initial_key) = tuning_key.as_deref() {
+                let final_key = tune::path_key(&src_ep, &dst_ep);
+                if final_key.as_deref() == Some(initial_key) {
+                    tune::remember(initial_key, policy.settled());
+                } else if debug() {
+                    eprintln!(
+                        "syq: auto-tuning: transport changed during transfer; not updating cache"
+                    );
+                }
             }
         }
     }
@@ -4671,5 +4680,30 @@ mod tests {
                 "clean_root({given:?})"
             );
         }
+    }
+
+    #[test]
+    fn tcp_stats_distinguish_unavailable_fields_from_zero() {
+        let output = format_tcp_stats(
+            &[TcpPairStats {
+                label: "host".into(),
+                local: Some(TcpSocketStats {
+                    bytes_sent: Some(100),
+                    bytes_retransmitted: Some(0),
+                    segments_sent: Some(10),
+                    retransmissions: None,
+                    rtt_us: Some(1_000),
+                    min_rtt_us: None,
+                    ecn_ce_delivered: None,
+                    ..TcpSocketStats::default()
+                }),
+                peer: None,
+            }],
+            false,
+        );
+        assert!(output.contains("unavailable packets, 0 (0.000% of sent) bytes"));
+        assert!(output.contains("current average 1.00 ms, minimum unavailable"));
+        assert!(output.contains("receive unavailable, send-buffer unavailable"));
+        assert!(output.contains("tcp ECN CE deliveries: unavailable"));
     }
 }

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1,29 +1,35 @@
 //! Automatic tuning of the number of parallel workers / connections.
 //!
-//! When `-j` is not given, syq does not guess: it starts with a few workers
-//! and measures. Progress (bytes, plus a small credit per completed file so
-//! small-file transfers count too) is sampled every few seconds; a worker
-//! count has been *measured* once the rate has stopped changing — two
-//! consecutive samples agree — so a burst credit running out, or a link that
-//! is still ramping up, is waited out rather than attributed to the last
-//! change. Each measured count is compared with the previous one: the count
-//! grows by [`STEP`] while that pays at least a third of what linear scaling
-//! would give, shrinks by [`STEP`] while that costs nothing, and then holds.
-//! It never stops watching: in the hold phase it periodically probes a step
-//! down (if throughput doesn't drop, fewer connections were enough — this is
-//! what saves a spinning disk from seek thrash) and a step up (the route or a
-//! shared NAS may have freed up).
+//! When `-j` is not given, syq starts with a modest (or previously learned)
+//! count and measures. Progress (bytes, plus a small credit per completed
+//! file so small-file transfers count too) is sampled every few seconds; a
+//! worker count has been *measured* once the rate has stopped changing. A
+//! successful move keeps exploring in the same direction. A failed move
+//! returns to the last good count and leaves a measured bound that later
+//! probes can refine one integer at a time. Independent per-direction aging
+//! and backoff decide when evidence is stale enough to probe again; when both
+//! directions are equally informative, upward wins the tie because transfer
+//! curves are usually concave or saturating and an extra connection therefore
+//! tends to have lower throughput regret than removing a useful one.
 //!
-//! Workers are never killed. Surplus ones are *parked* — they keep their
-//! connections open and simply stop taking work — so un-parking is instant.
-//! Parking takes effect within one block even in the middle of a huge range:
-//! the worker hands the rest of its range back to the scheduler.
+//! Candidate workers are connected while the current count remains active.
+//! They become active only when the whole candidate set is ready. Surplus
+//! workers are retired after a decision instead of retaining every connection
+//! ever tried (except that count one retains one ready spare for a cheap 1→2
+//! probe). Parking takes effect within one block even in a huge range: the
+//! worker hands the rest of its range back to the scheduler.
 //!
 //! [`Sampler`] turns raw samples into stable measurements and [`Policy`] is
 //! the decision state machine; both are pure and unit tested. [`Gate`] is the
 //! shared switch the workers consult; [`run`] is the driver.
 
+use crate::conn::{DataTransport, Endpoint};
 use crate::sched::Sched;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
@@ -41,13 +47,9 @@ pub const START_LOCAL: usize = 32;
 /// Never auto-tune beyond this many workers.
 pub const MAX: usize = 64;
 /// Never auto-tune below this many.
-pub const MIN: usize = 2;
+pub const MIN: usize = 1;
 /// Multiplicative step between worker counts, up or down.
 pub const STEP: f64 = 1.3;
-/// The initial ramp-up uses this coarser step, so a path that wants many
-/// connections gets them in a few steps; once a coarse step stops paying,
-/// the ramp goes back to the last good count and refines with STEP.
-pub const COARSE_STEP: f64 = 2.0;
 /// A step up is kept if it gains at least this fraction of what linear
 /// scaling would have given (STEP - 1). Lenient on purpose: a false "no
 /// gain" strands a window-capped ssh path at half speed, while a false
@@ -56,11 +58,14 @@ const GAIN_FRACTION: f64 = 1.0 / 3.0;
 /// A step down is kept unless throughput fell by more than this.
 const DOWN_TOLERANCE: f64 = 0.05;
 /// Measurements in the hold phase between probes. Each failed probe in a
-/// direction doubles the wait before that direction is tried again (up to
+/// direction doubles only that direction's wait (up to
 /// 2^PROBE_BACKOFF_MAX times), so a sharp knee — a disk that collapses one
 /// step up — isn't paid for every few measurements forever.
 const PROBE_EVERY: usize = 6;
 const PROBE_BACKOFF_MAX: u32 = 3;
+/// Old high-water measurements must not permanently prevent adaptation when
+/// the path changes during a long transfer.
+const EVIDENCE_MAX_AGE: usize = PROBE_EVERY * 4;
 /// How often progress is sampled.
 pub const SAMPLE: Duration = Duration::from_millis(2500);
 /// Two consecutive samples this close count as a stable rate.
@@ -73,6 +78,143 @@ const TAIL_BYTES_PER_WORKER: u64 = 64 << 20;
 /// A completed file counts as this many bytes, so small-file transfers
 /// (where bytes are negligible) still produce a usable signal.
 pub const FILE_CREDIT: u64 = 512 * 1024;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct TuningCache {
+    /// Deliberately only path+transport → last settled count. Volatile facts
+    /// such as RTT, loss, workload and filesystem are telemetry, not key
+    /// dimensions: a stale count is merely a cheap starting hint.
+    paths: BTreeMap<String, usize>,
+}
+
+fn endpoint_key(endpoint: &Endpoint) -> String {
+    match endpoint {
+        Endpoint::Local => "local".into(),
+        Endpoint::Remote(spec) => spec.label(),
+    }
+}
+
+fn transport_key(endpoint: &Endpoint) -> Option<&'static str> {
+    match endpoint {
+        Endpoint::Local => None,
+        Endpoint::Remote(spec) => Some(match spec.data_transport() {
+            DataTransport::Ssh => "ssh",
+            DataTransport::EncryptedTcp | DataTransport::PlaintextTcp => "tcp",
+        }),
+    }
+}
+
+/// Stable identity for the directional data path. TCP and ssh results never
+/// seed one another. Local-only work is intentionally not persisted: its best
+/// count is primarily a property of whichever filesystems happen to be used.
+pub fn path_key(src: &Endpoint, dst: &Endpoint) -> Option<String> {
+    if !src.is_remote() && !dst.is_remote() {
+        return None;
+    }
+    let transport = [transport_key(src), transport_key(dst)]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join("+");
+    Some(format!(
+        "v1|{}>{}|{transport}",
+        endpoint_key(src),
+        endpoint_key(dst)
+    ))
+}
+
+fn cache_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("SYQ_TUNING_CACHE") {
+        return (!path.is_empty()).then(|| PathBuf::from(path));
+    }
+    std::env::var_os("XDG_CACHE_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|path| !path.is_empty())
+                .map(|home| PathBuf::from(home).join(".cache"))
+        })
+        .map(|root| root.join("syq/tuning-v1.json"))
+}
+
+fn lock_file(path: &Path, exclusive: bool) -> std::io::Result<std::fs::File> {
+    let lock_path = path.with_extension("json.lock");
+    let lock = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(lock_path)?;
+    let operation = if exclusive {
+        libc::LOCK_EX
+    } else {
+        libc::LOCK_SH
+    };
+    if unsafe { libc::flock(lock.as_raw_fd(), operation) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(lock)
+}
+
+fn read_cache(path: &Path) -> TuningCache {
+    std::fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .unwrap_or_default()
+}
+
+fn cached_at(path: &Path, key: &str) -> Option<usize> {
+    let _lock = lock_file(path, false).ok()?;
+    read_cache(path)
+        .paths
+        .get(key)
+        .copied()
+        .map(|n| n.clamp(MIN, MAX))
+}
+
+fn remember_at(path: &Path, key: &str, connections: usize) -> std::io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    let _lock = lock_file(path, true)?;
+    let mut cache = read_cache(path);
+    cache
+        .paths
+        .insert(key.to_string(), connections.clamp(MIN, MAX));
+    let temporary = parent.join(format!(
+        ".{}.{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("tuning"),
+        std::process::id()
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temporary)?;
+    file.write_all(&serde_json::to_vec_pretty(&cache)?)?;
+    file.sync_all()?;
+    std::fs::rename(temporary, path)?;
+    Ok(())
+}
+
+pub fn cached(key: &str) -> Option<usize> {
+    cached_at(&cache_path()?, key)
+}
+
+pub fn remember(key: &str, connections: usize) {
+    let Some(path) = cache_path() else {
+        return;
+    };
+    if let Err(error) = remember_at(&path, key, connections) {
+        if crate::transfer::debug() {
+            eprintln!("syq: tuning cache {}: {error}", path.display());
+        }
+    }
+}
 
 /// Next count up / down by `factor`, always moving by at least one.
 pub fn step_up_by(n: usize, factor: f64) -> usize {
@@ -125,33 +267,69 @@ impl Sampler {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Direction {
+    Down,
+    Up,
+}
+
+impl Direction {
+    fn index(self) -> usize {
+        match self {
+            Direction::Down => 0,
+            Direction::Up => 1,
+        }
+    }
+
+    fn opposite(self) -> Self {
+        match self {
+            Direction::Down => Direction::Up,
+            Direction::Up => Direction::Down,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum State {
-    /// Stepping up while each step pays (`up`; by COARSE_STEP first, then
-    /// STEP), or down while each step costs nothing (`!up`).
-    Ramp { up: bool, coarse: bool },
-    /// Steady; counting measurements until the next probe.
-    Hold { measured: usize, next_up: bool },
-    /// Trying a different count; `from` is where to go back to.
-    Probe { from: usize, up: bool },
+    /// Waiting for the starting count's first useful measurement.
+    Initial,
+    /// Measuring `n` against the last accepted count and its frozen score.
+    Explore {
+        from: usize,
+        base: f64,
+        direction: Direction,
+    },
+    /// The last decision is settled; wait until evidence in either direction
+    /// is old enough to be worth another probe.
+    Hold,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Point {
+    score: f64,
+    measured_at: usize,
 }
 
 /// Pure decision logic. Feed it one stable score per worker count; it
 /// returns the number of workers that should be active from now on.
 #[derive(Debug, Clone)]
 pub struct Policy {
+    /// Candidate count. It can be ahead of `active` while workers warm.
     pub n: usize,
     pub min: usize,
     pub max: usize,
+    /// Highest count that was actually activated, not merely requested.
     pub peak: usize,
+    active: usize,
     state: State,
-    /// The count before the last change.
-    prev: usize,
-    /// Score of the count we compare against.
-    base: Option<f64>,
+    points: BTreeMap<usize, Point>,
     /// Consecutive failed probes up / down.
     fails: [u32; 2],
-    /// Decision log, for --stats / debug.
+    /// Stable-measurement number when each direction may next be probed.
+    due: [usize; 2],
+    tick: usize,
+    comparisons: usize,
+    /// Counts actually activated, for --stats / debug.
     pub history: Vec<usize>,
 }
 
@@ -163,13 +341,13 @@ impl Policy {
             min,
             max,
             peak: n,
-            state: State::Ramp {
-                up: true,
-                coarse: true,
-            },
-            prev: n,
-            base: None,
+            active: n,
+            state: State::Initial,
+            points: BTreeMap::new(),
             fails: [0, 0],
+            due: [PROBE_EVERY, PROBE_EVERY],
+            tick: 0,
+            comparisons: 0,
             history: vec![n],
         }
     }
@@ -178,154 +356,245 @@ impl Policy {
     /// progress, in which case the count it will return to if the probe fails.
     pub fn settled(&self) -> usize {
         match self.state {
-            State::Probe { from, .. } => from,
+            State::Explore { from, .. } => from,
             _ => self.n,
         }
     }
 
-    /// Change the count (clamped). Returns true if it actually changed.
-    fn set(&mut self, n: usize) -> bool {
+    /// Record that the candidate count has become active. Warming a candidate
+    /// does not inflate the peak or the decision history.
+    pub fn activated(&mut self) {
+        if self.active == self.n {
+            return;
+        }
+        self.active = self.n;
+        self.peak = self.peak.max(self.n);
+        self.history.push(self.n);
+    }
+
+    pub fn active(&self) -> usize {
+        self.active
+    }
+
+    /// True only after at least two worker counts were genuinely measured.
+    /// This is the minimum evidence worth persisting as a future start hint.
+    pub fn measured(&self) -> bool {
+        self.comparisons > 0
+    }
+
+    fn probe_base(&self) -> Option<f64> {
+        match self.state {
+            State::Explore { base, .. } => Some(base),
+            _ => None,
+        }
+    }
+
+    /// Cancel a candidate that has not yet been activated (normally because
+    /// the transfer entered its tail before enough workers finished warming).
+    pub fn cancel_unapplied(&mut self) {
+        if self.active == self.n {
+            return;
+        }
+        if let State::Explore {
+            from, direction, ..
+        } = self.state
+        {
+            self.n = from;
+            self.state = State::Hold;
+            // Provisioning is not throughput evidence, but retrying the same
+            // unavailable candidate on the very next measurement is wasteful.
+            self.due[direction.index()] = self.tick + PROBE_EVERY;
+        }
+    }
+
+    /// Change the candidate count (clamped). Returns true if it changed.
+    fn set_candidate(&mut self, n: usize) -> bool {
         let n = n.clamp(self.min, self.max);
         if n == self.n {
             return false;
         }
-        self.prev = self.n;
         self.n = n;
-        self.peak = self.peak.max(n);
-        self.history.push(n);
         true
     }
 
-    fn hold(&mut self, next_up: bool) {
-        self.state = State::Hold {
-            measured: 0,
-            next_up,
-        };
+    fn retry_after(&self, direction: Direction) -> usize {
+        let backoff = self.fails[direction.index()].min(PROBE_BACKOFF_MAX);
+        PROBE_EVERY << backoff
     }
 
-    /// The gain a step up by `factor` must show to be kept.
+    /// The gain a step up by `factor` must show to be kept. This deliberately
+    /// asks for only part of linear scaling: getting stuck below the knee is
+    /// normally more expensive than briefly trying one surplus connection.
     fn gain_needed(factor: f64) -> f64 {
         1.0 + (factor - 1.0) * GAIN_FRACTION
     }
 
-    /// One stable measurement of the current count. Returns the worker count
-    /// to apply from now on (`self.n` when nothing changes).
-    pub fn observe(&mut self, score: f64) -> usize {
-        let Some(base) = self.base else {
-            self.base = Some(score);
-            if let State::Ramp { up: true, coarse } = self.state {
-                if score > 0.0 {
-                    // First real measurement: try a step up right away.
-                    let f = if coarse { COARSE_STEP } else { STEP };
-                    self.set(step_up_by(self.n, f));
+    fn record(&mut self, n: usize, score: f64) {
+        self.points
+            .entry(n)
+            .and_modify(|point| {
+                point.score = 0.5 * point.score + 0.5 * score;
+                point.measured_at = self.tick;
+            })
+            .or_insert(Point {
+                score,
+                measured_at: self.tick,
+            });
+    }
+
+    /// Pick an unmeasured integer inside the nearest bound before taking
+    /// another geometric step. This is what turns measurements at 10 and 13
+    /// into a later probe at 11 rather than needlessly re-testing 10.
+    fn target(&self, direction: Direction) -> usize {
+        match direction {
+            Direction::Down => {
+                if self.n <= self.min {
+                    return self.n;
                 }
+                if let Some((&lower, point)) = self.points.range(self.min..self.n).next_back() {
+                    if self.n - lower > 1 {
+                        return lower + (self.n - lower) / 2;
+                    }
+                    if self.tick.saturating_sub(point.measured_at) <= EVIDENCE_MAX_AGE
+                        && point.score < self.recent_best() * (1.0 - DOWN_TOLERANCE)
+                    {
+                        return self.n;
+                    }
+                    return lower;
+                }
+                step_down(self.n).max(self.min)
             }
-            return self.n;
-        };
-        if base <= 0.0 && score <= 0.0 {
-            return self.n; // nothing is moving; no information
+            Direction::Up => {
+                if self.n >= self.max {
+                    return self.n;
+                }
+                if let Some((&upper, point)) = self
+                    .points
+                    .range((
+                        std::ops::Bound::Excluded(self.n),
+                        std::ops::Bound::Included(self.max),
+                    ))
+                    .next()
+                {
+                    if upper - self.n > 1 {
+                        return self.n + (upper - self.n).div_ceil(2);
+                    }
+                    let current = self.points.get(&self.n).map_or(0.0, |point| point.score);
+                    let factor = upper as f64 / self.n as f64;
+                    if self.tick.saturating_sub(point.measured_at) <= EVIDENCE_MAX_AGE
+                        && point.score <= current * Self::gain_needed(factor)
+                    {
+                        return self.n;
+                    }
+                    return upper;
+                }
+                step_up(self.n).min(self.max)
+            }
         }
-        let ratio = if base > 0.0 {
-            score / base
-        } else {
-            f64::INFINITY
+    }
+
+    fn begin(&mut self, direction: Direction, base: f64) -> bool {
+        let from = self.n;
+        let target = self.target(direction);
+        if !self.set_candidate(target) {
+            self.due[direction.index()] = if (direction == Direction::Down && self.n == self.min)
+                || (direction == Direction::Up && self.n == self.max)
+            {
+                usize::MAX
+            } else {
+                self.tick + self.retry_after(direction)
+            };
+            return false;
+        }
+        self.state = State::Explore {
+            from,
+            base,
+            direction,
         };
+        true
+    }
+
+    fn begin_due_probe(&mut self, base: f64) {
+        let down = self.due[Direction::Down.index()] <= self.tick && self.n > self.min;
+        let up = self.due[Direction::Up.index()] <= self.tick && self.n < self.max;
+        // Up is the deterministic tie-break. It is a prior, not an invariant:
+        // a failed upward probe backs off independently, allowing down to win.
+        let direction = match (down, up) {
+            (_, true) => Some(Direction::Up),
+            (true, false) => Some(Direction::Down),
+            (false, false) => None,
+        };
+        if let Some(direction) = direction {
+            self.begin(direction, base);
+        }
+    }
+
+    fn recent_best(&self) -> f64 {
+        self.points
+            .values()
+            .filter(|point| self.tick.saturating_sub(point.measured_at) <= EVIDENCE_MAX_AGE)
+            .map(|point| point.score)
+            .fold(0.0, f64::max)
+    }
+
+    /// One stable measurement of the current count. Returns the worker count
+    /// to prepare or apply next (`self.n` when nothing changes).
+    pub fn observe(&mut self, score: f64) -> usize {
+        debug_assert_eq!(
+            self.active, self.n,
+            "candidate must be active before measuring"
+        );
+        self.tick += 1;
+        self.record(self.n, score);
         match self.state {
-            State::Ramp { up: true, coarse } => {
-                let factor = if coarse { COARSE_STEP } else { STEP };
-                let p = self.prev.min(self.n);
-                if ratio > Self::gain_needed(factor) {
-                    self.base = Some(score);
-                    if self.n < self.max {
-                        self.set(step_up_by(self.n, factor));
-                    } else {
-                        // It paid all the way up to the cap: stay there.
-                        self.hold(false);
-                    }
-                } else if coarse && step_up(p) < self.n {
-                    // The doubling from `p` didn't pay as a whole, but the
-                    // best count may lie between p and 2p: go back to p and
-                    // refine upward in finer steps, judged against p's score.
-                    self.set(step_up(p));
-                    self.prev = p;
-                    self.state = State::Ramp {
-                        up: true,
-                        coarse: false,
-                    };
-                } else if p > self.min && step_down(p) >= self.min {
-                    // Even a fine step from `p` bought nothing (or hurt):
-                    // `p` did the same work for less. Maybe fewer still
-                    // does — ramp down, judging each step against p's score
-                    // (`base`), going there directly.
-                    self.set(step_down(p));
-                    self.prev = p;
-                    self.state = State::Ramp {
-                        up: false,
-                        coarse: false,
-                    };
-                } else {
-                    self.set(p);
-                    self.base = Some(score);
-                    self.hold(false);
-                }
-            }
-            State::Ramp { up: false, .. } => {
-                if ratio >= 1.0 - DOWN_TOLERANCE {
-                    // Fewer kept up: keep it, try fewer again.
-                    self.base = Some(score);
-                    if self.n > self.min && step_down(self.n) >= self.min {
-                        self.set(step_down(self.n));
-                    } else {
-                        self.hold(true);
-                    }
-                } else {
-                    // Too few: go back to the last count that kept up.
-                    self.set(self.prev);
-                    self.hold(true);
-                }
-            }
-            State::Hold { measured, next_up } => {
-                // Track the baseline slowly so a drifting route doesn't make
-                // every later comparison meaningless.
-                self.base = Some(0.5 * base + 0.5 * score);
-                let measured = measured + 1;
-                let backoff = self.fails[usize::from(!next_up)].min(PROBE_BACKOFF_MAX);
-                if measured < PROBE_EVERY << backoff {
-                    self.state = State::Hold { measured, next_up };
-                } else {
-                    let target = if next_up {
-                        step_up(self.n)
-                    } else {
-                        step_down(self.n)
-                    };
-                    let from = self.n;
-                    if self.set(target) {
-                        self.state = State::Probe { from, up: next_up };
-                    } else {
-                        // Can't move that way; try the other direction next time.
-                        self.hold(!next_up);
+            State::Initial => {
+                if score > 0.0 {
+                    // A first 1.3× upward step discovers paths that can use
+                    // more workers without greedily opening twice the start.
+                    if !self.begin(Direction::Up, score) {
+                        self.begin(Direction::Down, score);
                     }
                 }
             }
-            State::Probe { from, up } => {
-                let keep = if up {
-                    ratio > Self::gain_needed(STEP)
+            State::Hold => self.begin_due_probe(score),
+            State::Explore {
+                from,
+                base,
+                direction,
+            } => {
+                if base <= 0.0 && score <= 0.0 {
+                    return self.n;
+                }
+                let ratio = if base > 0.0 {
+                    score / base
                 } else {
-                    ratio >= 1.0 - DOWN_TOLERANCE
+                    f64::INFINITY
                 };
+                let keep = match direction {
+                    Direction::Up => {
+                        let factor = self.n as f64 / from as f64;
+                        ratio > Self::gain_needed(factor)
+                    }
+                    Direction::Down => score >= self.recent_best() * (1.0 - DOWN_TOLERANCE),
+                };
+                self.comparisons += 1;
+                let idx = direction.index();
+                let inverse = direction.opposite().index();
                 if keep {
-                    // A successful move: try further in the same direction
-                    // sooner than usual.
-                    self.fails[usize::from(!up)] = 0;
-                    self.base = Some(score);
-                    self.state = State::Hold {
-                        measured: PROBE_EVERY / 2,
-                        next_up: up,
-                    };
+                    self.fails[idx] = 0;
+                    self.due[inverse] = self.due[inverse].max(self.tick + PROBE_EVERY);
+                    self.state = State::Hold;
+                    // Success is direct evidence that there may be more gain
+                    // in the same direction, so continue immediately.
+                    self.begin(direction, score);
                 } else {
-                    self.fails[usize::from(!up)] += 1;
-                    self.set(from);
-                    self.hold(!up);
+                    self.fails[idx] += 1;
+                    self.due[idx] = self.tick + self.retry_after(direction);
+                    // Do not mechanically bounce to the opposite side after
+                    // a failed probe. Let current throughput settle first.
+                    self.due[inverse] = self.due[inverse].max(self.tick + PROBE_EVERY);
+                    self.set_candidate(from);
+                    self.state = State::Hold;
                 }
             }
         }
@@ -333,49 +602,158 @@ impl Policy {
     }
 }
 
-/// The switch workers consult: worker `id` may work iff `id < limit`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SlotPhase {
+    Absent,
+    Warming,
+    Ready,
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+struct Slot {
+    phase: SlotPhase,
+}
+
+impl Default for Slot {
+    fn default() -> Self {
+        Self {
+            phase: SlotPhase::Absent,
+        }
+    }
+}
+
+/// The worker lifecycle shared by the tuner and workers. `active` controls who
+/// may take work; `retain` controls who keeps a connection while parked. Slot
+/// state distinguishes a genuinely ready connection from one still warming or
+/// one whose setup failed.
 pub struct Gate {
-    limit: AtomicUsize,
-    /// Workers whose connections are up (parked or not).
-    pub connected: AtomicUsize,
-    m: Mutex<()>,
+    active: AtomicUsize,
+    retain: AtomicUsize,
+    slots: Mutex<Vec<Slot>>,
     cv: Condvar,
 }
 
 impl Gate {
-    pub fn new(limit: usize) -> Arc<Self> {
+    pub fn new(active: usize) -> Arc<Self> {
         Arc::new(Gate {
-            limit: AtomicUsize::new(limit),
-            connected: AtomicUsize::new(0),
-            m: Mutex::new(()),
+            active: AtomicUsize::new(active),
+            retain: AtomicUsize::new(active),
+            slots: Mutex::new(Vec::new()),
             cv: Condvar::new(),
         })
     }
 
     pub fn allowed(&self, id: usize) -> bool {
-        id < self.limit.load(Relaxed)
+        id < self.active.load(Relaxed)
     }
 
-    pub fn set_limit(&self, n: usize) {
-        let _g = self.m.lock().unwrap();
-        self.limit.store(n, Relaxed);
+    pub fn active(&self) -> usize {
+        self.active.load(Relaxed)
+    }
+
+    pub fn set_active(&self, n: usize) {
+        let _g = self.slots.lock().unwrap();
+        self.active.store(n, Relaxed);
+        self.retain.fetch_max(n, Relaxed);
         self.cv.notify_all();
     }
 
+    pub fn set_retain(&self, n: usize) {
+        let _g = self.slots.lock().unwrap();
+        self.retain.store(n.max(self.active()), Relaxed);
+        self.cv.notify_all();
+    }
+
+    /// Claim absent slots through `n` for connection setup.
+    pub fn begin_warming(&self, n: usize) -> Vec<usize> {
+        let mut slots = self.slots.lock().unwrap();
+        slots.resize_with(n, Slot::default);
+        let mut ids = Vec::new();
+        for (id, slot) in slots.iter_mut().take(n).enumerate() {
+            if slot.phase == SlotPhase::Absent {
+                slot.phase = SlotPhase::Warming;
+                ids.push(id);
+            }
+        }
+        ids
+    }
+
+    pub fn mark_ready(&self, id: usize) {
+        let mut slots = self.slots.lock().unwrap();
+        slots.resize_with(id + 1, Slot::default);
+        slots[id].phase = SlotPhase::Ready;
+        self.cv.notify_all();
+    }
+
+    pub fn mark_warming(&self, id: usize) {
+        let mut slots = self.slots.lock().unwrap();
+        slots.resize_with(id + 1, Slot::default);
+        slots[id].phase = SlotPhase::Warming;
+        self.cv.notify_all();
+    }
+
+    /// Mark a cleanly retired worker reusable immediately.
+    pub fn mark_absent(&self, id: usize) {
+        let mut slots = self.slots.lock().unwrap();
+        slots.resize_with(id + 1, Slot::default);
+        slots[id] = Slot::default();
+        self.cv.notify_all();
+    }
+
+    /// Mark setup or repeated connection loss after bounded retries.
+    pub fn mark_failed(&self, id: usize) {
+        let mut slots = self.slots.lock().unwrap();
+        slots.resize_with(id + 1, Slot::default);
+        slots[id].phase = SlotPhase::Failed;
+        self.cv.notify_all();
+    }
+
+    pub fn retained(&self, id: usize) -> bool {
+        id < self.retain.load(Relaxed)
+    }
+
+    pub fn ready_through(&self, n: usize) -> bool {
+        let slots = self.slots.lock().unwrap();
+        slots.len() >= n
+            && slots
+                .iter()
+                .take(n)
+                .all(|slot| slot.phase == SlotPhase::Ready)
+    }
+
+    pub fn permanent_failure_through(&self, n: usize) -> bool {
+        self.slots
+            .lock()
+            .unwrap()
+            .iter()
+            .take(n)
+            .any(|slot| slot.phase == SlotPhase::Failed)
+    }
+
+    pub fn clear_failed_from(&self, first: usize) {
+        let mut slots = self.slots.lock().unwrap();
+        for slot in slots.iter_mut().skip(first) {
+            if slot.phase == SlotPhase::Failed {
+                *slot = Slot::default();
+            }
+        }
+    }
+
     /// Block until `id` is allowed again. Returns false if the transfer is
-    /// over (`done` became true) and the worker should exit instead.
+    /// over or this surplus connection should be retired.
     pub fn park(&self, id: usize, done: impl Fn() -> bool) -> bool {
-        let mut g = self.m.lock().unwrap();
+        let mut slots = self.slots.lock().unwrap();
         loop {
             if self.allowed(id) {
                 return true;
             }
-            if done() {
+            if done() || id >= self.retain.load(Relaxed) {
                 return false;
             }
-            g = self
+            slots = self
                 .cv
-                .wait_timeout(g, Duration::from_millis(250))
+                .wait_timeout(slots, Duration::from_millis(250))
                 .unwrap()
                 .0;
         }
@@ -398,17 +776,94 @@ pub fn run(
     sched: Arc<Sched>,
     meter: Arc<dyn Meter>,
     mut spawn: impl FnMut(usize),
-    mut spawned: usize,
 ) -> Policy {
     let mut policy = policy;
     let mut sampler = Sampler::default();
     sampler.reset();
     let mut last = (meter.bytes(), meter.files());
     let mut sample_start = std::time::Instant::now();
+    let mut active = policy.active();
+    let mut collapse_samples = 0;
     meter.set_active(policy.n);
     loop {
         std::thread::sleep(Duration::from_millis(250));
         if sched.is_aborted() || sched.finished() {
+            break;
+        }
+
+        // Apply reductions immediately. An increase leaves the current set
+        // active while its candidate workers connect in the background.
+        if policy.n < active {
+            let before = active;
+            gate.set_active(policy.n);
+            active = policy.n;
+            policy.activated();
+            meter.set_active(active);
+            gate.set_retain(if active == 1 { 2 } else { active });
+            sampler.reset();
+            collapse_samples = 0;
+            last = (meter.bytes(), meter.files());
+            sample_start = std::time::Instant::now();
+            if crate::transfer::debug() {
+                eprintln!(
+                    "syq: tune: {before} -> {active} workers (state {:?})",
+                    policy.state
+                );
+            }
+            continue;
+        }
+        if policy.n > active {
+            if !sched.work_left_for(policy.n, TAIL_BYTES_PER_WORKER) {
+                policy.cancel_unapplied();
+                gate.set_retain(if active == 1 { 2 } else { active });
+                continue;
+            }
+            gate.set_retain(policy.n);
+            for id in gate.begin_warming(policy.n) {
+                spawn(id);
+            }
+            if gate.permanent_failure_through(policy.n) {
+                if gate.permanent_failure_through(active) {
+                    sched.abort();
+                    break;
+                }
+                // Failure to provision an optional upward probe is not a
+                // throughput result and must not fail the copy.
+                policy.cancel_unapplied();
+                gate.set_retain(if active == 1 { 2 } else { active });
+                gate.clear_failed_from(active);
+                continue;
+            }
+            if gate.ready_through(policy.n) {
+                let before = active;
+                gate.set_active(policy.n);
+                active = policy.n;
+                policy.activated();
+                meter.set_active(active);
+                sampler.reset();
+                collapse_samples = 0;
+                last = (meter.bytes(), meter.files());
+                sample_start = std::time::Instant::now();
+                if crate::transfer::debug() {
+                    eprintln!(
+                        "syq: tune: {before} -> {active} workers (candidate ready, state {:?})",
+                        policy.state
+                    );
+                }
+            }
+            // Provisioning time is not a throughput measurement.
+            continue;
+        }
+
+        // Heal an unexpectedly missing active slot. At one active worker keep
+        // exactly one ready spare so the important 1→2 probe is instantaneous.
+        let retain = if active == 1 { 2 } else { active };
+        gate.set_retain(retain);
+        for id in gate.begin_warming(retain) {
+            spawn(id);
+        }
+        if gate.permanent_failure_through(active) {
+            sched.abort();
             break;
         }
         if sample_start.elapsed() < SAMPLE {
@@ -420,8 +875,7 @@ pub fn run(
         // Only judge a configuration once every requested worker is actually
         // connected (ssh sessions can take seconds each), and only while there
         // is enough work left — in the tail, idle workers say nothing.
-        let all_up = gate.connected.load(Relaxed) >= policy.n.min(spawned);
-        if !all_up || !sched.work_left_for(policy.n, TAIL_BYTES_PER_WORKER) {
+        if !gate.ready_through(active) || !sched.work_left_for(active, TAIL_BYTES_PER_WORKER) {
             last = now;
             sampler.reset();
             continue;
@@ -430,22 +884,31 @@ pub fn run(
         // throughput change.
         let rate = ((now.0 - last.0) as f64 + (now.1 - last.1) as f64 * FILE_CREDIT as f64) / secs;
         last = now;
+        if policy
+            .probe_base()
+            .is_some_and(|base| base > 0.0 && rate < 0.5 * base)
+        {
+            collapse_samples += 1;
+        } else {
+            collapse_samples = 0;
+        }
+        if collapse_samples >= 2 {
+            policy.observe(rate);
+            sampler.reset();
+            collapse_samples = 0;
+            continue;
+        }
         let Some(score) = sampler.push(rate) else {
             continue;
         };
         let before = policy.n;
-        let n = policy.observe(score);
-        if n != before {
-            while spawned < n {
-                spawn(spawned);
-                spawned += 1;
-            }
-            gate.set_limit(n);
-            meter.set_active(n);
+        policy.observe(score);
+        if policy.n != before {
             sampler.reset();
             if crate::transfer::debug() {
                 eprintln!(
-                    "syq: tune: {before} -> {n} workers (measured {:.1} MB/s at {before}, state {:?})",
+                    "syq: tune: candidate {before} -> {} workers (measured {:.1} MB/s at {before}, state {:?})",
+                    policy.n,
                     score / 1e6,
                     policy.state
                 );
@@ -459,13 +922,51 @@ pub fn run(
 mod tests {
     use super::*;
 
+    fn remote(host: &str, tcp: bool) -> Endpoint {
+        Endpoint::Remote(crate::conn::RemoteSpec {
+            user: Some("user".into()),
+            host: host.into(),
+            rsh: vec!["ssh".into()],
+            syq_path: None,
+            auto_helper: false,
+            helper_install: Default::default(),
+            quiet: true,
+            tcp: std::sync::Arc::new(std::sync::Mutex::new(tcp.then(|| crate::conn::TcpInfo {
+                addrs: vec!["127.0.0.1".into()],
+                port: 1,
+                key: Some(vec![0; 32]),
+                token: vec![],
+                failed: false,
+                failure: None,
+                next: Default::default(),
+            }))),
+            diagnostics: Default::default(),
+        })
+    }
+
+    fn temporary_cache(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "syq-tune-test-{}-{name}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn measure(p: &mut Policy, score: f64) {
+        p.observe(score);
+        p.activated();
+    }
+
     /// Feed the policy a model where throughput rises linearly with workers
     /// up to `cap` workers and is flat after.
     fn simulate(start: usize, cap: usize, rounds: usize, noise: impl Fn(usize) -> f64) -> Policy {
         let mut p = Policy::new(start, MIN, MAX);
         for i in 0..rounds {
             let eff = p.n.min(cap) as f64;
-            p.observe(eff * 10e6 * noise(i));
+            measure(&mut p, eff * 10e6 * noise(i));
         }
         p
     }
@@ -475,7 +976,7 @@ mod tests {
         assert_eq!(step_up(8), 10);
         assert_eq!(step_up(2), 3);
         assert_eq!(step_down(8), 6);
-        assert_eq!(step_down(3), 2);
+        assert_eq!(step_down(2), 1);
         let mut n = START_SSH;
         let mut steps = 0;
         while n < MAX {
@@ -486,62 +987,71 @@ mod tests {
     }
 
     #[test]
-    fn ramps_to_the_plateau_and_holds() {
-        let p = simulate(START_SSH, 32, 40, |_| 1.0);
-        // Doubles up to the knee, overshoots once, refines, and stays.
-        assert_eq!(
-            &p.history[..5],
-            &[8, 16, 32, 64, 42],
-            "history {:?}",
-            p.history
-        );
-        assert!((25..=42).contains(&p.settled()), "history {:?}", p.history);
+    fn first_probe_is_modest_instead_of_doubling() {
+        let mut p = Policy::new(START_SSH, MIN, MAX);
+        measure(&mut p, 80.0);
+        assert_eq!(p.n, 10);
+        assert_eq!(p.history, vec![8, 10]);
+    }
+
+    #[test]
+    fn successful_direction_continues_to_the_plateau() {
+        let p = simulate(START_SSH, 32, 80, |_| 1.0);
+        assert_eq!(&p.history[..6], &[8, 10, 13, 17, 22, 29]);
+        // 31 is the smallest integer within 5% of the observed best (32).
+        assert_eq!(p.settled(), 31, "history {:?}", p.history);
     }
 
     #[test]
     fn a_gain_at_the_cap_holds_at_the_cap() {
-        // Linear all the way past MAX (e.g. a fast NAS): 32 -> 64 doubles
-        // throughput, and 64 is the cap, so it must stay at 64.
-        let p = simulate(START_LOCAL, 200, 30, |_| 1.0);
-        assert_eq!(&p.history[..2], &[32, 64], "history {:?}", p.history);
-        assert_eq!(p.settled(), MAX, "history {:?}", p.history);
-        assert!(
-            p.history[1..].iter().all(|&n| n >= 48),
-            "history {:?}",
-            p.history
-        );
+        let p = simulate(START_LOCAL, 200, 40, |_| 1.0);
+        // Once the cap establishes the best score, downward refinement finds
+        // the smallest integer within the 5% near-best tolerance.
+        assert_eq!(p.settled(), 61, "history {:?}", p.history);
+        assert_eq!(p.peak, MAX);
     }
 
     #[test]
-    fn coarse_ramp_refines_between_doublings() {
-        // Scales linearly up to 24 workers: 16 -> 32 as a whole gains only
-        // 50% of the 100% linear would give... which is above a third, so
-        // model a sharper case: flat past 20. 16 -> 32 gains 25% (< 33%),
-        // so it goes back to 16 and refines: 21 (+25% of 30%: kept), 27
-        // (flat), back to 21, then descends 16 (worse), settles 21.
-        let p = simulate(START_SSH, 20, 40, |_| 1.0);
-        assert_eq!(
-            &p.history[..5],
-            &[8, 16, 32, 21, 27],
-            "history {:?}",
-            p.history
-        );
-        assert_eq!(p.settled(), 21, "history {:?}", p.history);
+    fn a_failed_up_probe_does_not_immediately_bounce_down() {
+        let mut p = Policy::new(10, MIN, MAX);
+        measure(&mut p, 100.0); // 10 -> 13
+        measure(&mut p, 130.0); // 13 paid; try 17
+        measure(&mut p, 130.0); // 17 did not; return to 13
+        assert_eq!(p.n, 13);
+        for _ in 0..PROBE_EVERY - 1 {
+            measure(&mut p, 130.0);
+            assert_eq!(p.n, 13, "history {:?}", p.history);
+        }
+        measure(&mut p, 130.0);
+        // The later down probe refines the measured 10..13 bracket.
+        assert_eq!(p.n, 11, "history {:?}", p.history);
     }
 
     #[test]
-    fn does_not_grow_when_it_never_pays() {
-        // One worker already saturates the link (TCP on a clean path).
-        let p = simulate(START_SSH, 1, 40, |_| 1.0);
-        // The doubling fails, the fine step fails, then it walks down since
-        // nothing drops.
-        assert!(p.settled() < START_SSH, "history {:?}", p.history);
-        assert_eq!(&p.history[..3], &[8, 16, 10]);
+    fn refines_to_the_smallest_near_best_integer() {
+        let mut p = Policy::new(10, MIN, MAX);
+        measure(&mut p, 100.0);
+        measure(&mut p, 130.0);
+        measure(&mut p, 130.0);
+        for _ in 0..PROBE_EVERY {
+            measure(&mut p, 130.0);
+        }
+        assert_eq!(p.n, 11);
+        measure(&mut p, 129.0);
+        // 10 is a fresh lower bound and was materially slower; do not retest
+        // it immediately just because the probe at 11 succeeded.
+        assert_eq!(p.settled(), 11);
+        assert_eq!(p.n, 11);
+    }
+
+    #[test]
+    fn descends_all_the_way_to_one_when_one_saturates_the_link() {
+        let p = simulate(START_SSH, 1, 80, |_| 1.0);
+        assert_eq!(p.settled(), 1, "history {:?}", p.history);
     }
 
     #[test]
     fn backs_off_when_more_workers_hurt() {
-        // A spinning disk: scales to 8 workers, collapses past that.
         let score = |n: usize| {
             if n <= 8 {
                 n as f64 * 12.5e6
@@ -550,45 +1060,12 @@ mod tests {
             }
         };
         let mut p = Policy::new(START_SSH, MIN, MAX);
-        for _ in 0..40 {
-            p.observe(score(p.n));
+        for _ in 0..80 {
+            let n = p.n;
+            measure(&mut p, score(n));
         }
         assert_eq!(p.settled(), 8, "history {:?}", p.history);
-        // 16 hurt; refine: 10 hurt too; 6 (judged against 8) was too few; back to 8.
-        assert_eq!(&p.history[..5], &[8, 16, 10, 6, 8]);
-        // Probes back off: far fewer than one excursion per 6 measurements.
-        assert!(p.history.len() <= 12, "history {:?}", p.history);
-    }
-
-    #[test]
-    fn descends_quickly_from_a_high_local_start() {
-        // Same disk, started at the local default of 32.
-        let score = |n: usize| {
-            if n <= 8 {
-                n as f64 * 12.5e6
-            } else {
-                30e6
-            }
-        };
-        let mut p = Policy::new(START_LOCAL, MIN, MAX);
-        let mut settled_at = None;
-        for i in 0..60 {
-            p.observe(score(p.n));
-            if settled_at.is_none() && (7..=8).contains(&p.settled()) && p.n == p.settled() {
-                settled_at = Some(i + 1);
-            }
-        }
-        // The 1.3x grid around the knee is 7 / 9, so 7 is the best it can do.
-        assert!((7..=8).contains(&p.settled()), "history {:?}", p.history);
-        // 32 -> 64 (hurt) -> 42 (hurt) -> 25 -> 19 -> 15 -> 12 -> 9 -> 7 -> 5
-        // (worse) -> 7: one measurement per step.
-        assert!(
-            settled_at.unwrap() <= 13,
-            "took {:?}: {:?}",
-            settled_at,
-            p.history
-        );
-        assert_eq!(&p.history[..4], &[32, 64, 42, 25]);
+        assert!(p.history.len() < 20, "history {:?}", p.history);
     }
 
     #[test]
@@ -601,9 +1078,43 @@ mod tests {
     fn silence_is_not_a_signal() {
         let mut p = Policy::new(START_SSH, MIN, MAX);
         for _ in 0..10 {
-            p.observe(0.0);
+            measure(&mut p, 0.0);
         }
         assert_eq!(p.history, vec![START_SSH]);
+    }
+
+    #[test]
+    fn cache_remembers_only_the_named_path_and_clamps_values() {
+        let dir = temporary_cache("roundtrip");
+        let path = dir.join("tuning.json");
+        remember_at(&path, "a>b|tcp", 13).unwrap();
+        remember_at(&path, "a>b|ssh", MAX + 100).unwrap();
+        assert_eq!(cached_at(&path, "a>b|tcp"), Some(13));
+        assert_eq!(cached_at(&path, "a>b|ssh"), Some(MAX));
+        assert_eq!(cached_at(&path, "b>a|tcp"), None);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn cache_key_separates_direction_and_transport() {
+        let local = Endpoint::Local;
+        let ssh = remote("host", false);
+        let tcp = remote("host", true);
+        assert_ne!(path_key(&local, &ssh), path_key(&ssh, &local));
+        assert_ne!(path_key(&local, &ssh), path_key(&local, &tcp));
+        assert_eq!(path_key(&local, &local), None);
+    }
+
+    #[test]
+    fn corrupt_cache_is_ignored_and_replaced() {
+        let dir = temporary_cache("corrupt");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("tuning.json");
+        std::fs::write(&path, b"not json").unwrap();
+        assert_eq!(cached_at(&path, "a>b|tcp"), None);
+        remember_at(&path, "a>b|tcp", 7).unwrap();
+        assert_eq!(cached_at(&path, "a>b|tcp"), Some(7));
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]
@@ -642,10 +1153,11 @@ mod tests {
         let g = Gate::new(2);
         assert!(g.allowed(1));
         assert!(!g.allowed(2));
+        g.set_retain(3);
         let g2 = g.clone();
         let t = std::thread::spawn(move || g2.park(2, || false));
         std::thread::sleep(Duration::from_millis(50));
-        g.set_limit(3);
+        g.set_active(3);
         assert!(t.join().unwrap());
         let g3 = g.clone();
         let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -653,5 +1165,24 @@ mod tests {
         let t = std::thread::spawn(move || g3.park(5, || d.load(Relaxed)));
         done.store(true, Relaxed);
         assert!(!t.join().unwrap());
+    }
+
+    #[test]
+    fn gate_distinguishes_warming_ready_active_and_retired() {
+        let gate = Gate::new(2);
+        assert_eq!(gate.begin_warming(2), vec![0, 1]);
+        assert!(!gate.ready_through(2));
+        gate.mark_ready(0);
+        assert!(!gate.ready_through(2));
+        gate.mark_ready(1);
+        assert!(gate.ready_through(2));
+
+        gate.set_active(1);
+        gate.set_retain(1);
+        assert!(gate.allowed(0));
+        assert!(!gate.allowed(1));
+        assert!(!gate.park(1, || false), "surplus slot should retire");
+        gate.mark_absent(1);
+        assert_eq!(gate.begin_warming(2), vec![1]);
     }
 }

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -50,13 +50,10 @@ pub const MAX: usize = 64;
 pub const MIN: usize = 1;
 /// Multiplicative step between worker counts, up or down.
 pub const STEP: f64 = 1.3;
-/// A step up is kept if it gains at least this fraction of what linear
-/// scaling would have given (STEP - 1). Lenient on purpose: a false "no
-/// gain" strands a window-capped ssh path at half speed, while a false
-/// "gain" costs a few idle connections that the next down-probe reclaims.
-const GAIN_FRACTION: f64 = 1.0 / 3.0;
-/// A step down is kept unless throughput fell by more than this.
-const DOWN_TOLERANCE: f64 = 0.05;
+/// Prefer the smallest measured count whose throughput is this close to the
+/// recent best. Probe scheduling handles noise independently from this
+/// objective; acceptance must not impose a stricter, contradictory threshold.
+const NEAR_BEST_TOLERANCE: f64 = 0.05;
 /// Measurements in the hold phase between probes. Each failed probe in a
 /// direction doubles only that direction's wait (up to
 /// 2^PROBE_BACKOFF_MAX times), so a sharp knee — a disk that collapses one
@@ -422,13 +419,6 @@ impl Policy {
         PROBE_EVERY << backoff
     }
 
-    /// The gain a step up by `factor` must show to be kept. This deliberately
-    /// asks for only part of linear scaling: getting stuck below the knee is
-    /// normally more expensive than briefly trying one surplus connection.
-    fn gain_needed(factor: f64) -> f64 {
-        1.0 + (factor - 1.0) * GAIN_FRACTION
-    }
-
     fn record(&mut self, n: usize, score: f64) {
         self.points
             .entry(n)
@@ -456,7 +446,7 @@ impl Policy {
                         return lower + (self.n - lower) / 2;
                     }
                     if self.tick.saturating_sub(point.measured_at) <= EVIDENCE_MAX_AGE
-                        && point.score < self.recent_best() * (1.0 - DOWN_TOLERANCE)
+                        && point.score < self.recent_best() * (1.0 - NEAR_BEST_TOLERANCE)
                     {
                         return self.n;
                     }
@@ -480,9 +470,9 @@ impl Policy {
                         return self.n + (upper - self.n).div_ceil(2);
                     }
                     let current = self.points.get(&self.n).map_or(0.0, |point| point.score);
-                    let factor = upper as f64 / self.n as f64;
+                    let best = self.recent_best().max(point.score);
                     if self.tick.saturating_sub(point.measured_at) <= EVIDENCE_MAX_AGE
-                        && point.score <= current * Self::gain_needed(factor)
+                        && current >= best * (1.0 - NEAR_BEST_TOLERANCE)
                     {
                         return self.n;
                     }
@@ -565,17 +555,17 @@ impl Policy {
                 if base <= 0.0 && score <= 0.0 {
                     return self.n;
                 }
-                let ratio = if base > 0.0 {
-                    score / base
-                } else {
-                    f64::INFINITY
-                };
+                let best = self.recent_best();
+                let floor = best * (1.0 - NEAR_BEST_TOLERANCE);
                 let keep = match direction {
+                    // Keep the larger count only when it is near-best and the
+                    // smaller baseline is not. If both qualify, the objective
+                    // explicitly prefers the smaller one.
                     Direction::Up => {
-                        let factor = self.n as f64 / from as f64;
-                        ratio > Self::gain_needed(factor)
+                        let from_score = self.points.get(&from).map_or(base, |point| point.score);
+                        score >= floor && from_score < floor
                     }
-                    Direction::Down => score >= self.recent_best() * (1.0 - DOWN_TOLERANCE),
+                    Direction::Down => score >= floor,
                 };
                 self.comparisons += 1;
                 let idx = direction.index();
@@ -767,6 +757,12 @@ pub trait Meter: Send + Sync {
     fn set_active(&self, n: usize);
 }
 
+fn activity_rate(last: (u64, u64), now: (u64, u64), seconds: f64) -> Option<f64> {
+    let bytes = now.0.checked_sub(last.0)?;
+    let files = now.1.checked_sub(last.1)?;
+    Some((bytes as f64 + files as f64 * FILE_CREDIT as f64) / seconds)
+}
+
 /// Drive the policy: sample progress, hand stable scores to the policy,
 /// apply its decisions to the gate and spawn workers that don't exist yet.
 /// Returns the final policy (for stats).
@@ -882,7 +878,15 @@ pub fn run(
         }
         // Per second, so jitter in the sample length doesn't masquerade as a
         // throughput change.
-        let rate = ((now.0 - last.0) as f64 + (now.1 - last.1) as f64 * FILE_CREDIT as f64) / secs;
+        let Some(rate) = activity_rate(last, now, secs) else {
+            // Progress can be retracted after uncertain acknowledgements. The
+            // production meter is monotonic, but keep the generic driver safe
+            // and discard any interval from a regressing implementation.
+            last = now;
+            sampler.reset();
+            collapse_samples = 0;
+            continue;
+        };
         last = now;
         if policy
             .probe_base()
@@ -995,6 +999,29 @@ mod tests {
     }
 
     #[test]
+    fn upward_acceptance_uses_the_near_best_objective() {
+        let mut worthwhile = Policy::new(10, MIN, MAX);
+        measure(&mut worthwhile, 100.0);
+        measure(&mut worthwhile, 107.0);
+        assert_eq!(worthwhile.settled(), 13);
+
+        let mut unnecessary = Policy::new(10, MIN, MAX);
+        measure(&mut unnecessary, 100.0);
+        measure(&mut unnecessary, 104.0);
+        assert_eq!(unnecessary.settled(), 10);
+    }
+
+    #[test]
+    fn activity_rate_discards_a_regressing_sample() {
+        assert_eq!(activity_rate((100, 2), (90, 3), 1.0), None);
+        assert_eq!(activity_rate((100, 2), (110, 1), 1.0), None);
+        assert_eq!(
+            activity_rate((100, 2), (110, 3), 2.0),
+            Some((10.0 + FILE_CREDIT as f64) / 2.0)
+        );
+    }
+
+    #[test]
     fn successful_direction_continues_to_the_plateau() {
         let p = simulate(START_SSH, 32, 80, |_| 1.0);
         assert_eq!(&p.history[..6], &[8, 10, 13, 17, 22, 29]);
@@ -1084,6 +1111,15 @@ mod tests {
     }
 
     #[test]
+    fn a_short_run_has_no_cacheable_comparison() {
+        let mut p = Policy::new(START_SSH, MIN, MAX);
+        measure(&mut p, 80.0);
+        assert!(!p.measured());
+        measure(&mut p, 80.0);
+        assert!(p.measured());
+    }
+
+    #[test]
     fn cache_remembers_only_the_named_path_and_clamps_values() {
         let dir = temporary_cache("roundtrip");
         let path = dir.join("tuning.json");
@@ -1103,6 +1139,18 @@ mod tests {
         assert_ne!(path_key(&local, &ssh), path_key(&ssh, &local));
         assert_ne!(path_key(&local, &ssh), path_key(&local, &tcp));
         assert_eq!(path_key(&local, &local), None);
+    }
+
+    #[test]
+    fn tcp_fallback_changes_the_cache_key() {
+        let local = Endpoint::Local;
+        let remote = remote("host", true);
+        let initial = path_key(&local, &remote);
+        let Endpoint::Remote(spec) = &remote else {
+            unreachable!()
+        };
+        spec.tcp.lock().unwrap().as_mut().unwrap().failed = true;
+        assert_ne!(path_key(&local, &remote), initial);
     }
 
     #[test]
@@ -1184,5 +1232,20 @@ mod tests {
         assert!(!gate.park(1, || false), "surplus slot should retire");
         gate.mark_absent(1);
         assert_eq!(gate.begin_warming(2), vec![1]);
+    }
+
+    #[test]
+    fn optional_provisioning_failure_does_not_poison_active_slots() {
+        let gate = Gate::new(2);
+        assert_eq!(gate.begin_warming(3), vec![0, 1, 2]);
+        gate.mark_ready(0);
+        gate.mark_ready(1);
+        gate.mark_failed(2);
+        assert!(!gate.permanent_failure_through(2));
+        assert!(gate.permanent_failure_through(3));
+
+        gate.clear_failed_from(2);
+        assert_eq!(gate.begin_warming(3), vec![2]);
+        assert!(gate.ready_through(2));
     }
 }

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -65,16 +65,46 @@ const PROBE_BACKOFF_MAX: u32 = 3;
 const EVIDENCE_MAX_AGE: usize = PROBE_EVERY * 4;
 /// How often progress is sampled.
 pub const SAMPLE: Duration = Duration::from_millis(2500);
+/// One discarded warm-up interval plus the two samples needed for stability.
+const MEASUREMENT_SAMPLES: f64 = 3.0;
 /// Two consecutive samples this close count as a stable rate.
 const STABLE_WITHIN: f64 = 0.10;
 /// Give up waiting for stability after this many samples and use what we have.
 const MAX_SAMPLES: usize = 8;
-/// Don't judge a worker count unless each worker has at least this much left
-/// to do: in the tail of a transfer, idle workers say nothing about the path.
-const TAIL_BYTES_PER_WORKER: u64 = 64 << 20;
+/// Conservative requirement before the first rate sample. Every real probe is
+/// based on a measured duration estimate; this is only a startup fallback.
+const TAIL_FALLBACK_BYTES_PER_WORKER: u64 = 64 << 20;
 /// A completed file counts as this many bytes, so small-file transfers
 /// (where bytes are negligible) still produce a usable signal.
 pub const FILE_CREDIT: u64 = 512 * 1024;
+
+fn sample_interval() -> Duration {
+    #[cfg(debug_assertions)]
+    if let Some(milliseconds) = std::env::var_os("SYQ_TEST_TUNE_SAMPLE_MS")
+        .and_then(|value| value.to_string_lossy().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+    {
+        return Duration::from_millis(milliseconds);
+    }
+    SAMPLE
+}
+
+fn required_remaining_activity(rate: Option<f64>, workers: usize, sample: Duration) -> u64 {
+    match rate.filter(|rate| rate.is_finite() && *rate >= 0.0) {
+        Some(rate) => (rate * sample.as_secs_f64() * MEASUREMENT_SAMPLES)
+            .ceil()
+            .clamp(0.0, u64::MAX as f64) as u64,
+        None => (workers as u64).saturating_mul(TAIL_FALLBACK_BYTES_PER_WORKER),
+    }
+}
+
+fn enough_work(sched: &Sched, workers: usize, rate: Option<f64>, sample: Duration) -> bool {
+    sched.work_left_for(
+        workers,
+        required_remaining_activity(rate, workers, sample),
+        FILE_CREDIT,
+    )
+}
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct TuningCache {
@@ -290,7 +320,8 @@ impl Direction {
 enum State {
     /// Waiting for the starting count's first useful measurement.
     Initial,
-    /// Measuring `n` against the last accepted count and its frozen score.
+    /// Measuring `n` against the last accepted count and its baseline score.
+    /// An upward baseline may refresh while candidate workers are warming.
     Explore {
         from: usize,
         base: f64,
@@ -383,6 +414,35 @@ impl Policy {
         match self.state {
             State::Explore { base, .. } => Some(base),
             _ => None,
+        }
+    }
+
+    /// Refresh an upward probe's comparison while its extra workers warm. The
+    /// settled count remains active, so this is baseline evidence rather than
+    /// a new policy tick or worker-count comparison.
+    fn refresh_warming_baseline(&mut self, score: f64) -> bool {
+        let from = match &mut self.state {
+            State::Explore {
+                from,
+                base,
+                direction: Direction::Up,
+            } if *from == self.active => {
+                *base = score;
+                Some(*from)
+            }
+            _ => None,
+        };
+        if let Some(from) = from {
+            self.points.insert(
+                from,
+                Point {
+                    score,
+                    measured_at: self.tick,
+                },
+            );
+            true
+        } else {
+            false
         }
     }
 
@@ -561,10 +621,7 @@ impl Policy {
                     // Keep the larger count only when it is near-best and the
                     // smaller baseline is not. If both qualify, the objective
                     // explicitly prefers the smaller one.
-                    Direction::Up => {
-                        let from_score = self.points.get(&from).map_or(base, |point| point.score);
-                        score >= floor && from_score < floor
-                    }
+                    Direction::Up => score >= floor && base < floor,
                     Direction::Down => score >= floor,
                 };
                 self.comparisons += 1;
@@ -780,9 +837,12 @@ pub fn run(
     let mut sample_start = std::time::Instant::now();
     let mut active = policy.active();
     let mut collapse_samples = 0;
+    let sample = sample_interval();
+    let poll = Duration::from_millis(250).min(sample);
+    let mut last_rate = None;
     meter.set_active(policy.n);
     loop {
-        std::thread::sleep(Duration::from_millis(250));
+        std::thread::sleep(poll);
         if sched.is_aborted() || sched.finished() {
             break;
         }
@@ -809,7 +869,7 @@ pub fn run(
             continue;
         }
         if policy.n > active {
-            if !sched.work_left_for(policy.n, TAIL_BYTES_PER_WORKER) {
+            if !enough_work(&sched, policy.n, last_rate, sample) {
                 policy.cancel_unapplied();
                 gate.set_retain(if active == 1 { 2 } else { active });
                 continue;
@@ -846,8 +906,45 @@ pub fn run(
                         policy.state
                     );
                 }
+                continue;
             }
-            // Provisioning time is not a throughput measurement.
+
+            // The settled workers keep providing a fresh comparison while an
+            // upward candidate connects. This prevents handshake delay from
+            // turning unrelated path drift into an apparent candidate effect.
+            if sample_start.elapsed() >= sample {
+                let now = (meter.bytes(), meter.files());
+                let secs = sample_start.elapsed().as_secs_f64();
+                sample_start = std::time::Instant::now();
+                if !gate.ready_through(active) {
+                    last = now;
+                    sampler.reset();
+                    continue;
+                }
+                let Some(rate) = activity_rate(last, now, secs) else {
+                    last = now;
+                    sampler.reset();
+                    continue;
+                };
+                last = now;
+                last_rate = Some(rate);
+                if !enough_work(&sched, policy.n, last_rate, sample) {
+                    policy.cancel_unapplied();
+                    gate.set_retain(if active == 1 { 2 } else { active });
+                    sampler.reset();
+                    continue;
+                }
+                if let Some(score) = sampler.push(rate) {
+                    policy.refresh_warming_baseline(score);
+                    if crate::transfer::debug() {
+                        eprintln!(
+                            "syq: tune: refreshed {active}-worker baseline to {:.1} MB/s while {} workers warm",
+                            score / 1e6,
+                            policy.n
+                        );
+                    }
+                }
+            }
             continue;
         }
 
@@ -862,16 +959,15 @@ pub fn run(
             sched.abort();
             break;
         }
-        if sample_start.elapsed() < SAMPLE {
+        if sample_start.elapsed() < sample {
             continue;
         }
         let now = (meter.bytes(), meter.files());
         let secs = sample_start.elapsed().as_secs_f64();
         sample_start = std::time::Instant::now();
         // Only judge a configuration once every requested worker is actually
-        // connected (ssh sessions can take seconds each), and only while there
-        // is enough work left — in the tail, idle workers say nothing.
-        if !gate.ready_through(active) || !sched.work_left_for(active, TAIL_BYTES_PER_WORKER) {
+        // connected (ssh sessions can take seconds each).
+        if !gate.ready_through(active) {
             last = now;
             sampler.reset();
             continue;
@@ -888,6 +984,15 @@ pub fn run(
             continue;
         };
         last = now;
+        last_rate = Some(rate);
+        // Estimate the time left at the rate just observed. In the tail, idle
+        // workers say nothing; unlike a fixed byte threshold this remains
+        // useful on both very slow and very fast paths.
+        if !enough_work(&sched, active, last_rate, sample) {
+            sampler.reset();
+            collapse_samples = 0;
+            continue;
+        }
         if policy
             .probe_base()
             .is_some_and(|base| base > 0.0 && rate < 0.5 * base)
@@ -1019,6 +1124,32 @@ mod tests {
             activity_rate((100, 2), (110, 3), 2.0),
             Some((10.0 + FILE_CREDIT as f64) / 2.0)
         );
+    }
+
+    #[test]
+    fn remaining_work_requirement_scales_with_rate_not_worker_count() {
+        let slow = required_remaining_activity(Some(1_000_000.0), 8, SAMPLE);
+        let fast = required_remaining_activity(Some(1_000_000_000.0), 8, SAMPLE);
+        assert_eq!(slow, 7_500_000);
+        assert_eq!(fast, 7_500_000_000);
+        assert_eq!(
+            required_remaining_activity(None, 8, SAMPLE),
+            8 * TAIL_FALLBACK_BYTES_PER_WORKER
+        );
+    }
+
+    #[test]
+    fn upward_probe_refreshes_its_baseline_while_warming() {
+        let mut policy = Policy::new(10, MIN, MAX);
+        policy.observe(100.0);
+        assert_eq!(policy.active(), 10);
+        assert_eq!(policy.n, 13);
+        assert!(policy.refresh_warming_baseline(70.0));
+        assert_eq!(policy.probe_base(), Some(70.0));
+
+        policy.activated();
+        policy.observe(75.0);
+        assert_eq!(policy.settled(), 13);
     }
 
     #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1123,6 +1123,82 @@ fn dropped_write_connection_is_reopened_and_uncertain_range_is_retried() {
 
 #[cfg(debug_assertions)]
 #[test]
+fn live_warming_retirement_and_post_sample_recovery_stay_consistent() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    let data: Vec<u8> = (0..2 * 1024 * 1024)
+        .map(|offset| (offset % 251) as u8)
+        .collect();
+    fs::create_dir_all(t.path("src")).unwrap();
+    for index in 0..10 {
+        write(&t.path(&format!("src/file-{index}")), &data);
+    }
+    let remote = format!("fake:{}", t.s("dst"));
+    let marker = t.path("drop-after-samples");
+    let cache = t.path("tuning.json");
+    write(
+        &cache,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "paths": { "v1|local>fake|ssh": 2 }
+        }))
+        .unwrap()
+        .as_bytes(),
+    );
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("-e")
+        .arg(&rsh)
+        .args([
+            "--no-tcp",
+            "-a",
+            "--no-bootstrap",
+            "--block-size=64K",
+            "--bwlimit=4M",
+            "--stats",
+            &t.s("src/"),
+            &remote,
+            "--no-progress",
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("SYQ_TUNING_CACHE", &cache)
+        .env("SYQ_DEBUG", "1")
+        .env("SYQ_TEST_TUNE_SAMPLE_MS", "50")
+        .env("SYQ_TEST_DROP_AFTER_REQUEST", "write")
+        .env("SYQ_TEST_DROP_AFTER_N_REQUESTS", "32")
+        .env("SYQ_TEST_DROP_MARKER", &marker)
+        .output()
+        .unwrap();
+
+    assert_output_ok(&out);
+    assert!(marker.exists());
+    for index in 0..10 {
+        assert_eq!(read(&t.path(&format!("dst/file-{index}"))), data);
+    }
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("connection dropped; reopening"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("2 -> 3 workers (candidate ready"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("3 -> 2 workers"), "{stderr}");
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("connections: auto:"),
+        "{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
 fn lost_finalize_response_is_verified_after_reconnect() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -825,6 +825,7 @@ fn double_verbose_dry_run_reports_tcp_without_extra_connection() {
         .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
         .env("FAKE_RSH_LOG", t.path("rsh.log"))
         .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_CACHE_HOME", t.path("cache"))
         .output()
         .expect("run double-verbose dry-run over TCP");
 
@@ -996,6 +997,7 @@ fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
         .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
         .env("FAKE_RSH_LOG", t.path("rsh.log"))
         .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_CACHE_HOME", t.path("cache"))
         .output()
         .expect("run syq over TCP through fake remote shell");
 
@@ -1004,6 +1006,10 @@ fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         stdout.contains("connections: auto: settled at 16 (path 16, peak 16)"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("tcp retransmissions (loss signal):"),
         "{stdout}"
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -1015,6 +1021,138 @@ fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
         stderr.contains("concurrency: starting with 16 connections (auto-tuned)"),
         "{stderr}"
     );
+}
+
+#[test]
+fn remembered_path_count_seeds_auto_tuning_but_fixed_count_does_not_rewrite_it() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    let cache = t.path("tuning.json");
+    write(
+        &cache,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "paths": { "v1|local>fake|ssh": 1 }
+        }))
+        .unwrap()
+        .as_bytes(),
+    );
+    let run = |destination: &str, fixed: Option<usize>| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+        command
+            .arg("-e")
+            .arg(&rsh)
+            .arg("--syq-path")
+            .arg(env!("CARGO_BIN_EXE_syq"))
+            .args(["--no-tcp", "--stats", "-avv"]);
+        if let Some(fixed) = fixed {
+            command.args(["-j", &fixed.to_string()]);
+        }
+        command
+            .arg(t.s("src"))
+            .arg(format!("fake:{}", t.s(destination)))
+            .arg("--no-progress")
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env("SYQ_TUNING_CACHE", &cache)
+            .output()
+            .unwrap()
+    };
+    write(&t.path("src"), b"remembered start");
+
+    let automatic = run("auto", None);
+    assert_output_ok(&automatic);
+    assert!(
+        String::from_utf8_lossy(&automatic.stderr)
+            .contains("starting with 1 connections remembered for this path"),
+        "{}",
+        String::from_utf8_lossy(&automatic.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&automatic.stdout)
+            .contains("connections: auto: settled at 1 (path 1, peak 1)"),
+        "{}",
+        String::from_utf8_lossy(&automatic.stdout)
+    );
+
+    let fixed = run("fixed", Some(3));
+    assert_output_ok(&fixed);
+    let cached: serde_json::Value = serde_json::from_slice(&read(&cache)).unwrap();
+    assert_eq!(cached["paths"]["v1|local>fake|ssh"], 1);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn dropped_write_connection_is_reopened_and_uncertain_range_is_retried() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    let data: Vec<u8> = (0..2 * 1024 * 1024)
+        .map(|offset| (offset % 251) as u8)
+        .collect();
+    write(&t.path("src"), &data);
+    let remote = format!("fake:{}", t.s("dst"));
+    let marker = t.path("drop-write-once");
+
+    let out = remote_syq_command(
+        &t,
+        &rsh,
+        &[
+            "-a",
+            "--no-bootstrap",
+            "--block-size=64K",
+            &t.s("src"),
+            &remote,
+        ],
+    )
+    .env("SYQ_TEST_DROP_AFTER_REQUEST", "write")
+    .env("SYQ_TEST_DROP_MARKER", &marker)
+    .output()
+    .unwrap();
+
+    assert_output_ok(&out);
+    assert!(marker.exists());
+    assert_eq!(read(&t.path("dst")), data);
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("connection dropped; reopening"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn lost_finalize_response_is_verified_after_reconnect() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    let data = vec![b'z'; 2 * 1024 * 1024];
+    write(&t.path("src"), &data);
+    let remote = format!("fake:{}", t.s("dst"));
+    let marker = t.path("drop-finalize-once");
+
+    let out = remote_syq_command(
+        &t,
+        &rsh,
+        &[
+            "-a",
+            "--no-bootstrap",
+            "--block-size=64K",
+            &t.s("src"),
+            &remote,
+        ],
+    )
+    .env("SYQ_TEST_DROP_AFTER_REQUEST", "finalize")
+    .env("SYQ_TEST_DROP_MARKER", &marker)
+    .output()
+    .unwrap();
+
+    assert_output_ok(&out);
+    assert!(marker.exists());
+    assert_eq!(read(&t.path("dst")), data);
+    assert!(partial_files(&t.0).is_empty());
 }
 
 fn set_mtime(p: &Path, secs: i64) {


### PR DESCRIPTION
## Summary

- tune across 1–64 connections with evidence-aware 1.3x probes, bounded refinement, and upward tie-breaking
- remember the last measured connection count for each transport endpoint and use it as the next tuning start point
- manage warming, ready, active, and retired connections so surplus workers close while a useful upward probe stays pre-warmed
- recover dropped connections with bounded retries and preserve safe copy progress
- expose TCP loss, RTT, congestion-window, delivery, receive-window, and ECN statistics where the platform provides them
- keep UDP/FEC as a documented future transport rather than silently changing transfer semantics

## Testing

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets