### PR TITLE
Match rsync files-from comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,9 +849,11 @@ parent that resolves to a file or dangles is an error. A listed directory is cop
 its contents unless `-r` is given on the command line itself — `-a` alone
 does not count, as in rsync — so `-a -r --files-from` walks the directories
 the list names (never the implied parents).
-Blank lines are ignored, leading `/` or `./` and trailing `/` are stripped,
-and `..` components or a line that names the root itself are rejected. A listed path that doesn't exist is an
-error (exit 23) and the rest is still copied. The destination must be a directory (an
+Blank entries and entries starting with `#` or `;` are ignored in both modes;
+spell a literal comment-looking name as `./#name` or `./;name`. Leading `/` or
+`./` and trailing `/` are stripped, and `..` components or an entry that names
+the root itself are rejected. A listed path that doesn't exist is an error
+(exit 23) and the rest is still copied. The destination must be a directory (an
 existing file there is an error, never replaced). `--files-from` can't be
 combined with `-i`/`--ignore-from` or `--delete`; for a remote-to-remote copy
 it needs `--relay` (the list is read on this machine).

--- a/RSYNC-COMPAT.md
+++ b/RSYNC-COMPAT.md
@@ -85,7 +85,7 @@ behavior; an entry without one is only believed, not held.
 | `-u`/`--update`: a destination regular file with a newer mtime is left alone | measured for regular files; see "Different" for symlinks/devices | `update_skips_files_newer_on_the_destination` |
 | `--existing` / `--ignore-existing`, including `--existing` covering directories | measured | `ignore_existing_and_existing`, `existing_never_creates_the_destination_root`, `existing_leaves_a_file_where_a_source_directory_would_go`, `existing_dry_run_lists_no_missing_directories`, `existing_opens_up_readonly_dirs_even_after_a_symlinked_dir` |
 | `--max-size` / `--min-size` on regular files only; `K`/`M`/`G` suffixes | measured | `size_limits_filter_files_and_protect_them_from_delete`, `bad_size_limits_fail_before_anything_connects` |
-| `--files-from` baseline: paths relative to one source; implied parents created; a plain listed directory is copied without its contents unless `-r` is given explicitly (`-a` doesn't count); `--from0`; `-` reads stdin; blank entries dropped | measured; entry *parsing* has gaps, open issue 2 | `files_from_copies_listed_paths_with_their_parents`, `files_from_creates_listed_and_implied_dirs_without_r`, `files_from_repeats_and_late_listed_dirs_across_chunks`, `files_from_root_may_be_a_symlink_and_root_lines_are_rejected` |
+| `--files-from` baseline: paths relative to one source; implied parents created; a plain listed directory is copied without its contents unless `-r` is given explicitly (`-a` doesn't count); `--from0`; `-` reads stdin; blank entries and entries starting with `#` or `;` dropped in both separator modes (literal names remain reachable as `./#name` and `./;name`) | measured; entry *parsing* has gaps, open issue 2 | `files_from_copies_listed_paths_with_their_parents`, `files_from_treats_hash_and_semicolon_entries_as_comments`, `files_from_creates_listed_and_implied_dirs_without_r`, `files_from_repeats_and_late_listed_dirs_across_chunks`, `files_from_root_may_be_a_symlink_and_root_lines_are_rejected` |
 | `--delete-after` / `--delete-delay` accepted as synonyms of `--delete` (they describe what syq does) | by construction | `delete_after_and_delay_are_synonyms` |
 | `--max-delete N` exists and exits 25 when it trips | believed (exit code matches rsync); see "Different" for the cap semantics | `max_delete_refuses_everything_past_the_limit` |
 | A normal operator-owned destination *argument* that is a symlink to a directory is that directory | measured; see open issue 6 for a root/cross-uid case | `symlink_destination_is_followed`, `destination_root_symlink_preserves_target_metadata_for_both_spellings`, `existing_updates_through_a_destination_root_symlink_to_a_dir` |
@@ -218,14 +218,12 @@ command says what to change.
    `--ignore`/`--ignore-from` long-only; reject a bare `-i` with a specific
    explanation until itemized output exists. Don't pick another rsync short
    letter for ignore (`-I` is `--ignore-times`).
-2. **`--files-from` entry parsing doesn't match rsync's** (measured on 3.2.7
-   and 3.5.0). Adopt the full rule set as one change: skip entries starting
-   with `#` or `;` (line mode and `--from0`); normalize `..` and clamp it at
-   the source root instead of rejecting; preserve a trailing slash (`dir/`
-   selects the directory's immediate children without `-r`, `dir` only the
-   directory); accept `.`/`/` as the root entry (children without `-r`); add
-   `-0` as an alias of `--from0`. Comment-looking names remain reachable as
-   `./#name`.
+2. **The remaining `--files-from` entry parsing doesn't match rsync's**
+   (measured on 3.2.7 and 3.5.0). Finish the related path rules as one change:
+   normalize `..` and clamp it at the source root instead of rejecting;
+   preserve a trailing slash (`dir/` selects the directory's immediate
+   children without `-r`, `dir` only the directory); accept `.`/`/` as the root
+   entry (children without `-r`); add `-0` as an alias of `--from0`.
 3. **Repeated identical sources should be deduplicated**, not reported as a
    collision (rsync scans a source given ten times once). Only for
    byte-identical source arguments including trailing-slash mode; distinct

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -359,9 +359,10 @@ impl Args {
 }
 
 /// Read a --files-from list: one path per line (or NUL-separated with --from0),
-/// relative to the source root. Blank lines are dropped; `.` and empty
-/// components (so leading `/`, `./`, trailing `/`, `a//b`) are removed; `..`
-/// components and lines naming the root itself are rejected.
+/// relative to the source root. Blank entries and entries starting with `#` or
+/// `;` are dropped; `.` and empty components (so leading `/`, `./`, trailing
+/// `/`, `a//b`) are removed; `..` components and entries naming the root itself
+/// are rejected.
 fn read_files_from(file: &str, nul: bool) -> Result<Vec<Vec<u8>>> {
     use std::io::Read;
     let mut raw = Vec::new();
@@ -379,7 +380,10 @@ fn read_files_from(file: &str, nul: bool) -> Result<Vec<Vec<u8>>> {
             .collect()
     };
     for item in items {
-        if item.is_empty() {
+        // rsync treats these prefixes as comments in both line and NUL modes.
+        // A literal name remains selectable by spelling it as `./#name` or
+        // `./;name`.
+        if item.is_empty() || matches!(item.first(), Some(b'#' | b';')) {
             continue;
         }
         if item.contains(&0) {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3093,6 +3093,43 @@ fn files_from_copies_listed_paths_with_their_parents() {
     assert!(!t.path("dst3").exists());
 }
 
+#[test]
+fn files_from_treats_hash_and_semicolon_entries_as_comments() {
+    let t = Tmp::new();
+    for f in ["ordinary", "#literal", ";literal"] {
+        write(&t.path("src").join(f), f.as_bytes());
+    }
+
+    // A comment-looking name is still reachable through an explicit `./`.
+    write(
+        &t.path("list"),
+        b"# ignored\n; ignored too\nordinary\n./#literal\n./;literal\n",
+    );
+    run_ok(&["-a", "--files-from", &t.s("list"), &t.s("src"), &t.s("dst")]);
+    assert_eq!(
+        listing(&t.path("dst")),
+        ["#literal", ";literal", "ordinary"]
+    );
+
+    // rsync applies the same comment rule when entries are NUL-separated.
+    write(
+        &t.path("list0"),
+        b"# ignored\0; ignored too\0ordinary\0./#literal\0./;literal\0",
+    );
+    run_ok(&[
+        "-a",
+        "--from0",
+        "--files-from",
+        &t.s("list0"),
+        &t.s("src"),
+        &t.s("dst0"),
+    ]);
+    assert_eq!(
+        listing(&t.path("dst0")),
+        ["#literal", ";literal", "ordinary"]
+    );
+}
+
 // ------------------------------------------------------------ review fixes
 
 #[test]


### PR DESCRIPTION
## Summary

- ignore files-from entries beginning with # or ; in line and NUL-separated modes
- keep comment-looking filenames reachable through an explicit ./ prefix
- document and test the rsync-compatible behavior

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets