### PR TITLE
Constrain agent delegation for remote-to-remote transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,8 +14,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -24,9 +24,9 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
  "cpubits",
- "cpufeatures",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ checksum = "7f2b8006a0c83f52b62ba44a97b58bf76fe2f70a329e588f67f89691d93d498f"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.5.2",
  "ctr",
  "ctutils",
  "ghash",
@@ -118,16 +118,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -180,13 +207,23 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "inout",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -253,6 +290,12 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -262,6 +305,15 @@ name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -344,6 +396,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,7 +425,7 @@ checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "getrandom 0.4.3",
  "hybrid-array",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -360,7 +434,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -374,15 +448,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.1",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -400,14 +489,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 2.2.0",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -416,7 +550,19 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "signature",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "sha2 0.10.9",
+ "subtle",
 ]
 
 [[package]]
@@ -425,9 +571,9 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "sha2",
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -437,6 +583,25 @@ name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embedded-io"
@@ -461,6 +626,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +670,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +700,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -525,6 +723,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -555,6 +764,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -599,6 +817,15 @@ dependencies = [
 
 [[package]]
 name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
@@ -639,10 +866,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -682,6 +924,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,10 +981,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -712,7 +1067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
- "cpufeatures",
+ "cpufeatures 0.3.1",
  "universal-hash",
 ]
 
@@ -727,6 +1082,24 @@ dependencies = [
  "embedded-io 0.6.1",
  "heapless",
  "serde",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -752,6 +1125,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -797,6 +1199,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +1220,27 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -889,6 +1322,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,13 +1416,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -983,6 +1450,16 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
@@ -994,12 +1471,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-agent-lib"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b528981371b3bfdfe927a5ef37221446e0ba44551e673b569fd0fd38e5dcb292"
+dependencies = [
+ "byteorder",
+ "secrecy",
+ "signature 2.2.0",
+ "ssh-encoding",
+ "ssh-key",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "cipher 0.4.4",
+ "ssh-encoding",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "ed25519-dalek 2.2.0",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1050,7 +1601,7 @@ dependencies = [
  "anyhow",
  "base64",
  "clap",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "flate2",
  "getrandom 0.4.3",
  "ignore",
@@ -1062,11 +1613,28 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_json_canonicalizer",
- "sha2",
+ "sha2 0.11.0",
  "shell-words",
+ "signature 2.2.0",
+ "ssh-agent-lib",
+ "ssh-key",
+ "tempfile",
  "ureq",
  "xxhash-rust",
  "zstd",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1117,7 +1685,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -1166,6 +1734,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1294,6 +1868,26 @@ name = "xxhash-rust"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ semver = "1"
 sha2 = "0.11"
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 ssh-agent-lib = { version = "0.6", default-features = false }
-ssh-key = { version = "0.6.7", features = ["p256", "rsa"] }
+ssh-key = { version = "0.6.7", features = ["ed25519", "p256", "p384", "p521", "rsa"] }
 tempfile = "3"
 signature = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ flate2 = "1"
 semver = "1"
 sha2 = "0.11"
 ureq = { version = "3", default-features = false, features = ["rustls"] }
+ssh-agent-lib = { version = "0.6", default-features = false }
+ssh-key = { version = "0.6.7", features = ["p256", "rsa"] }
+tempfile = "3"
 
 [profile.release]
 opt-level = 3
@@ -51,3 +54,4 @@ strip = "symbols"
 
 [dev-dependencies]
 libc = "0.2"
+signature = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ureq = { version = "3", default-features = false, features = ["rustls"] }
 ssh-agent-lib = { version = "0.6", default-features = false }
 ssh-key = { version = "0.6.7", features = ["p256", "rsa"] }
 tempfile = "3"
+signature = "2"
 
 [profile.release]
 opt-level = 3
@@ -54,4 +55,3 @@ strip = "symbols"
 
 [dev-dependencies]
 libc = "0.2"
-signature = "2"

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `--verify-only` | Hash every file in the run's scope on both sides and report differences; write nothing |
 | `--inplace` | Write directly into destination files (no partial + rename) |
 | `--checkpoint FILE` | Avoid completed-file destination lookups on later runs; normal resume does not need it |
-| `-e CMD`, `--rsh CMD` | Remote shell command; controls agent forwarding when set (default `ssh`) |
+| `-e CMD`, `--rsh CMD` | Remote shell command; bypasses syq's constrained-agent setup and controls agent forwarding itself (default `ssh`) |
 | `--syq-path PATH` | Use this exact remote `syq` instead of the managed helper |
 | `--no-bootstrap` | Require `syq` on the remote `PATH`; do not install a managed helper |
 | `--no-tcp` | Send data over the ssh connection instead of separate TCP sockets |
@@ -195,7 +195,8 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `--from0` | `--files-from` entries are NUL-separated |
 | `--rm` | Remove the given paths recursively and in parallel (see below) |
 | `--relay` | Remote-to-remote: route data through this machine instead of running on the source host |
-| `--no-forward-agent` | Remote-to-remote with default `ssh`: disable agent forwarding (conflicts with `-e`) |
+| `--no-forward-agent` | Remote-to-remote with default `ssh`: give hostA no agent; it must have credentials for hostB (conflicts with `-e`) |
+| `--unrestricted-agent-forwarding` | Remote-to-remote compatibility escape hatch: expose the complete local agent to hostA instead of the constrained broker |
 | `--detach` | Remote-to-remote: run the transfer detached on the source host so it survives losing this ssh session; prints the follow target even with `-q` |
 | `--follow HOST:LOG` | Attach to a detached transfer's log and stream its progress |
 | `-h` | No-op for rsync compatibility; sizes are always human-readable. Use `--help` for help |
@@ -220,35 +221,70 @@ does not change file contents, hashes, resume offsets, or `--bwlimit` accounting
 
 ### Remote-to-remote
 
-`syq hostA:src hostB:dst` starts the orchestrator *on hostA* over `ssh -A`
-(agent forwarding), which then pushes to hostB with N connections, so data
-flows A → B directly. Matching helpers are installed automatically on both
-hosts. HostA must be able to ssh to hostB (with your forwarded agent, or its
-own keys). Progress and `-v` output are streamed back. If hostA can't reach
-hostB, `--relay` keeps the orchestrator here and routes every byte A → you → B
-— always works, at half the bandwidth.
+`syq hostA:src hostB:dst` starts the orchestrator *on hostA*, which then pushes
+to hostB with N connections, so data flows A → B directly. Matching helpers
+are installed automatically on both hosts. Progress and `-v` output are
+streamed back. If hostA can't reach hostB, `--relay` keeps the orchestrator
+here and routes every byte A → you → B — always works, at half the bandwidth.
 `syq hostA:src hostA:dst` (same host and user on both ends) simply runs a
 local copy on hostA and disables agent forwarding.
 
-Agent forwarding does not copy private keys to hostA, but a process that can
-access the forwarded socket while the SSH connection is alive can ask the
-agent to authenticate on its behalf. Pass `--no-forward-agent` to use `ssh -a`
-and override any `ForwardAgent yes` in SSH configuration; hostA must then have
-its own credentials for hostB. With an explicit `-e/--rsh`, SYQ adds neither
-`-A` nor `-a`, so include the desired agent-forwarding policy in that command;
-`--no-forward-agent` therefore conflicts with `-e`. `--relay` also avoids
-exposing the agent to hostA, at the cost of routing the file data through this
-machine.
+With implicit OpenSSH, the default is a temporary local agent broker rather
+than unrestricted `ssh -A`. HostA may list the ambient agent's public
+identities, but the broker releases a signature only after validating exactly
+this path:
 
-Like rsync, SYQ leaves host-key checking to `ssh` and therefore inherits the
-user's SSH configuration and OpenSSH defaults. First contact therefore fails
-when `ssh` cannot interactively confirm an unknown host. If accepting and
-recording a new host key is appropriate, opt in explicitly with
-`-e 'ssh -o StrictHostKeyChecking=accept-new'`.
+```text
+trusted hostA session -> configured-user@trusted-hostB session
+```
 
-Add `--detach` to let a remote-to-remote transfer outlive the ssh session that
-launched it: syq starts it on hostA, returns, and writes progress to a log on
-hostA. Reattach with `syq --follow hostA:LOG` to stream that progress.
+It verifies OpenSSH session-bind signatures for both hosts and strictly checks
+the final host-bound authentication request's session ID, destination login
+user, host key, selected credential, and signature algorithm. Key addition,
+removal, raw or legacy signing, unknown extensions, and extra forwarding hops
+are refused. Private keys remain in the original agent, so hardware-backed,
+PIV/OpenPGP agent, and desktop-agent identities continue to handle their own
+touch/PIN/approval behavior. The broker socket and every open channel are
+closed when the attached transfer ends.
+
+This restricts *where and as whom* hostA may authenticate; stock OpenSSH does
+not bind the subsequent command. A compromised hostA still receives the
+authority of that destination account for the transfer's lifetime. Command or
+filesystem restrictions require destination-side policy such as a forced syq
+receiver.
+
+The constrained path currently requires OpenSSH session-bind and host-bound
+authentication support, a local `SSH_AUTH_SOCK`, and exact plain host keys for
+both hosts in the effective local `known_hosts` files. Host-certificate/CA-only
+trust is refused until syq can validate certificate principals and validity as
+strictly as OpenSSH. The local configuration resolves hostB's login user, and
+syq passes it explicitly to hostA. Connection multiplexing is disabled for the
+outer session so a pre-existing master cannot substitute another forwarded
+agent.
+
+Pass `--no-forward-agent` to give hostA no agent at all; hostA must then have
+its own credentials for hostB. `--unrestricted-agent-forwarding` is a
+conspicuous compatibility escape hatch that exposes the complete ambient agent
+to hostA for the attached transfer. With an explicit `-e/--rsh`, syq creates no
+broker and adds neither `-A` nor `-a`, so that command is the complete agent
+policy; `--no-forward-agent` and the unrestricted escape hatch therefore
+conflict with `-e`. `--relay` also avoids exposing authentication to hostA, at
+the cost of routing file data through this machine.
+
+SYQ inherits the user's SSH configuration and OpenSSH host-key checking. The
+default constrained broker additionally requires already recorded exact keys
+for hostA and hostB before connecting; it never learns a key through hostA or
+silently accepts one. If first-contact trust is appropriate, establish it with
+ordinary SSH (directly or through the configured jump path) before starting
+the transfer. An explicit `-e 'ssh -o StrictHostKeyChecking=accept-new'`
+bypasses the broker and leaves that policy to the supplied command.
+
+Add `--detach --no-forward-agent` to let a remote-to-remote transfer outlive
+the ssh session that launched it: syq starts it on hostA, returns, and writes
+progress to a log on hostA. HostA needs its own hostB credential because a
+temporary local broker cannot survive detachment. An explicit `--rsh` may
+provide another persistent authentication policy. Reattach with
+`syq --follow hostA:LOG` to stream that progress.
 An explicit `--checkpoint` path belongs to the machine running the
 orchestrator: normally the invoking machine, but hostA for a direct or detached
 remote-to-remote copy (`--relay` keeps it local).
@@ -907,9 +943,10 @@ fix for that.
   unauthenticated clients; see [Server performance tuning](SERVER-TUNING.md).
   Auto-tuning starts at 16 for TCP data, or 8 for ssh data, and only opens more
   once they have been shown to pay.
-- Direct remote→remote with a *forwarded* agent authenticates every session
-  through your machine; over a slow link that dominates setup time. Keys on the
-  source host avoid it.
+- Direct remote→remote with the constrained broker authenticates every hostB
+  session through your ambient agent; over a slow link that dominates setup
+  time. `--no-forward-agent` with a narrowly scoped key on the source host
+  avoids that round trip.
 - Measured on two 160-core hosts on a 20 Gbit LAN: a single ssh stream tops out
   around 450–550 MB/s; `syq -j8` into tmpfs reached ~1.2–1.3 GiB/s (the raw
   multi-stream ssh ceiling), while writes to the destination's ext4 NVMe capped

--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ here and routes every byte A → you → B — always works, at half the bandwid
 local copy on hostA and disables agent forwarding.
 
 With implicit OpenSSH, the default is a temporary local agent broker rather
-than unrestricted `ssh -A`. HostA may list the ambient agent's public
-identities, but the broker releases a signature only after validating exactly
-this path:
+than unrestricted `ssh -A`. HostA may list a sanitized snapshot of the ambient
+agent's supported public identities, but the broker signs only with an exact
+credential from that snapshot and only after validating this path:
 
 ```text
 trusted hostA session -> configured-user@trusted-hostB session
@@ -243,11 +243,19 @@ the final host-bound authentication request's session ID, destination login
 user, host key, selected credential, and signature algorithm. Key addition,
 removal, raw or legacy signing, unknown extensions, and extra forwarding hops
 are refused. The A → B client is forced to use host-bound public-key
-authentication. Validated session binds are also replayed to the ambient agent,
-so a stock OpenSSH agent's existing per-key destination constraints remain an
-additional restriction; agents that do not implement session binding may reject
-that extension and continue under the broker's mandatory checks. Successful
-ambient signatures are verified before release.
+authentication. Validated session binds are also replayed to the ambient agent.
+The broker's checks are independent of whether that agent enforces the replayed
+bindings; agents that do not implement session binding may reject the extension
+and continue under the broker's mandatory checks. Successful ambient signatures
+are verified before release.
+
+Use OpenSSH 10.5 or newer for the ambient agent if relying on its existing
+per-key destination constraints as an additional layer. OpenSSH 10.5 fixed an
+interaction in which a locked agent refused session-bind requests, allowing
+operations intended to be local—including use of destination-restricted
+keys—to occur remotely ([OpenSSH 10.5 release notes](https://www.openssh.com/txt/release-10.5);
+CVE-2026-73281). Syq cannot query an agent's version and does not count that
+extra layer as part of its own mandatory path restriction.
 
 Private keys remain in the original agent, so hardware-backed, PIV/OpenPGP
 agent, and desktop-agent identities continue to handle their own
@@ -257,7 +265,9 @@ matching raw agent identity, validates the exact certificate-bearing host-bound
 request, and translates only the agent request's outer credential back to the
 matching raw key. This supports the common arrangement where a YubiKey or other
 agent lists the private key while a centrally managed certificate is a local
-file. An OpenSSH agent may itself reject that translation when the raw key has
+file. When no `CertificateFile` is explicitly configured, syq also follows
+OpenSSH's implicit `<IdentityFile>-cert.pub` convention. An OpenSSH agent may
+itself reject certificate translation when the raw key has
 `ssh-add -h` destination constraints but the certificate was not associated
 with the agent; that combination fails closed. Loading the certificate into the
 agent avoids translation. The broker socket and every open channel are closed
@@ -278,11 +288,17 @@ validate certificate principals and validity as strictly as OpenSSH. Static
 `HostKeyAlgorithms` and `RequiredRSASize` policy is enforced. A configured
 `KnownHostsCommand` or `RevokedHostKeys` KRL is refused because the broker does
 not yet reproduce those dynamic or external revocation checks. Local
-`CertificateFile` expansion supports the ordinary OpenSSH percent tokens except
-`%C`; named-user tildes are also refused rather than guessed.
+`CertificateFile` and implicit `IdentityFile` certificate expansion supports the
+ordinary OpenSSH percent tokens except `%C`; named-user tildes are also refused
+rather than guessed. Credential and host-key algorithms that syq's SSH library
+cannot cryptographically verify are removed or refused rather than failing only
+after a signing request.
 
 The local configuration resolves hostB's login user, and syq passes it
-explicitly to hostA. Connection multiplexing is disabled for the outer session
+explicitly to hostA. The inner client is forced to use its forwarded
+`SSH_AUTH_SOCK` with agent identities enabled, so hostA's `IdentityAgent` or
+`IdentitiesOnly` configuration cannot bypass the broker. Connection
+multiplexing is disabled for the outer session
 so a pre-existing master cannot substitute another forwarded agent. Configured
 port forwards, X11 and GSS credential delegation, PTY allocation, and
 `LocalCommand` are also disabled on that session.
@@ -303,10 +319,10 @@ conflict with `-e`. `--relay` also avoids exposing authentication to hostA, at
 the cost of routing file data through this machine.
 
 SYQ uses the user's SSH configuration to resolve the login user, host-key name,
-port, static known-hosts files, host-key algorithms, RSA size, and configured
-user certificates. The default constrained broker requires already recorded
-exact keys for hostA and hostB before connecting; it never learns a key through
-hostA or silently accepts one. Dynamic `KnownHostsCommand`, external
+port, static known-hosts files, host-key algorithms, RSA size, and configured or
+implicit user certificates. The default constrained broker requires already
+recorded exact keys for hostA and hostB before connecting; it never learns a key
+through hostA or silently accepts one. Dynamic `KnownHostsCommand`, external
 `RevokedHostKeys`, and host-certificate trust are currently refused as described
 above. If first-contact trust is appropriate, establish it with ordinary SSH
 (directly or through the configured jump path) before starting the transfer.

--- a/README.md
+++ b/README.md
@@ -242,25 +242,56 @@ It verifies OpenSSH session-bind signatures for both hosts and strictly checks
 the final host-bound authentication request's session ID, destination login
 user, host key, selected credential, and signature algorithm. Key addition,
 removal, raw or legacy signing, unknown extensions, and extra forwarding hops
-are refused. Private keys remain in the original agent, so hardware-backed,
-PIV/OpenPGP agent, and desktop-agent identities continue to handle their own
-touch/PIN/approval behavior. The broker socket and every open channel are
-closed when the attached transfer ends.
+are refused. The A → B client is forced to use host-bound public-key
+authentication. Validated session binds are also replayed to the ambient agent,
+so a stock OpenSSH agent's existing per-key destination constraints remain an
+additional restriction; agents that do not implement session binding may reject
+that extension and continue under the broker's mandatory checks. Successful
+ambient signatures are verified before release.
+
+Private keys remain in the original agent, so hardware-backed, PIV/OpenPGP
+agent, and desktop-agent identities continue to handle their own
+touch/PIN/approval behavior. For a user certificate selected by hostB's local
+`CertificateFile`, syq exposes only that exact certificate in place of its
+matching raw agent identity, validates the exact certificate-bearing host-bound
+request, and translates only the agent request's outer credential back to the
+matching raw key. This supports the common arrangement where a YubiKey or other
+agent lists the private key while a centrally managed certificate is a local
+file. An OpenSSH agent may itself reject that translation when the raw key has
+`ssh-add -h` destination constraints but the certificate was not associated
+with the agent; that combination fails closed. Loading the certificate into the
+agent avoids translation. The broker socket and every open channel are closed
+when the attached transfer ends.
 
 This restricts *where and as whom* hostA may authenticate; stock OpenSSH does
 not bind the subsequent command. A compromised hostA still receives the
 authority of that destination account for the transfer's lifetime. Command or
 filesystem restrictions require destination-side policy such as a forced syq
-receiver.
+receiver. This is not a signed grant: it adds no timestamp, expiry, or replay
+cache beyond the live SSH sessions and the broker socket's lifetime.
 
-The constrained path currently requires OpenSSH session-bind and host-bound
-authentication support, a local `SSH_AUTH_SOCK`, and exact plain host keys for
-both hosts in the effective local `known_hosts` files. Host-certificate/CA-only
-trust is refused until syq can validate certificate principals and validity as
-strictly as OpenSSH. The local configuration resolves hostB's login user, and
-syq passes it explicitly to hostA. Connection multiplexing is disabled for the
-outer session so a pre-existing master cannot substitute another forwarded
-agent.
+The constrained path requires OpenSSH 8.9 or newer session-bind and host-bound
+authentication support on the local machine, hostA, and hostB; a local
+`SSH_AUTH_SOCK`; and exact plain host keys for both hosts in the effective local
+`known_hosts` files. Host-certificate/CA-only trust is refused until syq can
+validate certificate principals and validity as strictly as OpenSSH. Static
+`HostKeyAlgorithms` and `RequiredRSASize` policy is enforced. A configured
+`KnownHostsCommand` or `RevokedHostKeys` KRL is refused because the broker does
+not yet reproduce those dynamic or external revocation checks. Local
+`CertificateFile` expansion supports the ordinary OpenSSH percent tokens except
+`%C`; named-user tildes are also refused rather than guessed.
+
+The local configuration resolves hostB's login user, and syq passes it
+explicitly to hostA. Connection multiplexing is disabled for the outer session
+so a pre-existing master cannot substitute another forwarded agent. Configured
+port forwards, X11 and GSS credential delegation, PTY allocation, and
+`LocalCommand` are also disabled on that session.
+
+Session binding identifies a host by its host key, not by a DNS name or network
+address. The configured name chooses the locally trusted key set, but an
+endpoint that shares hostB's private host key is intentionally equivalent to
+hostB for this broker. Deployments requiring distinct host identities must not
+reuse host private keys between them.
 
 Pass `--no-forward-agent` to give hostA no agent at all; hostA must then have
 its own credentials for hostB. `--unrestricted-agent-forwarding` is a
@@ -271,13 +302,16 @@ policy; `--no-forward-agent` and the unrestricted escape hatch therefore
 conflict with `-e`. `--relay` also avoids exposing authentication to hostA, at
 the cost of routing file data through this machine.
 
-SYQ inherits the user's SSH configuration and OpenSSH host-key checking. The
-default constrained broker additionally requires already recorded exact keys
-for hostA and hostB before connecting; it never learns a key through hostA or
-silently accepts one. If first-contact trust is appropriate, establish it with
-ordinary SSH (directly or through the configured jump path) before starting
-the transfer. An explicit `-e 'ssh -o StrictHostKeyChecking=accept-new'`
-bypasses the broker and leaves that policy to the supplied command.
+SYQ uses the user's SSH configuration to resolve the login user, host-key name,
+port, static known-hosts files, host-key algorithms, RSA size, and configured
+user certificates. The default constrained broker requires already recorded
+exact keys for hostA and hostB before connecting; it never learns a key through
+hostA or silently accepts one. Dynamic `KnownHostsCommand`, external
+`RevokedHostKeys`, and host-certificate trust are currently refused as described
+above. If first-contact trust is appropriate, establish it with ordinary SSH
+(directly or through the configured jump path) before starting the transfer.
+An explicit `-e 'ssh -o StrictHostKeyChecking=accept-new'` bypasses the broker
+and leaves that policy to the supplied command.
 
 Add `--detach --no-forward-agent` to let a remote-to-remote transfer outlive
 the ssh session that launched it: syq starts it on hostA, returns, and writes

--- a/README.md
+++ b/README.md
@@ -231,8 +231,9 @@ local copy on hostA and disables agent forwarding.
 
 With implicit OpenSSH, the default is a temporary local agent broker rather
 than unrestricted `ssh -A`. HostA may list a sanitized snapshot of the ambient
-agent's supported public identities, but the broker signs only with an exact
-credential from that snapshot and only after validating this path:
+agent's supported public identities with identity comments removed, but the
+broker signs only with an exact credential from that snapshot and only after
+validating this path:
 
 ```text
 trusted hostA session -> configured-user@trusted-hostB session
@@ -271,7 +272,9 @@ itself reject certificate translation when the raw key has
 `ssh-add -h` destination constraints but the certificate was not associated
 with the agent; that combination fails closed. Loading the certificate into the
 agent avoids translation. The broker socket and every open channel are closed
-when the attached transfer ends.
+when the attached transfer ends. Stalled broker and ambient-agent operations
+time out after two minutes, long enough for ordinary hardware-token approval
+while preventing idle clients from holding worker slots indefinitely.
 
 This restricts *where and as whom* hostA may authenticate; stock OpenSSH does
 not bind the subsequent command. A compromised hostA still receives the
@@ -292,7 +295,11 @@ not yet reproduce those dynamic or external revocation checks. Local
 ordinary OpenSSH percent tokens except `%C`; named-user tildes are also refused
 rather than guessed. Credential and host-key algorithms that syq's SSH library
 cannot cryptographically verify are removed or refused rather than failing only
-after a signing request.
+after a signing request. OpenSSH's `ssh -G` output does not preserve quoting for
+custom known-hosts filenames. Syq therefore accepts OpenSSH's separately
+verified compiled default list, or one absolute whitespace-free configured file
+per `UserKnownHostsFile`/`GlobalKnownHostsFile` directive; ambiguous custom
+multi-file or whitespace-containing values fail closed.
 
 The local configuration resolves hostB's login user, and syq passes it
 explicitly to hostA. The inner client is forced to use its forwarded
@@ -310,13 +317,15 @@ hostB for this broker. Deployments requiring distinct host identities must not
 reuse host private keys between them.
 
 Pass `--no-forward-agent` to give hostA no agent at all; hostA must then have
-its own credentials for hostB. `--unrestricted-agent-forwarding` is a
+its own credentials for hostB, and its own `IdentityAgent` configuration is
+left intact. `--unrestricted-agent-forwarding` is a
 conspicuous compatibility escape hatch that exposes the complete ambient agent
-to hostA for the attached transfer. With an explicit `-e/--rsh`, syq creates no
-broker and adds neither `-A` nor `-a`, so that command is the complete agent
-policy; `--no-forward-agent` and the unrestricted escape hatch therefore
-conflict with `-e`. `--relay` also avoids exposing authentication to hostA, at
-the cost of routing file data through this machine.
+to hostA for the attached transfer without imposing the constrained path's
+host-bound authentication requirement. With an explicit `-e/--rsh`, syq
+creates no broker and adds neither `-A` nor `-a`, so that command is the
+complete agent policy; `--no-forward-agent` and the unrestricted escape hatch
+therefore conflict with `-e`. `--relay` also avoids exposing authentication to
+hostA, at the cost of routing file data through this machine.
 
 SYQ uses the user's SSH configuration to resolve the login user, host-key name,
 port, static known-hosts files, host-key algorithms, RSA size, and configured or

--- a/README.md
+++ b/README.md
@@ -296,9 +296,13 @@ ordinary OpenSSH percent tokens except `%C`; named-user tildes are also refused
 rather than guessed. Credential and host-key algorithms that syq's SSH library
 cannot cryptographically verify are removed or refused rather than failing only
 after a signing request. OpenSSH's `ssh -G` output does not preserve quoting for
-custom known-hosts filenames. Syq therefore accepts OpenSSH's separately
-verified compiled default list, or one absolute whitespace-free configured file
-per `UserKnownHostsFile`/`GlobalKnownHostsFile` directive; ambiguous custom
+custom known-hosts filenames. Syq uses OpenSSH's debug provenance to inspect the
+configuration files OpenSSH actually read for the host. It accepts the compiled
+default list only when none of those files contains the corresponding
+known-hosts directive; an explicitly configured value that renders exactly like
+the defaults is still treated as configured. Otherwise syq accepts one absolute
+whitespace-free configured file per
+`UserKnownHostsFile`/`GlobalKnownHostsFile` directive. Ambiguous custom
 multi-file or whitespace-containing values fail closed.
 
 The local configuration resolves hostB's login user, and syq passes it

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,9 @@ targets = [
 [advisories]
 unmaintained = "workspace"
 yanked = "warn"
+ignore = [
+  { id = "RUSTSEC-2023-0071", reason = "rsa is used only to parse SSH public credentials and verify signatures; syq never performs the vulnerable RSA private-key decryption or signing operations" },
+]
 
 [licenses]
 confidence-threshold = 0.93

--- a/src/agent_broker.rs
+++ b/src/agent_broker.rs
@@ -7,12 +7,17 @@
 //! user. The broker never accepts key-management or opaque signing requests.
 
 use anyhow::{anyhow, bail, Context, Result};
+use signature::Verifier;
 use ssh_agent_lib::proto::extension::{MessageExtension, SessionBind};
-use ssh_agent_lib::proto::{Request, Response, SignRequest};
+use ssh_agent_lib::proto::{Extension, Identity, PublicCredential, Request, Response, SignRequest};
 use ssh_agent_lib::ssh_encoding::{Decode, Encode};
-use ssh_agent_lib::ssh_key::{public::KeyData, PublicKey};
+use ssh_agent_lib::ssh_key::{
+    certificate::{CertType, Certificate},
+    public::KeyData,
+    PublicKey,
+};
 use std::collections::HashMap;
-use std::ffi::OsString;
+use std::ffi::{CStr, OsString};
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
@@ -27,10 +32,6 @@ use std::time::Duration;
 /// Agent messages are normally only a few KiB. This accommodates large
 /// identity lists without allowing a peer to force an unbounded allocation.
 const MAX_AGENT_FRAME: usize = 256 * 1024;
-/// syq establishes at most 32 SSH handshakes concurrently. Keep a hard broker
-/// cap as a second bound against a source host that opens idle agent channels.
-const MAX_BROKER_CONNECTIONS: usize = 32;
-
 const SSH_AGENT_FAILURE: &[u8] = &[5];
 const SSH_AGENT_SUCCESS: &[u8] = &[6];
 const SSH_AGENT_EXTENSION_FAILURE: &[u8] = &[28];
@@ -40,6 +41,28 @@ pub struct HostPolicy {
     pub login_user: String,
     host_keys: Vec<KeyData>,
     known_hosts_name: String,
+    host_key_algorithms: Vec<String>,
+    required_rsa_size: usize,
+    user_certificates: Vec<Certificate>,
+}
+
+impl HostPolicy {
+    fn authorizes_binding(&self, binding: &SessionBind) -> bool {
+        self.host_keys.contains(&binding.host_key)
+            && self
+                .host_key_algorithms
+                .iter()
+                .any(|allowed| allowed == binding.signature.algorithm().as_str())
+            && binding.host_key.rsa().is_none_or(|rsa| {
+                rsa.n.as_positive_bytes().is_some_and(|modulus| {
+                    let bits = modulus
+                        .first()
+                        .map(|first| modulus.len() * 8 - first.leading_zeros() as usize)
+                        .unwrap_or(0);
+                    bits >= self.required_rsa_size
+                })
+            })
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -65,6 +88,7 @@ pub fn resolve_host_policy(
     ssh_program: &str,
     explicit_user: Option<&str>,
     host: &str,
+    load_user_certificates: bool,
 ) -> Result<HostPolicy> {
     let mut command = Command::new(ssh_program);
     command.arg("-G");
@@ -89,7 +113,8 @@ pub fn resolve_host_policy(
     let config = parse_ssh_config(&output.stdout)
         .with_context(|| format!("parse `ssh -G` output for {host}"))?;
     let keygen = ssh_keygen_for(ssh_program);
-    let (host_keys, saw_ca) = read_known_host_keys(&keygen, &config.lookup, &config.files)?;
+    let (mut host_keys, saw_ca) = read_known_host_keys(&keygen, &config.lookup, &config.files)?;
+    host_keys.retain(|key| configured_host_key_allowed(&config, key));
     if host_keys.is_empty() {
         if saw_ca {
             bail!(
@@ -97,22 +122,38 @@ pub fn resolve_host_policy(
             );
         }
         bail!(
-            "no exact trusted host key for {host} ({}) was found in the configured known_hosts files; connect once with ssh to record it, use --relay, or use --no-forward-agent with credentials on the source host",
+            "no exact trusted host key for {host} ({}) allowed by HostKeyAlgorithms and RequiredRSASize was found in the configured known_hosts files; connect once with ssh to record it, use --relay, or use --no-forward-agent with credentials on the source host",
             config.lookup
         );
     }
+    let user_certificates = if load_user_certificates {
+        let certificate_paths = certificate_paths(&config, host)?;
+        read_user_certificates(&certificate_paths)?
+    } else {
+        Vec::new()
+    };
     Ok(HostPolicy {
         login_user: config.user,
         host_keys,
         known_hosts_name: config.lookup,
+        host_key_algorithms: config.host_key_algorithms,
+        required_rsa_size: config.required_rsa_size,
+        user_certificates,
     })
 }
 
 #[derive(Debug)]
 struct EffectiveSshConfig {
     user: String,
+    hostname: String,
+    port: u16,
+    host_key_alias: Option<String>,
+    proxy_jump: Option<String>,
     lookup: String,
     files: Vec<PathBuf>,
+    host_key_algorithms: Vec<String>,
+    required_rsa_size: usize,
+    certificate_files: Vec<String>,
 }
 
 fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
@@ -121,7 +162,11 @@ fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
     let mut hostname = None;
     let mut port = None;
     let mut hostkey_alias = None;
+    let mut proxy_jump = None;
     let mut files = Vec::new();
+    let mut host_key_algorithms = None;
+    let mut required_rsa_size = None;
+    let mut certificate_files = Vec::new();
     for line in output.lines() {
         let Some((name, value)) = line.split_once(' ') else {
             continue;
@@ -132,6 +177,33 @@ fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
             "hostname" => hostname = Some(value.to_string()),
             "port" => port = Some(value.parse::<u16>().context("invalid SSH port")?),
             "hostkeyalias" if value != "none" => hostkey_alias = Some(value.to_string()),
+            "proxyjump" if value != "none" => proxy_jump = Some(value.to_string()),
+            "hostkeyalgorithms" => {
+                let algorithms: Vec<_> = value
+                    .split(',')
+                    .filter(|algorithm| !algorithm.is_empty())
+                    .map(str::to_string)
+                    .collect();
+                if algorithms.is_empty() {
+                    bail!("empty HostKeyAlgorithms in `ssh -G` output");
+                }
+                host_key_algorithms = Some(algorithms);
+            }
+            "requiredrsasize" => {
+                required_rsa_size =
+                    Some(value.parse::<usize>().context("invalid RequiredRSASize")?);
+            }
+            "knownhostscommand" if value != "none" => {
+                bail!(
+                    "KnownHostsCommand is configured as {value:?}; constrained agent forwarding cannot safely reproduce dynamic OpenSSH host-key policy"
+                );
+            }
+            "revokedhostkeys" if value != "none" => {
+                bail!(
+                    "RevokedHostKeys is configured as {value:?}; constrained agent forwarding does not yet query OpenSSH KRL revocations"
+                );
+            }
+            "certificatefile" if value != "none" => certificate_files.push(value.to_string()),
             "userknownhostsfile" | "globalknownhostsfile" => {
                 for path in value
                     .split_ascii_whitespace()
@@ -153,18 +225,243 @@ fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
         .filter(|value| !value.is_empty())
         .context("missing SSH hostname")?;
     let port = port.context("missing SSH port")?;
-    let lookup = match hostkey_alias {
-        Some(alias) => alias,
-        None if port == 22 => hostname,
+    let lookup = match &hostkey_alias {
+        Some(alias) => alias.clone(),
+        None if port == 22 => hostname.clone(),
         None => format!("[{hostname}]:{port}"),
     };
     files.sort();
     files.dedup();
     Ok(EffectiveSshConfig {
         user,
+        hostname,
+        port,
+        host_key_alias: hostkey_alias,
+        proxy_jump,
         lookup,
         files,
+        host_key_algorithms: host_key_algorithms.context("missing SSH HostKeyAlgorithms")?,
+        required_rsa_size: required_rsa_size.context("missing SSH RequiredRSASize")?,
+        certificate_files,
     })
+}
+
+fn configured_host_key_allowed(config: &EffectiveSshConfig, key: &KeyData) -> bool {
+    if let Some(rsa) = key.rsa() {
+        let Some(modulus) = rsa.n.as_positive_bytes() else {
+            return false;
+        };
+        let bits = modulus
+            .first()
+            .map(|first| modulus.len() * 8 - first.leading_zeros() as usize)
+            .unwrap_or(0);
+        if bits < config.required_rsa_size {
+            return false;
+        }
+        return config.host_key_algorithms.iter().any(|algorithm| {
+            matches!(
+                algorithm.as_str(),
+                "ssh-rsa" | "rsa-sha2-256" | "rsa-sha2-512"
+            )
+        });
+    }
+    let algorithm = key.algorithm();
+    config
+        .host_key_algorithms
+        .iter()
+        .any(|allowed| allowed == algorithm.as_str())
+}
+
+fn certificate_paths(config: &EffectiveSshConfig, original_host: &str) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for configured in &config.certificate_files {
+        let expanded = expand_certificate_path(configured, config, original_host)
+            .with_context(|| format!("expand CertificateFile {configured:?}"))?;
+        if !paths.contains(&expanded) {
+            paths.push(expanded);
+        }
+    }
+    Ok(paths)
+}
+
+fn expand_certificate_path(
+    configured: &str,
+    config: &EffectiveSshConfig,
+    original_host: &str,
+) -> Result<PathBuf> {
+    let configured = expand_environment(configured)?;
+    let needs_account = configured == "~"
+        || configured.starts_with("~/")
+        || configured.contains("%d")
+        || configured.contains("%u");
+    let account = needs_account
+        .then(local_account)
+        .transpose()?
+        .unwrap_or_default();
+    let home = account.home;
+    let configured = if configured == "~" {
+        home.clone()
+    } else if let Some(rest) = configured.strip_prefix("~/") {
+        format!("{home}/{rest}")
+    } else if configured.starts_with('~') {
+        bail!("CertificateFile uses an unsupported named-user tilde");
+    } else {
+        configured
+    };
+
+    let host_key_name = config.host_key_alias.as_deref().unwrap_or(original_host);
+    let mut expanded = String::with_capacity(configured.len());
+    let mut chars = configured.chars();
+    while let Some(character) = chars.next() {
+        if character != '%' {
+            expanded.push(character);
+            continue;
+        }
+        let token = chars.next().context("trailing '%' in CertificateFile")?;
+        match token {
+            '%' => expanded.push('%'),
+            'd' => expanded.push_str(&home),
+            'h' => expanded.push_str(&config.hostname),
+            'i' => expanded.push_str(&unsafe { libc::getuid() }.to_string()),
+            'j' => expanded.push_str(config.proxy_jump.as_deref().unwrap_or("")),
+            'k' => expanded.push_str(host_key_name),
+            'L' => {
+                let hostname = local_hostname()?;
+                expanded.push_str(
+                    hostname
+                        .split_once('.')
+                        .map_or(hostname.as_str(), |(short, _)| short),
+                );
+            }
+            'l' => expanded.push_str(&local_hostname()?),
+            'n' => expanded.push_str(original_host),
+            'p' => expanded.push_str(&config.port.to_string()),
+            'r' => expanded.push_str(&config.user),
+            'u' => expanded.push_str(&account.username),
+            'C' => bail!(
+                "CertificateFile uses OpenSSH's %C connection hash, which syq cannot reproduce safely"
+            ),
+            other => bail!("unsupported CertificateFile token %{other}"),
+        }
+    }
+    Ok(PathBuf::from(expanded))
+}
+
+#[derive(Default)]
+struct LocalAccount {
+    username: String,
+    home: String,
+}
+
+fn local_account() -> Result<LocalAccount> {
+    const MAX_ACCOUNT_BUFFER: usize = 1024 * 1024;
+
+    let uid = unsafe { libc::getuid() };
+    let configured_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    let mut size = if configured_size > 0 {
+        configured_size as usize
+    } else {
+        16 * 1024
+    }
+    .clamp(1024, MAX_ACCOUNT_BUFFER);
+    loop {
+        let mut entry = unsafe { std::mem::zeroed::<libc::passwd>() };
+        let mut result = std::ptr::null_mut();
+        let mut buffer = vec![0u8; size];
+        let status = unsafe {
+            libc::getpwuid_r(
+                uid,
+                &mut entry,
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+                &mut result,
+            )
+        };
+        if status == libc::ERANGE && size < MAX_ACCOUNT_BUFFER {
+            size = size.saturating_mul(2).min(MAX_ACCOUNT_BUFFER);
+            continue;
+        }
+        if status != 0 {
+            return Err(io::Error::from_raw_os_error(status)).context("look up local SSH user");
+        }
+        if result.is_null() {
+            bail!("local SSH user for uid {uid} was not found");
+        }
+        if entry.pw_name.is_null() || entry.pw_dir.is_null() {
+            bail!("local SSH account record for uid {uid} was incomplete");
+        }
+        let username = unsafe { CStr::from_ptr(entry.pw_name) }
+            .to_str()
+            .context("local SSH username was not UTF-8")?
+            .to_string();
+        let home = unsafe { CStr::from_ptr(entry.pw_dir) }
+            .to_str()
+            .context("local SSH home directory was not UTF-8")?
+            .to_string();
+        return Ok(LocalAccount { username, home });
+    }
+}
+
+fn expand_environment(configured: &str) -> Result<String> {
+    let mut expanded = String::with_capacity(configured.len());
+    let mut rest = configured;
+    while let Some(start) = rest.find("${") {
+        expanded.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let end = after
+            .find('}')
+            .context("unterminated environment variable in CertificateFile")?;
+        let name = &after[..end];
+        if name.is_empty()
+            || !name
+                .bytes()
+                .all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+        {
+            bail!("invalid environment variable in CertificateFile");
+        }
+        let value = std::env::var(name)
+            .with_context(|| format!("CertificateFile environment variable {name} is unset"))?;
+        expanded.push_str(&value);
+        rest = &after[end + 1..];
+    }
+    expanded.push_str(rest);
+    Ok(expanded)
+}
+
+fn local_hostname() -> Result<String> {
+    let mut bytes = [0u8; 256];
+    if unsafe { libc::gethostname(bytes.as_mut_ptr().cast(), bytes.len()) } != 0 {
+        return Err(io::Error::last_os_error()).context("read local hostname");
+    }
+    let length = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .context("local hostname exceeded 255 bytes")?;
+    String::from_utf8(bytes[..length].to_vec()).context("local hostname was not UTF-8")
+}
+
+fn read_user_certificates(paths: &[PathBuf]) -> Result<Vec<Certificate>> {
+    let mut certificates = Vec::new();
+    for path in paths {
+        if !path.exists() {
+            continue;
+        }
+        let certificate = Certificate::read_file(path)
+            .with_context(|| format!("read user CertificateFile {}", path.display()))?;
+        if certificate.cert_type() != CertType::User {
+            bail!(
+                "CertificateFile {} is not a user certificate",
+                path.display()
+            );
+        }
+        certificate
+            .verify_signature()
+            .with_context(|| format!("verify CertificateFile {}", path.display()))?;
+        if !certificates.contains(&certificate) {
+            certificates.push(certificate);
+        }
+    }
+    Ok(certificates)
 }
 
 fn ssh_keygen_for(ssh_program: &str) -> OsString {
@@ -286,17 +583,24 @@ impl std::fmt::Debug for ConstrainedAgentBroker {
 }
 
 impl ConstrainedAgentBroker {
-    pub fn start(policy: BrokerPolicy) -> Result<Self> {
+    pub fn start(policy: BrokerPolicy, max_connections: usize) -> Result<Self> {
         let ambient = std::env::var_os("SSH_AUTH_SOCK")
             .filter(|value| !value.is_empty())
             .map(PathBuf::from)
             .context(
                 "SSH_AUTH_SOCK is not set; constrained direct remote-to-remote authentication needs a local SSH agent (or use --relay/--no-forward-agent)",
             )?;
-        Self::start_with_socket(ambient, policy)
+        Self::start_with_socket(ambient, policy, max_connections)
     }
 
-    fn start_with_socket(ambient_socket: PathBuf, policy: BrokerPolicy) -> Result<Self> {
+    fn start_with_socket(
+        ambient_socket: PathBuf,
+        policy: BrokerPolicy,
+        max_connections: usize,
+    ) -> Result<Self> {
+        if max_connections == 0 {
+            bail!("constrained agent broker needs at least one connection slot");
+        }
         if !ambient_socket.is_absolute() {
             bail!("SSH_AUTH_SOCK must be an absolute Unix socket path");
         }
@@ -334,6 +638,7 @@ impl ConstrainedAgentBroker {
                     listener,
                     thread_ambient,
                     policy,
+                    max_connections,
                     thread_shutdown,
                     thread_connections,
                 )
@@ -391,6 +696,7 @@ fn accept_connections(
     listener: UnixListener,
     ambient_socket: PathBuf,
     policy: Arc<BrokerPolicy>,
+    max_connections: usize,
     shutdown: Arc<AtomicBool>,
     connections: Arc<ConnectionRegistry>,
 ) {
@@ -399,7 +705,7 @@ fn accept_connections(
         reap_workers(&mut workers);
         match listener.accept() {
             Ok((stream, _)) => {
-                if workers.len() >= MAX_BROKER_CONNECTIONS {
+                if workers.len() >= max_connections {
                     let _ = stream.shutdown(Shutdown::Both);
                     continue;
                 }
@@ -525,10 +831,8 @@ impl BindState {
             .verify_signature()
             .context("invalid session-bind host-key signature")?;
         match self.bindings.len() {
-            0 if binding.is_forwarding && policy.delegate.host_keys.contains(&binding.host_key) => {
-            }
-            1 if !binding.is_forwarding
-                && policy.destination.host_keys.contains(&binding.host_key) => {}
+            0 if binding.is_forwarding && policy.delegate.authorizes_binding(&binding) => {}
+            1 if !binding.is_forwarding && policy.destination.authorizes_binding(&binding) => {}
             0 => bail!(
                 "first session-bind did not identify trusted delegate {}",
                 policy.delegate.known_hosts_name
@@ -596,6 +900,7 @@ fn serve_client(
 ) -> Result<()> {
     let mut state = BindState::default();
     let mut upstream: Option<TrackedStream> = None;
+    let mut ambient_identities: Option<Vec<Identity>> = None;
     while let Some(frame) = read_frame(&mut downstream)? {
         let Some(message_id) = frame.first().copied() else {
             break;
@@ -606,9 +911,14 @@ fn serve_client(
                     &mut upstream,
                     ambient_socket,
                     &connections,
+                    &state.bindings,
                     &frame,
                     UpstreamResponse::Identities,
                 )?;
+                let identities = decode_identities_response(&response)?;
+                ambient_identities = Some(identities.clone());
+                let response =
+                    add_configured_certificates(identities, &policy.destination.user_certificates)?;
                 write_frame(&mut downstream, &response)?;
             }
             13 => {
@@ -621,18 +931,66 @@ fn serve_client(
                     write_frame(&mut downstream, SSH_AGENT_FAILURE)?;
                     break;
                 }
+                if ambient_identities.is_none() {
+                    let response = upstream_request(
+                        &mut upstream,
+                        ambient_socket,
+                        &connections,
+                        &state.bindings,
+                        &[11],
+                        UpstreamResponse::Identities,
+                    )?;
+                    ambient_identities = Some(decode_identities_response(&response)?);
+                }
+                if authorize_selected_credential(
+                    &request.credential,
+                    &policy.destination.user_certificates,
+                )
+                .is_err()
+                {
+                    write_frame(&mut downstream, SSH_AGENT_FAILURE)?;
+                    break;
+                }
+                let upstream_frame = translated_sign_request(
+                    &request,
+                    ambient_identities.as_deref().unwrap_or_default(),
+                    &policy.destination.user_certificates,
+                )?;
                 let response = upstream_request(
                     &mut upstream,
                     ambient_socket,
                     &connections,
-                    &frame,
+                    &state.bindings,
+                    &upstream_frame,
                     UpstreamResponse::Signature,
                 )?;
+                if verify_agent_sign_response(
+                    &response,
+                    request.credential.key_data(),
+                    &request.data,
+                )
+                .is_err()
+                {
+                    write_frame(&mut downstream, SSH_AGENT_FAILURE)?;
+                    break;
+                }
                 write_frame(&mut downstream, &response)?;
             }
             27 => {
                 let binding = parse_session_bind(&frame);
-                match binding.and_then(|binding| state.add(policy, binding)) {
+                match binding.and_then(|binding| {
+                    state.add(policy, binding)?;
+                    if let Some(stream) = upstream.as_mut() {
+                        replay_session_bind(
+                            stream,
+                            state
+                                .bindings
+                                .last()
+                                .context("missing validated session-bind")?,
+                        )?;
+                    }
+                    Ok(())
+                }) {
                     Ok(()) => write_frame(&mut downstream, SSH_AGENT_SUCCESS)?,
                     Err(_) => {
                         write_frame(&mut downstream, SSH_AGENT_EXTENSION_FAILURE)?;
@@ -692,6 +1050,7 @@ fn upstream_request(
     upstream: &mut Option<TrackedStream>,
     ambient_socket: &Path,
     connections: &Arc<ConnectionRegistry>,
+    bindings: &[SessionBind],
     request: &[u8],
     expected: UpstreamResponse,
 ) -> Result<Vec<u8>> {
@@ -702,13 +1061,154 @@ fn upstream_request(
                 ambient_socket.display()
             )
         })?;
-        *upstream = Some(connections.track(stream)?);
+        let mut stream = connections.track(stream)?;
+        for binding in bindings {
+            replay_session_bind(&mut stream, binding)?;
+        }
+        *upstream = Some(stream);
     }
     let stream = upstream.as_mut().context("ambient SSH agent unavailable")?;
     write_frame(stream, request)?;
     let response = read_frame(stream)?.context("ambient SSH agent closed without a response")?;
     validate_upstream_response(&response, expected)?;
     Ok(response)
+}
+
+fn replay_session_bind(stream: &mut TrackedStream, binding: &SessionBind) -> Result<()> {
+    let request = Request::Extension(Extension::new_message(binding.clone())?);
+    let mut frame = Vec::new();
+    request.encode(&mut frame)?;
+    write_frame(stream, &frame)?;
+    let response = read_frame(stream)?.context("ambient SSH agent closed during session-bind")?;
+    let mut input = response.as_slice();
+    let response = Response::decode(&mut input).context("decode ambient session-bind response")?;
+    if !input.is_empty() {
+        bail!("trailing bytes in ambient session-bind response");
+    }
+    match response {
+        // OpenSSH accepts and enforces the binding. Agents that do not
+        // implement session-bind commonly reject it but remain usable; syq's
+        // own broker policy is still mandatory for every downstream request.
+        Response::Success | Response::Failure | Response::ExtensionFailure => Ok(()),
+        _ => bail!("ambient agent returned an unexpected session-bind response"),
+    }
+}
+
+fn decode_identities_response(frame: &[u8]) -> Result<Vec<Identity>> {
+    let mut input = frame;
+    let response = Response::decode(&mut input).context("decode ambient identities response")?;
+    if !input.is_empty() {
+        bail!("trailing bytes in ambient identities response");
+    }
+    match response {
+        Response::IdentitiesAnswer(identities) => Ok(identities),
+        Response::Failure => Ok(Vec::new()),
+        _ => bail!("ambient agent returned an unexpected identities response"),
+    }
+}
+
+fn add_configured_certificates(
+    identities: Vec<Identity>,
+    certificates: &[Certificate],
+) -> Result<Vec<u8>> {
+    let ambient_raw_keys: Vec<_> = identities
+        .iter()
+        .filter_map(|identity| match &identity.credential {
+            PublicCredential::Key(key) => Some(key.clone()),
+            PublicCredential::Cert(_) => None,
+        })
+        .collect();
+    let mut identities: Vec<_> = identities
+        .into_iter()
+        .filter(|identity| {
+            let covered = certificates
+                .iter()
+                .any(|certificate| certificate.public_key() == identity.credential.key_data());
+            !covered
+                || certificates.iter().any(|certificate| {
+                    identity.credential == PublicCredential::Cert(Box::new(certificate.clone()))
+                })
+        })
+        .collect();
+    for certificate in certificates {
+        let credential = PublicCredential::Cert(Box::new(certificate.clone()));
+        if identities
+            .iter()
+            .any(|identity| identity.credential == credential)
+        {
+            continue;
+        }
+        if ambient_raw_keys.contains(certificate.public_key()) {
+            identities.push(Identity {
+                credential,
+                comment: format!("syq CertificateFile {}", certificate.key_id()),
+            });
+        }
+    }
+    let mut frame = Vec::new();
+    Response::IdentitiesAnswer(identities).encode(&mut frame)?;
+    Ok(frame)
+}
+
+fn authorize_selected_credential(
+    credential: &PublicCredential,
+    certificates: &[Certificate],
+) -> Result<()> {
+    let covered_by_certificate_file = certificates
+        .iter()
+        .any(|certificate| certificate.public_key() == credential.key_data());
+    match credential {
+        PublicCredential::Key(_) if covered_by_certificate_file => {
+            bail!("raw key is covered by a configured CertificateFile")
+        }
+        PublicCredential::Cert(certificate)
+            if covered_by_certificate_file && !certificates.contains(certificate.as_ref()) =>
+        {
+            bail!("certificate was not an exact configured CertificateFile")
+        }
+        _ => Ok(()),
+    }
+}
+
+fn translated_sign_request(
+    request: &SignRequest,
+    ambient_identities: &[Identity],
+    certificates: &[Certificate],
+) -> Result<Vec<u8>> {
+    let mut translated = request.clone();
+    if let PublicCredential::Cert(certificate) = &request.credential {
+        let ambient_has_exact_certificate = ambient_identities
+            .iter()
+            .any(|identity| identity.credential == request.credential);
+        let configured_locally = certificates.contains(certificate.as_ref());
+        let ambient_has_raw_key = ambient_identities.iter().any(|identity| {
+            matches!(
+                &identity.credential,
+                PublicCredential::Key(key) if key == certificate.public_key()
+            )
+        });
+        if !ambient_has_exact_certificate && configured_locally && ambient_has_raw_key {
+            translated.credential = PublicCredential::Key(certificate.public_key().clone());
+        }
+    }
+    let mut frame = Vec::new();
+    Request::SignRequest(translated).encode(&mut frame)?;
+    Ok(frame)
+}
+
+fn verify_agent_sign_response(frame: &[u8], key: &KeyData, data: &[u8]) -> Result<()> {
+    let mut input = frame;
+    let response = Response::decode(&mut input).context("decode ambient signature response")?;
+    if !input.is_empty() {
+        bail!("trailing bytes in ambient signature response");
+    }
+    match response {
+        Response::SignResponse(signature) => key
+            .verify(data, &signature)
+            .context("ambient agent returned an invalid signature"),
+        Response::Failure => Ok(()),
+        _ => bail!("ambient agent returned an unexpected signature response"),
+    }
 }
 
 fn validate_upstream_response(frame: &[u8], expected: UpstreamResponse) -> Result<()> {
@@ -869,6 +1369,8 @@ mod tests {
     use std::sync::mpsc;
     use std::time::Instant;
 
+    const TEST_BROKER_CONNECTIONS: usize = 4;
+
     fn key(seed: u8) -> (Ed25519Keypair, KeyData) {
         let keypair = Ed25519Keypair::from_seed(&[seed; 32]);
         let public = KeyData::Ed25519(keypair.public);
@@ -876,10 +1378,14 @@ mod tests {
     }
 
     fn host_policy(user: &str, name: &str, key: KeyData) -> HostPolicy {
+        let algorithm = key.algorithm().as_str().to_string();
         HostPolicy {
             login_user: user.into(),
             host_keys: vec![key],
             known_hosts_name: name.into(),
+            host_key_algorithms: vec![algorithm],
+            required_rsa_size: 1024,
+            user_certificates: Vec::new(),
         }
     }
 
@@ -927,7 +1433,11 @@ mod tests {
             value.encode(&mut data).unwrap();
         }
         data.push(1);
-        b"ssh-ed25519".as_slice().encode(&mut data).unwrap();
+        let algorithm = match credential {
+            PublicCredential::Key(key) => key.algorithm().as_str().to_string(),
+            PublicCredential::Cert(certificate) => certificate.algorithm().to_certificate_type(),
+        };
+        algorithm.as_bytes().encode(&mut data).unwrap();
         credential_blob.as_slice().encode(&mut data).unwrap();
         host_key_blob.as_slice().encode(&mut data).unwrap();
         data
@@ -940,13 +1450,37 @@ mod tests {
         identity: KeyData,
         host_key: &KeyData,
     ) -> SignRequest {
-        let credential = identity.into();
+        sign_request_for_credential(session_id, user, method, identity.into(), host_key)
+    }
+
+    fn sign_request_for_credential(
+        session_id: &[u8],
+        user: &[u8],
+        method: &[u8],
+        credential: PublicCredential,
+        host_key: &KeyData,
+    ) -> SignRequest {
         let data = hostbound_data(session_id, user, method, &credential, host_key);
         SignRequest {
             credential,
             data,
             flags: 0,
         }
+    }
+
+    fn user_certificate(subject: &KeyData, ca_seed: u8, key_id: &str) -> Certificate {
+        let ca =
+            ssh_agent_lib::ssh_key::PrivateKey::from(Ed25519Keypair::from_seed(&[ca_seed; 32]));
+        let mut builder = ssh_agent_lib::ssh_key::certificate::Builder::new(
+            vec![ca_seed; 16],
+            subject.clone(),
+            0,
+            4_000_000_000,
+        )
+        .unwrap();
+        builder.key_id(key_id).unwrap();
+        builder.valid_principal("backup").unwrap();
+        builder.sign(&ca).unwrap()
     }
 
     fn read_response(stream: &mut UnixStream) -> Response {
@@ -981,6 +1515,7 @@ mod tests {
             while let Some(frame) = read_frame(&mut stream).unwrap() {
                 sent.send(frame.clone()).unwrap();
                 let response = match frame.first() {
+                    Some(27) => Response::ExtensionFailure,
                     Some(11) => Response::IdentitiesAnswer(vec![Identity {
                         credential: KeyData::Ed25519(identity.public).into(),
                         comment: "hardware-backed test key".into(),
@@ -1002,11 +1537,12 @@ mod tests {
     #[test]
     fn parses_effective_host_lookup_and_files() {
         let config = parse_ssh_config(
-            b"host alias\nuser backup\nhostname vault.internal\nport 2222\nuserknownhostsfile /tmp/one /tmp/two\nglobalknownhostsfile none\n",
+            b"host alias\nuser backup\nhostname vault.internal\nport 2222\nuserknownhostsfile /tmp/one /tmp/two\nglobalknownhostsfile none\nhostkeyalgorithms ssh-ed25519,rsa-sha2-512\nrequiredrsasize 3072\n",
         )
         .unwrap();
         assert_eq!(config.user, "backup");
         assert_eq!(config.lookup, "[vault.internal]:2222");
+        assert_eq!(config.required_rsa_size, 3072);
         assert_eq!(
             config.files,
             [PathBuf::from("/tmp/one"), PathBuf::from("/tmp/two")]
@@ -1016,10 +1552,159 @@ mod tests {
     #[test]
     fn host_key_alias_is_used_verbatim() {
         let config = parse_ssh_config(
-            b"user backup\nhostname vault.internal\nport 2222\nhostkeyalias stable-vault\nuserknownhostsfile /tmp/known\n",
+            b"user backup\nhostname vault.internal\nport 2222\nhostkeyalias stable-vault\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\nrequiredrsasize 1024\n",
         )
         .unwrap();
         assert_eq!(config.lookup, "stable-vault");
+    }
+
+    #[test]
+    fn dynamic_and_external_revocation_host_policies_fail_closed() {
+        for policy in [
+            "knownhostscommand /usr/local/bin/known-host %h",
+            "revokedhostkeys /etc/ssh/revoked.krl",
+        ] {
+            let config = format!(
+                "user backup\nhostname vault.internal\nport 22\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\nrequiredrsasize 1024\n{policy}\n"
+            );
+            let error = parse_ssh_config(config.as_bytes()).unwrap_err();
+            assert!(error.to_string().contains("constrained agent forwarding"));
+        }
+    }
+
+    #[test]
+    fn host_key_algorithms_and_required_rsa_size_are_enforced() {
+        use ssh_agent_lib::ssh_key::{public::RsaPublicKey, Mpint};
+
+        let config = parse_ssh_config(
+            b"user backup\nhostname vault.internal\nport 22\nuserknownhostsfile /tmp/known\nhostkeyalgorithms rsa-sha2-512\nrequiredrsasize 3072\n",
+        )
+        .unwrap();
+        let rsa = KeyData::Rsa(RsaPublicKey {
+            e: Mpint::from_positive_bytes(&[1, 0, 1]).unwrap(),
+            n: Mpint::from_positive_bytes(&[0x80; 256]).unwrap(),
+        });
+        assert!(!configured_host_key_allowed(&config, &rsa));
+        let mut config = config;
+        config.required_rsa_size = 2048;
+        assert!(configured_host_key_allowed(&config, &rsa));
+        let (_, ed25519) = key(50);
+        assert!(!configured_host_key_allowed(&config, &ed25519));
+    }
+
+    #[test]
+    fn certificate_paths_expand_effective_remote_tokens() {
+        let config = parse_ssh_config(
+            b"user backup\nhostname vault.internal\nport 2222\nhostkeyalias stable-vault\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\nrequiredrsasize 1024\ncertificatefile /tmp/%r@%h:%p-%k-%n-cert.pub\n",
+        )
+        .unwrap();
+        assert_eq!(
+            certificate_paths(&config, "vault-alias").unwrap(),
+            [PathBuf::from(
+                "/tmp/backup@vault.internal:2222-stable-vault-vault-alias-cert.pub"
+            )]
+        );
+    }
+
+    #[test]
+    fn configured_certificate_is_advertised_and_translated_only_for_its_raw_key() {
+        let (raw_private, raw_key) = key(61);
+        let certificate = user_certificate(&raw_key, 62, "central-cert");
+        let ambient = vec![Identity {
+            credential: PublicCredential::Key(raw_key.clone()),
+            comment: "YubiKey raw key".into(),
+        }];
+        let response =
+            add_configured_certificates(ambient.clone(), std::slice::from_ref(&certificate))
+                .unwrap();
+        let advertised = decode_identities_response(&response).unwrap();
+        assert_eq!(advertised.len(), 1);
+        assert_eq!(
+            advertised[0].credential,
+            PublicCredential::Cert(Box::new(certificate.clone()))
+        );
+        assert!(authorize_selected_credential(
+            &PublicCredential::Key(raw_key.clone()),
+            std::slice::from_ref(&certificate)
+        )
+        .is_err());
+
+        let request = SignRequest {
+            credential: PublicCredential::Cert(Box::new(certificate.clone())),
+            data: b"host-bound request containing the exact certificate".to_vec(),
+            flags: 0,
+        };
+        let translated =
+            translated_sign_request(&request, &ambient, std::slice::from_ref(&certificate))
+                .unwrap();
+        let translated = parse_sign_request(&translated).unwrap();
+        assert_eq!(
+            translated.credential,
+            PublicCredential::Key(raw_key.clone())
+        );
+        assert_eq!(translated.data, request.data);
+        authorize_selected_credential(&request.credential, std::slice::from_ref(&certificate))
+            .unwrap();
+        let mut valid_response = Vec::new();
+        Response::SignResponse(raw_private.try_sign(&request.data).unwrap())
+            .encode(&mut valid_response)
+            .unwrap();
+        verify_agent_sign_response(&valid_response, &raw_key, &request.data).unwrap();
+        let (wrong_private, _) = key(64);
+        let mut invalid_response = Vec::new();
+        Response::SignResponse(wrong_private.try_sign(&request.data).unwrap())
+            .encode(&mut invalid_response)
+            .unwrap();
+        assert!(verify_agent_sign_response(&invalid_response, &raw_key, &request.data).is_err());
+
+        let (source_private, source) = key(65);
+        let (destination_private, destination) = key(66);
+        let mut broker_policy = policy(source.clone(), destination.clone());
+        broker_policy.destination.user_certificates = vec![certificate.clone()];
+        let mut state = BindState::default();
+        state
+            .add(
+                &broker_policy,
+                binding(&source_private, source, b"source-cert-session", true),
+            )
+            .unwrap();
+        state
+            .add(
+                &broker_policy,
+                binding(
+                    &destination_private,
+                    destination.clone(),
+                    b"destination-cert-session",
+                    false,
+                ),
+            )
+            .unwrap();
+        let certificate_request = sign_request_for_credential(
+            b"destination-cert-session",
+            b"backup",
+            b"publickey-hostbound-v00@openssh.com",
+            PublicCredential::Cert(Box::new(certificate.clone())),
+            &destination,
+        );
+        state
+            .authorize(&broker_policy, &certificate_request)
+            .unwrap();
+        let mut mismatched_outer = certificate_request.clone();
+        mismatched_outer.credential = PublicCredential::Key(raw_key.clone());
+        assert!(state.authorize(&broker_policy, &mismatched_outer).is_err());
+
+        let unrelated = user_certificate(&raw_key, 63, "not-configured");
+        let request = SignRequest {
+            credential: PublicCredential::Cert(Box::new(unrelated.clone())),
+            data: Vec::new(),
+            flags: 0,
+        };
+        assert!(authorize_selected_credential(&request.credential, &[certificate]).is_err());
+        let untranslated = translated_sign_request(&request, &ambient, &[]).unwrap();
+        assert_eq!(
+            parse_sign_request(&untranslated).unwrap().credential,
+            request.credential
+        );
     }
 
     #[test]
@@ -1099,6 +1784,20 @@ mod tests {
         let (destination_private, destination) = key(2);
         let (other_private, other) = key(3);
         let policy = policy(source.clone(), destination.clone());
+
+        let mut disallowed_algorithm = policy.clone();
+        disallowed_algorithm.delegate.host_key_algorithms = vec!["rsa-sha2-512".into()];
+        assert!(BindState::default()
+            .add(
+                &disallowed_algorithm,
+                binding(
+                    &source_private,
+                    source.clone(),
+                    b"disallowed-algorithm",
+                    true,
+                ),
+            )
+            .is_err());
 
         let mut state = BindState::default();
         assert!(state
@@ -1220,6 +1919,7 @@ mod tests {
         let broker = ConstrainedAgentBroker::start_with_socket(
             ambient_socket,
             policy(source.clone(), destination.clone()),
+            TEST_BROKER_CONNECTIONS,
         )
         .unwrap();
         let broker_path = broker.socket_path().to_path_buf();
@@ -1233,11 +1933,8 @@ mod tests {
         );
         let mut client = UnixStream::connect(&broker_path).unwrap();
 
-        write_frame(
-            &mut client,
-            &bind_request(binding(&source_private, source, b"source-session", true)),
-        )
-        .unwrap();
+        let source_bind = bind_request(binding(&source_private, source, b"source-session", true));
+        write_frame(&mut client, &source_bind).unwrap();
         assert!(matches!(read_response(&mut client), Response::Success));
 
         write_frame(&mut client, &[11]).unwrap();
@@ -1246,19 +1943,18 @@ mod tests {
         };
         assert_eq!(identities.len(), 1);
         assert_eq!(identities[0].comment, "hardware-backed test key");
+        assert_eq!(requests.recv().unwrap(), source_bind);
         assert_eq!(requests.recv().unwrap(), vec![11]);
 
-        write_frame(
-            &mut client,
-            &bind_request(binding(
-                &destination_private,
-                destination.clone(),
-                b"destination-session",
-                false,
-            )),
-        )
-        .unwrap();
+        let destination_bind = bind_request(binding(
+            &destination_private,
+            destination.clone(),
+            b"destination-session",
+            false,
+        ));
+        write_frame(&mut client, &destination_bind).unwrap();
         assert!(matches!(read_response(&mut client), Response::Success));
+        assert_eq!(requests.recv().unwrap(), destination_bind);
         let request = sign_request(
             b"destination-session",
             b"backup",
@@ -1291,6 +1987,7 @@ mod tests {
         let broker = ConstrainedAgentBroker::start_with_socket(
             ambient_socket,
             policy(source, destination.clone()),
+            TEST_BROKER_CONNECTIONS,
         )
         .unwrap();
 
@@ -1338,12 +2035,15 @@ mod tests {
         let _ambient = UnixListener::bind(&ambient_socket).unwrap();
         let (_, source) = key(41);
         let (_, destination) = key(42);
-        let broker =
-            ConstrainedAgentBroker::start_with_socket(ambient_socket, policy(source, destination))
-                .unwrap();
+        let broker = ConstrainedAgentBroker::start_with_socket(
+            ambient_socket,
+            policy(source, destination),
+            TEST_BROKER_CONNECTIONS,
+        )
+        .unwrap();
         let path = broker.socket_path().to_path_buf();
         let mut clients = Vec::new();
-        for _ in 0..MAX_BROKER_CONNECTIONS {
+        for _ in 0..TEST_BROKER_CONNECTIONS {
             let mut client = UnixStream::connect(&path).unwrap();
             client.write_all(&[0]).unwrap(); // keep each worker waiting on its header
             clients.push(client);
@@ -1355,7 +2055,7 @@ mod tests {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .len()
-            < MAX_BROKER_CONNECTIONS
+            < TEST_BROKER_CONNECTIONS
             && Instant::now() < deadline
         {
             thread::sleep(Duration::from_millis(5));
@@ -1367,7 +2067,7 @@ mod tests {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .len(),
-            MAX_BROKER_CONNECTIONS
+            TEST_BROKER_CONNECTIONS
         );
         let mut excess = UnixStream::connect(&path).unwrap();
         excess

--- a/src/agent_broker.rs
+++ b/src/agent_broker.rs
@@ -18,6 +18,7 @@ use ssh_agent_lib::ssh_key::{
 };
 use std::collections::HashMap;
 use std::ffi::{CStr, OsString};
+use std::fs;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
@@ -35,6 +36,8 @@ const MAX_AGENT_FRAME: usize = 256 * 1024;
 /// Bound stalled forwarded clients and ambient-agent operations while leaving
 /// enough time for hardware-token touch/PIN/confirmation prompts.
 const BROKER_IO_TIMEOUT: Duration = Duration::from_secs(120);
+const MAX_SSH_CONFIG_FILES: usize = 256;
+const MAX_SSH_CONFIG_BYTES: usize = 1024 * 1024;
 const SSH_AGENT_FAILURE: &[u8] = &[5];
 const SSH_AGENT_SUCCESS: &[u8] = &[6];
 const SSH_AGENT_EXTENSION_FAILURE: &[u8] = &[28];
@@ -95,11 +98,15 @@ pub fn resolve_host_policy(
     host: &str,
     load_user_certificates: bool,
 ) -> Result<HostPolicy> {
-    let output = inspect_ssh_configuration(ssh_program, explicit_user, host, false)?;
+    let inspection = inspect_ssh_configuration(ssh_program, explicit_user, host, false)?;
     let defaults = inspect_ssh_configuration(ssh_program, explicit_user, host, true)?;
-    let defaults = KnownHostsDefaults::from_openssh(&defaults)?;
-    let config = parse_ssh_config_with_defaults(&output, Some(&defaults))
-        .with_context(|| format!("parse `ssh -G` output for {host}"))?;
+    let defaults = KnownHostsDefaults::from_openssh(&defaults.output)?;
+    let config = parse_ssh_config_with_defaults(
+        &inspection.output,
+        Some(&defaults),
+        &inspection.known_hosts_configured,
+    )
+    .with_context(|| format!("parse `ssh -G` output for {host}"))?;
     let keygen = ssh_keygen_for(ssh_program);
     let (mut host_keys, saw_ca) = read_known_host_keys(&keygen, &config.lookup, &config.files)?;
     host_keys.retain(|key| configured_host_key_allowed(&config, key));
@@ -130,16 +137,27 @@ pub fn resolve_host_policy(
     })
 }
 
+struct SshConfigurationInspection {
+    output: Vec<u8>,
+    known_hosts_configured: KnownHostsConfigured,
+}
+
 fn inspect_ssh_configuration(
     ssh_program: &str,
     explicit_user: Option<&str>,
     host: &str,
     compiled_defaults_only: bool,
-) -> Result<Vec<u8>> {
+) -> Result<SshConfigurationInspection> {
     let mut command = Command::new(ssh_program);
     command.arg("-G");
     if compiled_defaults_only {
         command.args(["-F", "/dev/null"]);
+    } else {
+        // OpenSSH does not retain filename quoting in `ssh -G` output. Its
+        // debug stream identifies the configuration files that contributed to
+        // this query, which lets us distinguish compiled defaults from an
+        // explicitly configured value that happens to render identically.
+        command.arg("-vvv");
     }
     if let Some(user) = explicit_user {
         command.args(["-l", user]);
@@ -159,7 +177,89 @@ fn inspect_ssh_configuration(
             }
         );
     }
-    Ok(output.stdout)
+    let known_hosts_configured = if compiled_defaults_only {
+        KnownHostsConfigured::default()
+    } else {
+        configured_known_hosts_directives(&output.stderr)?
+    };
+    Ok(SshConfigurationInspection {
+        output: output.stdout,
+        known_hosts_configured,
+    })
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct KnownHostsConfigured {
+    user: bool,
+    global: bool,
+}
+
+fn configured_known_hosts_directives(debug: &[u8]) -> Result<KnownHostsConfigured> {
+    const PREFIX: &str = "debug1: Reading configuration data ";
+    let debug = std::str::from_utf8(debug).context("OpenSSH debug output was not UTF-8")?;
+    let mut paths = Vec::new();
+    for line in debug.lines() {
+        let Some(path) = line.strip_prefix(PREFIX) else {
+            continue;
+        };
+        let path = PathBuf::from(path);
+        if !path.is_absolute() {
+            bail!(
+                "OpenSSH reported a non-absolute configuration path while resolving known_hosts provenance"
+            );
+        }
+        if !paths.contains(&path) {
+            if paths.len() == MAX_SSH_CONFIG_FILES {
+                bail!(
+                    "OpenSSH read too many configuration files to establish known_hosts provenance"
+                );
+            }
+            paths.push(path);
+        }
+    }
+
+    let mut configured = KnownHostsConfigured::default();
+    for path in paths {
+        let mut file = fs::File::open(&path)
+            .with_context(|| format!("open SSH configuration file {}", path.display()))?;
+        let metadata = file
+            .metadata()
+            .with_context(|| format!("inspect SSH configuration file {}", path.display()))?;
+        if !metadata.is_file() || metadata.len() > MAX_SSH_CONFIG_BYTES as u64 {
+            bail!(
+                "SSH configuration file {} is not a bounded regular file; constrained agent forwarding cannot establish known_hosts provenance",
+                path.display()
+            );
+        }
+        let mut contents = Vec::new();
+        Read::by_ref(&mut file)
+            .take(MAX_SSH_CONFIG_BYTES as u64 + 1)
+            .read_to_end(&mut contents)
+            .with_context(|| format!("read SSH configuration file {}", path.display()))?;
+        if contents.len() > MAX_SSH_CONFIG_BYTES {
+            bail!(
+                "SSH configuration file {} grew beyond the provenance size limit",
+                path.display()
+            );
+        }
+        configured.user |= contains_ssh_config_directive(&contents, b"userknownhostsfile");
+        configured.global |= contains_ssh_config_directive(&contents, b"globalknownhostsfile");
+    }
+    Ok(configured)
+}
+
+fn contains_ssh_config_directive(contents: &[u8], keyword: &[u8]) -> bool {
+    contents.split(|byte| *byte == b'\n').any(|line| {
+        let line = line.trim_ascii_start();
+        if line.is_empty() || line[0] == b'#' {
+            return false;
+        }
+        let end = line
+            .iter()
+            .position(|byte| byte.is_ascii_whitespace() || *byte == b'=')
+            .unwrap_or(line.len());
+        line[..end].eq_ignore_ascii_case(keyword)
+    })
 }
 
 #[derive(Debug)]
@@ -224,12 +324,13 @@ impl KnownHostsDefaults {
 
 #[cfg(test)]
 fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
-    parse_ssh_config_with_defaults(output, None)
+    parse_ssh_config_with_defaults(output, None, &KnownHostsConfigured::default())
 }
 
 fn parse_ssh_config_with_defaults(
     output: &[u8],
     defaults: Option<&KnownHostsDefaults>,
+    configured: &KnownHostsConfigured,
 ) -> Result<EffectiveSshConfig> {
     let output = std::str::from_utf8(output).context("SSH configuration was not UTF-8")?;
     let mut user = None;
@@ -287,10 +388,20 @@ fn parse_ssh_config_with_defaults(
             }
             "identityfile" if value != "none" => identity_files.push(value.to_string()),
             "userknownhostsfile" => {
-                append_known_hosts_files(&mut files, value, defaults.map(|item| &item.user))?;
+                append_known_hosts_files(
+                    &mut files,
+                    value,
+                    defaults.map(|item| &item.user),
+                    configured.user,
+                )?;
             }
             "globalknownhostsfile" => {
-                append_known_hosts_files(&mut files, value, defaults.map(|item| &item.global))?;
+                append_known_hosts_files(
+                    &mut files,
+                    value,
+                    defaults.map(|item| &item.global),
+                    configured.global,
+                )?;
             }
             _ => {}
         }
@@ -369,11 +480,14 @@ fn append_known_hosts_files(
     files: &mut Vec<PathBuf>,
     value: &str,
     compiled_default: Option<&KnownHostsDefault>,
+    configured: bool,
 ) -> Result<()> {
     if value == "none" {
         return Ok(());
     }
-    if let Some(compiled_default) = compiled_default.filter(|default| default.rendered == value) {
+    if let Some(compiled_default) =
+        compiled_default.filter(|default| !configured && default.rendered == value)
+    {
         files.extend(compiled_default.files.iter().cloned());
         return Ok(());
     }
@@ -1800,7 +1914,12 @@ mod tests {
                 files: Vec::new(),
             },
         };
-        let config = parse_ssh_config_with_defaults(output, Some(&defaults)).unwrap();
+        let config = parse_ssh_config_with_defaults(
+            output,
+            Some(&defaults),
+            &KnownHostsConfigured::default(),
+        )
+        .unwrap();
         assert_eq!(config.user, "backup");
         assert_eq!(config.lookup, "[vault.internal]:2222");
         assert_eq!(config.required_rsa_size, 3072);
@@ -1825,6 +1944,55 @@ mod tests {
                 "unexpected error for {value:?}: {error:#}"
             );
         }
+    }
+
+    #[test]
+    fn configured_value_identical_to_flattened_defaults_fails_closed() {
+        let rendered = "/home/grant/.ssh/known_hosts /home/grant/.ssh/known_hosts2";
+        let output = format!(
+            "user backup\nhostname vault.internal\nport 22\nuserknownhostsfile {rendered}\nglobalknownhostsfile none\nhostkeyalgorithms ssh-ed25519\n"
+        );
+        let defaults = KnownHostsDefaults {
+            user: KnownHostsDefault {
+                rendered: rendered.into(),
+                files: vec![
+                    "/home/grant/.ssh/known_hosts".into(),
+                    "/home/grant/.ssh/known_hosts2".into(),
+                ],
+            },
+            global: KnownHostsDefault {
+                rendered: "none".into(),
+                files: Vec::new(),
+            },
+        };
+        let error = parse_ssh_config_with_defaults(
+            output.as_bytes(),
+            Some(&defaults),
+            &KnownHostsConfigured {
+                user: true,
+                global: false,
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("ambiguous known_hosts"));
+    }
+
+    #[test]
+    fn configured_known_hosts_provenance_uses_files_openssh_read() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = temp.path().join("ssh_config");
+        std::fs::write(
+            &config,
+            b"# GlobalKnownHostsFile /ignored/comment\nHost *\n  UserKnownHostsFile=\"/tmp/known hosts\"\n",
+        )
+        .unwrap();
+        let debug = format!(
+            "OpenSSH test\ndebug1: Reading configuration data {}\n",
+            config.display()
+        );
+        let configured = configured_known_hosts_directives(debug.as_bytes()).unwrap();
+        assert!(configured.user);
+        assert!(!configured.global);
     }
 
     #[test]
@@ -2198,7 +2366,7 @@ mod tests {
     #[test]
     fn openssh_defaults_and_hashed_known_hosts_lookup_are_exercised() {
         let output = inspect_ssh_configuration("ssh", None, "unused.example", true).unwrap();
-        let defaults = KnownHostsDefaults::from_openssh(&output).unwrap();
+        let defaults = KnownHostsDefaults::from_openssh(&output.output).unwrap();
         assert_eq!(defaults.user.files.len(), 2);
         assert!(defaults.user.files.iter().all(|path| path.is_absolute()));
         assert!(defaults.global.files.iter().all(|path| path.is_absolute()));

--- a/src/agent_broker.rs
+++ b/src/agent_broker.rs
@@ -14,7 +14,7 @@ use ssh_agent_lib::ssh_encoding::{Decode, Encode};
 use ssh_agent_lib::ssh_key::{
     certificate::{CertType, Certificate},
     public::KeyData,
-    PublicKey,
+    Algorithm, PublicKey,
 };
 use std::collections::HashMap;
 use std::ffi::{CStr, OsString};
@@ -48,7 +48,9 @@ pub struct HostPolicy {
 
 impl HostPolicy {
     fn authorizes_binding(&self, binding: &SessionBind) -> bool {
-        self.host_keys.contains(&binding.host_key)
+        key_is_cryptographically_verifiable(&binding.host_key)
+            && signature_algorithm_is_cryptographically_verifiable(&binding.signature.algorithm())
+            && self.host_keys.contains(&binding.host_key)
             && self
                 .host_key_algorithms
                 .iter()
@@ -122,7 +124,7 @@ pub fn resolve_host_policy(
             );
         }
         bail!(
-            "no exact trusted host key for {host} ({}) allowed by HostKeyAlgorithms and RequiredRSASize was found in the configured known_hosts files; connect once with ssh to record it, use --relay, or use --no-forward-agent with credentials on the source host",
+            "no exact trusted host key for {host} ({}) allowed by HostKeyAlgorithms and RequiredRSASize and supported by syq's cryptographic verifier was found in the configured known_hosts files; connect once with ssh to record it, use --relay, or use --no-forward-agent with credentials on the source host",
             config.lookup
         );
     }
@@ -154,6 +156,8 @@ struct EffectiveSshConfig {
     host_key_algorithms: Vec<String>,
     required_rsa_size: usize,
     certificate_files: Vec<String>,
+    certificate_files_configured: bool,
+    identity_files: Vec<String>,
 }
 
 fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
@@ -167,6 +171,8 @@ fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
     let mut host_key_algorithms = None;
     let mut required_rsa_size = None;
     let mut certificate_files = Vec::new();
+    let mut certificate_files_configured = false;
+    let mut identity_files = Vec::new();
     for line in output.lines() {
         let Some((name, value)) = line.split_once(' ') else {
             continue;
@@ -203,7 +209,13 @@ fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
                     "RevokedHostKeys is configured as {value:?}; constrained agent forwarding does not yet query OpenSSH KRL revocations"
                 );
             }
-            "certificatefile" if value != "none" => certificate_files.push(value.to_string()),
+            "certificatefile" => {
+                certificate_files_configured = true;
+                if value != "none" {
+                    certificate_files.push(value.to_string());
+                }
+            }
+            "identityfile" if value != "none" => identity_files.push(value.to_string()),
             "userknownhostsfile" | "globalknownhostsfile" => {
                 for path in value
                     .split_ascii_whitespace()
@@ -241,12 +253,19 @@ fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
         lookup,
         files,
         host_key_algorithms: host_key_algorithms.context("missing SSH HostKeyAlgorithms")?,
-        required_rsa_size: required_rsa_size.context("missing SSH RequiredRSASize")?,
+        // RequiredRSASize was added after the OpenSSH 8.9 functional floor.
+        // Before the directive existed, OpenSSH's minimum was 1024 bits.
+        required_rsa_size: required_rsa_size.unwrap_or(1024),
         certificate_files,
+        certificate_files_configured,
+        identity_files,
     })
 }
 
 fn configured_host_key_allowed(config: &EffectiveSshConfig, key: &KeyData) -> bool {
+    if !key_is_cryptographically_verifiable(key) {
+        return false;
+    }
     if let Some(rsa) = key.rsa() {
         let Some(modulus) = rsa.n.as_positive_bytes() else {
             return false;
@@ -258,12 +277,10 @@ fn configured_host_key_allowed(config: &EffectiveSshConfig, key: &KeyData) -> bo
         if bits < config.required_rsa_size {
             return false;
         }
-        return config.host_key_algorithms.iter().any(|algorithm| {
-            matches!(
-                algorithm.as_str(),
-                "ssh-rsa" | "rsa-sha2-256" | "rsa-sha2-512"
-            )
-        });
+        return config
+            .host_key_algorithms
+            .iter()
+            .any(|algorithm| matches!(algorithm.as_str(), "rsa-sha2-256" | "rsa-sha2-512"));
     }
     let algorithm = key.algorithm();
     config
@@ -272,11 +289,60 @@ fn configured_host_key_allowed(config: &EffectiveSshConfig, key: &KeyData) -> bo
         .any(|allowed| allowed == algorithm.as_str())
 }
 
+fn key_is_cryptographically_verifiable(key: &KeyData) -> bool {
+    matches!(
+        key,
+        KeyData::Ecdsa(_)
+            | KeyData::Ed25519(_)
+            | KeyData::Rsa(_)
+            | KeyData::SkEcdsaSha2NistP256(_)
+            | KeyData::SkEd25519(_)
+    )
+}
+
+fn signature_algorithm_is_cryptographically_verifiable(algorithm: &Algorithm) -> bool {
+    matches!(
+        algorithm,
+        Algorithm::Ecdsa { .. }
+            | Algorithm::Ed25519
+            | Algorithm::Rsa { hash: Some(_) }
+            | Algorithm::SkEcdsaSha2NistP256
+            | Algorithm::SkEd25519
+    )
+}
+
+fn credential_is_cryptographically_verifiable(credential: &PublicCredential) -> bool {
+    key_is_cryptographically_verifiable(credential.key_data())
+        && match credential {
+            PublicCredential::Key(_) => true,
+            PublicCredential::Cert(certificate) => certificate.verify_signature().is_ok(),
+        }
+}
+
 fn certificate_paths(config: &EffectiveSshConfig, original_host: &str) -> Result<Vec<PathBuf>> {
+    let candidates: Vec<(String, &str)> = if config.certificate_files_configured {
+        config
+            .certificate_files
+            .iter()
+            .cloned()
+            .map(|path| (path, "CertificateFile"))
+            .collect()
+    } else {
+        config
+            .identity_files
+            .iter()
+            .map(|path| {
+                (
+                    format!("{path}-cert.pub"),
+                    "implicit IdentityFile certificate",
+                )
+            })
+            .collect()
+    };
     let mut paths = Vec::new();
-    for configured in &config.certificate_files {
-        let expanded = expand_certificate_path(configured, config, original_host)
-            .with_context(|| format!("expand CertificateFile {configured:?}"))?;
+    for (configured, source) in candidates {
+        let expanded = expand_credential_path(&configured, config, original_host)
+            .with_context(|| format!("expand {source} {configured:?}"))?;
         if !paths.contains(&expanded) {
             paths.push(expanded);
         }
@@ -284,12 +350,23 @@ fn certificate_paths(config: &EffectiveSshConfig, original_host: &str) -> Result
     Ok(paths)
 }
 
-fn expand_certificate_path(
+fn expand_credential_path(
     configured: &str,
     config: &EffectiveSshConfig,
     original_host: &str,
 ) -> Result<PathBuf> {
-    let configured = expand_environment(configured)?;
+    expand_credential_path_with_env(configured, config, original_host, |name| {
+        std::env::var(name)
+            .with_context(|| format!("SSH credential path environment variable {name} is unset"))
+    })
+}
+
+fn expand_credential_path_with_env(
+    configured: &str,
+    config: &EffectiveSshConfig,
+    original_host: &str,
+    environment: impl Fn(&str) -> Result<String>,
+) -> Result<PathBuf> {
     let needs_account = configured == "~"
         || configured.starts_with("~/")
         || configured.contains("%d")
@@ -304,44 +381,70 @@ fn expand_certificate_path(
     } else if let Some(rest) = configured.strip_prefix("~/") {
         format!("{home}/{rest}")
     } else if configured.starts_with('~') {
-        bail!("CertificateFile uses an unsupported named-user tilde");
+        bail!("SSH credential path uses an unsupported named-user tilde");
     } else {
-        configured
+        configured.to_owned()
     };
 
     let host_key_name = config.host_key_alias.as_deref().unwrap_or(original_host);
     let mut expanded = String::with_capacity(configured.len());
-    let mut chars = configured.chars();
+    let mut chars = configured.chars().peekable();
     while let Some(character) = chars.next() {
-        if character != '%' {
-            expanded.push(character);
-            continue;
-        }
-        let token = chars.next().context("trailing '%' in CertificateFile")?;
-        match token {
-            '%' => expanded.push('%'),
-            'd' => expanded.push_str(&home),
-            'h' => expanded.push_str(&config.hostname),
-            'i' => expanded.push_str(&unsafe { libc::getuid() }.to_string()),
-            'j' => expanded.push_str(config.proxy_jump.as_deref().unwrap_or("")),
-            'k' => expanded.push_str(host_key_name),
-            'L' => {
-                let hostname = local_hostname()?;
-                expanded.push_str(
-                    hostname
-                        .split_once('.')
-                        .map_or(hostname.as_str(), |(short, _)| short),
-                );
+        match character {
+            '%' => {
+                let token = chars
+                    .next()
+                    .context("trailing '%' in SSH credential path")?;
+                match token {
+                    '%' => expanded.push('%'),
+                    'd' => expanded.push_str(&home),
+                    'h' => expanded.push_str(&config.hostname),
+                    'i' => expanded.push_str(&unsafe { libc::getuid() }.to_string()),
+                    'j' => expanded.push_str(config.proxy_jump.as_deref().unwrap_or("")),
+                    'k' => expanded.push_str(host_key_name),
+                    'L' => {
+                        let hostname = local_hostname()?;
+                        expanded.push_str(
+                            hostname
+                                .split_once('.')
+                                .map_or(hostname.as_str(), |(short, _)| short),
+                        );
+                    }
+                    'l' => expanded.push_str(&local_hostname()?),
+                    'n' => expanded.push_str(original_host),
+                    'p' => expanded.push_str(&config.port.to_string()),
+                    'r' => expanded.push_str(&config.user),
+                    'u' => expanded.push_str(&account.username),
+                    'C' => bail!(
+                        "SSH credential path uses OpenSSH's %C connection hash, which syq cannot reproduce safely"
+                    ),
+                    other => bail!("unsupported SSH credential path token %{other}"),
+                }
             }
-            'l' => expanded.push_str(&local_hostname()?),
-            'n' => expanded.push_str(original_host),
-            'p' => expanded.push_str(&config.port.to_string()),
-            'r' => expanded.push_str(&config.user),
-            'u' => expanded.push_str(&account.username),
-            'C' => bail!(
-                "CertificateFile uses OpenSSH's %C connection hash, which syq cannot reproduce safely"
-            ),
-            other => bail!("unsupported CertificateFile token %{other}"),
+            '$' if chars.peek() == Some(&'{') => {
+                chars.next();
+                let mut name = String::new();
+                loop {
+                    match chars.next() {
+                        Some('}') => break,
+                        Some(character) => name.push(character),
+                        None => {
+                            bail!("unterminated environment variable in SSH credential path")
+                        }
+                    }
+                }
+                if name.is_empty()
+                    || !name
+                        .bytes()
+                        .all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+                {
+                    bail!("invalid environment variable in SSH credential path");
+                }
+                // OpenSSH expands percent tokens and environment variables in
+                // one pass. Do not reinterpret '%' or '${...}' in this value.
+                expanded.push_str(&environment(&name)?);
+            }
+            _ => expanded.push(character),
         }
     }
     Ok(PathBuf::from(expanded))
@@ -402,32 +505,6 @@ fn local_account() -> Result<LocalAccount> {
     }
 }
 
-fn expand_environment(configured: &str) -> Result<String> {
-    let mut expanded = String::with_capacity(configured.len());
-    let mut rest = configured;
-    while let Some(start) = rest.find("${") {
-        expanded.push_str(&rest[..start]);
-        let after = &rest[start + 2..];
-        let end = after
-            .find('}')
-            .context("unterminated environment variable in CertificateFile")?;
-        let name = &after[..end];
-        if name.is_empty()
-            || !name
-                .bytes()
-                .all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
-        {
-            bail!("invalid environment variable in CertificateFile");
-        }
-        let value = std::env::var(name)
-            .with_context(|| format!("CertificateFile environment variable {name} is unset"))?;
-        expanded.push_str(&value);
-        rest = &after[end + 1..];
-    }
-    expanded.push_str(rest);
-    Ok(expanded)
-}
-
 fn local_hostname() -> Result<String> {
     let mut bytes = [0u8; 256];
     if unsafe { libc::gethostname(bytes.as_mut_ptr().cast(), bytes.len()) } != 0 {
@@ -452,6 +529,13 @@ fn read_user_certificates(paths: &[PathBuf]) -> Result<Vec<Certificate>> {
             bail!(
                 "CertificateFile {} is not a user certificate",
                 path.display()
+            );
+        }
+        if !key_is_cryptographically_verifiable(certificate.public_key()) {
+            bail!(
+                "user certificate {} uses unsupported authentication algorithm {}",
+                path.display(),
+                certificate.public_key().algorithm()
             );
         }
         certificate
@@ -827,6 +911,11 @@ impl BindState {
         if binding.session_id.is_empty() || binding.session_id.len() > 64 {
             bail!("invalid SSH session identifier length");
         }
+        if !key_is_cryptographically_verifiable(&binding.host_key)
+            || !signature_algorithm_is_cryptographically_verifiable(&binding.signature.algorithm())
+        {
+            bail!("session-bind used an unsupported host-key or signature algorithm");
+        }
         binding
             .verify_signature()
             .context("invalid session-bind host-key signature")?;
@@ -900,7 +989,7 @@ fn serve_client(
 ) -> Result<()> {
     let mut state = BindState::default();
     let mut upstream: Option<TrackedStream> = None;
-    let mut ambient_identities: Option<Vec<Identity>> = None;
+    let mut sanitized_identities: Option<SanitizedIdentities> = None;
     while let Some(frame) = read_frame(&mut downstream)? {
         let Some(message_id) = frame.first().copied() else {
             break;
@@ -916,9 +1005,10 @@ fn serve_client(
                     UpstreamResponse::Identities,
                 )?;
                 let identities = decode_identities_response(&response)?;
-                ambient_identities = Some(identities.clone());
-                let response =
-                    add_configured_certificates(identities, &policy.destination.user_certificates)?;
+                let identities =
+                    sanitize_identities(identities, &policy.destination.user_certificates);
+                let response = encode_identities_response(&identities.advertised)?;
+                sanitized_identities = Some(identities);
                 write_frame(&mut downstream, &response)?;
             }
             13 => {
@@ -927,33 +1017,19 @@ fn serve_client(
                     write_frame(&mut downstream, SSH_AGENT_FAILURE)?;
                     break;
                 };
-                if state.authorize(policy, &request).is_err() {
+                let Some(identities) = sanitized_identities.as_ref() else {
                     write_frame(&mut downstream, SSH_AGENT_FAILURE)?;
                     break;
-                }
-                if ambient_identities.is_none() {
-                    let response = upstream_request(
-                        &mut upstream,
-                        ambient_socket,
-                        &connections,
-                        &state.bindings,
-                        &[11],
-                        UpstreamResponse::Identities,
-                    )?;
-                    ambient_identities = Some(decode_identities_response(&response)?);
-                }
-                if authorize_selected_credential(
-                    &request.credential,
-                    &policy.destination.user_certificates,
-                )
-                .is_err()
+                };
+                if !identities.advertises(&request.credential)
+                    || state.authorize(policy, &request).is_err()
                 {
                     write_frame(&mut downstream, SSH_AGENT_FAILURE)?;
                     break;
                 }
                 let upstream_frame = translated_sign_request(
                     &request,
-                    ambient_identities.as_deref().unwrap_or_default(),
+                    &identities.ambient,
                     &policy.destination.user_certificates,
                 )?;
                 let response = upstream_request(
@@ -1107,67 +1183,78 @@ fn decode_identities_response(frame: &[u8]) -> Result<Vec<Identity>> {
     }
 }
 
-fn add_configured_certificates(
+struct SanitizedIdentities {
+    ambient: Vec<Identity>,
+    advertised: Vec<Identity>,
+}
+
+impl SanitizedIdentities {
+    fn advertises(&self, credential: &PublicCredential) -> bool {
+        self.advertised
+            .iter()
+            .any(|identity| &identity.credential == credential)
+    }
+}
+
+fn sanitize_identities(
     identities: Vec<Identity>,
     certificates: &[Certificate],
-) -> Result<Vec<u8>> {
-    let ambient_raw_keys: Vec<_> = identities
+) -> SanitizedIdentities {
+    let ambient: Vec<_> = identities
+        .into_iter()
+        .filter(|identity| credential_is_cryptographically_verifiable(&identity.credential))
+        .collect();
+    let ambient_raw_keys: Vec<_> = ambient
         .iter()
         .filter_map(|identity| match &identity.credential {
             PublicCredential::Key(key) => Some(key.clone()),
             PublicCredential::Cert(_) => None,
         })
         .collect();
-    let mut identities: Vec<_> = identities
-        .into_iter()
+    let mut advertised: Vec<_> = ambient
+        .iter()
         .filter(|identity| {
             let covered = certificates
                 .iter()
                 .any(|certificate| certificate.public_key() == identity.credential.key_data());
             !covered
                 || certificates.iter().any(|certificate| {
-                    identity.credential == PublicCredential::Cert(Box::new(certificate.clone()))
+                    matches!(
+                        &identity.credential,
+                        PublicCredential::Cert(advertised) if advertised.as_ref() == certificate
+                    )
                 })
         })
+        .cloned()
         .collect();
     for certificate in certificates {
         let credential = PublicCredential::Cert(Box::new(certificate.clone()));
-        if identities
+        if !credential_is_cryptographically_verifiable(&credential) {
+            continue;
+        }
+        if advertised
             .iter()
             .any(|identity| identity.credential == credential)
         {
             continue;
         }
         if ambient_raw_keys.contains(certificate.public_key()) {
-            identities.push(Identity {
+            advertised.push(Identity {
                 credential,
                 comment: format!("syq CertificateFile {}", certificate.key_id()),
             });
         }
     }
-    let mut frame = Vec::new();
-    Response::IdentitiesAnswer(identities).encode(&mut frame)?;
-    Ok(frame)
+    SanitizedIdentities {
+        ambient,
+        advertised,
+    }
 }
 
-fn authorize_selected_credential(
-    credential: &PublicCredential,
-    certificates: &[Certificate],
-) -> Result<()> {
-    let covered_by_certificate_file = certificates
-        .iter()
-        .any(|certificate| certificate.public_key() == credential.key_data());
-    match credential {
-        PublicCredential::Key(_) if covered_by_certificate_file => {
-            bail!("raw key is covered by a configured CertificateFile")
-        }
-        PublicCredential::Cert(certificate)
-            if covered_by_certificate_file && !certificates.contains(certificate.as_ref()) =>
-        {
-            bail!("certificate was not an exact configured CertificateFile")
-        }
-        _ => Ok(()),
-    }
+fn encode_identities_response(identities: &[Identity]) -> Result<Vec<u8>> {
+    let mut frame = Vec::new();
+    Response::IdentitiesAnswer(identities.to_vec()).encode(&mut frame)?;
+    Ok(frame)
 }
 
 fn translated_sign_request(
@@ -1296,9 +1383,17 @@ impl<'a> HostboundUserauth<'a> {
 fn validate_signature_algorithm(algorithm: &[u8], credential: &[u8], flags: u32) -> Result<()> {
     let mut credential = SshCursor::new(credential);
     let key_type = credential.string()?;
-    let expected_flags = match (key_type, algorithm) {
+    if matches!(
+        (key_type, algorithm),
         (b"ssh-rsa", b"ssh-rsa")
-        | (b"ssh-rsa-cert-v01@openssh.com", b"ssh-rsa-cert-v01@openssh.com") => 0,
+            | (
+                b"ssh-rsa-cert-v01@openssh.com",
+                b"ssh-rsa-cert-v01@openssh.com"
+            )
+    ) {
+        bail!("RSA/SHA-1 userauth signatures cannot be verified safely");
+    }
+    let expected_flags = match (key_type, algorithm) {
         (b"ssh-rsa", b"rsa-sha2-256")
         | (b"ssh-rsa-cert-v01@openssh.com", b"rsa-sha2-256-cert-v01@openssh.com") => 2,
         (b"ssh-rsa", b"rsa-sha2-512")
@@ -1550,6 +1645,15 @@ mod tests {
     }
 
     #[test]
+    fn pre_required_rsa_size_config_uses_historical_default() {
+        let config = parse_ssh_config(
+            b"user backup\nhostname vault.internal\nport 22\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\n",
+        )
+        .unwrap();
+        assert_eq!(config.required_rsa_size, 1024);
+    }
+
+    #[test]
     fn host_key_alias_is_used_verbatim() {
         let config = parse_ssh_config(
             b"user backup\nhostname vault.internal\nport 2222\nhostkeyalias stable-vault\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\nrequiredrsasize 1024\n",
@@ -1595,7 +1699,7 @@ mod tests {
     #[test]
     fn certificate_paths_expand_effective_remote_tokens() {
         let config = parse_ssh_config(
-            b"user backup\nhostname vault.internal\nport 2222\nhostkeyalias stable-vault\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\nrequiredrsasize 1024\ncertificatefile /tmp/%r@%h:%p-%k-%n-cert.pub\n",
+            b"user backup\nhostname vault.internal\nport 2222\nhostkeyalias stable-vault\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\nrequiredrsasize 1024\nidentityfile /tmp/ignored-identity\ncertificatefile /tmp/%r@%h:%p-%k-%n-cert.pub\n",
         )
         .unwrap();
         assert_eq!(
@@ -1607,6 +1711,99 @@ mod tests {
     }
 
     #[test]
+    fn credential_path_environment_values_are_not_recursively_expanded() {
+        let config = parse_ssh_config(
+            b"user backup\nhostname vault.internal\nport 2222\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\nrequiredrsasize 1024\n",
+        )
+        .unwrap();
+        let expanded = expand_credential_path_with_env(
+            "${CERT_ROOT}/%r-cert.pub",
+            &config,
+            "vault-alias",
+            |name| {
+                assert_eq!(name, "CERT_ROOT");
+                Ok("/tmp/%n-${OTHER}".to_owned())
+            },
+        )
+        .unwrap();
+        assert_eq!(expanded, PathBuf::from("/tmp/%n-${OTHER}/backup-cert.pub"));
+    }
+
+    #[test]
+    fn identity_file_implicitly_loads_certificate_only_without_certificate_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let configured_identity_path = temp.path().join("%r-id_ed25519");
+        let expanded_identity_path = temp.path().join("backup-id_ed25519");
+        let implicit_path = PathBuf::from(format!("{}-cert.pub", expanded_identity_path.display()));
+        let (_, raw_key) = key(58);
+        let certificate = user_certificate(&raw_key, 59, "implicit-central-cert");
+        certificate.write_file(&implicit_path).unwrap();
+        let base = format!(
+            "user backup\nhostname vault.internal\nport 22\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\nidentityfile {}\n",
+            configured_identity_path.display()
+        );
+        let config = parse_ssh_config(base.as_bytes()).unwrap();
+        assert_eq!(
+            certificate_paths(&config, "vault").unwrap(),
+            [implicit_path]
+        );
+        let certificates =
+            read_user_certificates(&certificate_paths(&config, "vault").unwrap()).unwrap();
+        assert_eq!(certificates.as_slice(), std::slice::from_ref(&certificate));
+
+        let identities = sanitize_identities(
+            vec![Identity {
+                credential: PublicCredential::Key(raw_key.clone()),
+                comment: "YubiKey raw key".into(),
+            }],
+            &certificates,
+        );
+        assert!(!identities.advertises(&PublicCredential::Key(raw_key)));
+        assert!(identities.advertises(&PublicCredential::Cert(Box::new(certificate))));
+
+        let explicit_none =
+            parse_ssh_config(format!("{base}certificatefile none\n").as_bytes()).unwrap();
+        assert!(certificate_paths(&explicit_none, "vault")
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn unsupported_opaque_algorithms_are_not_trusted_or_advertised() {
+        use ssh_agent_lib::ssh_key::public::{OpaquePublicKey, SkEd25519};
+
+        let unsupported = KeyData::Other(OpaquePublicKey::new(
+            vec![1, 2, 3],
+            Algorithm::new("ssh-mldsa44-ed25519@openssh.com").unwrap(),
+        ));
+        assert!(!key_is_cryptographically_verifiable(&unsupported));
+        let config = parse_ssh_config(
+            b"user backup\nhostname vault.internal\nport 22\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-mldsa44-ed25519@openssh.com\n",
+        )
+        .unwrap();
+        assert!(!configured_host_key_allowed(&config, &unsupported));
+        let identities = sanitize_identities(
+            vec![Identity {
+                credential: PublicCredential::Key(unsupported),
+                comment: "unsupported experimental key".into(),
+            }],
+            &[],
+        );
+        assert!(identities.ambient.is_empty());
+        assert!(identities.advertised.is_empty());
+        let (supported_private, supported) = key(60);
+        assert!(key_is_cryptographically_verifiable(&supported));
+        assert!(signature_algorithm_is_cryptographically_verifiable(
+            &Algorithm::Ed25519
+        ));
+        assert!(!signature_algorithm_is_cryptographically_verifiable(
+            &Algorithm::Rsa { hash: None }
+        ));
+        let fido = KeyData::SkEd25519(SkEd25519::new(supported_private.public, "ssh:".to_string()));
+        assert!(key_is_cryptographically_verifiable(&fido));
+    }
+
+    #[test]
     fn configured_certificate_is_advertised_and_translated_only_for_its_raw_key() {
         let (raw_private, raw_key) = key(61);
         let certificate = user_certificate(&raw_key, 62, "central-cert");
@@ -1614,20 +1811,14 @@ mod tests {
             credential: PublicCredential::Key(raw_key.clone()),
             comment: "YubiKey raw key".into(),
         }];
-        let response =
-            add_configured_certificates(ambient.clone(), std::slice::from_ref(&certificate))
-                .unwrap();
-        let advertised = decode_identities_response(&response).unwrap();
+        let identities = sanitize_identities(ambient.clone(), std::slice::from_ref(&certificate));
+        let advertised = &identities.advertised;
         assert_eq!(advertised.len(), 1);
         assert_eq!(
             advertised[0].credential,
             PublicCredential::Cert(Box::new(certificate.clone()))
         );
-        assert!(authorize_selected_credential(
-            &PublicCredential::Key(raw_key.clone()),
-            std::slice::from_ref(&certificate)
-        )
-        .is_err());
+        assert!(!identities.advertises(&PublicCredential::Key(raw_key.clone())));
 
         let request = SignRequest {
             credential: PublicCredential::Cert(Box::new(certificate.clone())),
@@ -1643,8 +1834,7 @@ mod tests {
             PublicCredential::Key(raw_key.clone())
         );
         assert_eq!(translated.data, request.data);
-        authorize_selected_credential(&request.credential, std::slice::from_ref(&certificate))
-            .unwrap();
+        assert!(identities.advertises(&request.credential));
         let mut valid_response = Vec::new();
         Response::SignResponse(raw_private.try_sign(&request.data).unwrap())
             .encode(&mut valid_response)
@@ -1699,12 +1889,25 @@ mod tests {
             data: Vec::new(),
             flags: 0,
         };
-        assert!(authorize_selected_credential(&request.credential, &[certificate]).is_err());
+        assert!(!identities.advertises(&request.credential));
         let untranslated = translated_sign_request(&request, &ambient, &[]).unwrap();
         assert_eq!(
             parse_sign_request(&untranslated).unwrap().credential,
             request.credential
         );
+    }
+
+    #[test]
+    fn failure_or_empty_identity_list_advertises_no_signing_credential() {
+        let mut failure = Vec::new();
+        Response::Failure.encode(&mut failure).unwrap();
+        let identities = sanitize_identities(decode_identities_response(&failure).unwrap(), &[]);
+        assert!(identities.advertised.is_empty());
+        let (_, key) = key(67);
+        assert!(!identities.advertises(&PublicCredential::Key(key)));
+
+        let identities = sanitize_identities(Vec::new(), &[]);
+        assert!(identities.advertised.is_empty());
     }
 
     #[test]
@@ -1749,6 +1952,7 @@ mod tests {
         rsa.extend_from_slice(b"key fields are irrelevant here");
         validate_signature_algorithm(b"rsa-sha2-512", &rsa, 4).unwrap();
         assert!(validate_signature_algorithm(b"rsa-sha2-256", &rsa, 4).is_err());
+        assert!(validate_signature_algorithm(b"ssh-rsa", &rsa, 0).is_err());
         assert!(validate_signature_algorithm(b"ssh-ed25519", &rsa, 0).is_err());
     }
 
@@ -1970,10 +2174,96 @@ mod tests {
         assert_eq!(signature, identity_private.try_sign(&request.data).unwrap());
         assert_eq!(requests.recv().unwrap(), encoded);
 
+        let (_, unadvertised) = key(24);
+        let request = sign_request(
+            b"destination-session",
+            b"backup",
+            b"publickey-hostbound-v00@openssh.com",
+            unadvertised,
+            &destination,
+        );
+        write_frame(&mut client, &encode_request(Request::SignRequest(request))).unwrap();
+        assert!(matches!(read_response(&mut client), Response::Failure));
+        assert_closed(&mut client);
+        assert!(requests.try_recv().is_err());
+
         drop(client);
         drop(broker);
         ambient.join().unwrap();
         assert!(!broker_path.exists());
+    }
+
+    #[test]
+    fn failed_identity_list_cannot_be_followed_by_signing() {
+        let temp = tempfile::tempdir().unwrap();
+        let ambient_socket = temp.path().join("ambient.sock");
+        let listener = UnixListener::bind(&ambient_socket).unwrap();
+        let (sent, requests) = mpsc::channel();
+        let ambient = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            while let Some(frame) = read_frame(&mut stream).unwrap() {
+                sent.send(frame.clone()).unwrap();
+                let response = match frame.first() {
+                    Some(27) => Response::ExtensionFailure,
+                    Some(11) => Response::Failure,
+                    other => panic!("unexpected upstream request {other:?}"),
+                };
+                let mut response_frame = Vec::new();
+                response.encode(&mut response_frame).unwrap();
+                write_frame(&mut stream, &response_frame).unwrap();
+            }
+        });
+        let (source_private, source) = key(25);
+        let (destination_private, destination) = key(26);
+        let (_, identity) = key(27);
+        let broker = ConstrainedAgentBroker::start_with_socket(
+            ambient_socket,
+            policy(source.clone(), destination.clone()),
+            TEST_BROKER_CONNECTIONS,
+        )
+        .unwrap();
+        let mut client = UnixStream::connect(broker.socket_path()).unwrap();
+
+        let source_bind = bind_request(binding(
+            &source_private,
+            source,
+            b"source-failed-list",
+            true,
+        ));
+        write_frame(&mut client, &source_bind).unwrap();
+        assert!(matches!(read_response(&mut client), Response::Success));
+        write_frame(&mut client, &[11]).unwrap();
+        let Response::IdentitiesAnswer(identities) = read_response(&mut client) else {
+            panic!("expected sanitized empty identities response")
+        };
+        assert!(identities.is_empty());
+        assert_eq!(requests.recv().unwrap(), source_bind);
+        assert_eq!(requests.recv().unwrap(), vec![11]);
+
+        let destination_bind = bind_request(binding(
+            &destination_private,
+            destination.clone(),
+            b"destination-failed-list",
+            false,
+        ));
+        write_frame(&mut client, &destination_bind).unwrap();
+        assert!(matches!(read_response(&mut client), Response::Success));
+        assert_eq!(requests.recv().unwrap(), destination_bind);
+        let request = sign_request(
+            b"destination-failed-list",
+            b"backup",
+            b"publickey-hostbound-v00@openssh.com",
+            identity,
+            &destination,
+        );
+        write_frame(&mut client, &encode_request(Request::SignRequest(request))).unwrap();
+        assert!(matches!(read_response(&mut client), Response::Failure));
+        assert_closed(&mut client);
+        assert!(requests.try_recv().is_err());
+
+        drop(client);
+        drop(broker);
+        ambient.join().unwrap();
     }
 
     #[test]

--- a/src/agent_broker.rs
+++ b/src/agent_broker.rs
@@ -1996,6 +1996,42 @@ mod tests {
     }
 
     #[test]
+    fn openssh_quoted_default_collision_is_rejected_end_to_end() {
+        let defaults_output =
+            inspect_ssh_configuration("ssh", None, "unused.example", true).unwrap();
+        let defaults = KnownHostsDefaults::from_openssh(&defaults_output.output).unwrap();
+        assert!(!defaults.user.rendered.contains(['"', '\\', '\n', '\r']));
+
+        let temp = tempfile::tempdir().unwrap();
+        let config = temp.path().join("ssh_config");
+        std::fs::write(
+            &config,
+            format!(
+                "Host *\n  UserKnownHostsFile \"{}\"\n",
+                defaults.user.rendered
+            ),
+        )
+        .unwrap();
+        let output = Command::new("ssh")
+            .args(["-G", "-vvv", "-F"])
+            .arg(&config)
+            .args(["--", "unused.example"])
+            .env("LC_ALL", "C")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "ssh -G failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let configured = configured_known_hosts_directives(&output.stderr).unwrap();
+        assert!(configured.user);
+        let error = parse_ssh_config_with_defaults(&output.stdout, Some(&defaults), &configured)
+            .unwrap_err();
+        assert!(error.to_string().contains("ambiguous known_hosts"));
+    }
+
+    #[test]
     fn pre_required_rsa_size_config_uses_historical_default() {
         let config = parse_ssh_config(
             b"user backup\nhostname vault.internal\nport 22\nuserknownhostsfile /tmp/known\nhostkeyalgorithms ssh-ed25519\n",

--- a/src/agent_broker.rs
+++ b/src/agent_broker.rs
@@ -1,0 +1,1388 @@
+//! A fail-closed SSH-agent proxy for live direct remote-to-remote transfers.
+//!
+//! The source host sees public identities from the caller's ambient agent, but
+//! signatures are released only for one hostA -> user@hostB SSH authentication
+//! path. OpenSSH's session-bind messages prove the two SSH sessions and the
+//! host-bound userauth request binds the signature to B's host key and login
+//! user. The broker never accepts key-management or opaque signing requests.
+
+use anyhow::{anyhow, bail, Context, Result};
+use ssh_agent_lib::proto::extension::{MessageExtension, SessionBind};
+use ssh_agent_lib::proto::{Request, Response, SignRequest};
+use ssh_agent_lib::ssh_encoding::{Decode, Encode};
+use ssh_agent_lib::ssh_key::{public::KeyData, PublicKey};
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::io::{self, Read, Write};
+use std::net::Shutdown;
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+/// Agent messages are normally only a few KiB. This accommodates large
+/// identity lists without allowing a peer to force an unbounded allocation.
+const MAX_AGENT_FRAME: usize = 256 * 1024;
+/// syq establishes at most 32 SSH handshakes concurrently. Keep a hard broker
+/// cap as a second bound against a source host that opens idle agent channels.
+const MAX_BROKER_CONNECTIONS: usize = 32;
+
+const SSH_AGENT_FAILURE: &[u8] = &[5];
+const SSH_AGENT_SUCCESS: &[u8] = &[6];
+const SSH_AGENT_EXTENSION_FAILURE: &[u8] = &[28];
+
+#[derive(Clone, Debug)]
+pub struct HostPolicy {
+    pub login_user: String,
+    host_keys: Vec<KeyData>,
+    known_hosts_name: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct BrokerPolicy {
+    delegate: HostPolicy,
+    destination: HostPolicy,
+}
+
+impl BrokerPolicy {
+    pub fn new(delegate: HostPolicy, destination: HostPolicy) -> Self {
+        Self {
+            delegate,
+            destination,
+        }
+    }
+}
+
+/// Resolve the effective user and exact, already trusted plain host keys using
+/// the caller's OpenSSH configuration and known_hosts files. Host certificates
+/// are deliberately rejected for now: treating a CA key as the presented host
+/// key would silently weaken the name/principal checks OpenSSH performs.
+pub fn resolve_host_policy(
+    ssh_program: &str,
+    explicit_user: Option<&str>,
+    host: &str,
+) -> Result<HostPolicy> {
+    let mut command = Command::new(ssh_program);
+    command.arg("-G");
+    if let Some(user) = explicit_user {
+        command.args(["-l", user]);
+    }
+    command.args(["--", host]).env("LC_ALL", "C");
+    let output = command
+        .output()
+        .with_context(|| format!("inspect SSH configuration for {host}"))?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "could not inspect SSH configuration for {host}{}",
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        );
+    }
+    let config = parse_ssh_config(&output.stdout)
+        .with_context(|| format!("parse `ssh -G` output for {host}"))?;
+    let keygen = ssh_keygen_for(ssh_program);
+    let (host_keys, saw_ca) = read_known_host_keys(&keygen, &config.lookup, &config.files)?;
+    if host_keys.is_empty() {
+        if saw_ca {
+            bail!(
+                "{host} is trusted only through an SSH host certificate; constrained agent forwarding currently requires an exact plain host key in known_hosts"
+            );
+        }
+        bail!(
+            "no exact trusted host key for {host} ({}) was found in the configured known_hosts files; connect once with ssh to record it, use --relay, or use --no-forward-agent with credentials on the source host",
+            config.lookup
+        );
+    }
+    Ok(HostPolicy {
+        login_user: config.user,
+        host_keys,
+        known_hosts_name: config.lookup,
+    })
+}
+
+#[derive(Debug)]
+struct EffectiveSshConfig {
+    user: String,
+    lookup: String,
+    files: Vec<PathBuf>,
+}
+
+fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
+    let output = std::str::from_utf8(output).context("SSH configuration was not UTF-8")?;
+    let mut user = None;
+    let mut hostname = None;
+    let mut port = None;
+    let mut hostkey_alias = None;
+    let mut files = Vec::new();
+    for line in output.lines() {
+        let Some((name, value)) = line.split_once(' ') else {
+            continue;
+        };
+        let value = value.trim();
+        match name {
+            "user" => user = Some(value.to_string()),
+            "hostname" => hostname = Some(value.to_string()),
+            "port" => port = Some(value.parse::<u16>().context("invalid SSH port")?),
+            "hostkeyalias" if value != "none" => hostkey_alias = Some(value.to_string()),
+            "userknownhostsfile" | "globalknownhostsfile" => {
+                for path in value
+                    .split_ascii_whitespace()
+                    .filter(|path| *path != "none")
+                {
+                    if path.contains('%') || path.starts_with('~') {
+                        bail!("unexpanded known_hosts path {path:?} in `ssh -G` output");
+                    }
+                    files.push(PathBuf::from(path));
+                }
+            }
+            _ => {}
+        }
+    }
+    let user = user
+        .filter(|value| !value.is_empty())
+        .context("missing SSH user")?;
+    let hostname = hostname
+        .filter(|value| !value.is_empty())
+        .context("missing SSH hostname")?;
+    let port = port.context("missing SSH port")?;
+    let lookup = match hostkey_alias {
+        Some(alias) => alias,
+        None if port == 22 => hostname,
+        None => format!("[{hostname}]:{port}"),
+    };
+    files.sort();
+    files.dedup();
+    Ok(EffectiveSshConfig {
+        user,
+        lookup,
+        files,
+    })
+}
+
+fn ssh_keygen_for(ssh_program: &str) -> OsString {
+    let path = Path::new(ssh_program);
+    if path.components().count() > 1 {
+        let mut sibling = path.to_path_buf();
+        sibling.set_file_name("ssh-keygen");
+        sibling.into_os_string()
+    } else {
+        OsString::from("ssh-keygen")
+    }
+}
+
+fn read_known_host_keys(
+    keygen: &OsString,
+    lookup: &str,
+    files: &[PathBuf],
+) -> Result<(Vec<KeyData>, bool)> {
+    let mut trusted = Vec::new();
+    let mut revoked = Vec::new();
+    let mut saw_ca = false;
+    for file in files {
+        if !file.exists() {
+            continue;
+        }
+        let output = Command::new(keygen)
+            .args(["-F", lookup, "-f"])
+            .arg(file)
+            .env("LC_ALL", "C")
+            .output()
+            .with_context(|| format!("search {} for {lookup}", file.display()))?;
+        if !output.status.success() {
+            if output.status.code() == Some(1)
+                && output.stdout.is_empty()
+                && output.stderr.is_empty()
+            {
+                continue;
+            }
+            let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            bail!(
+                "could not search {} for {lookup}{}",
+                file.display(),
+                if detail.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {detail}")
+                }
+            );
+        }
+        let text = std::str::from_utf8(&output.stdout)
+            .with_context(|| format!("{} contained non-UTF-8 key text", file.display()))?;
+        parse_known_host_output(text, file, &mut trusted, &mut revoked, &mut saw_ca)?;
+    }
+    trusted.retain(|key| !revoked.contains(key));
+    Ok((trusted, saw_ca))
+}
+
+fn parse_known_host_output(
+    text: &str,
+    file: &Path,
+    trusted: &mut Vec<KeyData>,
+    revoked: &mut Vec<KeyData>,
+    saw_ca: &mut bool,
+) -> Result<()> {
+    for line in text.lines().filter(|line| !line.starts_with('#')) {
+        let fields: Vec<_> = line.split_ascii_whitespace().collect();
+        if fields.is_empty() {
+            continue;
+        }
+        let (marker, offset) = if fields[0].starts_with('@') {
+            (Some(fields[0]), 1)
+        } else {
+            (None, 0)
+        };
+        if fields.len() < offset + 3 {
+            bail!("malformed known_hosts result from {}", file.display());
+        }
+        if marker == Some("@cert-authority") {
+            *saw_ca = true;
+            continue;
+        }
+        let public =
+            PublicKey::from_openssh(&format!("{} {}", fields[offset + 1], fields[offset + 2]))
+                .with_context(|| format!("parse host key from {}", file.display()))?;
+        let key = public.key_data().clone();
+        if marker == Some("@revoked") {
+            revoked.push(key);
+        } else if marker.is_none() && !trusted.contains(&key) {
+            trusted.push(key);
+        } else if marker.is_some() {
+            bail!(
+                "unsupported known_hosts marker {} in {}",
+                marker.unwrap_or_default(),
+                file.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// A running broker. Dropping it closes every active client/upstream socket,
+/// joins the listener and workers, and removes the private socket directory.
+pub struct ConstrainedAgentBroker {
+    ambient_socket: PathBuf,
+    socket_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+    connections: Arc<ConnectionRegistry>,
+    listener_thread: Option<JoinHandle<()>>,
+    _socket_dir: tempfile::TempDir,
+}
+
+impl std::fmt::Debug for ConstrainedAgentBroker {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ConstrainedAgentBroker")
+            .field("socket_path", &self.socket_path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ConstrainedAgentBroker {
+    pub fn start(policy: BrokerPolicy) -> Result<Self> {
+        let ambient = std::env::var_os("SSH_AUTH_SOCK")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .context(
+                "SSH_AUTH_SOCK is not set; constrained direct remote-to-remote authentication needs a local SSH agent (or use --relay/--no-forward-agent)",
+            )?;
+        Self::start_with_socket(ambient, policy)
+    }
+
+    fn start_with_socket(ambient_socket: PathBuf, policy: BrokerPolicy) -> Result<Self> {
+        if !ambient_socket.is_absolute() {
+            bail!("SSH_AUTH_SOCK must be an absolute Unix socket path");
+        }
+        validate_openssh_option_path(&ambient_socket, "SSH_AUTH_SOCK")?;
+        let ambient_metadata = std::fs::metadata(&ambient_socket).with_context(|| {
+            format!("inspect ambient SSH agent at {}", ambient_socket.display())
+        })?;
+        if !ambient_metadata.file_type().is_socket() {
+            bail!(
+                "SSH_AUTH_SOCK {} is not a Unix socket",
+                ambient_socket.display()
+            );
+        }
+        let socket_dir = tempfile::Builder::new()
+            .prefix("syq-agent-")
+            .tempdir()
+            .context("create private constrained-agent directory")?;
+        let socket_path = socket_dir.path().join("agent.sock");
+        validate_openssh_option_path(&socket_path, "temporary constrained-agent path")?;
+        let listener = UnixListener::bind(&socket_path)
+            .with_context(|| format!("bind constrained agent at {}", socket_path.display()))?;
+        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))?;
+        listener.set_nonblocking(true)?;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let connections = Arc::new(ConnectionRegistry::default());
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_connections = Arc::clone(&connections);
+        let thread_ambient = ambient_socket.clone();
+        let policy = Arc::new(policy);
+        let listener_thread = thread::Builder::new()
+            .name("syq-agent-listener".into())
+            .spawn(move || {
+                accept_connections(
+                    listener,
+                    thread_ambient,
+                    policy,
+                    thread_shutdown,
+                    thread_connections,
+                )
+            })
+            .context("start constrained-agent listener")?;
+
+        Ok(Self {
+            ambient_socket,
+            socket_path,
+            shutdown,
+            connections,
+            listener_thread: Some(listener_thread),
+            _socket_dir: socket_dir,
+        })
+    }
+
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    pub fn ambient_socket(&self) -> &Path {
+        &self.ambient_socket
+    }
+}
+
+fn validate_openssh_option_path(path: &Path, label: &str) -> Result<()> {
+    let text = path
+        .to_str()
+        .with_context(|| format!("{label} is not valid UTF-8"))?;
+    if !text.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric()
+            || matches!(
+                byte,
+                b'/' | b'.' | b'_' | b'-' | b'+' | b':' | b'@' | b',' | b'='
+            )
+    }) {
+        bail!("{label} contains characters that are unsafe in an OpenSSH command-line option");
+    }
+    Ok(())
+}
+
+impl Drop for ConstrainedAgentBroker {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        self.connections.shutdown_all();
+        // Wake accept immediately instead of waiting for the nonblocking poll.
+        let _ = UnixStream::connect(&self.socket_path);
+        if let Some(listener) = self.listener_thread.take() {
+            let _ = listener.join();
+        }
+    }
+}
+
+fn accept_connections(
+    listener: UnixListener,
+    ambient_socket: PathBuf,
+    policy: Arc<BrokerPolicy>,
+    shutdown: Arc<AtomicBool>,
+    connections: Arc<ConnectionRegistry>,
+) {
+    let mut workers: Vec<JoinHandle<()>> = Vec::new();
+    while !shutdown.load(Ordering::Acquire) {
+        reap_workers(&mut workers);
+        match listener.accept() {
+            Ok((stream, _)) => {
+                if workers.len() >= MAX_BROKER_CONNECTIONS {
+                    let _ = stream.shutdown(Shutdown::Both);
+                    continue;
+                }
+                let Ok(stream) = connections.track(stream) else {
+                    continue;
+                };
+                let worker_ambient = ambient_socket.clone();
+                let worker_policy = Arc::clone(&policy);
+                let worker_connections = Arc::clone(&connections);
+                match thread::Builder::new()
+                    .name("syq-agent-client".into())
+                    .spawn(move || {
+                        let _ = serve_client(
+                            stream,
+                            &worker_ambient,
+                            &worker_policy,
+                            worker_connections,
+                        );
+                    }) {
+                    Ok(worker) => workers.push(worker),
+                    Err(_) => continue,
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(_) => break,
+        }
+    }
+    connections.shutdown_all();
+    for worker in workers {
+        let _ = worker.join();
+    }
+}
+
+fn reap_workers(workers: &mut Vec<JoinHandle<()>>) {
+    let mut index = 0;
+    while index < workers.len() {
+        if workers[index].is_finished() {
+            let worker = workers.swap_remove(index);
+            let _ = worker.join();
+        } else {
+            index += 1;
+        }
+    }
+}
+
+#[derive(Default)]
+struct ConnectionRegistry {
+    next_id: AtomicU64,
+    streams: Mutex<HashMap<u64, UnixStream>>,
+}
+
+impl ConnectionRegistry {
+    fn track(self: &Arc<Self>, stream: UnixStream) -> io::Result<TrackedStream> {
+        let registered = stream.try_clone()?;
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.streams
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(id, registered);
+        Ok(TrackedStream {
+            stream,
+            id,
+            registry: Arc::clone(self),
+        })
+    }
+
+    fn shutdown_all(&self) {
+        let streams = self
+            .streams
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for stream in streams.values() {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+    }
+}
+
+struct TrackedStream {
+    stream: UnixStream,
+    id: u64,
+    registry: Arc<ConnectionRegistry>,
+}
+
+impl Drop for TrackedStream {
+    fn drop(&mut self) {
+        self.registry
+            .streams
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.id);
+    }
+}
+
+impl Read for TrackedStream {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        self.stream.read(buffer)
+    }
+}
+
+impl Write for TrackedStream {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.stream.write(buffer)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stream.flush()
+    }
+}
+
+#[derive(Default)]
+struct BindState {
+    bindings: Vec<SessionBind>,
+}
+
+impl BindState {
+    fn add(&mut self, policy: &BrokerPolicy, binding: SessionBind) -> Result<()> {
+        if binding.session_id.is_empty() || binding.session_id.len() > 64 {
+            bail!("invalid SSH session identifier length");
+        }
+        binding
+            .verify_signature()
+            .context("invalid session-bind host-key signature")?;
+        match self.bindings.len() {
+            0 if binding.is_forwarding && policy.delegate.host_keys.contains(&binding.host_key) => {
+            }
+            1 if !binding.is_forwarding
+                && policy.destination.host_keys.contains(&binding.host_key) => {}
+            0 => bail!(
+                "first session-bind did not identify trusted delegate {}",
+                policy.delegate.known_hosts_name
+            ),
+            1 => bail!(
+                "final session-bind did not identify trusted destination {}",
+                policy.destination.known_hosts_name
+            ),
+            _ => bail!("unexpected extra SSH forwarding hop"),
+        }
+        if self
+            .bindings
+            .iter()
+            .any(|previous| previous.session_id == binding.session_id)
+        {
+            bail!("reused SSH session identifier");
+        }
+        self.bindings.push(binding);
+        Ok(())
+    }
+
+    fn authorize(&self, policy: &BrokerPolicy, request: &SignRequest) -> Result<()> {
+        let [_, destination] = self.bindings.as_slice() else {
+            bail!("signature requested before the exact two-hop path was bound");
+        };
+        let parsed = HostboundUserauth::parse(&request.data)?;
+        if parsed.session_id != destination.session_id {
+            bail!("userauth session did not match session-bind");
+        }
+        if parsed.user != policy.destination.login_user.as_bytes() {
+            bail!("userauth login user was not authorized");
+        }
+        if parsed.service != b"ssh-connection" {
+            bail!("userauth service was not ssh-connection");
+        }
+        if parsed.method != b"publickey-hostbound-v00@openssh.com" {
+            bail!("legacy or non-host-bound userauth request");
+        }
+        let mut credential = Vec::new();
+        request
+            .credential
+            .encode(&mut credential)
+            .context("encode requested credential")?;
+        if parsed.credential != credential {
+            bail!("embedded userauth credential did not match sign request");
+        }
+        let mut host_key = Vec::new();
+        destination
+            .host_key
+            .encode(&mut host_key)
+            .context("encode bound host key")?;
+        if parsed.host_key != host_key {
+            bail!("embedded userauth host key did not match session-bind");
+        }
+        validate_signature_algorithm(parsed.algorithm, parsed.credential, request.flags)?;
+        Ok(())
+    }
+}
+
+fn serve_client(
+    mut downstream: TrackedStream,
+    ambient_socket: &Path,
+    policy: &BrokerPolicy,
+    connections: Arc<ConnectionRegistry>,
+) -> Result<()> {
+    let mut state = BindState::default();
+    let mut upstream: Option<TrackedStream> = None;
+    while let Some(frame) = read_frame(&mut downstream)? {
+        let Some(message_id) = frame.first().copied() else {
+            break;
+        };
+        match message_id {
+            11 if frame.len() == 1 && !state.bindings.is_empty() => {
+                let response = upstream_request(
+                    &mut upstream,
+                    ambient_socket,
+                    &connections,
+                    &frame,
+                    UpstreamResponse::Identities,
+                )?;
+                write_frame(&mut downstream, &response)?;
+            }
+            13 => {
+                let request = parse_sign_request(&frame);
+                let Ok(request) = request else {
+                    write_frame(&mut downstream, SSH_AGENT_FAILURE)?;
+                    break;
+                };
+                if state.authorize(policy, &request).is_err() {
+                    write_frame(&mut downstream, SSH_AGENT_FAILURE)?;
+                    break;
+                }
+                let response = upstream_request(
+                    &mut upstream,
+                    ambient_socket,
+                    &connections,
+                    &frame,
+                    UpstreamResponse::Signature,
+                )?;
+                write_frame(&mut downstream, &response)?;
+            }
+            27 => {
+                let binding = parse_session_bind(&frame);
+                match binding.and_then(|binding| state.add(policy, binding)) {
+                    Ok(()) => write_frame(&mut downstream, SSH_AGENT_SUCCESS)?,
+                    Err(_) => {
+                        write_frame(&mut downstream, SSH_AGENT_EXTENSION_FAILURE)?;
+                        break;
+                    }
+                }
+            }
+            _ => {
+                // Mutations, query/unknown extensions, legacy protocol
+                // operations and malformed identity requests all fail closed.
+                write_frame(&mut downstream, SSH_AGENT_FAILURE)?;
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_sign_request(frame: &[u8]) -> Result<SignRequest> {
+    let mut input = frame;
+    let request = Request::decode(&mut input).context("decode sign request")?;
+    if !input.is_empty() {
+        bail!("trailing bytes in sign request");
+    }
+    match request {
+        Request::SignRequest(request) => Ok(request),
+        _ => bail!("not a sign request"),
+    }
+}
+
+fn parse_session_bind(frame: &[u8]) -> Result<SessionBind> {
+    let mut input = frame;
+    let request = Request::decode(&mut input).context("decode agent extension")?;
+    if !input.is_empty() {
+        bail!("trailing bytes in agent extension");
+    }
+    let Request::Extension(extension) = request else {
+        bail!("not an agent extension");
+    };
+    if extension.name != SessionBind::NAME {
+        bail!("unsupported agent extension");
+    }
+    let mut details = extension.details.as_ref();
+    let binding = SessionBind::decode(&mut details).context("decode session-bind")?;
+    if !details.is_empty() {
+        bail!("trailing bytes in session-bind");
+    }
+    Ok(binding)
+}
+
+enum UpstreamResponse {
+    Identities,
+    Signature,
+}
+
+fn upstream_request(
+    upstream: &mut Option<TrackedStream>,
+    ambient_socket: &Path,
+    connections: &Arc<ConnectionRegistry>,
+    request: &[u8],
+    expected: UpstreamResponse,
+) -> Result<Vec<u8>> {
+    if upstream.is_none() {
+        let stream = UnixStream::connect(ambient_socket).with_context(|| {
+            format!(
+                "connect to ambient SSH agent at {}",
+                ambient_socket.display()
+            )
+        })?;
+        *upstream = Some(connections.track(stream)?);
+    }
+    let stream = upstream.as_mut().context("ambient SSH agent unavailable")?;
+    write_frame(stream, request)?;
+    let response = read_frame(stream)?.context("ambient SSH agent closed without a response")?;
+    validate_upstream_response(&response, expected)?;
+    Ok(response)
+}
+
+fn validate_upstream_response(frame: &[u8], expected: UpstreamResponse) -> Result<()> {
+    let mut input = frame;
+    let response = Response::decode(&mut input).context("decode ambient agent response")?;
+    if !input.is_empty() {
+        bail!("trailing bytes in ambient agent response");
+    }
+    match (expected, response) {
+        (_, Response::Failure)
+        | (UpstreamResponse::Identities, Response::IdentitiesAnswer(_))
+        | (UpstreamResponse::Signature, Response::SignResponse(_)) => Ok(()),
+        _ => bail!("ambient agent returned an unexpected response"),
+    }
+}
+
+fn read_frame(stream: &mut impl Read) -> io::Result<Option<Vec<u8>>> {
+    let mut length = [0u8; 4];
+    let first = stream.read(&mut length[..1])?;
+    if first == 0 {
+        return Ok(None);
+    }
+    stream.read_exact(&mut length[1..])?;
+    let length = u32::from_be_bytes(length) as usize;
+    if !(1..=MAX_AGENT_FRAME).contains(&length) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "SSH agent frame length is outside the allowed range",
+        ));
+    }
+    let mut frame = vec![0u8; length];
+    stream.read_exact(&mut frame)?;
+    Ok(Some(frame))
+}
+
+fn write_frame(stream: &mut impl Write, frame: &[u8]) -> io::Result<()> {
+    let length = u32::try_from(frame.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "SSH agent frame too large"))?;
+    stream.write_all(&length.to_be_bytes())?;
+    stream.write_all(frame)?;
+    stream.flush()
+}
+
+struct HostboundUserauth<'a> {
+    session_id: &'a [u8],
+    user: &'a [u8],
+    service: &'a [u8],
+    method: &'a [u8],
+    algorithm: &'a [u8],
+    credential: &'a [u8],
+    host_key: &'a [u8],
+}
+
+impl<'a> HostboundUserauth<'a> {
+    fn parse(data: &'a [u8]) -> Result<Self> {
+        let mut input = SshCursor::new(data);
+        let session_id = input.string()?;
+        if input.byte()? != 50 {
+            bail!("signing data was not SSH2_MSG_USERAUTH_REQUEST");
+        }
+        let user = input.string()?;
+        let service = input.string()?;
+        let method = input.string()?;
+        if input.byte()? != 1 {
+            bail!("public-key request did not contain a signature");
+        }
+        let algorithm = input.string()?;
+        let credential = input.string()?;
+        let host_key = input.string()?;
+        if !input.is_empty() {
+            bail!("trailing bytes in host-bound userauth request");
+        }
+        Ok(Self {
+            session_id,
+            user,
+            service,
+            method,
+            algorithm,
+            credential,
+            host_key,
+        })
+    }
+}
+
+fn validate_signature_algorithm(algorithm: &[u8], credential: &[u8], flags: u32) -> Result<()> {
+    let mut credential = SshCursor::new(credential);
+    let key_type = credential.string()?;
+    let expected_flags = match (key_type, algorithm) {
+        (b"ssh-rsa", b"ssh-rsa")
+        | (b"ssh-rsa-cert-v01@openssh.com", b"ssh-rsa-cert-v01@openssh.com") => 0,
+        (b"ssh-rsa", b"rsa-sha2-256")
+        | (b"ssh-rsa-cert-v01@openssh.com", b"rsa-sha2-256-cert-v01@openssh.com") => 2,
+        (b"ssh-rsa", b"rsa-sha2-512")
+        | (b"ssh-rsa-cert-v01@openssh.com", b"rsa-sha2-512-cert-v01@openssh.com") => 4,
+        (key_type, algorithm) if key_type == algorithm => 0,
+        _ => bail!("userauth signature algorithm did not match credential"),
+    };
+    if flags != expected_flags {
+        bail!("agent signature flags did not match userauth algorithm");
+    }
+    Ok(())
+}
+
+struct SshCursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> SshCursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn byte(&mut self) -> Result<u8> {
+        let value = *self
+            .bytes
+            .get(self.offset)
+            .context("truncated SSH signing data")?;
+        self.offset += 1;
+        Ok(value)
+    }
+
+    fn string(&mut self) -> Result<&'a [u8]> {
+        let end = self
+            .offset
+            .checked_add(4)
+            .context("SSH string offset overflow")?;
+        let length: [u8; 4] = self
+            .bytes
+            .get(self.offset..end)
+            .context("truncated SSH string length")?
+            .try_into()
+            .map_err(|_| anyhow!("invalid SSH string length"))?;
+        self.offset = end;
+        let end = self
+            .offset
+            .checked_add(u32::from_be_bytes(length) as usize)
+            .context("SSH string length overflow")?;
+        let value = self
+            .bytes
+            .get(self.offset..end)
+            .context("truncated SSH string")?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.offset == self.bytes.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use signature::Signer;
+    use ssh_agent_lib::proto::{Extension, Identity};
+    use ssh_agent_lib::ssh_key::private::Ed25519Keypair;
+    use std::sync::mpsc;
+    use std::time::Instant;
+
+    fn key(seed: u8) -> (Ed25519Keypair, KeyData) {
+        let keypair = Ed25519Keypair::from_seed(&[seed; 32]);
+        let public = KeyData::Ed25519(keypair.public);
+        (keypair, public)
+    }
+
+    fn host_policy(user: &str, name: &str, key: KeyData) -> HostPolicy {
+        HostPolicy {
+            login_user: user.into(),
+            host_keys: vec![key],
+            known_hosts_name: name.into(),
+        }
+    }
+
+    fn policy(delegate: KeyData, destination: KeyData) -> BrokerPolicy {
+        BrokerPolicy::new(
+            host_policy("source-user", "source", delegate),
+            host_policy("backup", "destination", destination),
+        )
+    }
+
+    fn binding(keypair: &Ed25519Keypair, key: KeyData, id: &[u8], forwarding: bool) -> SessionBind {
+        SessionBind {
+            host_key: key,
+            session_id: id.to_vec(),
+            signature: keypair.try_sign(id).unwrap(),
+            is_forwarding: forwarding,
+        }
+    }
+
+    fn encode_request(request: Request) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        request.encode(&mut encoded).unwrap();
+        encoded
+    }
+
+    fn bind_request(binding: SessionBind) -> Vec<u8> {
+        encode_request(Request::Extension(Extension::new_message(binding).unwrap()))
+    }
+
+    fn hostbound_data(
+        session_id: &[u8],
+        user: &[u8],
+        method: &[u8],
+        credential: &ssh_agent_lib::proto::PublicCredential,
+        host_key: &KeyData,
+    ) -> Vec<u8> {
+        let mut credential_blob = Vec::new();
+        credential.encode(&mut credential_blob).unwrap();
+        let mut host_key_blob = Vec::new();
+        host_key.encode(&mut host_key_blob).unwrap();
+        let mut data = Vec::new();
+        session_id.encode(&mut data).unwrap();
+        data.push(50);
+        for value in [user, b"ssh-connection", method] {
+            value.encode(&mut data).unwrap();
+        }
+        data.push(1);
+        b"ssh-ed25519".as_slice().encode(&mut data).unwrap();
+        credential_blob.as_slice().encode(&mut data).unwrap();
+        host_key_blob.as_slice().encode(&mut data).unwrap();
+        data
+    }
+
+    fn sign_request(
+        session_id: &[u8],
+        user: &[u8],
+        method: &[u8],
+        identity: KeyData,
+        host_key: &KeyData,
+    ) -> SignRequest {
+        let credential = identity.into();
+        let data = hostbound_data(session_id, user, method, &credential, host_key);
+        SignRequest {
+            credential,
+            data,
+            flags: 0,
+        }
+    }
+
+    fn read_response(stream: &mut UnixStream) -> Response {
+        let frame = read_frame(stream).unwrap().unwrap();
+        let mut input = frame.as_slice();
+        let response = Response::decode(&mut input).unwrap();
+        assert!(input.is_empty());
+        response
+    }
+
+    fn assert_closed(stream: &mut UnixStream) {
+        let mut byte = [0];
+        match stream.read(&mut byte) {
+            Ok(0) => {}
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::ConnectionReset | io::ErrorKind::BrokenPipe
+                ) => {}
+            other => panic!("agent connection was not closed: {other:?}"),
+        }
+    }
+
+    fn fake_ambient(
+        socket: &Path,
+        identity: Ed25519Keypair,
+    ) -> (JoinHandle<()>, mpsc::Receiver<Vec<u8>>) {
+        let listener = UnixListener::bind(socket).unwrap();
+        let (sent, received) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            while let Some(frame) = read_frame(&mut stream).unwrap() {
+                sent.send(frame.clone()).unwrap();
+                let response = match frame.first() {
+                    Some(11) => Response::IdentitiesAnswer(vec![Identity {
+                        credential: KeyData::Ed25519(identity.public).into(),
+                        comment: "hardware-backed test key".into(),
+                    }]),
+                    Some(13) => {
+                        let request = parse_sign_request(&frame).unwrap();
+                        Response::SignResponse(identity.try_sign(&request.data).unwrap())
+                    }
+                    other => panic!("unexpected upstream request {other:?}"),
+                };
+                let mut response_frame = Vec::new();
+                response.encode(&mut response_frame).unwrap();
+                write_frame(&mut stream, &response_frame).unwrap();
+            }
+        });
+        (worker, received)
+    }
+
+    #[test]
+    fn parses_effective_host_lookup_and_files() {
+        let config = parse_ssh_config(
+            b"host alias\nuser backup\nhostname vault.internal\nport 2222\nuserknownhostsfile /tmp/one /tmp/two\nglobalknownhostsfile none\n",
+        )
+        .unwrap();
+        assert_eq!(config.user, "backup");
+        assert_eq!(config.lookup, "[vault.internal]:2222");
+        assert_eq!(
+            config.files,
+            [PathBuf::from("/tmp/one"), PathBuf::from("/tmp/two")]
+        );
+    }
+
+    #[test]
+    fn host_key_alias_is_used_verbatim() {
+        let config = parse_ssh_config(
+            b"user backup\nhostname vault.internal\nport 2222\nhostkeyalias stable-vault\nuserknownhostsfile /tmp/known\n",
+        )
+        .unwrap();
+        assert_eq!(config.lookup, "stable-vault");
+    }
+
+    #[test]
+    fn known_hosts_parser_keeps_plain_keys_and_tracks_ca_and_revocation() {
+        let (_, plain) = key(51);
+        let (_, revoked_key) = key(52);
+        let plain_text = PublicKey::new(plain.clone(), "").to_openssh().unwrap();
+        let revoked_text = PublicKey::new(revoked_key.clone(), "")
+            .to_openssh()
+            .unwrap();
+        let text = format!(
+            "host {plain_text}\n@cert-authority host {plain_text}\n@revoked host {revoked_text}\n"
+        );
+        let mut trusted = Vec::new();
+        let mut revoked = Vec::new();
+        let mut saw_ca = false;
+        parse_known_host_output(
+            &text,
+            Path::new("known_hosts"),
+            &mut trusted,
+            &mut revoked,
+            &mut saw_ca,
+        )
+        .unwrap();
+        assert_eq!(trusted, [plain]);
+        assert_eq!(revoked, [revoked_key]);
+        assert!(saw_ca);
+        assert!(parse_known_host_output(
+            &format!("@unknown host {plain_text}\n"),
+            Path::new("known_hosts"),
+            &mut trusted,
+            &mut revoked,
+            &mut saw_ca,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn signature_algorithm_and_flags_must_match_key_blob() {
+        let mut rsa = Vec::new();
+        b"ssh-rsa".as_slice().encode(&mut rsa).unwrap();
+        rsa.extend_from_slice(b"key fields are irrelevant here");
+        validate_signature_algorithm(b"rsa-sha2-512", &rsa, 4).unwrap();
+        assert!(validate_signature_algorithm(b"rsa-sha2-256", &rsa, 4).is_err());
+        assert!(validate_signature_algorithm(b"ssh-ed25519", &rsa, 0).is_err());
+    }
+
+    #[test]
+    fn hostbound_parser_rejects_trailing_or_legacy_data() {
+        let mut data = Vec::new();
+        b"session".as_slice().encode(&mut data).unwrap();
+        data.push(50);
+        for value in [
+            b"user".as_slice(),
+            b"ssh-connection".as_slice(),
+            b"publickey".as_slice(),
+        ] {
+            value.encode(&mut data).unwrap();
+        }
+        data.push(1);
+        for value in [
+            b"ssh-ed25519".as_slice(),
+            b"key".as_slice(),
+            b"host".as_slice(),
+        ] {
+            value.encode(&mut data).unwrap();
+        }
+        let parsed = HostboundUserauth::parse(&data).unwrap();
+        assert_eq!(parsed.method, b"publickey");
+        data.push(0);
+        assert!(HostboundUserauth::parse(&data).is_err());
+    }
+
+    #[test]
+    fn bind_state_rejects_bad_signatures_wrong_hosts_and_extra_hops() {
+        let (source_private, source) = key(1);
+        let (destination_private, destination) = key(2);
+        let (other_private, other) = key(3);
+        let policy = policy(source.clone(), destination.clone());
+
+        let mut state = BindState::default();
+        assert!(state
+            .add(
+                &policy,
+                binding(&other_private, source.clone(), b"bad-signature", true)
+            )
+            .is_err());
+        assert!(state
+            .add(
+                &policy,
+                binding(&other_private, other.clone(), b"wrong-source", true)
+            )
+            .is_err());
+        state
+            .add(
+                &policy,
+                binding(&source_private, source, b"source-session", true),
+            )
+            .unwrap();
+        assert!(state
+            .add(
+                &policy,
+                binding(&other_private, other.clone(), b"wrong-destination", false)
+            )
+            .is_err());
+        state
+            .add(
+                &policy,
+                binding(
+                    &destination_private,
+                    destination,
+                    b"destination-session",
+                    false,
+                ),
+            )
+            .unwrap();
+        assert!(state
+            .add(&policy, binding(&other_private, other, b"third-hop", true))
+            .is_err());
+    }
+
+    #[test]
+    fn authorization_is_exact_for_user_session_host_and_method() {
+        let (source_private, source) = key(11);
+        let (destination_private, destination) = key(12);
+        let (_, identity) = key(13);
+        let (_, other_host) = key(14);
+        let policy = policy(source.clone(), destination.clone());
+        let mut state = BindState::default();
+        state
+            .add(
+                &policy,
+                binding(&source_private, source, b"source-session", true),
+            )
+            .unwrap();
+        state
+            .add(
+                &policy,
+                binding(
+                    &destination_private,
+                    destination.clone(),
+                    b"destination-session",
+                    false,
+                ),
+            )
+            .unwrap();
+
+        let allowed = sign_request(
+            b"destination-session",
+            b"backup",
+            b"publickey-hostbound-v00@openssh.com",
+            identity.clone(),
+            &destination,
+        );
+        state.authorize(&policy, &allowed).unwrap();
+        for denied in [
+            sign_request(
+                b"other-session",
+                b"backup",
+                b"publickey-hostbound-v00@openssh.com",
+                identity.clone(),
+                &destination,
+            ),
+            sign_request(
+                b"destination-session",
+                b"root",
+                b"publickey-hostbound-v00@openssh.com",
+                identity.clone(),
+                &destination,
+            ),
+            sign_request(
+                b"destination-session",
+                b"backup",
+                b"publickey",
+                identity.clone(),
+                &destination,
+            ),
+            sign_request(
+                b"destination-session",
+                b"backup",
+                b"publickey-hostbound-v00@openssh.com",
+                identity,
+                &other_host,
+            ),
+        ] {
+            assert!(state.authorize(&policy, &denied).is_err());
+        }
+    }
+
+    #[test]
+    fn broker_forwards_only_list_and_fully_bound_sign_requests() {
+        let temp = tempfile::tempdir().unwrap();
+        let ambient_socket = temp.path().join("ambient.sock");
+        let (identity_private, identity) = key(23);
+        let (ambient, requests) = fake_ambient(&ambient_socket, identity_private.clone());
+        let (source_private, source) = key(21);
+        let (destination_private, destination) = key(22);
+        let broker = ConstrainedAgentBroker::start_with_socket(
+            ambient_socket,
+            policy(source.clone(), destination.clone()),
+        )
+        .unwrap();
+        let broker_path = broker.socket_path().to_path_buf();
+        assert_eq!(
+            std::fs::metadata(&broker_path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let mut client = UnixStream::connect(&broker_path).unwrap();
+
+        write_frame(
+            &mut client,
+            &bind_request(binding(&source_private, source, b"source-session", true)),
+        )
+        .unwrap();
+        assert!(matches!(read_response(&mut client), Response::Success));
+
+        write_frame(&mut client, &[11]).unwrap();
+        let Response::IdentitiesAnswer(identities) = read_response(&mut client) else {
+            panic!("expected identities response")
+        };
+        assert_eq!(identities.len(), 1);
+        assert_eq!(identities[0].comment, "hardware-backed test key");
+        assert_eq!(requests.recv().unwrap(), vec![11]);
+
+        write_frame(
+            &mut client,
+            &bind_request(binding(
+                &destination_private,
+                destination.clone(),
+                b"destination-session",
+                false,
+            )),
+        )
+        .unwrap();
+        assert!(matches!(read_response(&mut client), Response::Success));
+        let request = sign_request(
+            b"destination-session",
+            b"backup",
+            b"publickey-hostbound-v00@openssh.com",
+            identity,
+            &destination,
+        );
+        let encoded = encode_request(Request::SignRequest(request.clone()));
+        write_frame(&mut client, &encoded).unwrap();
+        let Response::SignResponse(signature) = read_response(&mut client) else {
+            panic!("expected signature response")
+        };
+        assert_eq!(signature, identity_private.try_sign(&request.data).unwrap());
+        assert_eq!(requests.recv().unwrap(), encoded);
+
+        drop(client);
+        drop(broker);
+        ambient.join().unwrap();
+        assert!(!broker_path.exists());
+    }
+
+    #[test]
+    fn unbound_sign_mutation_unknown_extension_and_oversize_never_reach_ambient() {
+        let temp = tempfile::tempdir().unwrap();
+        let ambient_socket = temp.path().join("ambient.sock");
+        let _ambient = UnixListener::bind(&ambient_socket).unwrap();
+        let (_, source) = key(31);
+        let (_, destination) = key(32);
+        let (_, identity) = key(33);
+        let broker = ConstrainedAgentBroker::start_with_socket(
+            ambient_socket,
+            policy(source, destination.clone()),
+        )
+        .unwrap();
+
+        let request = sign_request(
+            b"unbound-session",
+            b"backup",
+            b"publickey-hostbound-v00@openssh.com",
+            identity,
+            &destination,
+        );
+        let cases = [
+            (encode_request(Request::SignRequest(request)), false),
+            (vec![11], false),
+            (vec![17], false),
+            (
+                encode_request(Request::Extension(Extension {
+                    name: "query".into(),
+                    details: Vec::new().into(),
+                })),
+                true,
+            ),
+        ];
+        for (request, extension_failure) in cases {
+            let mut client = UnixStream::connect(broker.socket_path()).unwrap();
+            write_frame(&mut client, &request).unwrap();
+            let response = read_response(&mut client);
+            assert!(
+                matches!(response, Response::ExtensionFailure) == extension_failure,
+                "unexpected response: {response:?}"
+            );
+            assert!(read_frame(&mut client).unwrap().is_none());
+        }
+
+        let mut oversized = UnixStream::connect(broker.socket_path()).unwrap();
+        oversized
+            .write_all(&((MAX_AGENT_FRAME as u32) + 1).to_be_bytes())
+            .unwrap();
+        assert!(read_frame(&mut oversized).unwrap().is_none());
+    }
+
+    #[test]
+    fn broker_bounds_idle_clients_and_drop_closes_them() {
+        let temp = tempfile::tempdir().unwrap();
+        let ambient_socket = temp.path().join("ambient.sock");
+        let _ambient = UnixListener::bind(&ambient_socket).unwrap();
+        let (_, source) = key(41);
+        let (_, destination) = key(42);
+        let broker =
+            ConstrainedAgentBroker::start_with_socket(ambient_socket, policy(source, destination))
+                .unwrap();
+        let path = broker.socket_path().to_path_buf();
+        let mut clients = Vec::new();
+        for _ in 0..MAX_BROKER_CONNECTIONS {
+            let mut client = UnixStream::connect(&path).unwrap();
+            client.write_all(&[0]).unwrap(); // keep each worker waiting on its header
+            clients.push(client);
+        }
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while broker
+            .connections
+            .streams
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
+            < MAX_BROKER_CONNECTIONS
+            && Instant::now() < deadline
+        {
+            thread::sleep(Duration::from_millis(5));
+        }
+        assert_eq!(
+            broker
+                .connections
+                .streams
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .len(),
+            MAX_BROKER_CONNECTIONS
+        );
+        let mut excess = UnixStream::connect(&path).unwrap();
+        excess
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        excess.write_all(&[0]).unwrap();
+        assert_closed(&mut excess);
+
+        drop(broker);
+        assert!(!path.exists());
+        for mut client in clients {
+            client
+                .set_read_timeout(Some(Duration::from_secs(1)))
+                .unwrap();
+            assert_closed(&mut client);
+        }
+    }
+}

--- a/src/agent_broker.rs
+++ b/src/agent_broker.rs
@@ -32,6 +32,9 @@ use std::time::Duration;
 /// Agent messages are normally only a few KiB. This accommodates large
 /// identity lists without allowing a peer to force an unbounded allocation.
 const MAX_AGENT_FRAME: usize = 256 * 1024;
+/// Bound stalled forwarded clients and ambient-agent operations while leaving
+/// enough time for hardware-token touch/PIN/confirmation prompts.
+const BROKER_IO_TIMEOUT: Duration = Duration::from_secs(120);
 const SSH_AGENT_FAILURE: &[u8] = &[5];
 const SSH_AGENT_SUCCESS: &[u8] = &[6];
 const SSH_AGENT_EXTENSION_FAILURE: &[u8] = &[28];
@@ -92,27 +95,10 @@ pub fn resolve_host_policy(
     host: &str,
     load_user_certificates: bool,
 ) -> Result<HostPolicy> {
-    let mut command = Command::new(ssh_program);
-    command.arg("-G");
-    if let Some(user) = explicit_user {
-        command.args(["-l", user]);
-    }
-    command.args(["--", host]).env("LC_ALL", "C");
-    let output = command
-        .output()
-        .with_context(|| format!("inspect SSH configuration for {host}"))?;
-    if !output.status.success() {
-        let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        bail!(
-            "could not inspect SSH configuration for {host}{}",
-            if detail.is_empty() {
-                String::new()
-            } else {
-                format!(": {detail}")
-            }
-        );
-    }
-    let config = parse_ssh_config(&output.stdout)
+    let output = inspect_ssh_configuration(ssh_program, explicit_user, host, false)?;
+    let defaults = inspect_ssh_configuration(ssh_program, explicit_user, host, true)?;
+    let defaults = KnownHostsDefaults::from_openssh(&defaults)?;
+    let config = parse_ssh_config_with_defaults(&output, Some(&defaults))
         .with_context(|| format!("parse `ssh -G` output for {host}"))?;
     let keygen = ssh_keygen_for(ssh_program);
     let (mut host_keys, saw_ca) = read_known_host_keys(&keygen, &config.lookup, &config.files)?;
@@ -144,6 +130,38 @@ pub fn resolve_host_policy(
     })
 }
 
+fn inspect_ssh_configuration(
+    ssh_program: &str,
+    explicit_user: Option<&str>,
+    host: &str,
+    compiled_defaults_only: bool,
+) -> Result<Vec<u8>> {
+    let mut command = Command::new(ssh_program);
+    command.arg("-G");
+    if compiled_defaults_only {
+        command.args(["-F", "/dev/null"]);
+    }
+    if let Some(user) = explicit_user {
+        command.args(["-l", user]);
+    }
+    command.args(["--", host]).env("LC_ALL", "C");
+    let output = command
+        .output()
+        .with_context(|| format!("inspect SSH configuration for {host}"))?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "could not inspect SSH configuration for {host}{}",
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        );
+    }
+    Ok(output.stdout)
+}
+
 #[derive(Debug)]
 struct EffectiveSshConfig {
     user: String,
@@ -160,7 +178,59 @@ struct EffectiveSshConfig {
     identity_files: Vec<String>,
 }
 
+#[derive(Debug)]
+struct KnownHostsDefault {
+    rendered: String,
+    files: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+struct KnownHostsDefaults {
+    user: KnownHostsDefault,
+    global: KnownHostsDefault,
+}
+
+impl KnownHostsDefaults {
+    fn from_openssh(output: &[u8]) -> Result<Self> {
+        let (user, global) = known_hosts_values(output)?;
+        let account = local_account()?;
+        let user_files = [
+            PathBuf::from(&account.home).join(".ssh/known_hosts"),
+            PathBuf::from(&account.home).join(".ssh/known_hosts2"),
+        ];
+        let expected_user = user_files
+            .iter()
+            .map(|path| path.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if user != expected_user {
+            bail!(
+                "OpenSSH reported unfamiliar compiled UserKnownHostsFile defaults; constrained agent forwarding cannot recover their filename boundaries"
+            );
+        }
+        let global_files = parse_compiled_global_known_hosts(&global)?;
+        Ok(Self {
+            user: KnownHostsDefault {
+                rendered: user,
+                files: user_files.into_iter().collect(),
+            },
+            global: KnownHostsDefault {
+                rendered: global,
+                files: global_files,
+            },
+        })
+    }
+}
+
+#[cfg(test)]
 fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
+    parse_ssh_config_with_defaults(output, None)
+}
+
+fn parse_ssh_config_with_defaults(
+    output: &[u8],
+    defaults: Option<&KnownHostsDefaults>,
+) -> Result<EffectiveSshConfig> {
     let output = std::str::from_utf8(output).context("SSH configuration was not UTF-8")?;
     let mut user = None;
     let mut hostname = None;
@@ -216,16 +286,11 @@ fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
                 }
             }
             "identityfile" if value != "none" => identity_files.push(value.to_string()),
-            "userknownhostsfile" | "globalknownhostsfile" => {
-                for path in value
-                    .split_ascii_whitespace()
-                    .filter(|path| *path != "none")
-                {
-                    if path.contains('%') || path.starts_with('~') {
-                        bail!("unexpanded known_hosts path {path:?} in `ssh -G` output");
-                    }
-                    files.push(PathBuf::from(path));
-                }
+            "userknownhostsfile" => {
+                append_known_hosts_files(&mut files, value, defaults.map(|item| &item.user))?;
+            }
+            "globalknownhostsfile" => {
+                append_known_hosts_files(&mut files, value, defaults.map(|item| &item.global))?;
             }
             _ => {}
         }
@@ -260,6 +325,72 @@ fn parse_ssh_config(output: &[u8]) -> Result<EffectiveSshConfig> {
         certificate_files_configured,
         identity_files,
     })
+}
+
+fn known_hosts_values(output: &[u8]) -> Result<(String, String)> {
+    let output = std::str::from_utf8(output).context("SSH configuration was not UTF-8")?;
+    let mut user = None;
+    let mut global = None;
+    for line in output.lines() {
+        let Some((name, value)) = line.split_once(' ') else {
+            continue;
+        };
+        match name {
+            "userknownhostsfile" => user = Some(value.trim().to_owned()),
+            "globalknownhostsfile" => global = Some(value.trim().to_owned()),
+            _ => {}
+        }
+    }
+    Ok((
+        user.context("missing SSH UserKnownHostsFile")?,
+        global.context("missing SSH GlobalKnownHostsFile")?,
+    ))
+}
+
+fn parse_compiled_global_known_hosts(value: &str) -> Result<Vec<PathBuf>> {
+    if value == "none" {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    for path in value.split_ascii_whitespace() {
+        let path = PathBuf::from(path);
+        if !path.is_absolute() {
+            bail!("OpenSSH reported a relative compiled GlobalKnownHostsFile default");
+        }
+        files.push(path);
+    }
+    if files.is_empty() {
+        bail!("OpenSSH reported empty compiled GlobalKnownHostsFile defaults");
+    }
+    Ok(files)
+}
+
+fn append_known_hosts_files(
+    files: &mut Vec<PathBuf>,
+    value: &str,
+    compiled_default: Option<&KnownHostsDefault>,
+) -> Result<()> {
+    if value == "none" {
+        return Ok(());
+    }
+    if let Some(compiled_default) = compiled_default.filter(|default| default.rendered == value) {
+        files.extend(compiled_default.files.iter().cloned());
+        return Ok(());
+    }
+    if value.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        bail!(
+            "ambiguous known_hosts filenames in `ssh -G` output {value:?}; OpenSSH removes quoting, so constrained agent forwarding accepts only one whitespace-free configured file per directive"
+        );
+    }
+    if value.contains('%') || value.starts_with('~') {
+        bail!("unexpanded known_hosts path {value:?} in `ssh -G` output");
+    }
+    let path = PathBuf::from(value);
+    if !path.is_absolute() {
+        bail!("relative known_hosts path {value:?} in `ssh -G` output");
+    }
+    files.push(path);
+    Ok(())
 }
 
 fn configured_host_key_allowed(config: &EffectiveSshConfig, key: &KeyData) -> bool {
@@ -541,7 +672,10 @@ fn read_user_certificates(paths: &[PathBuf]) -> Result<Vec<Certificate>> {
         certificate
             .verify_signature()
             .with_context(|| format!("verify CertificateFile {}", path.display()))?;
-        if !certificates.contains(&certificate) {
+        if !certificates
+            .iter()
+            .any(|existing| certificates_equal_on_wire(existing, &certificate))
+        {
             certificates.push(certificate);
         }
     }
@@ -845,6 +979,8 @@ struct ConnectionRegistry {
 
 impl ConnectionRegistry {
     fn track(self: &Arc<Self>, stream: UnixStream) -> io::Result<TrackedStream> {
+        stream.set_read_timeout(Some(BROKER_IO_TIMEOUT))?;
+        stream.set_write_timeout(Some(BROKER_IO_TIMEOUT))?;
         let registered = stream.try_clone()?;
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         self.streams
@@ -1192,8 +1328,23 @@ impl SanitizedIdentities {
     fn advertises(&self, credential: &PublicCredential) -> bool {
         self.advertised
             .iter()
-            .any(|identity| &identity.credential == credential)
+            .any(|identity| credentials_equal_on_wire(&identity.credential, credential))
     }
+}
+
+fn credentials_equal_on_wire(left: &PublicCredential, right: &PublicCredential) -> bool {
+    let mut left_encoded = Vec::new();
+    let mut right_encoded = Vec::new();
+    left.encode(&mut left_encoded).is_ok()
+        && right.encode(&mut right_encoded).is_ok()
+        && left_encoded == right_encoded
+}
+
+fn certificates_equal_on_wire(left: &Certificate, right: &Certificate) -> bool {
+    credentials_equal_on_wire(
+        &PublicCredential::Cert(Box::new(left.clone())),
+        &PublicCredential::Cert(Box::new(right.clone())),
+    )
 }
 
 fn sanitize_identities(
@@ -1221,11 +1372,16 @@ fn sanitize_identities(
                 || certificates.iter().any(|certificate| {
                     matches!(
                         &identity.credential,
-                        PublicCredential::Cert(advertised) if advertised.as_ref() == certificate
+                        PublicCredential::Cert(advertised)
+                            if certificates_equal_on_wire(advertised, certificate)
                     )
                 })
         })
         .cloned()
+        .map(|mut identity| {
+            identity.comment.clear();
+            identity
+        })
         .collect();
     for certificate in certificates {
         let credential = PublicCredential::Cert(Box::new(certificate.clone()));
@@ -1234,14 +1390,14 @@ fn sanitize_identities(
         }
         if advertised
             .iter()
-            .any(|identity| identity.credential == credential)
+            .any(|identity| credentials_equal_on_wire(&identity.credential, &credential))
         {
             continue;
         }
         if ambient_raw_keys.contains(certificate.public_key()) {
             advertised.push(Identity {
                 credential,
-                comment: format!("syq CertificateFile {}", certificate.key_id()),
+                comment: String::new(),
             });
         }
     }
@@ -1266,8 +1422,10 @@ fn translated_sign_request(
     if let PublicCredential::Cert(certificate) = &request.credential {
         let ambient_has_exact_certificate = ambient_identities
             .iter()
-            .any(|identity| identity.credential == request.credential);
-        let configured_locally = certificates.contains(certificate.as_ref());
+            .any(|identity| credentials_equal_on_wire(&identity.credential, &request.credential));
+        let configured_locally = certificates
+            .iter()
+            .any(|configured| certificates_equal_on_wire(configured, certificate));
         let ambient_has_raw_key = ambient_identities.iter().any(|identity| {
             matches!(
                 &identity.credential,
@@ -1631,17 +1789,42 @@ mod tests {
 
     #[test]
     fn parses_effective_host_lookup_and_files() {
-        let config = parse_ssh_config(
-            b"host alias\nuser backup\nhostname vault.internal\nport 2222\nuserknownhostsfile /tmp/one /tmp/two\nglobalknownhostsfile none\nhostkeyalgorithms ssh-ed25519,rsa-sha2-512\nrequiredrsasize 3072\n",
-        )
-        .unwrap();
+        let output = b"host alias\nuser backup\nhostname vault.internal\nport 2222\nuserknownhostsfile /tmp/default-one /tmp/default-two\nglobalknownhostsfile none\nhostkeyalgorithms ssh-ed25519,rsa-sha2-512\nrequiredrsasize 3072\n";
+        let defaults = KnownHostsDefaults {
+            user: KnownHostsDefault {
+                rendered: "/tmp/default-one /tmp/default-two".into(),
+                files: vec!["/tmp/default-one".into(), "/tmp/default-two".into()],
+            },
+            global: KnownHostsDefault {
+                rendered: "none".into(),
+                files: Vec::new(),
+            },
+        };
+        let config = parse_ssh_config_with_defaults(output, Some(&defaults)).unwrap();
         assert_eq!(config.user, "backup");
         assert_eq!(config.lookup, "[vault.internal]:2222");
         assert_eq!(config.required_rsa_size, 3072);
         assert_eq!(
             config.files,
-            [PathBuf::from("/tmp/one"), PathBuf::from("/tmp/two")]
+            [
+                PathBuf::from("/tmp/default-one"),
+                PathBuf::from("/tmp/default-two")
+            ]
         );
+    }
+
+    #[test]
+    fn ambiguous_or_relative_known_hosts_filenames_fail_closed() {
+        for value in ["/tmp/known hosts", "/tmp/one /tmp/two", "relative-hosts"] {
+            let output = format!(
+                "user backup\nhostname vault.internal\nport 22\nuserknownhostsfile {value}\nglobalknownhostsfile none\nhostkeyalgorithms ssh-ed25519\n"
+            );
+            let error = parse_ssh_config(output.as_bytes()).unwrap_err();
+            assert!(
+                error.to_string().contains("known_hosts"),
+                "unexpected error for {value:?}: {error:#}"
+            );
+        }
     }
 
     #[test]
@@ -1766,6 +1949,73 @@ mod tests {
         assert!(certificate_paths(&explicit_none, "vault")
             .unwrap()
             .is_empty());
+    }
+
+    #[test]
+    fn openssh_certificate_comments_do_not_break_translation() {
+        let temp = tempfile::tempdir().unwrap();
+        let ca = temp.path().join("ca");
+        let subject = temp.path().join("subject");
+        for (path, comment) in [
+            (&ca, "test certificate authority"),
+            (&subject, "raw key comment"),
+        ] {
+            let status = Command::new("ssh-keygen")
+                .args(["-q", "-t", "ed25519", "-N", "", "-C", comment, "-f"])
+                .arg(path)
+                .status()
+                .expect("run ssh-keygen key generation");
+            assert!(status.success(), "ssh-keygen key generation failed");
+        }
+        let status = Command::new("ssh-keygen")
+            .args(["-q", "-s"])
+            .arg(&ca)
+            .args(["-I", "central-cert", "-n", "backup", "-V", "+1h"])
+            .arg(subject.with_extension("pub"))
+            .status()
+            .expect("run ssh-keygen certificate signing");
+        assert!(status.success(), "ssh-keygen certificate signing failed");
+
+        let certificate_path = temp.path().join("subject-cert.pub");
+        let configured = read_user_certificates(std::slice::from_ref(&certificate_path)).unwrap();
+        assert_eq!(configured.len(), 1);
+        assert!(!configured[0].comment().is_empty());
+        let raw_key = PublicKey::read_openssh_file(&subject.with_extension("pub"))
+            .unwrap()
+            .key_data()
+            .clone();
+        let ambient = vec![Identity {
+            credential: PublicCredential::Key(raw_key.clone()),
+            comment: "ambient comment must stay private".into(),
+        }];
+        let identities = sanitize_identities(ambient.clone(), &configured);
+        assert_eq!(identities.advertised.len(), 1);
+        assert!(identities.advertised[0].comment.is_empty());
+
+        let mut encoded = Vec::new();
+        identities.advertised[0]
+            .credential
+            .encode(&mut encoded)
+            .unwrap();
+        let mut input = encoded.as_slice();
+        let echoed = PublicCredential::decode(&mut input).unwrap();
+        assert!(input.is_empty());
+        let PublicCredential::Cert(echoed_certificate) = &echoed else {
+            panic!("expected echoed user certificate")
+        };
+        assert!(echoed_certificate.comment().is_empty());
+        assert!(identities.advertises(&echoed));
+
+        let request = SignRequest {
+            credential: echoed,
+            data: b"host-bound certificate request".to_vec(),
+            flags: 0,
+        };
+        let translated = translated_sign_request(&request, &ambient, &configured).unwrap();
+        assert_eq!(
+            parse_sign_request(&translated).unwrap().credential,
+            PublicCredential::Key(raw_key)
+        );
     }
 
     #[test]
@@ -1943,6 +2193,39 @@ mod tests {
             &mut saw_ca,
         )
         .is_err());
+    }
+
+    #[test]
+    fn openssh_defaults_and_hashed_known_hosts_lookup_are_exercised() {
+        let output = inspect_ssh_configuration("ssh", None, "unused.example", true).unwrap();
+        let defaults = KnownHostsDefaults::from_openssh(&output).unwrap();
+        assert_eq!(defaults.user.files.len(), 2);
+        assert!(defaults.user.files.iter().all(|path| path.is_absolute()));
+        assert!(defaults.global.files.iter().all(|path| path.is_absolute()));
+
+        let temp = tempfile::tempdir().unwrap();
+        let known_hosts = temp.path().join("known_hosts");
+        let lookup = "[vault.internal]:2222";
+        let (_, host_key) = key(53);
+        let public = PublicKey::new(host_key.clone(), "").to_openssh().unwrap();
+        std::fs::write(&known_hosts, format!("{lookup} {public}\n")).unwrap();
+        let status = Command::new("ssh-keygen")
+            .args(["-q", "-H", "-f"])
+            .arg(&known_hosts)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("hash test known_hosts entry");
+        assert!(status.success(), "ssh-keygen known_hosts hashing failed");
+
+        let (trusted, saw_ca) = read_known_host_keys(
+            &ssh_keygen_for("ssh"),
+            lookup,
+            std::slice::from_ref(&known_hosts),
+        )
+        .unwrap();
+        assert_eq!(trusted, [host_key]);
+        assert!(!saw_ca);
     }
 
     #[test]
@@ -2146,7 +2429,7 @@ mod tests {
             panic!("expected identities response")
         };
         assert_eq!(identities.len(), 1);
-        assert_eq!(identities[0].comment, "hardware-backed test key");
+        assert!(identities[0].comment.is_empty());
         assert_eq!(requests.recv().unwrap(), source_bind);
         assert_eq!(requests.recv().unwrap(), vec![11]);
 
@@ -2374,5 +2657,20 @@ mod tests {
                 .unwrap();
             assert_closed(&mut client);
         }
+    }
+
+    #[test]
+    fn tracked_broker_connections_have_bounded_io() {
+        let (stream, _peer) = UnixStream::pair().unwrap();
+        let registry = Arc::new(ConnectionRegistry::default());
+        let tracked = registry.track(stream).unwrap();
+        assert_eq!(
+            tracked.stream.read_timeout().unwrap(),
+            Some(BROKER_IO_TIMEOUT)
+        );
+        assert_eq!(
+            tracked.stream.write_timeout().unwrap(),
+            Some(BROKER_IO_TIMEOUT)
+        );
     }
 }

--- a/src/agent_broker.rs
+++ b/src/agent_broker.rs
@@ -149,15 +149,9 @@ fn inspect_ssh_configuration(
     compiled_defaults_only: bool,
 ) -> Result<SshConfigurationInspection> {
     let mut command = Command::new(ssh_program);
-    command.arg("-G");
+    command.args(["-G", "-vvv"]);
     if compiled_defaults_only {
         command.args(["-F", "/dev/null"]);
-    } else {
-        // OpenSSH does not retain filename quoting in `ssh -G` output. Its
-        // debug stream identifies the configuration files that contributed to
-        // this query, which lets us distinguish compiled defaults from an
-        // explicitly configured value that happens to render identically.
-        command.arg("-vvv");
     }
     if let Some(user) = explicit_user {
         command.args(["-l", user]);
@@ -177,10 +171,22 @@ fn inspect_ssh_configuration(
             }
         );
     }
+    // OpenSSH does not retain filename quoting in `ssh -G` output. Its debug
+    // stream identifies the configuration files that contributed to this
+    // query, which lets us distinguish compiled defaults from an explicitly
+    // configured value that happens to render identically. Requiring the
+    // controlled query to name /dev/null also validates that this OpenSSH's
+    // debug format is one we can use as provenance.
+    let configuration_paths = ssh_configuration_paths(&output.stderr)?;
     let known_hosts_configured = if compiled_defaults_only {
+        if configuration_paths != [PathBuf::from("/dev/null")] {
+            bail!(
+                "OpenSSH did not report /dev/null as the sole configuration source for the compiled-default query"
+            );
+        }
         KnownHostsConfigured::default()
     } else {
-        configured_known_hosts_directives(&output.stderr)?
+        configured_known_hosts_directives(&configuration_paths)?
     };
     Ok(SshConfigurationInspection {
         output: output.stdout,
@@ -194,7 +200,7 @@ struct KnownHostsConfigured {
     global: bool,
 }
 
-fn configured_known_hosts_directives(debug: &[u8]) -> Result<KnownHostsConfigured> {
+fn ssh_configuration_paths(debug: &[u8]) -> Result<Vec<PathBuf>> {
     const PREFIX: &str = "debug1: Reading configuration data ";
     let debug = std::str::from_utf8(debug).context("OpenSSH debug output was not UTF-8")?;
     let mut paths = Vec::new();
@@ -217,10 +223,13 @@ fn configured_known_hosts_directives(debug: &[u8]) -> Result<KnownHostsConfigure
             paths.push(path);
         }
     }
+    Ok(paths)
+}
 
+fn configured_known_hosts_directives(paths: &[PathBuf]) -> Result<KnownHostsConfigured> {
     let mut configured = KnownHostsConfigured::default();
     for path in paths {
-        let mut file = fs::File::open(&path)
+        let mut file = fs::File::open(path)
             .with_context(|| format!("open SSH configuration file {}", path.display()))?;
         let metadata = file
             .metadata()
@@ -1990,7 +1999,8 @@ mod tests {
             "OpenSSH test\ndebug1: Reading configuration data {}\n",
             config.display()
         );
-        let configured = configured_known_hosts_directives(debug.as_bytes()).unwrap();
+        let paths = ssh_configuration_paths(debug.as_bytes()).unwrap();
+        let configured = configured_known_hosts_directives(&paths).unwrap();
         assert!(configured.user);
         assert!(!configured.global);
     }
@@ -2024,7 +2034,8 @@ mod tests {
             "ssh -G failed: {}",
             String::from_utf8_lossy(&output.stderr)
         );
-        let configured = configured_known_hosts_directives(&output.stderr).unwrap();
+        let paths = ssh_configuration_paths(&output.stderr).unwrap();
+        let configured = configured_known_hosts_directives(&paths).unwrap();
         assert!(configured.user);
         let error = parse_ssh_config_with_defaults(&output.stdout, Some(&defaults), &configured)
             .unwrap_err();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,6 +169,13 @@ pub struct Args {
     /// must authenticate to the destination with its own credentials
     #[arg(long, conflicts_with = "rsh")]
     pub no_forward_agent: bool,
+    /// Remote-to-remote with the default ssh: expose the unrestricted local agent to the source
+    /// host. This is a compatibility escape hatch; the default broker permits only user@hostB
+    #[arg(
+        long,
+        conflicts_with_all = ["rsh", "no_forward_agent", "detach", "relay"]
+    )]
+    pub unrestricted_agent_forwarding: bool,
     /// Terminal width for the progress display (internal; used for remote-to-remote)
     #[arg(long, hide = true)]
     pub width: Option<usize>,

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -6,20 +6,48 @@ use anyhow::{bail, Context, Result};
 use std::io::IsTerminal;
 use std::process::{Command, Stdio};
 
+#[derive(Clone, Debug)]
+enum AgentForwarding {
+    Disabled,
+    Unrestricted,
+    Constrained { ambient: String, broker: String },
+}
+
 fn direct_command(
     rsh: &[String],
     user: Option<&str>,
     host: &str,
     remote_cmd: &str,
-    default_ssh_forward_agent: Option<bool>,
+    default_ssh_forward_agent: Option<&AgentForwarding>,
 ) -> Command {
     let mut cmd = Command::new(&rsh[0]);
     cmd.args(&rsh[1..]);
     if rsh[0].ends_with("ssh") {
         // Manage agent forwarding only for syq's implicit `ssh`. An explicit
         // -e/--rsh command is a complete user policy and is left unchanged.
-        if let Some(forward_agent) = default_ssh_forward_agent {
-            cmd.arg(if forward_agent { "-A" } else { "-a" });
+        match default_ssh_forward_agent {
+            Some(AgentForwarding::Disabled) => {
+                cmd.arg("-a");
+            }
+            Some(AgentForwarding::Unrestricted) => {
+                cmd.arg("-A");
+            }
+            Some(AgentForwarding::Constrained { ambient, broker }) => {
+                // Authenticate this local->A connection normally, but expose a
+                // different, filtered agent socket on A. Multiplexing must be
+                // off or an older master could substitute its forwarded agent.
+                cmd.args([
+                    "-o",
+                    &format!("IdentityAgent={ambient}"),
+                    "-o",
+                    &format!("ForwardAgent={broker}"),
+                    "-o",
+                    "ControlMaster=no",
+                    "-o",
+                    "ControlPath=none",
+                ]);
+            }
+            None => {}
         }
         if let Some(user) = user {
             cmd.args(["-l", user]);
@@ -32,9 +60,58 @@ fn direct_command(
     cmd
 }
 
+fn source_setup_rsh(rsh: &[String], explicit_rsh: bool) -> Vec<String> {
+    let mut setup = rsh.to_vec();
+    if !explicit_rsh {
+        // Probes and helper installation never need delegated credentials.
+        setup.push("-a".into());
+    }
+    setup
+}
+
+fn destination_rsh(explicit_rsh: Option<&str>, same_host: bool) -> Option<&str> {
+    // A uses the broker to authenticate to B, but B must never receive it.
+    (!same_host).then_some(explicit_rsh.unwrap_or("ssh -a"))
+}
+
 pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     let rsh = parse_rsh(&args.rsh)?;
     let src_host = srcs[0].host.clone().unwrap();
+    let same_host = srcs[0].same_host(dst);
+    if args.detach && args.rsh.is_none() && !same_host && !args.no_forward_agent {
+        bail!(
+            "a constrained agent exists only while syq is attached; --detach requires --no-forward-agent and credentials on {src_host}, or an explicit --rsh policy"
+        );
+    }
+
+    let mut broker_guard = None;
+    let mut destination_login_user = None;
+    let default_ssh_agent_policy = if args.rsh.is_some() {
+        None
+    } else if same_host || args.no_forward_agent {
+        Some(AgentForwarding::Disabled)
+    } else if args.unrestricted_agent_forwarding {
+        Some(AgentForwarding::Unrestricted)
+    } else {
+        let source_policy =
+            crate::agent_broker::resolve_host_policy(&rsh[0], srcs[0].user.as_deref(), &src_host)?;
+        let destination_policy = crate::agent_broker::resolve_host_policy(
+            &rsh[0],
+            dst.user.as_deref(),
+            dst.host.as_deref().unwrap(),
+        )?;
+        destination_login_user = Some(destination_policy.login_user.clone());
+        let broker = crate::agent_broker::ConstrainedAgentBroker::start(
+            crate::agent_broker::BrokerPolicy::new(source_policy, destination_policy),
+        )?;
+        let ambient = broker.ambient_socket().to_string_lossy().into_owned();
+        let socket = broker.socket_path().to_string_lossy().into_owned();
+        broker_guard = Some(broker);
+        Some(AgentForwarding::Constrained {
+            ambient,
+            broker: socket,
+        })
+    };
     // The follow target must reconnect the way we did: keep an explicit user.
     let src_target = match &srcs[0].user {
         Some(user) => format!("{user}@{src_host}"),
@@ -43,7 +120,7 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     let spec = crate::conn::RemoteSpec {
         user: srcs[0].user.clone(),
         host: src_host.clone(),
-        rsh: rsh.clone(),
+        rsh: source_setup_rsh(&rsh, args.rsh.is_some()),
         syq_path: args.syq_path.clone(),
         auto_helper: args.syq_path.is_none() && !args.no_bootstrap,
         helper_install: Default::default(),
@@ -157,9 +234,9 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     if let Some(p) = &args.syq_path {
         remote.push(format!("--syq-path={p}"));
     }
-    if let Some(e) = &args.rsh {
+    if let Some(e) = destination_rsh(args.rsh.as_deref(), same_host) {
         remote.push("-e".into());
-        remote.push(e.clone());
+        remote.push(e.into());
     }
     remote.push("--".into());
     for s in srcs {
@@ -168,7 +245,7 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     // Same host (and user) on both ends: on that host this is a plain local
     // copy — no ssh back to itself, copy_file_range applies, and the
     // copy-into-itself check sees both paths on one machine.
-    let dst_str = if srcs[0].same_host(dst) {
+    let dst_str = if same_host {
         // A relative remote path is relative to the home; anchor it so the
         // orchestrator's local parse can't take it for something else.
         if dst.path.starts_with('/')
@@ -182,7 +259,7 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
             format!("./{}", dst.path)
         }
     } else {
-        match &dst.user {
+        match destination_login_user.as_ref().or(dst.user.as_ref()) {
             Some(u) => format!("{u}@{}:{}", dst.host.as_ref().unwrap(), dst.path),
             None => format!("{}:{}", dst.host.as_ref().unwrap(), dst.path),
         }
@@ -245,19 +322,20 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         remote_cmd
     };
 
-    let default_ssh_forward_agent = args
-        .rsh
-        .is_none()
-        .then(|| !args.no_forward_agent && !srcs[0].same_host(dst));
     let make_command = || {
         direct_command(
             &rsh,
             srcs[0].user.as_deref(),
             &src_host,
             &remote_cmd,
-            default_ssh_forward_agent,
+            default_ssh_agent_policy.as_ref(),
         )
     };
+    if args.unrestricted_agent_forwarding && !args.quiet {
+        eprintln!(
+            "syq: warning: --unrestricted-agent-forwarding exposes every capability in your SSH agent to {src_host} for this transfer"
+        );
+    }
     if args.detach {
         let run = || {
             let mut cmd = make_command();
@@ -300,6 +378,9 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         spec.install_helper()?;
         status = run()?;
     }
+    // Keep the broker alive until the outer SSH connection and all forwarded
+    // channels have closed.
+    drop(broker_guard);
     match status.code() {
         Some(0) => Ok(0),
         // 23 (some files failed) and 25 (--max-delete refused) pass through:
@@ -313,6 +394,13 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
         // be mistaken for the orchestrator.
         Some(c @ (23 | 25)) => Ok(c),
         Some(c) => {
+            if args.rsh.is_none()
+                && !args.no_forward_agent
+                && !args.unrestricted_agent_forwarding
+                && !same_host
+            {
+                bail!("remote-to-remote transfer on {src_host} failed (exit {c}); constrained authentication permits only {}@{} and requires OpenSSH session-bind/host-bound authentication. Retry with --relay, use --no-forward-agent with source-host credentials, or explicitly accept full agent exposure with --unrestricted-agent-forwarding", destination_login_user.as_deref().unwrap_or("the destination user"), dst.host.as_deref().unwrap_or("the destination"))
+            }
             bail!("remote-to-remote transfer on {src_host} failed (exit {c}); if {src_host} cannot reach the destination, retry with --relay")
         }
         None => bail!("remote syq on {src_host} killed by signal"),
@@ -422,15 +510,57 @@ mod tests {
     #[test]
     fn default_ssh_controls_agent_forwarding_explicitly() {
         let rsh = vec!["ssh".to_string(), "-p".to_string(), "2222".to_string()];
-        let forwarded = direct_command(&rsh, Some("alice"), "source", "syq ...", Some(true));
+        let forwarded = direct_command(
+            &rsh,
+            Some("alice"),
+            "source",
+            "syq ...",
+            Some(&AgentForwarding::Unrestricted),
+        );
         let forwarded = args(&forwarded);
         assert!(forwarded.contains(&OsStr::new("-A")));
         assert!(!forwarded.contains(&OsStr::new("-a")));
 
-        let disabled = direct_command(&rsh, Some("alice"), "source", "syq ...", Some(false));
+        let disabled = direct_command(
+            &rsh,
+            Some("alice"),
+            "source",
+            "syq ...",
+            Some(&AgentForwarding::Disabled),
+        );
         let disabled = args(&disabled);
         assert!(disabled.contains(&OsStr::new("-a")));
         assert!(!disabled.contains(&OsStr::new("-A")));
+    }
+
+    #[test]
+    fn constrained_agent_is_forwarded_without_changing_source_authentication() {
+        let rsh = vec!["ssh".to_string()];
+        let policy = AgentForwarding::Constrained {
+            ambient: "/tmp/ambient-agent".into(),
+            broker: "/tmp/syq-agent".into(),
+        };
+        let command = direct_command(&rsh, None, "source", "syq ...", Some(&policy));
+        let args = args(&command);
+        assert!(args.contains(&OsStr::new("IdentityAgent=/tmp/ambient-agent")));
+        assert!(args.contains(&OsStr::new("ForwardAgent=/tmp/syq-agent")));
+        assert!(args.contains(&OsStr::new("ControlMaster=no")));
+        assert!(args.contains(&OsStr::new("ControlPath=none")));
+        assert!(!args.contains(&OsStr::new("-A")));
+        assert!(!args.contains(&OsStr::new("-a")));
+    }
+
+    #[test]
+    fn setup_and_destination_connections_never_forward_an_agent() {
+        let rsh = vec!["ssh".to_string(), "-p".to_string(), "2222".to_string()];
+        assert_eq!(source_setup_rsh(&rsh, false), ["ssh", "-p", "2222", "-a"]);
+        assert_eq!(source_setup_rsh(&rsh, true), rsh);
+        assert_eq!(destination_rsh(None, false), Some("ssh -a"));
+        assert_eq!(
+            destination_rsh(Some("custom-rsh"), false),
+            Some("custom-rsh")
+        );
+        assert_eq!(destination_rsh(None, true), None);
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -76,13 +76,34 @@ fn source_setup_rsh(rsh: &[String], explicit_rsh: bool) -> Vec<String> {
     setup
 }
 
-fn destination_rsh(explicit_rsh: Option<&str>, same_host: bool) -> Option<&str> {
-    // A uses the broker to authenticate to B, but B must never receive it.
-    // Force the forwarded environment socket and its advertised identities;
-    // requiring host-bound authentication prevents A from omitting B's key.
-    (!same_host).then_some(explicit_rsh.unwrap_or(
-        "ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no -o PubkeyAuthentication=host-bound",
-    ))
+fn destination_rsh<'a>(
+    explicit_rsh: Option<&'a str>,
+    same_host: bool,
+    agent_forwarding: Option<&AgentForwarding>,
+) -> Option<&'a str> {
+    if same_host {
+        return None;
+    }
+    if let Some(explicit) = explicit_rsh {
+        return Some(explicit);
+    }
+    match agent_forwarding {
+        // A uses the broker to authenticate to B, but B must never receive it.
+        // Force the forwarded environment socket and its advertised identities;
+        // requiring host-bound authentication prevents A from omitting B's key.
+        Some(AgentForwarding::Constrained { .. }) => Some(
+            "ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no -o PubkeyAuthentication=host-bound",
+        ),
+        // The compatibility escape hatch still selects the forwarded ambient
+        // agent, but does not require host-bound authentication from OpenSSH
+        // versions that predate the constrained broker's 8.9 floor.
+        Some(AgentForwarding::Unrestricted) => {
+            Some("ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no")
+        }
+        // With no forwarded agent, preserve hostA's own IdentityAgent and
+        // authentication configuration while preventing another forwarding hop.
+        Some(AgentForwarding::Disabled) | None => Some("ssh -a"),
+    }
 }
 
 fn broker_connection_limit(connections_opt: Option<usize>, connections: usize) -> Result<usize> {
@@ -265,7 +286,11 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     if let Some(p) = &args.syq_path {
         remote.push(format!("--syq-path={p}"));
     }
-    if let Some(e) = destination_rsh(args.rsh.as_deref(), same_host) {
+    if let Some(e) = destination_rsh(
+        args.rsh.as_deref(),
+        same_host,
+        default_ssh_agent_policy.as_ref(),
+    ) {
         remote.push("-e".into());
         remote.push(e.into());
     }
@@ -587,21 +612,33 @@ mod tests {
     }
 
     #[test]
-    fn setup_and_destination_connections_never_forward_an_agent() {
+    fn setup_and_destination_connections_apply_only_the_selected_agent_policy() {
         let rsh = vec!["ssh".to_string(), "-p".to_string(), "2222".to_string()];
         assert_eq!(source_setup_rsh(&rsh, false), ["ssh", "-p", "2222", "-a"]);
         assert_eq!(source_setup_rsh(&rsh, true), rsh);
+        let constrained = AgentForwarding::Constrained {
+            ambient: "/tmp/ambient-agent".into(),
+            broker: "/tmp/syq-agent".into(),
+        };
         assert_eq!(
-            destination_rsh(None, false),
+            destination_rsh(None, false, Some(&constrained)),
             Some(
                 "ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no -o PubkeyAuthentication=host-bound"
             )
         );
         assert_eq!(
-            destination_rsh(Some("custom-rsh"), false),
+            destination_rsh(None, false, Some(&AgentForwarding::Unrestricted)),
+            Some("ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no")
+        );
+        assert_eq!(
+            destination_rsh(None, false, Some(&AgentForwarding::Disabled)),
+            Some("ssh -a")
+        );
+        assert_eq!(
+            destination_rsh(Some("custom-rsh"), false, None),
             Some("custom-rsh")
         );
-        assert_eq!(destination_rsh(None, true), None);
+        assert_eq!(destination_rsh(None, true, Some(&constrained)), None);
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -45,6 +45,13 @@ fn direct_command(
                     "ControlMaster=no",
                     "-o",
                     "ControlPath=none",
+                    "-o",
+                    "ClearAllForwardings=yes",
+                    "-x",
+                    "-k",
+                    "-T",
+                    "-o",
+                    "PermitLocalCommand=no",
                 ]);
             }
             None => {}
@@ -71,7 +78,23 @@ fn source_setup_rsh(rsh: &[String], explicit_rsh: bool) -> Vec<String> {
 
 fn destination_rsh(explicit_rsh: Option<&str>, same_host: bool) -> Option<&str> {
     // A uses the broker to authenticate to B, but B must never receive it.
-    (!same_host).then_some(explicit_rsh.unwrap_or("ssh -a"))
+    // Requiring host-bound public-key authentication prevents a compromised A
+    // from downgrading the agent request to one that omits B's host key.
+    (!same_host).then_some(explicit_rsh.unwrap_or("ssh -a -o PubkeyAuthentication=host-bound"))
+}
+
+fn broker_connection_limit(connections_opt: Option<usize>, connections: usize) -> Result<usize> {
+    // A direct transfer keeps one destination control connection open beside
+    // its data workers. Automatic tuning may grow beyond the initial worker
+    // count, while an explicit -j is a fixed user-selected upper bound.
+    let data_connections = if connections_opt.is_some() {
+        connections
+    } else {
+        crate::tune::MAX
+    };
+    data_connections
+        .checked_add(1)
+        .context("SSH connection count is too large for the constrained agent broker")
 }
 
 pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
@@ -93,16 +116,22 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     } else if args.unrestricted_agent_forwarding {
         Some(AgentForwarding::Unrestricted)
     } else {
-        let source_policy =
-            crate::agent_broker::resolve_host_policy(&rsh[0], srcs[0].user.as_deref(), &src_host)?;
+        let source_policy = crate::agent_broker::resolve_host_policy(
+            &rsh[0],
+            srcs[0].user.as_deref(),
+            &src_host,
+            false,
+        )?;
         let destination_policy = crate::agent_broker::resolve_host_policy(
             &rsh[0],
             dst.user.as_deref(),
             dst.host.as_deref().unwrap(),
+            true,
         )?;
         destination_login_user = Some(destination_policy.login_user.clone());
         let broker = crate::agent_broker::ConstrainedAgentBroker::start(
             crate::agent_broker::BrokerPolicy::new(source_policy, destination_policy),
+            broker_connection_limit(args.connections_opt, args.connections)?,
         )?;
         let ambient = broker.ambient_socket().to_string_lossy().into_owned();
         let socket = broker.socket_path().to_string_lossy().into_owned();
@@ -546,6 +575,11 @@ mod tests {
         assert!(args.contains(&OsStr::new("ForwardAgent=/tmp/syq-agent")));
         assert!(args.contains(&OsStr::new("ControlMaster=no")));
         assert!(args.contains(&OsStr::new("ControlPath=none")));
+        assert!(args.contains(&OsStr::new("ClearAllForwardings=yes")));
+        assert!(args.contains(&OsStr::new("-x")));
+        assert!(args.contains(&OsStr::new("-k")));
+        assert!(args.contains(&OsStr::new("-T")));
+        assert!(args.contains(&OsStr::new("PermitLocalCommand=no")));
         assert!(!args.contains(&OsStr::new("-A")));
         assert!(!args.contains(&OsStr::new("-a")));
     }
@@ -555,12 +589,22 @@ mod tests {
         let rsh = vec!["ssh".to_string(), "-p".to_string(), "2222".to_string()];
         assert_eq!(source_setup_rsh(&rsh, false), ["ssh", "-p", "2222", "-a"]);
         assert_eq!(source_setup_rsh(&rsh, true), rsh);
-        assert_eq!(destination_rsh(None, false), Some("ssh -a"));
+        assert_eq!(
+            destination_rsh(None, false),
+            Some("ssh -a -o PubkeyAuthentication=host-bound")
+        );
         assert_eq!(
             destination_rsh(Some("custom-rsh"), false),
             Some("custom-rsh")
         );
         assert_eq!(destination_rsh(None, true), None);
+    }
+
+    #[test]
+    fn broker_capacity_covers_control_and_planned_workers() {
+        assert_eq!(broker_connection_limit(None, 8).unwrap(), 65);
+        assert_eq!(broker_connection_limit(Some(128), 128).unwrap(), 129);
+        assert!(broker_connection_limit(Some(usize::MAX), usize::MAX).is_err());
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -78,9 +78,11 @@ fn source_setup_rsh(rsh: &[String], explicit_rsh: bool) -> Vec<String> {
 
 fn destination_rsh(explicit_rsh: Option<&str>, same_host: bool) -> Option<&str> {
     // A uses the broker to authenticate to B, but B must never receive it.
-    // Requiring host-bound public-key authentication prevents a compromised A
-    // from downgrading the agent request to one that omits B's host key.
-    (!same_host).then_some(explicit_rsh.unwrap_or("ssh -a -o PubkeyAuthentication=host-bound"))
+    // Force the forwarded environment socket and its advertised identities;
+    // requiring host-bound authentication prevents A from omitting B's key.
+    (!same_host).then_some(explicit_rsh.unwrap_or(
+        "ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no -o PubkeyAuthentication=host-bound",
+    ))
 }
 
 fn broker_connection_limit(connections_opt: Option<usize>, connections: usize) -> Result<usize> {
@@ -591,7 +593,9 @@ mod tests {
         assert_eq!(source_setup_rsh(&rsh, true), rsh);
         assert_eq!(
             destination_rsh(None, false),
-            Some("ssh -a -o PubkeyAuthentication=host-bound")
+            Some(
+                "ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no -o PubkeyAuthentication=host-bound"
+            )
         );
         assert_eq!(
             destination_rsh(Some("custom-rsh"), false),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod agent_broker;
 mod bwlimit;
 mod checkpoint;
 mod cli;

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -556,6 +556,13 @@ pub fn run(args: Args) -> Result<i32> {
             bail!("all sources must be on the same host");
         }
     }
+    if args.unrestricted_agent_forwarding
+        && (!srcs[0].is_remote() || !dst.is_remote() || srcs[0].same_host(dst) || args.relay)
+    {
+        bail!(
+            "--unrestricted-agent-forwarding is only valid for a live direct transfer between two different remote hosts"
+        );
+    }
     if let Some(checkpoint) = args.checkpoint.as_deref() {
         let checkpoint = crate::fsops::normalize(std::path::Path::new(checkpoint));
         for source in srcs.iter().filter(|source| !source.is_remote()) {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3638,6 +3638,53 @@ fn no_forward_agent_conflicts_with_explicit_rsh() {
     assert!(!t.path("dst").exists());
 }
 
+#[test]
+fn unrestricted_agent_forwarding_is_an_explicit_live_direct_only_escape_hatch() {
+    let t = Tmp::new();
+    write(&t.path("src"), b"data");
+    for conflicting in [
+        &["--unrestricted-agent-forwarding", "-e", "ssh -A"][..],
+        &["--unrestricted-agent-forwarding", "--no-forward-agent"],
+        &["--unrestricted-agent-forwarding", "--detach"],
+        &["--unrestricted-agent-forwarding", "--relay"],
+    ] {
+        let (src, dst) = (t.s("src"), t.s("dst"));
+        let mut argv = conflicting.to_vec();
+        argv.extend([src.as_str(), dst.as_str()]);
+        let out = syq(&argv);
+        assert_eq!(out.status.code(), Some(2), "{conflicting:?}");
+        assert!(
+            stderr_of(&out).contains("cannot be used with"),
+            "{conflicting:?}: {}",
+            stderr_of(&out)
+        );
+    }
+    for (src, dst) in [
+        (t.s("src"), "hostB:dst".to_string()),
+        ("hostA:src".to_string(), t.s("dst")),
+        ("same:src".to_string(), "same:dst".to_string()),
+    ] {
+        let out = syq(&["--unrestricted-agent-forwarding", &src, &dst]);
+        assert_eq!(out.status.code(), Some(1), "{src} -> {dst}");
+        assert!(
+            stderr_of(&out).contains("only valid for a live direct transfer"),
+            "{}",
+            stderr_of(&out)
+        );
+    }
+}
+
+#[test]
+fn detached_implicit_ssh_requires_source_host_credentials() {
+    let out = syq(&["--detach", "hostA:src", "hostB:dst"]);
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr_of(&out).contains("--detach requires --no-forward-agent"),
+        "{}",
+        stderr_of(&out)
+    );
+}
+
 // Ordinary copies keep no historical completion state: the current destination
 // determines what a later invocation repairs.
 #[test]


### PR DESCRIPTION
## Summary

- replace unrestricted agent forwarding for implicit-SSH remote-to-remote transfers with a temporary local filtering broker
- authorize only a cryptographically bound `hostA -> configured-user@hostB` OpenSSH authentication path
- keep private operations in the existing local agent, including hardware-backed/YubiKey identities and locally configured SSH certificates
- preserve validated upstream session bindings, force host-bound authentication, disable unrelated outer-SSH forwarding surfaces, and tear down every broker channel with the attached transfer
- retain explicit `--no-forward-agent` and conspicuous `--unrestricted-agent-forwarding` compatibility policies

This supersedes the narrower approach from closed PR #44: HostA needs no credential of its own, but it does not receive the unrestricted local agent.

## Security boundary

The broker verifies the ordered forwarding and destination session binds, their host-key signatures and allowed algorithms, the destination session ID, exact login user, host-bound method, embedded host key and credential, signing flags, and the sanitized advertised identity set (with comments blanked). Mutations, opaque signing, legacy public-key authentication, extra hops, unsupported algorithms, and identities not advertised through the broker fail closed. Successful ambient-agent signatures are cryptographically verified before release. Downstream and upstream broker sockets have two-minute read/write deadlines.

This restricts authentication to the planned host-key-equivalent `user@hostB`; it cannot restrict SSH commands or channels after login. A compromised HostA may use the permitted destination account for the attached transfer's lifetime. The signed forced-receiver stream is the separate command/filesystem restriction layer.

Session binding identifies hosts by host key, so endpoints sharing HostB's private host key are intentionally equivalent. The constrained path currently requires exact static plain host keys accepted by effective `HostKeyAlgorithms` and `RequiredRSASize`. Dynamic `KnownHostsCommand`, external `RevokedHostKeys`, host-certificate/CA-only trust, and unsupported verifier algorithms are refused rather than approximated. Because `ssh -G` flattens quoted filename boundaries, ambiguous whitespace-bearing or multi-file custom `UserKnownHostsFile` and `GlobalKnownHostsFile` values are refused. Syq obtains provenance from OpenSSH's verbose configuration query and conservatively scans every configuration file OpenSSH reports reading for the host; rendered compiled defaults are accepted only when the corresponding directive did not appear in those files. A controlled verbose `-F /dev/null` query must report `/dev/null` as its sole configuration source, validating the provenance format and failing closed for incompatible wrappers or OpenSSH output. Custom single-file paths must be absolute.

OpenSSH 8.9 or newer peers are required for session-bind and host-bound authentication. The broker's path checks are independent of the ambient agent. Use OpenSSH agent 10.5 or newer when relying on that agent's existing destination constraints as an additional layer; earlier agents are affected by the session-bind/agent-lock issue fixed in CVE-2026-73281.

Configured `CertificateFile` identities and OpenSSH's implicit `<IdentityFile>-cert.pub` convention are supported when the matching raw key is listed by the ambient agent. Certificate matching uses SSH wire identity rather than comments, so certificates emitted by `ssh-keygen -s` translate correctly. Certificate-to-raw translation may be rejected by an upstream destination-constrained agent unless that certificate is loaded into the agent; this fails closed.

## Dependency policy

RSA public-key support enables the broker to verify ordinary RSA host and user-auth signatures. It pulls in `rsa` 0.9.10 through `ssh-key`; RUSTSEC-2023-0071 concerns timing leakage from RSA private-key operations. This code never imports RSA private keys and never decrypts or signs with RSA—it parses public credentials and verifies signatures—so the vulnerable operation is unreachable. `deny.toml` records a structured ignore for only that advisory, with the same rationale; other advisories remain denied.

## Verification

- pinned cargo-deny 0.20.2 dependency-policy check, using CI's exact release SHA-256 (`9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5f`)
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets` (114 unit, 198 local integration, 9 update tests)
- focused constrained-broker and direct-command regressions are included in the counts above

The agent protocol, host-policy, known-hosts provenance/default collision, certificate-translation, concurrency, teardown, and CLI construction paths have adversarial in-process coverage. A live two-host OpenSSH/YubiKey transfer was not run in this environment.
