### PR TITLE
Speed up WAN small-file transfers

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -924,8 +924,32 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
         });
     }
     drop(tx);
-    for (i, reachable) in rx {
+
+    // A public SSH target is the known-good fallback. Once it connects, give
+    // higher-priority advertised NICs a short grace period, then stop waiting
+    // for unroutable private/overlay addresses to consume their full timeout.
+    // A genuinely faster LAN path will have completed well before a WAN
+    // fallback plus this grace period.
+    let overall_deadline = std::time::Instant::now() + std::time::Duration::from_millis(1000);
+    let mut fallback_deadline: Option<std::time::Instant> = None;
+    let mut remaining = candidates.len();
+    while remaining > 0 {
+        let deadline = fallback_deadline
+            .map(|deadline| deadline.min(overall_deadline))
+            .unwrap_or(overall_deadline);
+        let Some(wait) = deadline.checked_duration_since(std::time::Instant::now()) else {
+            break;
+        };
+        let Ok((i, reachable)) = rx.recv_timeout(wait) else {
+            break;
+        };
+        remaining -= 1;
         candidates[i].reachable = reachable;
+        if reachable && candidates[i].source == DataAddressSource::SshTarget {
+            fallback_deadline.get_or_insert_with(|| {
+                std::time::Instant::now() + std::time::Duration::from_millis(100)
+            });
+        }
     }
 }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -904,51 +904,64 @@ fn helper_needs_install(e: &anyhow::Error) -> bool {
 /// Concurrently probe which (addr, speed) entries accept a TCP connection on
 /// `port`, preserving the server's priority order. Used once per endpoint.
 fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
-    let (tx, rx) = std::sync::mpsc::channel();
+    // Resolve candidate names in parallel. More importantly, probe every
+    // resolved socket address in parallel too: a dual-stack name must not
+    // spend the whole candidate budget timing out on IPv6 before trying IPv4.
+    let (resolved_tx, resolved_rx) = std::sync::mpsc::channel();
     for (i, candidate) in candidates.iter().enumerate() {
-        let tx = tx.clone();
-        let addr = candidate.address.clone();
+        let tx = resolved_tx.clone();
+        let address = candidate.address.clone();
         std::thread::spawn(move || {
-            // Try every resolved address (a dual-stack name may return IPv6
-            // first while the listener is IPv4-only): reachable if any connects.
-            let ok = (addr.as_str(), port)
+            let addrs = (address.as_str(), port)
                 .to_socket_addrs()
-                .map(|it| {
-                    it.into_iter().any(|sa| {
-                        TcpStream::connect_timeout(&sa, std::time::Duration::from_millis(1000))
-                            .is_ok()
-                    })
-                })
-                .unwrap_or(false);
-            let _ = tx.send((i, ok));
+                .map(|addresses| addresses.collect())
+                .unwrap_or_default();
+            let _ = tx.send((i, addrs));
         });
+    }
+    drop(resolved_tx);
+    let mut resolved = vec![Vec::new(); candidates.len()];
+    for _ in 0..candidates.len() {
+        let Ok((i, addrs)) = resolved_rx.recv() else {
+            break;
+        };
+        resolved[i] = addrs;
+    }
+
+    let timeout = std::time::Duration::from_millis(1000);
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut remaining: Vec<usize> = resolved.iter().map(Vec::len).collect();
+    let mut undetermined = remaining.iter().filter(|&&count| count > 0).count();
+    let mut determined = vec![false; candidates.len()];
+    for (i, addrs) in resolved.into_iter().enumerate() {
+        for addr in addrs {
+            let tx = tx.clone();
+            std::thread::spawn(move || {
+                let _ = tx.send((i, TcpStream::connect_timeout(&addr, timeout).is_ok()));
+            });
+        }
     }
     drop(tx);
 
-    // A public SSH target is the known-good fallback. Once it connects, give
-    // higher-priority advertised NICs a short grace period, then stop waiting
-    // for unroutable private/overlay addresses to consume their full timeout.
-    // A genuinely faster LAN path will have completed well before a WAN
-    // fallback plus this grace period.
-    let overall_deadline = std::time::Instant::now() + std::time::Duration::from_millis(1000);
-    let mut fallback_deadline: Option<std::time::Instant> = None;
-    let mut remaining = candidates.len();
-    while remaining > 0 {
-        let deadline = fallback_deadline
-            .map(|deadline| deadline.min(overall_deadline))
-            .unwrap_or(overall_deadline);
+    // Every path gets its complete bounded probe window. Do not cut off a
+    // higher-bandwidth path merely because the public SSH fallback connected
+    // first; a higher-latency rail may still be the better transfer path.
+    let deadline = std::time::Instant::now() + timeout + std::time::Duration::from_millis(100);
+    while undetermined > 0 {
         let Some(wait) = deadline.checked_duration_since(std::time::Instant::now()) else {
             break;
         };
         let Ok((i, reachable)) = rx.recv_timeout(wait) else {
             break;
         };
-        remaining -= 1;
-        candidates[i].reachable = reachable;
-        if reachable && candidates[i].source == DataAddressSource::SshTarget {
-            fallback_deadline.get_or_insert_with(|| {
-                std::time::Instant::now() + std::time::Duration::from_millis(100)
-            });
+        if determined[i] {
+            continue;
+        }
+        remaining[i] -= 1;
+        if reachable || remaining[i] == 0 {
+            candidates[i].reachable = reachable;
+            determined[i] = true;
+            undetermined -= 1;
         }
     }
 }

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1383,25 +1383,24 @@ impl FsOps {
             } => self
                 .copy_local(src, dst, *inplace, partial_id, *size, *mode)
                 .map(|_| Response::Ok),
-            Request::PutSmall {
-                path,
-                partial_id,
-                data,
-                hash,
-                meta,
-                flags,
-            } => self
-                .put_small(
-                    PartialTarget {
-                        path,
-                        id: partial_id,
-                    },
-                    data,
-                    *hash,
-                    meta,
-                    *flags,
-                )
-                .map(|_| Response::Ok),
+            Request::PutSmallBatch(puts) => Ok(Response::Applied(
+                puts.iter()
+                    .map(|put| {
+                        self.put_small(
+                            PartialTarget {
+                                path: &put.path,
+                                id: &put.partial_id,
+                            },
+                            &put.data,
+                            put.hash,
+                            &put.meta,
+                            put.flags,
+                        )
+                        .err()
+                        .map(|error| errstr(&error))
+                    })
+                    .collect(),
+            )),
             Request::HashBlocks {
                 path,
                 which,
@@ -1417,6 +1416,18 @@ impl FsOps {
                 off,
                 len,
             } => self.read_range(path, *attempt, *off, *len),
+            Request::ReadSmallBatch(reads) => Ok(Response::SmallBlocks(
+                reads
+                    .iter()
+                    .map(
+                        |read| match self.read_range(&read.path, read.attempt, 0, read.len) {
+                            Ok(Response::Block { data, hash, .. }) => Ok(SmallBlock { data, hash }),
+                            Ok(other) => Err(format!("unexpected response {other:?}")),
+                            Err(error) => Err(errstr(&error)),
+                        },
+                    )
+                    .collect(),
+            )),
             Request::WriteRange {
                 path,
                 inplace,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -61,6 +61,34 @@ impl Entry {
     }
 }
 
+/// One whole-file read in the pipelined small-file path.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SmallRead {
+    pub path: PathBytes,
+    pub attempt: u32,
+    pub len: u32,
+}
+
+/// One whole-file publication in the pipelined small-file path.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SmallPut {
+    pub path: PathBytes,
+    pub partial_id: PartialId,
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+    pub hash: u64,
+    pub meta: Meta,
+    pub flags: u8,
+}
+
+/// Contents and integrity hash for one successful `SmallRead`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SmallBlock {
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+    pub hash: u64,
+}
+
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 pub struct Meta {
     pub mode: u32,
@@ -246,6 +274,8 @@ pub enum Request {
         off: u64,
         len: u32,
     },
+    /// Read a complete small-file batch in one frame and response.
+    ReadSmallBatch(Vec<SmallRead>),
     WriteRange {
         path: PathBytes,
         inplace: bool,
@@ -263,18 +293,8 @@ pub enum Request {
         meta: Meta,
         flags: u8,
     },
-    /// Whole small file in one request: verify, write a sidecar, then rename it
-    /// atomically over the final path. This preserves small-file pipelining
-    /// without exposing partial final-named files.
-    PutSmall {
-        path: PathBytes,
-        partial_id: PartialId,
-        #[serde(with = "serde_bytes")]
-        data: Vec<u8>,
-        hash: u64,
-        meta: Meta,
-        flags: u8,
-    },
+    /// Verify and atomically publish a complete small-file batch in one frame.
+    PutSmallBatch(Vec<SmallPut>),
     FileHash {
         path: PathBytes,
     },
@@ -322,6 +342,7 @@ pub enum Response {
         #[serde(with = "serde_bytes")]
         data: Vec<u8>,
     },
+    SmallBlocks(Vec<std::result::Result<SmallBlock, String>>),
     FileHash {
         size: u64,
         hash: u128,
@@ -341,7 +362,15 @@ impl SizeHint for Request {
     fn size_hint(&self) -> usize {
         match self {
             Request::WriteRange { data, path, .. } => data.len() + path.len() + 64,
-            Request::PutSmall { data, path, .. } => data.len() + path.len() + 96,
+            Request::ReadSmallBatch(reads) => {
+                reads.iter().map(|read| read.path.len() + 16).sum::<usize>() + 16
+            }
+            Request::PutSmallBatch(puts) => {
+                puts.iter()
+                    .map(|put| put.data.len() + put.path.len() + 96)
+                    .sum::<usize>()
+                    + 16
+            }
             Request::StatMany { paths, .. } => {
                 paths.iter().map(|p| p.len() + 8).sum::<usize>() + 16
             }
@@ -355,6 +384,16 @@ impl SizeHint for Response {
     fn size_hint(&self) -> usize {
         match self {
             Response::Block { data, .. } => data.len() + 64,
+            Response::SmallBlocks(blocks) => {
+                blocks
+                    .iter()
+                    .map(|block| match block {
+                        Ok(block) => block.data.len() + 16,
+                        Err(error) => error.len() + 8,
+                    })
+                    .sum::<usize>()
+                    + 16
+            }
             Response::ScanBatch(v) => v.len() * 160 + 16,
             Response::Stats(v) => v.len() * 96 + 16,
             Response::Hashes(v) | Response::HeldHashes { hashes: v, .. } => v.len() * 9 + 24,

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -9,6 +9,12 @@ use std::fs;
 use std::path::Path;
 
 pub const BATCH: usize = 4096;
+const FIRST_BATCH: usize = 1000;
+const FIRST_BATCH_MAX_DELAY: std::time::Duration = std::time::Duration::from_millis(50);
+
+fn batch_ready(len: usize, first: bool, elapsed: std::time::Duration) -> bool {
+    len >= BATCH || (first && len >= FIRST_BATCH && elapsed >= FIRST_BATCH_MAX_DELAY)
+}
 
 /// Per-entry result of the parallel read_dir hook.
 #[derive(Clone, Default, Debug)]
@@ -69,7 +75,11 @@ pub fn scan(
     if !md.is_dir() {
         return sink(vec![root_entry]);
     }
-    let mut batch = Vec::with_capacity(BATCH);
+    // Preserve bounded first-byte progress on slow/NFS walks without splitting
+    // a small, fast scan into several serialized WAN planning round trips.
+    let mut batch = Vec::with_capacity(FIRST_BATCH);
+    let scan_started = std::time::Instant::now();
+    let mut first_batch = true;
     batch.push(root_entry);
     let mut ignored_batch: Vec<PathBytes> = Vec::new();
 
@@ -141,8 +151,9 @@ pub fn scan(
         let rel = full.strip_prefix(root).unwrap_or(&full);
         entry.path = path_bytes(rel);
         batch.push(entry);
-        if batch.len() >= BATCH {
+        if batch_ready(batch.len(), first_batch, scan_started.elapsed()) {
             sink(std::mem::replace(&mut batch, Vec::with_capacity(BATCH)))?;
+            first_batch = false;
         }
     }
     if !batch.is_empty() {
@@ -152,4 +163,17 @@ pub fn scan(
         ignored(ignored_batch)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_batch_balances_progress_and_fast_scan_batching() {
+        assert!(!batch_ready(FIRST_BATCH, true, FIRST_BATCH_MAX_DELAY / 2));
+        assert!(batch_ready(FIRST_BATCH, true, FIRST_BATCH_MAX_DELAY));
+        assert!(!batch_ready(BATCH - 1, false, FIRST_BATCH_MAX_DELAY * 10));
+        assert!(batch_ready(BATCH, false, std::time::Duration::ZERO));
+    }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -7,14 +7,12 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use jwalk::WalkDirGeneric;
 use std::fs;
 use std::path::Path;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender};
+use std::time::{Duration, Instant};
 
 pub const BATCH: usize = 4096;
 const FIRST_BATCH: usize = 1000;
-const FIRST_BATCH_MAX_DELAY: std::time::Duration = std::time::Duration::from_millis(50);
-
-fn batch_ready(len: usize, first: bool, elapsed: std::time::Duration) -> bool {
-    len >= BATCH || (first && len >= FIRST_BATCH && elapsed >= FIRST_BATCH_MAX_DELAY)
-}
+const FIRST_BATCH_MAX_DELAY: Duration = Duration::from_millis(50);
 
 /// Per-entry result of the parallel read_dir hook.
 #[derive(Clone, Default, Debug)]
@@ -41,6 +39,178 @@ pub fn build_ignore(lines: &[String]) -> Result<Option<Gitignore>> {
             .map_err(|e| anyhow::anyhow!("bad ignore pattern {l:?}: {e}"))?;
     }
     Ok(Some(b.build()?))
+}
+
+enum ScanEvent {
+    Entry(Entry),
+    Ignored(PathBytes),
+    Warning(String),
+}
+
+type ScanChunk = Vec<ScanEvent>;
+
+fn send_scan_chunk(
+    tx: &SyncSender<ScanChunk>,
+    chunk: &mut ScanChunk,
+    entries_sent: &mut usize,
+    entries_in_chunk: &mut usize,
+) -> bool {
+    if chunk.is_empty() {
+        return true;
+    }
+    *entries_sent += *entries_in_chunk;
+    *entries_in_chunk = 0;
+    tx.send(std::mem::replace(chunk, Vec::with_capacity(FIRST_BATCH)))
+        .is_ok()
+}
+
+fn produce_scan(
+    root: std::path::PathBuf,
+    ignore: Option<Gitignore>,
+    report_ignored: bool,
+    tx: SyncSender<ScanChunk>,
+) {
+    let mut chunk = Vec::with_capacity(FIRST_BATCH);
+    let mut entries_sent = 1; // The root entry is already waiting in the consumer.
+    let mut entries_in_chunk = 0;
+    let match_root = root.clone();
+    let walk = WalkDirGeneric::<((), State)>::new(&root)
+        .follow_links(false)
+        .skip_hidden(false)
+        .process_read_dir(move |_depth, _path, _state, children| {
+            for child in children.iter_mut().flatten() {
+                let full = child.path();
+                let Ok(entry) = lstat_entry(Vec::new(), &full) else {
+                    child.client_state = State::Failed;
+                    continue;
+                };
+                if let Some(ig) = &ignore {
+                    let rel = full.strip_prefix(&match_root).unwrap_or(&full);
+                    let is_dir = entry.kind == crate::proto::Kind::Dir;
+                    if ig.matched(rel, is_dir).is_ignore() {
+                        // Pruned: neither listed nor descended into.
+                        child.read_children = None;
+                        child.client_state = if report_ignored {
+                            State::Ignored
+                        } else {
+                            State::Skipped
+                        };
+                        continue;
+                    }
+                }
+                child.client_state = State::Keep(entry);
+            }
+        });
+    for item in walk {
+        let mut de = match item {
+            Ok(de) => de,
+            Err(e) => {
+                chunk.push(ScanEvent::Warning(format!("scan: {e}")));
+                if chunk.len() >= FIRST_BATCH
+                    && !send_scan_chunk(&tx, &mut chunk, &mut entries_sent, &mut entries_in_chunk)
+                {
+                    return;
+                }
+                continue;
+            }
+        };
+        // Check this before skipping the root: an unreadable root is the
+        // most important warning there is (--delete relies on it).
+        if let Some(e) = de
+            .read_children
+            .as_ref()
+            .and_then(|children| children.error())
+        {
+            let warning = format!("scan: {}: {e}", de.path().display());
+            chunk.push(ScanEvent::Warning(warning));
+        }
+        if de.depth == 0 {
+            if chunk.len() >= FIRST_BATCH
+                && !send_scan_chunk(&tx, &mut chunk, &mut entries_sent, &mut entries_in_chunk)
+            {
+                return;
+            }
+            continue;
+        }
+        let event = match std::mem::take(&mut de.client_state) {
+            State::Keep(mut entry) => {
+                let full = de.path();
+                let rel = full.strip_prefix(&root).unwrap_or(&full);
+                entry.path = path_bytes(rel);
+                entries_in_chunk += 1;
+                ScanEvent::Entry(entry)
+            }
+            State::Skipped => continue,
+            State::Ignored => {
+                let full = de.path();
+                ScanEvent::Ignored(path_bytes(full.strip_prefix(&root).unwrap_or(&full)))
+            }
+            State::Failed => {
+                ScanEvent::Warning(format!("scan: cannot stat {}", de.path().display()))
+            }
+        };
+        chunk.push(event);
+        // Publish exactly when the consumer has its first 1,000 entries. Later
+        // chunks are only an amortization detail and can use the same size cap.
+        let first_batch_ready =
+            entries_sent < FIRST_BATCH && entries_sent + entries_in_chunk >= FIRST_BATCH;
+        if (first_batch_ready || chunk.len() >= FIRST_BATCH)
+            && !send_scan_chunk(&tx, &mut chunk, &mut entries_sent, &mut entries_in_chunk)
+        {
+            return;
+        }
+    }
+    let _ = send_scan_chunk(&tx, &mut chunk, &mut entries_sent, &mut entries_in_chunk);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn receive_scan(
+    rx: &Receiver<ScanChunk>,
+    scan_started: Instant,
+    batch: &mut Vec<Entry>,
+    ignored_batch: &mut Vec<PathBytes>,
+    sink: &mut dyn FnMut(Vec<Entry>) -> Result<()>,
+    ignored: &mut dyn FnMut(Vec<PathBytes>) -> Result<()>,
+    warn: &mut dyn FnMut(String),
+) -> Result<()> {
+    let mut first_batch = true;
+    loop {
+        if batch.len() >= BATCH {
+            sink(std::mem::replace(batch, Vec::with_capacity(BATCH)))?;
+            first_batch = false;
+            continue;
+        }
+        let chunk = if first_batch && batch.len() >= FIRST_BATCH {
+            let remaining = FIRST_BATCH_MAX_DELAY.saturating_sub(scan_started.elapsed());
+            match rx.recv_timeout(remaining) {
+                Ok(chunk) => Some(chunk),
+                Err(RecvTimeoutError::Timeout) => {
+                    sink(std::mem::replace(batch, Vec::with_capacity(BATCH)))?;
+                    first_batch = false;
+                    continue;
+                }
+                Err(RecvTimeoutError::Disconnected) => None,
+            }
+        } else {
+            rx.recv().ok()
+        };
+        let Some(chunk) = chunk else {
+            break;
+        };
+        for event in chunk {
+            match event {
+                ScanEvent::Entry(entry) => batch.push(entry),
+                ScanEvent::Ignored(path) => {
+                    ignored_batch.push(path);
+                    if ignored_batch.len() >= BATCH {
+                        ignored(std::mem::take(ignored_batch))?;
+                    }
+                }
+                ScanEvent::Warning(message) => warn(message),
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Walk `root`, calling `sink` with batches of entries (root first, as path "").
@@ -76,85 +246,33 @@ pub fn scan(
         return sink(vec![root_entry]);
     }
     // Preserve bounded first-byte progress on slow/NFS walks without splitting
-    // a small, fast scan into several serialized WAN planning round trips.
+    // a small, fast scan into several serialized WAN planning round trips. The
+    // producer is separate so a stalled metadata operation cannot hide a ready
+    // first batch past its deadline; the bounded channel limits scan-ahead.
     let mut batch = Vec::with_capacity(FIRST_BATCH);
-    let scan_started = std::time::Instant::now();
-    let mut first_batch = true;
+    let scan_started = Instant::now();
     batch.push(root_entry);
     let mut ignored_batch: Vec<PathBytes> = Vec::new();
-
     let root_buf = root.to_path_buf();
-    let walk = WalkDirGeneric::<((), State)>::new(root)
-        .follow_links(false)
-        .skip_hidden(false)
-        .process_read_dir(move |_depth, _path, _state, children| {
-            for child in children.iter_mut().flatten() {
-                let full = child.path();
-                let Ok(entry) = lstat_entry(Vec::new(), &full) else {
-                    child.client_state = State::Failed;
-                    continue;
-                };
-                if let Some(ig) = &ignore {
-                    let rel = full.strip_prefix(&root_buf).unwrap_or(&full);
-                    let is_dir = entry.kind == crate::proto::Kind::Dir;
-                    if ig.matched(rel, is_dir).is_ignore() {
-                        // Pruned: neither listed nor descended into.
-                        child.read_children = None;
-                        child.client_state = if report_ignored {
-                            State::Ignored
-                        } else {
-                            State::Skipped
-                        };
-                        continue;
-                    }
-                }
-                child.client_state = State::Keep(entry);
-            }
-        });
-    for item in walk {
-        let mut de = match item {
-            Ok(de) => de,
-            Err(e) => {
-                warn(format!("scan: {e}"));
-                continue;
-            }
-        };
-        // Check this before skipping the root: an unreadable root is the
-        // most important warning there is (--delete relies on it).
-        if let Some(e) = de
-            .read_children
-            .as_ref()
-            .and_then(|children| children.error())
-        {
-            warn(format!("scan: {}: {e}", de.path().display()));
-        }
-        if de.depth == 0 {
-            continue;
-        }
-        let mut entry = match std::mem::take(&mut de.client_state) {
-            State::Keep(e) => e,
-            State::Skipped => continue,
-            State::Ignored => {
-                let full = de.path();
-                ignored_batch.push(path_bytes(full.strip_prefix(root).unwrap_or(&full)));
-                if ignored_batch.len() >= BATCH {
-                    ignored(std::mem::take(&mut ignored_batch))?;
-                }
-                continue;
-            }
-            State::Failed => {
-                warn(format!("scan: cannot stat {}", de.path().display()));
-                continue;
-            }
-        };
-        let full = de.path();
-        let rel = full.strip_prefix(root).unwrap_or(&full);
-        entry.path = path_bytes(rel);
-        batch.push(entry);
-        if batch_ready(batch.len(), first_batch, scan_started.elapsed()) {
-            sink(std::mem::replace(&mut batch, Vec::with_capacity(BATCH)))?;
-            first_batch = false;
-        }
+    let (tx, rx) = mpsc::sync_channel(BATCH / FIRST_BATCH);
+    let producer = std::thread::Builder::new()
+        .name("syq-scan-producer".into())
+        .spawn(move || produce_scan(root_buf, ignore, report_ignored, tx))
+        .context("start scan producer")?;
+    let received = receive_scan(
+        &rx,
+        scan_started,
+        &mut batch,
+        &mut ignored_batch,
+        sink,
+        ignored,
+        warn,
+    );
+    drop(rx);
+    let producer_panicked = producer.join().is_err();
+    received?;
+    if producer_panicked {
+        anyhow::bail!("scan producer panicked");
     }
     if !batch.is_empty() {
         sink(batch)?;
@@ -169,11 +287,96 @@ pub fn scan(
 mod tests {
     use super::*;
 
+    fn entry() -> Entry {
+        Entry {
+            path: Vec::new(),
+            kind: crate::proto::Kind::File,
+            size: 1,
+            mtime: 0,
+            mtime_nsec: 0,
+            mode: 0o644,
+            uid: 0,
+            gid: 0,
+            rdev: 0,
+            dev: 0,
+            ino: 0,
+            link: None,
+        }
+    }
+
     #[test]
-    fn first_batch_balances_progress_and_fast_scan_batching() {
-        assert!(!batch_ready(FIRST_BATCH, true, FIRST_BATCH_MAX_DELAY / 2));
-        assert!(batch_ready(FIRST_BATCH, true, FIRST_BATCH_MAX_DELAY));
-        assert!(!batch_ready(BATCH - 1, false, FIRST_BATCH_MAX_DELAY * 10));
-        assert!(batch_ready(BATCH, false, std::time::Duration::ZERO));
+    fn first_batch_deadline_flushes_while_producer_is_stalled() {
+        let (tx, rx) = mpsc::sync_channel(BATCH);
+        let (release_tx, release_rx) = mpsc::channel();
+        let producer = std::thread::spawn(move || {
+            tx.send(
+                (1..FIRST_BATCH)
+                    .map(|_| ScanEvent::Entry(entry()))
+                    .collect(),
+            )
+            .unwrap();
+            release_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("ready first batch was not flushed while producer stalled");
+        });
+        let mut batch = vec![entry()];
+        let mut ignored_batch = Vec::new();
+        let mut sizes = Vec::new();
+        receive_scan(
+            &rx,
+            Instant::now(),
+            &mut batch,
+            &mut ignored_batch,
+            &mut |entries| {
+                sizes.push(entries.len());
+                release_tx.send(()).unwrap();
+                Ok(())
+            },
+            &mut |_| Ok(()),
+            &mut |_| {},
+        )
+        .unwrap();
+        producer.join().unwrap();
+        assert_eq!(sizes, [FIRST_BATCH]);
+        assert!(batch.is_empty());
+        assert!(ignored_batch.is_empty());
+    }
+
+    #[test]
+    fn fast_small_scan_reaches_eof_as_one_planning_batch() {
+        let (tx, rx) = mpsc::sync_channel(BATCH / FIRST_BATCH);
+        tx.send(
+            (1..FIRST_BATCH)
+                .map(|_| ScanEvent::Entry(entry()))
+                .collect(),
+        )
+        .unwrap();
+        tx.send(
+            (FIRST_BATCH..2000)
+                .map(|_| ScanEvent::Entry(entry()))
+                .collect(),
+        )
+        .unwrap();
+        drop(tx);
+
+        let mut batch = vec![entry()];
+        let mut ignored_batch = Vec::new();
+        let mut sizes = Vec::new();
+        receive_scan(
+            &rx,
+            Instant::now(),
+            &mut batch,
+            &mut ignored_batch,
+            &mut |entries| {
+                sizes.push(entries.len());
+                Ok(())
+            },
+            &mut |_| Ok(()),
+            &mut |_| {},
+        )
+        .unwrap();
+
+        assert!(sizes.is_empty(), "fast EOF should not flush at 1,000");
+        assert_eq!(batch.len(), 2000);
     }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -8,7 +8,7 @@ use jwalk::WalkDirGeneric;
 use std::fs;
 use std::path::Path;
 
-pub const BATCH: usize = 1000;
+pub const BATCH: usize = 4096;
 
 /// Per-entry result of the parallel read_dir hook.
 #[derive(Clone, Default, Debug)]

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -131,6 +131,22 @@ impl Sched {
             && g.finishes.is_empty()
     }
 
+    /// Whether another worker could claim useful work right now. Whole-file
+    /// probes are deliberately excluded: a fast small-file batch already has
+    /// an owner, so replacing a worker that retired after draining the queue
+    /// only creates an idle connection. A retry will put the file back in
+    /// `files`, at which point replacement becomes useful again.
+    pub fn has_assignable_work(&self) -> bool {
+        let g = self.inner.lock().unwrap();
+        !g.files.is_empty()
+            || !g.ranges.is_empty()
+            || !g.finishes.is_empty()
+            || g.inflight.iter().any(|handle| {
+                let range = handle.lock().unwrap();
+                range.pos < range.end
+            })
+    }
+
     /// Whether enough splittable activity remains to measure `n` workers.
     /// `minimum_activity` is derived from the observed aggregate rate and the
     /// time needed for a complete sampling window; queued files add the same
@@ -338,6 +354,21 @@ mod tests {
         assert!(sched.work_left_for(2, 1_200, 512));
         assert!(!sched.work_left_for(2, 1_300, 512));
         assert!(!sched.work_left_for(3, 1_000, 512));
+    }
+
+    #[test]
+    fn claimed_small_files_do_not_request_replacement_capacity() {
+        let sched = Sched::new(64, 128);
+        {
+            let mut inner = sched.inner.lock().unwrap();
+            inner.scan_done = true;
+            inner.probing = 2;
+        }
+        assert!(!sched.finished());
+        assert!(!sched.has_assignable_work());
+
+        sched.inner.lock().unwrap().files.push((100, Reverse(0)));
+        assert!(sched.has_assignable_work());
     }
 
     #[test]

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -47,6 +47,11 @@ struct Inner {
     outstanding: HashMap<usize, u32>,
     failed: HashSet<usize>,
     probing: usize,
+    /// Files owned by the pipelined small-file path. Unlike ordinary probes,
+    /// these will not expose ranges another worker can steal.
+    fast_probing: usize,
+    /// Workers currently processing one pipelined small-file batch.
+    fast_batches: usize,
     scan_done: bool,
     abort: bool,
 }
@@ -70,6 +75,8 @@ impl Sched {
                 outstanding: HashMap::new(),
                 failed: HashSet::new(),
                 probing: 0,
+                fast_probing: 0,
+                fast_batches: 0,
                 scan_done: false,
                 abort: false,
             }),
@@ -131,20 +138,54 @@ impl Sched {
             && g.finishes.is_empty()
     }
 
-    /// Whether another worker could claim useful work right now. Whole-file
-    /// probes are deliberately excluded: a fast small-file batch already has
-    /// an owner, so replacing a worker that retired after draining the queue
-    /// only creates an idle connection. A retry will put the file back in
-    /// `files`, at which point replacement becomes useful again.
-    pub fn has_assignable_work(&self) -> bool {
+    /// Whether useful capacity is queued or about to emerge from an ordinary
+    /// large-file probe. A pipelined small-file batch already has an owner and
+    /// will never expose ranges, so it does not justify replacing a worker
+    /// that retired after draining the queue.
+    pub fn needs_worker_capacity(&self) -> bool {
         let g = self.inner.lock().unwrap();
         !g.files.is_empty()
             || !g.ranges.is_empty()
             || !g.finishes.is_empty()
+            || g.probing > g.fast_probing
             || g.inflight.iter().any(|handle| {
                 let range = handle.lock().unwrap();
                 range.pos < range.end
             })
+    }
+
+    /// Mark the first file of a fast batch and choose a balanced total batch
+    /// size. Existing owners are subtracted from `active`, leaving each worker
+    /// that has not yet claimed a batch a comparable share of the queue. The
+    /// WAN ceiling remains useful without letting early local workers drain it.
+    pub fn begin_fast_batch(&self, active: usize, max_n: usize) -> usize {
+        let mut g = self.inner.lock().unwrap();
+        debug_assert!(g.probing > g.fast_probing);
+        let available_workers = active.saturating_sub(g.fast_batches).max(1);
+        let available_files = g.files.len() + 1;
+        let target = available_files.div_ceil(available_workers).clamp(1, max_n);
+        g.fast_probing += 1;
+        g.fast_batches += 1;
+        target
+    }
+
+    /// Further files claimed by a worker may include slow-path entries; mark
+    /// only those that survived its fast-path eligibility check.
+    pub fn mark_fast(&self, n: usize) {
+        let mut g = self.inner.lock().unwrap();
+        g.fast_probing += n;
+        debug_assert!(g.fast_probing <= g.probing);
+    }
+
+    /// Finish all scheduler bookkeeping for one fast batch at once.
+    pub fn complete_fast_batch(&self, n: usize) {
+        let mut g = self.inner.lock().unwrap();
+        debug_assert!(n > 0);
+        debug_assert!(g.probing >= n && g.fast_probing >= n && g.fast_batches > 0);
+        g.probing -= n;
+        g.fast_probing -= n;
+        g.fast_batches -= 1;
+        self.cv.notify_all();
     }
 
     /// Whether enough splittable activity remains to measure `n` workers.
@@ -363,12 +404,43 @@ mod tests {
             let mut inner = sched.inner.lock().unwrap();
             inner.scan_done = true;
             inner.probing = 2;
+            inner.fast_probing = 2;
+            inner.fast_batches = 1;
         }
         assert!(!sched.finished());
-        assert!(!sched.has_assignable_work());
+        assert!(!sched.needs_worker_capacity());
+
+        // A regular file probe will soon expose transferable ranges, so its
+        // spare connection should warm while hashing/preparation is underway.
+        sched.inner.lock().unwrap().probing += 1;
+        assert!(sched.needs_worker_capacity());
+        sched.inner.lock().unwrap().probing -= 1;
 
         sched.inner.lock().unwrap().files.push((100, Reverse(0)));
-        assert!(sched.has_assignable_work());
+        assert!(sched.needs_worker_capacity());
+    }
+
+    #[test]
+    fn fast_batches_share_the_queue_across_active_workers() {
+        let sched = Sched::new(4096, 8192);
+        {
+            let mut inner = sched.inner.lock().unwrap();
+            inner.scan_done = true;
+            for idx in 0..2000 {
+                inner.files.push((4096, Reverse(idx)));
+            }
+        }
+
+        assert!(matches!(sched.next(), Item::File(_)));
+        let first_target = sched.begin_fast_batch(32, 128);
+        assert_eq!(first_target, 63);
+        let first_extra = sched.take_small(4096, first_target - 1, u64::MAX);
+        sched.mark_fast(first_extra.len());
+        assert_eq!(first_extra.len() + 1, 63);
+
+        assert!(matches!(sched.next(), Item::File(_)));
+        let second_target = sched.begin_fast_batch(32, 128);
+        assert_eq!(second_target, 63);
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -146,6 +146,14 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 blocks += 1;
                 bytes += *len as u64;
             }
+            Request::ReadSmallBatch(reads) => {
+                blocks += reads.len() as u64;
+                bytes += reads.iter().map(|read| u64::from(read.len)).sum::<u64>();
+            }
+            Request::PutSmallBatch(puts) => {
+                blocks += puts.len() as u64;
+                bytes += puts.iter().map(|put| put.data.len() as u64).sum::<u64>();
+            }
             _ => {}
         }
         match req {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -3884,30 +3884,44 @@ impl Worker {
                 self.limit(j.entry.size);
             }
         }
-        self.src.send(Request::ReadSmallBatch(
-            jobs.iter()
-                .map(|job| SmallRead {
-                    path: job.src.clone(),
-                    attempt: job.attempts,
-                    len: job.entry.size as u32,
-                })
-                .collect(),
-        ))?;
-        let blocks = match ok(self.src.recv()?, "read small batch")? {
-            Response::SmallBlocks(blocks) if blocks.len() == jobs.len() => blocks,
-            other => bail!("unexpected response {other:?}"),
+        // Empty files need no source access. Besides saving wire work, this
+        // preserves the valid archive-copy case where an empty source is 000.
+        let reads: Vec<SmallRead> = jobs
+            .iter()
+            .filter(|job| job.entry.size > 0)
+            .map(|job| SmallRead {
+                path: job.src.clone(),
+                attempt: job.attempts,
+                len: job.entry.size as u32,
+            })
+            .collect();
+        let blocks = if reads.is_empty() {
+            Vec::new()
+        } else {
+            let count = reads.len();
+            self.src.send(Request::ReadSmallBatch(reads))?;
+            match ok(self.src.recv()?, "read small batch")? {
+                Response::SmallBlocks(blocks) if blocks.len() == count => blocks,
+                other => bail!("unexpected response {other:?}"),
+            }
         };
+        let mut blocks = blocks.into_iter();
         let mut data: Vec<Result<Vec<u8>>> = jobs
             .iter()
-            .zip(blocks)
-            .map(|(job, block)| match block {
-                Ok(SmallBlock { data, hash })
-                    if data.len() as u64 == job.entry.size && xxh3_64(&data) == hash =>
-                {
-                    Ok(data)
+            .map(|job| {
+                if job.entry.size == 0 {
+                    return Ok(Vec::new());
                 }
-                Ok(_) => Err(anyhow::anyhow!("block size or hash mismatch on read")),
-                Err(error) => Err(anyhow::anyhow!("read: {error}")),
+                match blocks.next() {
+                    Some(Ok(SmallBlock { data, hash }))
+                        if data.len() as u64 == job.entry.size && xxh3_64(&data) == hash =>
+                    {
+                        Ok(data)
+                    }
+                    Some(Ok(_)) => Err(anyhow::anyhow!("block size or hash mismatch on read")),
+                    Some(Err(error)) => Err(anyhow::anyhow!("read: {error}")),
+                    None => Err(anyhow::anyhow!("missing block in read small batch")),
+                }
             })
             .collect();
         self.fast.source += phase.elapsed().as_secs_f64();

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1036,7 +1036,8 @@ pub fn run(args: Args) -> Result<i32> {
         opts: &opts,
         completed: checkpoint_completed,
         checkpoint: checkpoint_writer,
-        destination_tree_known_missing: dst_initially_missing
+        destination_tree_known_missing: dst.is_remote()
+            && dst_initially_missing
             && !opts.ignore_existing
             && !opts.update
             && !opts.checksum,
@@ -1890,9 +1891,9 @@ struct Planner<'a> {
     completed:
         Option<std::sync::Arc<std::collections::HashMap<PathBytes, crate::checkpoint::Completed>>>,
     checkpoint: Option<std::sync::Arc<crate::checkpoint::Checkpoint>>,
-    /// Once syq has observed a missing destination root, every mapped path is
-    /// missing too. Avoid re-statting thousands of impossible descendants;
-    /// receiver-side mutations still perform their normal race-safe checks.
+    /// Once syq has observed a missing remote destination root, every mapped
+    /// path is missing too. Avoid WAN round trips for impossible descendants;
+    /// local stats stay cheap and warm filesystem metadata for the writers.
     destination_tree_known_missing: bool,
     /// Mapped payload paths that look like current sidecars, and every
     /// sidecar path the current job may use. Their intersection is unsafe.
@@ -3746,6 +3747,9 @@ impl Worker {
                 }
                 Item::File(idx) => {
                     if self.fast_eligible(idx) {
+                        let target = self
+                            .sched
+                            .begin_fast_batch(self.gate.active(), FAST_BATCH_FILES);
                         let mut batch = vec![idx];
                         // The fast path reads a whole batch before sending it.
                         // Keep rate-limited batches to one file so a push can't
@@ -3753,16 +3757,16 @@ impl Worker {
                         if self.bwlimit.is_none() {
                             batch.extend(self.sched.take_small(
                                 self.opts.block,
-                                FAST_BATCH_FILES - batch.len(),
+                                target - batch.len(),
                                 FAST_BATCH_BYTES,
                             ));
                         }
                         let (fast, slow): (Vec<usize>, Vec<usize>) =
                             batch.into_iter().partition(|&i| self.fast_eligible(i));
-                        if let Err(e) = self.fast_batch(&fast) {
-                            for &i in &fast {
-                                self.sched.ranges_ready(i, vec![]);
-                            }
+                        self.sched.mark_fast(fast.len() - 1);
+                        let fast_result = self.fast_batch(&fast);
+                        self.sched.complete_fast_batch(fast.len());
+                        if let Err(e) = fast_result {
                             if self.transport_dead() {
                                 for &i in &slow {
                                     self.sched.ranges_ready(i, vec![]);
@@ -3878,38 +3882,41 @@ impl Worker {
         for j in &jobs {
             if j.entry.size > 0 {
                 self.limit(j.entry.size);
-                self.src.send(Request::ReadRange {
-                    path: j.src.clone(),
-                    attempt: j.attempts,
-                    off: 0,
-                    len: j.entry.size as u32,
-                })?;
             }
         }
-        let mut data: Vec<Result<Vec<u8>>> = Vec::with_capacity(jobs.len());
-        for j in &jobs {
-            if j.entry.size == 0 {
-                data.push(Ok(Vec::new()));
-                continue;
-            }
-            data.push(match ok(self.src.recv()?, "read") {
-                Ok(Response::Block { hash, data, .. }) => {
-                    if xxh3_64(&data) != hash {
-                        Err(anyhow::anyhow!("block hash mismatch on read"))
-                    } else {
-                        Ok(data)
-                    }
+        self.src.send(Request::ReadSmallBatch(
+            jobs.iter()
+                .map(|job| SmallRead {
+                    path: job.src.clone(),
+                    attempt: job.attempts,
+                    len: job.entry.size as u32,
+                })
+                .collect(),
+        ))?;
+        let blocks = match ok(self.src.recv()?, "read small batch")? {
+            Response::SmallBlocks(blocks) if blocks.len() == jobs.len() => blocks,
+            other => bail!("unexpected response {other:?}"),
+        };
+        let mut data: Vec<Result<Vec<u8>>> = jobs
+            .iter()
+            .zip(blocks)
+            .map(|(job, block)| match block {
+                Ok(SmallBlock { data, hash })
+                    if data.len() as u64 == job.entry.size && xxh3_64(&data) == hash =>
+                {
+                    Ok(data)
                 }
-                Ok(other) => Err(anyhow::anyhow!("unexpected response {other:?}")),
-                Err(e) => Err(e),
-            });
-        }
+                Ok(_) => Err(anyhow::anyhow!("block size or hash mismatch on read")),
+                Err(error) => Err(anyhow::anyhow!("read: {error}")),
+            })
+            .collect();
         self.fast.source += phase.elapsed().as_secs_f64();
-        // One PutSmall per file (pipelined): the server writes each small file
-        // through its sidecar and atomically renames it into place.
+        // One batch request: the server still publishes every file through its
+        // own sidecar, but framing, compression and encryption are amortized.
         let phase = std::time::Instant::now();
         let flags = self.opts.flags | flags::MODE; // set the computed mode explicitly
         let mut sent: Vec<bool> = Vec::with_capacity(jobs.len());
+        let mut puts = Vec::with_capacity(jobs.len());
         for (j, d) in jobs.iter().zip(data.iter_mut()) {
             let Ok(bytes) = d else {
                 sent.push(false);
@@ -3919,18 +3926,33 @@ impl Worker {
             let hash = xxh3_64(&bytes);
             let mut meta = j.entry.meta();
             meta.mode = self.create_mode(j);
-            self.dst.send(Request::PutSmall {
+            puts.push(SmallPut {
                 path: j.dst.clone(),
                 partial_id: self.partial_id(),
                 data: bytes,
                 hash,
                 meta,
                 flags,
-            })?;
+            });
             sent.push(true);
+        }
+        if !puts.is_empty() {
+            self.dst.send(Request::PutSmallBatch(puts))?;
         }
         self.fast.dest_send += phase.elapsed().as_secs_f64();
         let phase = std::time::Instant::now();
+        let mut applied = if sent.iter().any(|sent| *sent) {
+            match ok(self.dst.recv()?, "put small batch")? {
+                Response::Applied(results)
+                    if results.len() == sent.iter().filter(|sent| **sent).count() =>
+                {
+                    results.into_iter()
+                }
+                other => bail!("unexpected response {other:?}"),
+            }
+        } else {
+            Vec::new().into_iter()
+        };
         let mut results: Vec<Result<()>> = Vec::with_capacity(jobs.len());
         for (d, &was_sent) in data.iter_mut().zip(sent.iter()) {
             let res: Result<()> = if !was_sent {
@@ -3939,7 +3961,10 @@ impl Worker {
                     Err(e) => Err(anyhow::anyhow!("{e:#}")),
                 }
             } else {
-                ok(self.dst.recv()?, "put").map(|_| ())
+                match applied.next().flatten() {
+                    None => Ok(()),
+                    Some(error) => Err(anyhow::anyhow!("put: {error}")),
+                }
             };
             results.push(res);
         }
@@ -3955,7 +3980,6 @@ impl Worker {
             .zip(jobs.iter())
             .zip(results.into_iter().zip(now.into_iter()))
         {
-            self.sched.ranges_ready(*idx, vec![]);
             if let Err(e) = res {
                 self.progress.error(&format!("syq: {}: {e:#}", j.rel));
                 self.sched.fail_file(*idx);
@@ -4112,7 +4136,7 @@ impl Worker {
             let full = || if size > 0 { vec![(0, size)] } else { vec![] };
             // Unless --inplace was explicit, changed files are published
             // through a sidecar + atomic rename. Small new files normally take
-            // the pipelined PutSmall path instead of reaching this worker path.
+            // the batched small-file path instead of reaching this worker path.
             self.set_inplace(idx, inplace);
 
             if inplace {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -21,7 +21,7 @@ use xxhash_rust::xxh3::xxh3_64;
 const WINDOW: usize = 4;
 const MAX_ATTEMPTS: u32 = 3;
 pub const LOCAL_DEFAULT_CONNECTIONS: usize = 32;
-const FAST_BATCH_FILES: usize = 64;
+const FAST_BATCH_FILES: usize = 128;
 const FAST_BATCH_BYTES: u64 = 16 << 20;
 const CONNECTION_RECOVERY_ATTEMPTS: u32 = 3;
 
@@ -405,6 +405,7 @@ fn copy_identity(
     dst: &Location,
     src_ctl: &mut dyn Conn,
     dst_ctl: &mut dyn Conn,
+    dst_canonical: Option<std::path::PathBuf>,
     opts: &Opts,
 ) -> Result<String> {
     let mut src_roots: Vec<(String, bool)> = Vec::with_capacity(srcs.len());
@@ -415,9 +416,12 @@ fn copy_identity(
             source.copies_contents(),
         ));
     }
-    let dst_root = canonical_path(dst_ctl, &dst.path, dst.is_remote())?
-        .to_string_lossy()
-        .into_owned();
+    let dst_root = match dst_canonical {
+        Some(path) => path,
+        None => canonical_path(dst_ctl, &dst.path, dst.is_remote())?,
+    }
+    .to_string_lossy()
+    .into_owned();
     Ok(crate::checkpoint::job_identity(
         &endpoint_identity(&srcs[0]),
         &src_roots,
@@ -746,6 +750,7 @@ pub fn run(args: Args) -> Result<i32> {
                         bwlimit: bwlimit.clone(),
                         gate: gate.clone(),
                         t: [0.0; 4],
+                        fast: FastTiming::default(),
                     };
                     if debug() {
                         eprintln!(
@@ -755,10 +760,8 @@ pub fn run(args: Args) -> Result<i32> {
                     }
                     let result = worker.run();
                     if collect_tcp_stats {
-                        transport_stats
-                            .lock()
-                            .unwrap()
-                            .extend(worker.collect_transport_stats());
+                        let stats = worker.collect_transport_stats();
+                        transport_stats.lock().unwrap().extend(stats);
                     }
                     let dropped = result.is_err() && worker.transport_dead();
                     match result {
@@ -902,12 +905,14 @@ pub fn run(args: Args) -> Result<i32> {
     // (lexically only; symlinks stay the self-copy guard's business) keeps
     // `dst`, `dst/`, `dst/.` and `dst//` from producing keys that disagree.
     let dst_root = clean_root(dst.path.as_bytes());
-    let dst_root_entry = stat_one(&mut *dst_ctl, &dst_root, false)?;
+    let (dst_root_entry, dst_canonical) =
+        stat_and_canonicalize(&mut *dst_ctl, &dst_root, &dst.path, dst.is_remote())?;
     // A destination that is a symlink to a directory is that directory (as
     // for rsync). Use the resolved target path for all planning and metadata,
     // so ordinary in-tree symlinks can still be replaced instead of followed.
     let (dst_root, dst_root_entry) = follow_dir_symlink(&mut *dst_ctl, &dst_root, dst_root_entry)?;
-    let dst_existed = dst_root_entry.is_some();
+    let dst_initially_missing = dst_root_entry.is_none();
+    let dst_existed = !dst_initially_missing;
     let dst_is_dir = match &dst_root_entry {
         Some(e) if e.kind == Kind::Dir => true,
         Some(_) if srcs.len() > 1 => {
@@ -971,7 +976,15 @@ pub fn run(args: Args) -> Result<i32> {
         }
     }
 
-    let identity = copy_identity(&args, srcs, dst, &mut *src_ctl, &mut *dst_ctl, &opts)?;
+    let identity = copy_identity(
+        &args,
+        srcs,
+        dst,
+        &mut *src_ctl,
+        &mut *dst_ctl,
+        Some(dst_canonical),
+        &opts,
+    )?;
     opts.partial_id
         .set(crate::checkpoint::partial_id(&identity))
         .expect("partial identity set once");
@@ -1002,7 +1015,6 @@ pub fn run(args: Args) -> Result<i32> {
     if create_root && srcs.len() == 1 {
         mkdir_root(&mut *dst_ctl, &dst_root)?;
     }
-
     let checkpoint_completed = checkpoint_state
         .as_ref()
         .map(|state| state.completed.clone());
@@ -1024,6 +1036,10 @@ pub fn run(args: Args) -> Result<i32> {
         opts: &opts,
         completed: checkpoint_completed,
         checkpoint: checkpoint_writer,
+        destination_tree_known_missing: dst_initially_missing
+            && !opts.ignore_existing
+            && !opts.update
+            && !opts.checksum,
         dst_seen: std::collections::HashMap::new(),
         missing_dirs: std::collections::HashSet::new(),
         dry_run_replaced_dirs: std::collections::HashSet::new(),
@@ -1046,11 +1062,7 @@ pub fn run(args: Args) -> Result<i32> {
         } else {
             None
         },
-        create_root: if create_root && srcs.len() > 1 {
-            Some(dst_root.clone())
-        } else {
-            None
-        },
+        create_root: (create_root && srcs.len() > 1).then(|| dst_root.clone()),
         keep_dirs: args.files_from.is_some(),
         delete_roots: Vec::new(),
         deletes: Deletes::default(),
@@ -1454,6 +1466,43 @@ fn stat_one(conn: &mut dyn Conn, path: &[u8], follow: bool) -> Result<Option<Ent
         .flatten())
 }
 
+/// Fetch the destination root's entry and canonical spelling in one network
+/// turn. They are independent read-only queries; sending both before waiting
+/// avoids an otherwise unnecessary RTT on every remote copy.
+fn stat_and_canonicalize(
+    conn: &mut dyn Conn,
+    stat_path: &[u8],
+    canonical_path: &str,
+    remote: bool,
+) -> Result<(Option<Entry>, std::path::PathBuf)> {
+    if !remote {
+        return Ok((
+            stat_one(conn, stat_path, false)?,
+            crate::fsops::normalize(&crate::fsops::resolve(canonical_path.as_bytes())),
+        ));
+    }
+    conn.send(Request::StatMany {
+        paths: vec![stat_path.to_vec()],
+        follow: false,
+    })?;
+    conn.send(Request::Canonicalize {
+        path: canonical_path.as_bytes().to_vec(),
+    })?;
+    // Consume both replies before interpreting either endpoint error so the
+    // reusable control stream cannot be left one response behind.
+    let stat_response = conn.recv();
+    let canonical_response = conn.recv();
+    let entry = match ok(stat_response?, "stat")? {
+        Response::Stats(mut entries) if entries.len() == 1 => entries.pop().flatten(),
+        other => bail!("unexpected response {other:?}"),
+    };
+    let canonical = match ok(canonical_response?, "canonicalize")? {
+        Response::Path(path) => crate::fsops::resolve(&path),
+        other => bail!("unexpected response {other:?}"),
+    };
+    Ok((entry, canonical))
+}
+
 /// Run a source scan whose batches feed the planner, and remember whether it
 /// reported any problem — `scan_warned` is what gates --delete, so every
 /// source walk must go through here.
@@ -1841,6 +1890,10 @@ struct Planner<'a> {
     completed:
         Option<std::sync::Arc<std::collections::HashMap<PathBytes, crate::checkpoint::Completed>>>,
     checkpoint: Option<std::sync::Arc<crate::checkpoint::Checkpoint>>,
+    /// Once syq has observed a missing destination root, every mapped path is
+    /// missing too. Avoid re-statting thousands of impossible descendants;
+    /// receiver-side mutations still perform their normal race-safe checks.
+    destination_tree_known_missing: bool,
     /// Mapped payload paths that look like current sidecars, and every
     /// sidecar path the current job may use. Their intersection is unsafe.
     /// Ordinary payload names cannot collide and do not need to stay in RAM.
@@ -2455,7 +2508,11 @@ impl Planner<'_> {
         // the same filtered list drives creation, listing and deferred
         // metadata so they can't disagree.
         if !dirs.is_empty() {
-            let stats = self.stat_directories_with_dry_run_overlay(&dirs, dst_root)?;
+            let stats = if self.destination_tree_known_missing {
+                vec![None; dirs.len()]
+            } else {
+                self.stat_directories_with_dry_run_overlay(&dirs, dst_root)?
+            };
             let mut planned: Vec<(PathBytes, PathBytes, Entry, Option<Entry>)> = Vec::new();
             for ((p, dst_rel, e), mut st) in dirs.into_iter().zip(stats) {
                 // Keep the parent-first overlay invariant explicit here too:
@@ -2630,10 +2687,14 @@ impl Planner<'_> {
             }
             others = kept;
         }
-        let stats = self.stat_many_with_dry_run_overlay(
-            others.iter().map(|p| p.dst.clone()).collect(),
-            dst_root,
-        )?;
+        let stats = if self.destination_tree_known_missing {
+            vec![None; others.len()]
+        } else {
+            self.stat_many_with_dry_run_overlay(
+                others.iter().map(|p| p.dst.clone()).collect(),
+                dst_root,
+            )?
+        };
         let mut ops: Vec<Op> = Vec::new();
         let mut op_names: Vec<String> = Vec::new();
         // Metadata repairs for quick-check-identical files, each with the
@@ -3602,6 +3663,18 @@ struct Worker {
     gate: Arc<Gate>,
     /// Debug timing: seconds blocked in source recv, dest send, dest ack, idle in scheduler.
     t: [f64; 4],
+    fast: FastTiming,
+}
+
+#[derive(Default)]
+struct FastTiming {
+    batches: usize,
+    files: usize,
+    source: f64,
+    dest_send: f64,
+    dest_ack: f64,
+    restat: f64,
+    bookkeeping: f64,
 }
 
 struct BlockDiff {
@@ -3654,8 +3727,19 @@ impl Worker {
                 Item::Exit => {
                     if debug() {
                         eprintln!(
-                            "syq: worker {} blocked: src recv {:.2}s, dst send {:.2}s, dst ack {:.2}s, idle {:.2}s",
-                            self.id, self.t[0], self.t[1], self.t[2], self.t[3]
+                            "syq: worker {} blocked: src recv {:.2}s, dst send {:.2}s, dst ack {:.2}s, idle {:.2}s; small: {} files in {} batches, src {:.2}s, dst send {:.2}s, dst ack {:.2}s, restat {:.2}s, bookkeeping {:.2}s",
+                            self.id,
+                            self.t[0],
+                            self.t[1],
+                            self.t[2],
+                            self.t[3],
+                            self.fast.files,
+                            self.fast.batches,
+                            self.fast.source,
+                            self.fast.dest_send,
+                            self.fast.dest_ack,
+                            self.fast.restat,
+                            self.fast.bookkeeping,
                         );
                     }
                     return Ok(());
@@ -3669,7 +3753,7 @@ impl Worker {
                         if self.bwlimit.is_none() {
                             batch.extend(self.sched.take_small(
                                 self.opts.block,
-                                FAST_BATCH_FILES,
+                                FAST_BATCH_FILES - batch.len(),
                                 FAST_BATCH_BYTES,
                             ));
                         }
@@ -3773,6 +3857,8 @@ impl Worker {
     }
 
     fn fast_batch(&mut self, batch: &[usize]) -> Result<()> {
+        self.fast.batches += 1;
+        self.fast.files += batch.len();
         let jobs: Vec<FileJob> = {
             let all = self.sched.jobs.lock().unwrap();
             batch.iter().map(|&i| all[i].clone()).collect()
@@ -3788,6 +3874,7 @@ impl Worker {
             );
         }
         // Reads.
+        let phase = std::time::Instant::now();
         for j in &jobs {
             if j.entry.size > 0 {
                 self.limit(j.entry.size);
@@ -3817,8 +3904,10 @@ impl Worker {
                 Err(e) => Err(e),
             });
         }
+        self.fast.source += phase.elapsed().as_secs_f64();
         // One PutSmall per file (pipelined): the server writes each small file
         // through its sidecar and atomically renames it into place.
+        let phase = std::time::Instant::now();
         let flags = self.opts.flags | flags::MODE; // set the computed mode explicitly
         let mut sent: Vec<bool> = Vec::with_capacity(jobs.len());
         for (j, d) in jobs.iter().zip(data.iter_mut()) {
@@ -3840,6 +3929,8 @@ impl Worker {
             })?;
             sent.push(true);
         }
+        self.fast.dest_send += phase.elapsed().as_secs_f64();
+        let phase = std::time::Instant::now();
         let mut results: Vec<Result<()>> = Vec::with_capacity(jobs.len());
         for (d, &was_sent) in data.iter_mut().zip(sent.iter()) {
             let res: Result<()> = if !was_sent {
@@ -3852,9 +3943,13 @@ impl Worker {
             };
             results.push(res);
         }
+        self.fast.dest_ack += phase.elapsed().as_secs_f64();
         // Did any source change while we were at it?
         let paths: Vec<PathBytes> = jobs.iter().map(|j| j.src.clone()).collect();
+        let phase = std::time::Instant::now();
         let now = stat_many(&mut *self.src, paths, false)?;
+        self.fast.restat += phase.elapsed().as_secs_f64();
+        let phase = std::time::Instant::now();
         for ((idx, j), (res, now)) in batch
             .iter()
             .zip(jobs.iter())
@@ -3912,6 +4007,7 @@ impl Worker {
                 self.progress.println(&j.rel);
             }
         }
+        self.fast.bookkeeping += phase.elapsed().as_secs_f64();
         Ok(())
     }
 

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -954,9 +954,9 @@ pub fn run(
         gate.set_retain(retain);
         // A pipelined whole-file batch is already owned and cannot be stolen.
         // Do not repeatedly reconnect slots that drained the queue while the
-        // remaining owners finish; a retry or range requeue makes work
-        // assignable and re-enables healing on the next poll.
-        if sched.has_assignable_work() {
+        // remaining owners finish. Queued/retried work or an ordinary
+        // large-file probe re-enables healing on the next poll.
+        if sched.needs_worker_capacity() {
             for id in gate.begin_warming(retain) {
                 spawn(id);
             }

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -952,8 +952,14 @@ pub fn run(
         // exactly one ready spare so the important 1→2 probe is instantaneous.
         let retain = if active == 1 { 2 } else { active };
         gate.set_retain(retain);
-        for id in gate.begin_warming(retain) {
-            spawn(id);
+        // A pipelined whole-file batch is already owned and cannot be stolen.
+        // Do not repeatedly reconnect slots that drained the queue while the
+        // remaining owners finish; a retry or range requeue makes work
+        // assignable and re-enables healing on the next poll.
+        if sched.has_assignable_work() {
+            for id in gate.begin_warming(retain) {
+                spawn(id);
+            }
         }
         if gate.permanent_failure_through(active) {
             sched.abort();

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1402,6 +1402,20 @@ fn single_file_to_new_name() {
 }
 
 #[test]
+fn archive_copies_mode_zero_empty_file_without_opening_source() {
+    let t = Tmp::new();
+    let src = t.path("src/empty");
+    write(&src, b"");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o000)).unwrap();
+
+    run_ok(&["-a", &t.s("src/empty"), &t.s("dst/empty")]);
+
+    let dst = fs::metadata(t.path("dst/empty")).unwrap();
+    assert_eq!(dst.len(), 0);
+    assert_eq!(dst.mode() & 0o777, 0);
+}
+
+#[test]
 fn single_file_into_existing_dir() {
     let t = Tmp::new();
     write(&t.path("src/f.txt"), b"data");


### PR DESCRIPTION
## Summary

- reduce avoidable WAN planning round trips by pipelining root stat/canonicalization and skipping impossible descendant stats for known-missing remote destinations
- preserve bounded first-byte progress on slow scans while allowing fast small scans to form one larger planning batch
- balance up-to-128-file batches across active workers, preventing early workers from draining local queues
- distinguish owned fast batches from ordinary large-file preparation so adaptive connection healing retains useful handshake overlap without small-file reconnect churn
- probe every resolved TCP socket address concurrently and give all candidate paths their complete bounded window
- send each worker small-file read/publication batch in one protocol frame, while retaining per-file atomic publication and error reporting
- add `SYQ_DEBUG=1` phase timings and collect per-connection statistics outside the shared lock

## Benchmarks

### WAN

Germany to a test host in Japan, about 262 ms RTT, 2,000 × 4 KiB files, archive mode, independently checksum-verified:

| result | wall time |
|---|---:|
| original syq median | 14.4 s |
| this branch after review fixes | 9.92 s / 9.42 s (9.67 s median) |
| reported rsync | 8.8 s |
| reported tar | 7.8 s |

This reduces syq wall time by about 33%. The safer probe now waits for all candidate paths instead of discarding a potentially faster path after the SSH target succeeds, so this deliberately no longer claims rsync parity. Both upload destinations passed `rsync -rcni --delete` verification with no differences; the batched read path also passed a reverse Japan-to-local transfer and verification.

### Local review workload

Alternating release runs copying 2,000 sparse 4 KiB files with 32 workers, exact base `0a8f17c` versus this branch:

| result | median (50 runs each) |
|---|---:|
| base | 0.257 s |
| this branch | 0.250 s |

The dynamic allocation removes the reviewed local regression; debug output shows all 32 workers receiving comparable one-batch shares instead of half owning 128 files while the rest idle.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (293 passed)
- two local-to-Japan WAN repeats and one Japan-to-local repeat, all independently checksum-verified
- 50 alternating local release runs per revision
