### PR TITLE
Harden streaming rm against leaf type changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,7 +863,9 @@ it needs `--relay` (the list is read on this machine).
 `syq --rm [-j N] [-n] [-v] PATH...` removes trees the way syq copies them:
 a parallel scan, files unlinked in batches across N workers, directories
 removed deepest-first with each level in parallel. Symlinks are removed, not
-followed. Remote paths (`host:path`) work. It refuses `/`, `.` and `~`. On
+followed. If a scanned non-directory is replaced by a directory before its
+batch runs, SYQ reports the type change and never recurses into the new
+directory. Remote paths (`host:path`) work. It refuses `/`, `.` and `~`. On
 NFS, where every unlink is a round trip, `-j32` removed 20,000 files in 2.5 s
 versus 9.7 s for `rm -rf`; on a local SSD `rm -rf` is already fast and syq is
 no faster.

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -597,10 +597,9 @@ fn apply_one(op: &Op) -> Result<()> {
                     r => r.with_context(|| format!("rmdir {}", p.display())),
                 }
             }
-            // Remove (for --rm) swallows lstat errors: rm -rf semantics, keep
-            // going. Unlink (below, for --delete) reports them: a mirror that
-            // silently failed to mirror would be worse. Deliberate divergence,
-            // pinned by unlink_never_recurses_into_a_directory.
+            // Remove follows the path's current type and may recurse. Planned
+            // deletion paths use Unlink/Rmdir below so a type change fails
+            // safely instead of broadening the selected deletion scope.
             Op::Remove { path } => {
                 let p = resolve(path);
                 match fs::symlink_metadata(&p) {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -134,6 +134,8 @@ pub enum Op {
         meta: Meta,
         flags: u8,
     },
+    /// Remove whatever currently occupies the path, recursively when it is a
+    /// directory. Planned deletion uses Unlink/Rmdir instead.
     Remove {
         path: PathBytes,
     },

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -75,7 +75,7 @@ fn worker(
         let names: Vec<PathBytes> = ops
             .iter()
             .map(|o| match o {
-                Op::Remove { path } | Op::Rmdir { path } => path.clone(),
+                Op::Remove { path } | Op::Rmdir { path } | Op::Unlink { path } => path.clone(),
                 _ => Vec::new(),
             })
             .collect();
@@ -225,7 +225,20 @@ pub fn run(args: Args) -> Result<i32> {
                             println!("{}", String::from_utf8_lossy(&full));
                         }
                     } else {
-                        batch.push(Op::Remove { path: full });
+                        #[cfg(debug_assertions)]
+                        {
+                            if let Some(ready) = std::env::var_os("SYQ_TEST_RM_LEAF_READY_FILE") {
+                                std::fs::write(&ready, b"ready")?;
+                            }
+                            if let Some(ms) = std::env::var_os("SYQ_TEST_HOLD_RM_LEAF_MS") {
+                                if let Ok(ms) = ms.to_string_lossy().parse::<u64>() {
+                                    std::thread::sleep(std::time::Duration::from_millis(ms));
+                                }
+                            }
+                        }
+                        // The scan selected a non-directory. Do not broaden that
+                        // decision if a directory appears here before execution.
+                        batch.push(Op::Unlink { path: full });
                         if batch.len() >= BATCH {
                             pool.submit(std::mem::replace(&mut batch, Vec::with_capacity(BATCH)));
                         }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -2184,6 +2184,53 @@ fn rm_normal_target_works() {
     assert!(!t.path("killme").exists());
 }
 
+#[cfg(debug_assertions)]
+#[test]
+fn rm_never_recurses_into_directory_that_replaced_scanned_leaf() {
+    let t = Tmp::new();
+    write(&t.path("killme/leaf"), b"old");
+    let ready = t.path("rm-leaf-ready");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["--rm", "-j", "1", &t.s("killme"), "--no-progress"])
+        .env("SYQ_TEST_RM_LEAF_READY_FILE", &ready)
+        .env("SYQ_TEST_HOLD_RM_LEAF_MS", "1000")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while !ready.exists() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    if !ready.exists() {
+        let _ = child.kill();
+        let out = child.wait_with_output().unwrap();
+        panic!(
+            "rm did not report the scanned leaf: stdout={} stderr={}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    fs::remove_file(t.path("killme/leaf")).unwrap();
+    write(&t.path("killme/leaf/important"), b"keep");
+
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(23),
+        "stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("is now a directory"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(read(&t.path("killme/leaf/important")), b"keep");
+}
+
 #[test]
 fn quiet_overrides_verbose_and_json_progress_for_rm() {
     let t = Tmp::new();


### PR DESCRIPTION
## Summary

- send leaf-only Unlink operations for non-directories selected by the streaming rm scan
- fail visibly instead of recursively deleting a directory that replaces a selected leaf
- document the race behavior and cover it with a deterministic integration test

The scan and deletion workers still overlap; this does not introduce population preflight or change directory ordering.

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets