### PR TITLE
Minimize SSH agent delegation for direct remote transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `--verify-only` | Hash every file in the run's scope on both sides and report differences; write nothing |
 | `--inplace` | Write directly into destination files (no partial + rename) |
 | `--checkpoint FILE` | Avoid completed-file destination lookups on later runs; normal resume does not need it |
-| `-e CMD`, `--rsh CMD` | Remote shell command; controls agent forwarding when set (default `ssh`) |
+| `-e CMD`, `--rsh CMD` | Remote shell command; its authentication and agent policy is used unchanged when set (default `ssh`) |
 | `--syq-path PATH` | Use this exact remote `syq` instead of the managed helper |
 | `--no-bootstrap` | Require `syq` on the remote `PATH`; do not install a managed helper |
 | `--no-tcp` | Send data over the ssh connection instead of separate TCP sockets |
@@ -195,7 +195,8 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `--from0` | `--files-from` entries are NUL-separated |
 | `--rm` | Remove the given paths recursively and in parallel (see below) |
 | `--relay` | Remote-to-remote: route data through this machine instead of running on the source host |
-| `--no-forward-agent` | Remote-to-remote with default `ssh`: disable agent forwarding (conflicts with `-e`) |
+| `--no-forward-agent` | Remote-to-remote with default `ssh`: explicitly disable agent forwarding (already the default; conflicts with `-e`) |
+| `--forward-agent` | Direct remote-to-remote with default `ssh`: explicitly forward the unrestricted local agent to the source (conflicts with `-e`, `--relay`, and `--detach`) |
 | `--detach` | Remote-to-remote: run the transfer detached on the source host so it survives losing this ssh session; prints the follow target even with `-q` |
 | `--follow HOST:LOG` | Attach to a detached transfer's log and stream its progress |
 | `-h` | No-op for rsync compatibility; sizes are always human-readable. Use `--help` for help |
@@ -220,25 +221,32 @@ does not change file contents, hashes, resume offsets, or `--bwlimit` accounting
 
 ### Remote-to-remote
 
-`syq hostA:src hostB:dst` starts the orchestrator *on hostA* over `ssh -A`
-(agent forwarding), which then pushes to hostB with N connections, so data
-flows A → B directly. Matching helpers are installed automatically on both
-hosts. HostA must be able to ssh to hostB (with your forwarded agent, or its
-own keys). Progress and `-v` output are streamed back. If hostA can't reach
-hostB, `--relay` keeps the orchestrator here and routes every byte A → you → B
-— always works, at half the bandwidth.
+`syq hostA:src hostB:dst` starts the orchestrator *on hostA* over `ssh -a`,
+which then pushes to hostB with N connections, so data flows A → B directly.
+Matching helpers are installed automatically on both hosts. HostA must be able
+to authenticate to hostB with credentials available on hostA. SYQ also uses
+`ssh -a` from hostA to hostB, overriding any `ForwardAgent yes` setting because
+the destination server does not need an agent. Progress and `-v` output are
+streamed back. If hostA cannot reach or authenticate to hostB, `--relay` keeps
+the orchestrator here and routes every byte A → you → B at half the bandwidth.
 `syq hostA:src hostA:dst` (same host and user on both ends) simply runs a
 local copy on hostA and disables agent forwarding.
 
-Agent forwarding does not copy private keys to hostA, but a process that can
-access the forwarded socket while the SSH connection is alive can ask the
-agent to authenticate on its behalf. Pass `--no-forward-agent` to use `ssh -a`
-and override any `ForwardAgent yes` in SSH configuration; hostA must then have
-its own credentials for hostB. With an explicit `-e/--rsh`, SYQ adds neither
-`-A` nor `-a`, so include the desired agent-forwarding policy in that command;
-`--no-forward-agent` therefore conflicts with `-e`. `--relay` also avoids
-exposing the agent to hostA, at the cost of routing the file data through this
-machine.
+If hostA has no suitable credential, `--forward-agent` is an explicit
+compatibility option. It uses `ssh -A` for the live launcher session and prints
+a warning. Agent forwarding does not copy private keys to hostA, but any
+process that can access the forwarded socket while the connection is alive can
+ask the unrestricted agent to authenticate on its behalf. SYQ does not forward
+that socket onward to hostB. Prefer credentials installed on hostA or `--relay`;
+`--no-forward-agent` remains available to state the safe default explicitly.
+
+An ordinary OpenSSH `ProxyJump` configured for either connection remains
+supported: it routes the SSH connection without giving the jump host an agent
+socket. A custom nested SSH chain or other special forwarding policy belongs in
+an explicit `-e/--rsh`; SYQ adds neither `-A` nor `-a` to that command, and the
+two agent-policy options therefore conflict with it. The dry-run summary states
+whether authorization comes from hostA, unrestricted agent forwarding, or the
+explicit remote shell.
 
 Like rsync, SYQ leaves host-key checking to `ssh` and therefore inherits the
 user's SSH configuration and OpenSSH defaults. First contact therefore fails

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,40 @@
 use anyhow::{bail, Result};
 use clap::Parser;
 
+#[derive(clap::ValueEnum, Debug, Clone, Copy)]
+pub enum PlanAuthorization {
+    NotRequired,
+    SourceCredentials,
+    ForwardedAgent,
+    RemoteShell,
+}
+
+impl PlanAuthorization {
+    pub fn as_arg(self) -> &'static str {
+        match self {
+            Self::NotRequired => "not-required",
+            Self::SourceCredentials => "source-credentials",
+            Self::ForwardedAgent => "forwarded-agent",
+            Self::RemoteShell => "remote-shell",
+        }
+    }
+
+    pub fn summary(self) -> &'static str {
+        match self {
+            Self::NotRequired => {
+                "no destination SSH credential needed (same remote host and user)"
+            }
+            Self::SourceCredentials => {
+                "local agent not forwarded; source host uses its own destination credentials"
+            }
+            Self::ForwardedAgent => {
+                "unrestricted local agent forwarded to source (--forward-agent), but not onward by syq"
+            }
+            Self::RemoteShell => "explicit --rsh controls authentication delegation",
+        }
+    }
+}
+
 #[derive(Parser, Debug, Clone)]
 #[command(
     name = "syq",
@@ -136,7 +170,7 @@ pub struct Args {
     )]
     pub checkpoint: Option<String>,
 
-    /// Remote shell command (default: ssh); controls agent forwarding when set
+    /// Remote shell command (default: ssh); its agent policy is used unchanged when set
     #[arg(short = 'e', long = "rsh", value_name = "COMMAND")]
     pub rsh: Option<String>,
     /// Use this exact syq executable on the remote instead of the managed helper
@@ -164,16 +198,25 @@ pub struct Args {
     /// Remote-to-remote: relay data through this machine instead of running on the source host
     #[arg(long)]
     pub relay: bool,
-    /// Remote-to-remote with the default ssh: disable agent forwarding to the source host; it
-    /// must authenticate to the destination with its own credentials
-    #[arg(long, conflicts_with = "rsh")]
+    /// Remote-to-remote with the default ssh: explicitly disable agent forwarding (the default)
+    #[arg(long, conflicts_with_all = ["rsh", "forward_agent"])]
     pub no_forward_agent: bool,
+    /// Remote-to-remote with the default ssh: forward the unrestricted local agent to the source
+    /// host for compatibility. Prefer source-host credentials or --relay
+    #[arg(
+        long,
+        conflicts_with_all = ["rsh", "no_forward_agent", "detach", "relay"]
+    )]
+    pub forward_agent: bool,
     /// Terminal width for the progress display (internal; used for remote-to-remote)
     #[arg(long, hide = true)]
     pub width: Option<usize>,
     /// Original source endpoint for a remotely orchestrated dry-run summary
     #[arg(long, hide = true)]
     pub plan_source_host: Option<String>,
+    /// Authentication delegation for a remotely orchestrated dry-run summary
+    #[arg(long, hide = true, value_enum)]
+    pub plan_authorization: Option<PlanAuthorization>,
 
     /// Skip paths matching PATTERN (gitignore syntax: `foo` matches at any depth, `/foo` only
     /// at the source root, `foo/` only directories, `!pat` re-includes). Repeatable; together

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -1,7 +1,7 @@
 //! Direct remote-to-remote: run the orchestrator on the source host so data
 //! flows source→destination without passing through this machine.
 
-use crate::cli::{parse_rsh, Args, Location};
+use crate::cli::{parse_rsh, Args, Location, PlanAuthorization};
 use anyhow::{bail, Context, Result};
 use std::io::IsTerminal;
 use std::process::{Command, Stdio};
@@ -32,18 +32,44 @@ fn direct_command(
     cmd
 }
 
+fn source_setup_rsh(rsh: &[String], explicit_rsh: bool) -> Vec<String> {
+    let mut setup = rsh.to_vec();
+    if !explicit_rsh {
+        setup.push("-a".into());
+    }
+    setup
+}
+
+fn default_ssh_agent_policy(
+    explicit_rsh: bool,
+    forward_agent: bool,
+    no_forward_agent: bool,
+    same_host: bool,
+) -> Option<bool> {
+    (!explicit_rsh).then_some(forward_agent && !no_forward_agent && !same_host)
+}
+
+fn destination_rsh(explicit_rsh: Option<&str>, same_host: bool) -> Option<&str> {
+    (!same_host).then_some(explicit_rsh.unwrap_or("ssh -a"))
+}
+
 pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     let rsh = parse_rsh(&args.rsh)?;
     let src_host = srcs[0].host.clone().unwrap();
+    let same_host = srcs[0].same_host(dst);
     // The follow target must reconnect the way we did: keep an explicit user.
     let src_target = match &srcs[0].user {
         Some(user) => format!("{user}@{src_host}"),
         None => src_host.clone(),
     };
+    // Helper probes and installation never need a delegated agent. Override a
+    // default-ssh ForwardAgent setting even when the transfer itself explicitly
+    // opts into forwarding.
+    let source_setup_rsh = source_setup_rsh(&rsh, args.rsh.is_some());
     let spec = crate::conn::RemoteSpec {
         user: srcs[0].user.clone(),
         host: src_host.clone(),
-        rsh: rsh.clone(),
+        rsh: source_setup_rsh,
         syq_path: args.syq_path.clone(),
         auto_helper: args.syq_path.is_none() && !args.no_bootstrap,
         helper_install: Default::default(),
@@ -141,6 +167,16 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     }
     if args.dry_run {
         remote.push(format!("--plan-source-host={src_target}"));
+        let authorization = if args.rsh.is_some() {
+            PlanAuthorization::RemoteShell
+        } else if same_host {
+            PlanAuthorization::NotRequired
+        } else if args.forward_agent {
+            PlanAuthorization::ForwardedAgent
+        } else {
+            PlanAuthorization::SourceCredentials
+        };
+        remote.push(format!("--plan-authorization={}", authorization.as_arg()));
     }
     // --ignore-from files were read locally; forward the merged lines.
     for l in &args.ignore_lines {
@@ -157,9 +193,12 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     if let Some(p) = &args.syq_path {
         remote.push(format!("--syq-path={p}"));
     }
-    if let Some(e) = &args.rsh {
+    // The destination only runs a syq server and never needs an agent. The
+    // implicit `ssh -a` preserves ordinary ProxyJump routing without giving
+    // the destination an agent socket; an explicit --rsh remains user policy.
+    if let Some(e) = destination_rsh(args.rsh.as_deref(), same_host) {
         remote.push("-e".into());
-        remote.push(e.clone());
+        remote.push(e.into());
     }
     remote.push("--".into());
     for s in srcs {
@@ -168,7 +207,7 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     // Same host (and user) on both ends: on that host this is a plain local
     // copy — no ssh back to itself, copy_file_range applies, and the
     // copy-into-itself check sees both paths on one machine.
-    let dst_str = if srcs[0].same_host(dst) {
+    let dst_str = if same_host {
         // A relative remote path is relative to the home; anchor it so the
         // orchestrator's local parse can't take it for something else.
         if dst.path.starts_with('/')
@@ -245,10 +284,12 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         remote_cmd
     };
 
-    let default_ssh_forward_agent = args
-        .rsh
-        .is_none()
-        .then(|| !args.no_forward_agent && !srcs[0].same_host(dst));
+    let default_ssh_forward_agent = default_ssh_agent_policy(
+        args.rsh.is_some(),
+        args.forward_agent,
+        args.no_forward_agent,
+        same_host,
+    );
     let make_command = || {
         direct_command(
             &rsh,
@@ -258,6 +299,11 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
             default_ssh_forward_agent,
         )
     };
+    if args.forward_agent && !same_host && !args.quiet {
+        eprintln!(
+            "syq: warning: --forward-agent exposes your unrestricted SSH agent to {src_host} for the life of this transfer"
+        );
+    }
     if args.detach {
         let run = || {
             let mut cmd = make_command();
@@ -313,6 +359,9 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         // be mistaken for the orchestrator.
         Some(c @ (23 | 25)) => Ok(c),
         Some(c) => {
+            if args.rsh.is_none() && !args.forward_agent && !same_host {
+                bail!("remote-to-remote transfer on {src_host} failed (exit {c}); the local agent was not forwarded: configure destination credentials on {src_host}, retry with --relay, or explicitly accept unrestricted delegation with --forward-agent")
+            }
             bail!("remote-to-remote transfer on {src_host} failed (exit {c}); if {src_host} cannot reach the destination, retry with --relay")
         }
         None => bail!("remote syq on {src_host} killed by signal"),
@@ -431,6 +480,40 @@ mod tests {
         let disabled = args(&disabled);
         assert!(disabled.contains(&OsStr::new("-a")));
         assert!(!disabled.contains(&OsStr::new("-A")));
+    }
+
+    #[test]
+    fn default_agent_policy_is_fail_closed() {
+        assert_eq!(
+            default_ssh_agent_policy(false, false, false, false),
+            Some(false)
+        );
+        assert_eq!(
+            default_ssh_agent_policy(false, true, false, false),
+            Some(true)
+        );
+        assert_eq!(
+            default_ssh_agent_policy(false, true, false, true),
+            Some(false)
+        );
+        assert_eq!(default_ssh_agent_policy(true, false, false, false), None);
+    }
+
+    #[test]
+    fn default_ssh_source_setup_never_forwards_an_agent() {
+        let rsh = vec!["ssh".to_string(), "-p".to_string(), "2222".to_string()];
+        assert_eq!(source_setup_rsh(&rsh, false), ["ssh", "-p", "2222", "-a"]);
+        assert_eq!(source_setup_rsh(&rsh, true), rsh);
+    }
+
+    #[test]
+    fn destination_never_receives_the_default_agent() {
+        assert_eq!(destination_rsh(None, false), Some("ssh -a"));
+        assert_eq!(
+            destination_rsh(Some("custom-rsh --policy"), false),
+            Some("custom-rsh --policy")
+        );
+        assert_eq!(destination_rsh(None, true), None);
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -477,6 +477,9 @@ pub fn run(args: Args) -> Result<i32> {
             bail!("all sources must be on the same host");
         }
     }
+    if args.forward_agent && (!srcs[0].is_remote() || !dst.is_remote() || srcs[0].same_host(dst)) {
+        bail!("--forward-agent is only valid for a direct remote-to-remote transfer between different hosts");
+    }
     if let Some(checkpoint) = args.checkpoint.as_deref() {
         let checkpoint = crate::fsops::normalize(std::path::Path::new(checkpoint));
         for source in srcs.iter().filter(|source| !source.is_remote()) {
@@ -1610,6 +1613,9 @@ fn print_dry_run_summary(
         }
     );
 
+    if let Some(authorization) = args.plan_authorization {
+        println!("  authorization: {}", authorization.summary());
+    }
     println!("  route: {}", selected_route(src_ep, dst_ep, args));
 }
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3424,6 +3424,50 @@ fn no_forward_agent_conflicts_with_explicit_rsh() {
     assert!(!t.path("dst").exists());
 }
 
+#[test]
+fn unrestricted_forwarding_requires_one_unambiguous_live_policy() {
+    let t = Tmp::new();
+    write(&t.path("src"), b"data");
+    for conflicting in [
+        &["--forward-agent", "-e", "ssh -A"][..],
+        &["--forward-agent", "--no-forward-agent"],
+        &["--forward-agent", "--detach"],
+        &["--forward-agent", "--relay"],
+    ] {
+        let (src, dst) = (t.s("src"), t.s("dst"));
+        let mut argv = conflicting.to_vec();
+        argv.extend([src.as_str(), dst.as_str()]);
+        let out = syq(&argv);
+        assert_eq!(out.status.code(), Some(2), "{conflicting:?}");
+        assert!(
+            stderr_of(&out).contains("cannot be used with"),
+            "{conflicting:?}: {}",
+            stderr_of(&out)
+        );
+    }
+    assert!(!t.path("dst").exists());
+}
+
+#[test]
+fn unrestricted_forwarding_requires_two_different_remote_hosts() {
+    let t = Tmp::new();
+    write(&t.path("src"), b"data");
+    for (src, dst) in [
+        (t.s("src"), "hostB:dst".to_string()),
+        ("hostA:src".to_string(), t.s("dst")),
+        ("same:src".to_string(), "same:dst".to_string()),
+    ] {
+        let out = syq(&["--forward-agent", &src, &dst]);
+        assert_eq!(out.status.code(), Some(1), "{src} -> {dst}");
+        assert!(
+            stderr_of(&out).contains("only valid for a direct remote-to-remote transfer"),
+            "{}",
+            stderr_of(&out)
+        );
+    }
+    assert!(!t.path("dst").exists());
+}
+
 // Ordinary copies keep no historical completion state: the current destination
 // determines what a later invocation repairs.
 #[test]
@@ -5902,6 +5946,11 @@ fn direct_remote_to_remote_verbose_diagnostics_are_orchestrator_relative() {
         stderr.contains("transport: SSH planned for a real transfer (--no-tcp)"),
         "{stderr}"
     );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("authorization: explicit --rsh controls authentication delegation"),
+        "{stdout}"
+    );
 
     let same_host_dst = format!("hostA:{}", t.s("same-host-dst"));
     let out = remote_syq(
@@ -5921,6 +5970,11 @@ fn direct_remote_to_remote_verbose_diagnostics_are_orchestrator_relative() {
         "{stderr}"
     );
     assert!(!stderr.contains("syq: hostA:\n"), "{stderr}");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("authorization: explicit --rsh controls authentication delegation"),
+        "{stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- stop forwarding the local SSH agent by default for direct remote-to-remote transfers
- force agent forwarding off during source helper setup and from the source to the destination
- add an explicit warned `--forward-agent` compatibility option
- show the selected authorization policy in remote-to-remote dry-run plans
- document ordinary single-host `ProxyJump` support and the boundary around custom nested SSH chains

## Behavior change

Previously, `syq hostA:src hostB:dst` launched hostA with `ssh -A`, exposing the unrestricted local agent socket to hostA. It now uses `ssh -a`; hostA must authenticate to hostB with credentials available on hostA.

If hostA lacks a suitable credential, users can relay through the invoking machine with `--relay` or explicitly accept unrestricted delegation with `--forward-agent`. The latter prints a warning and is rejected for relayed, detached, local, same-host, or explicit-`--rsh` transfers.

An ordinary OpenSSH `ProxyJump` remains available on either SSH edge because `-a` disables agent socket forwarding without removing the configured jump route.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (269 tests)
- `ssh -G -a -J jump.example target.example` retained `proxyjump jump.example` and reported `forwardagent no`
