### PR TITLE
Deduplicate identical source operands

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ Identical to rsync:
   sources doesn't change that: it would be overwritten, so it's a conflict.
   The price is memory: every scanned entry is held until the scans are
   validated, roughly a few hundred bytes per entry across all sources.
+- An exactly repeated source operand is scanned once. It still counts toward
+  the original source count for placement, so `syq file file new-dest` creates
+  the directory `new-dest` and writes `new-dest/file`.
 - An explicitly supplied destination root that is a symlink to a directory is
   that directory (the link is kept, with or without a trailing slash). A
   symlink encountered below the destination root is payload at that path: it

--- a/RSYNC-COMPAT.md
+++ b/RSYNC-COMPAT.md
@@ -130,10 +130,12 @@ item.
 4. **Two distinct sources mapping onto one destination file is an error.**
    Measured rsync silently keeps the first. Silent last-writer-wins (or
    first-writer-wins) on a collision is data loss with no message; syq refuses
-   and names both. *Identical* repeated sources should be deduplicated instead
-   — open issue 3. Naming the destination file itself as one of the sources
-   is a conflict too, not a licence for the other source to overwrite it.
+   and names both. Exactly repeated source operands are deduplicated before
+   scanning while retaining the original source count for placement. Naming
+   the destination file itself as one of the sources is a conflict too, not a
+   licence for the other source to overwrite it.
    *Tests: `duplicate_destination_rejected`,
+   `exactly_repeated_sources_are_deduplicated_without_changing_placement`,
    `dir_vs_file_destination_collision_rejected`,
    `cross_source_collision_is_detected_before_any_change`,
    `copy_onto_itself_among_sources_is_order_independent`,
@@ -225,14 +227,10 @@ command says what to change.
    preserve a trailing slash (`dir/` selects the directory's immediate
    children without `-r`, `dir` only the directory); accept `.`/`/` as the root
    entry (children without `-r`); add `-0` as an alias of `--from0`.
-3. **Repeated identical sources should be deduplicated**, not reported as a
-   collision (rsync scans a source given ten times once). Only for
-   byte-identical source arguments including trailing-slash mode; distinct
-   sources on one destination stay an error ("Incompatible on purpose" 4).
-4. **`-h` alone should print help**, as rsync does, while staying
+3. **`-h` alone should print help**, as rsync does, while staying
    `--human-readable` inside a cluster (`-avh`). Essentially free.
-5. **`-u` for symlinks/devices** — measure rsync, then align or record.
-6. **Cross-uid symlinks in an operator-named destination path.** Current rsync
+4. **`-u` for symlinks/devices** — measure rsync, then align or record.
+5. **Cross-uid symlinks in an operator-named destination path.** Current rsync
    refuses an absolute or relative destination component owned by another uid
    when root runs the copy, preventing an unprivileged user from redirecting a
    privileged copy outside the intended tree. syq currently follows it just as
@@ -244,6 +242,9 @@ command says what to change.
 
 ## Resolved
 
+- Exactly repeated raw source operands are deduplicated before scanning while
+  preserving the original operand count for destination placement. Distinct
+  spellings remain distinct even when parsing gives them the same endpoint.
 - Source entries named like sidecars were excluded from copies; PR #7's
   namespace preflight made them ordinary payload (rsync-compatible), and
   this branch follows it. Former open issue 4. Destination `--delete` now

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -175,6 +175,12 @@ pub struct Args {
     /// Original source endpoint for a remotely orchestrated dry-run summary
     #[arg(long, hide = true)]
     pub plan_source_host: Option<String>,
+    /// Original source-operand count for a direct remote orchestrator
+    #[arg(long, hide = true)]
+    pub direct_source_operand_count: Option<usize>,
+    /// Direct remote launch already deduplicated its raw source operands
+    #[arg(long, hide = true, requires = "direct_source_operand_count")]
+    pub direct_sources_prededuplicated: bool,
 
     /// Skip paths matching PATTERN (gitignore syntax: `foo` matches at any depth, `/foo` only
     /// at the source root, `foo/` only directories, `!pat` re-includes). Repeatable; together

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -32,7 +32,12 @@ fn direct_command(
     cmd
 }
 
-pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
+pub fn run(
+    args: &Args,
+    srcs: &[Location],
+    dst: &Location,
+    source_operand_count: usize,
+) -> Result<i32> {
     let rsh = parse_rsh(&args.rsh)?;
     let src_host = srcs[0].host.clone().unwrap();
     // The follow target must reconnect the way we did: keep an explicit user.
@@ -142,6 +147,10 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     if args.dry_run {
         remote.push(format!("--plan-source-host={src_target}"));
     }
+    remote.push(format!(
+        "--direct-source-operand-count={source_operand_count}"
+    ));
+    remote.push("--direct-sources-prededuplicated".into());
     // --ignore-from files were read locally; forward the merged lines.
     for l in &args.ignore_lines {
         // One argument, so a pattern starting with '-' can't be taken for a flag.

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -550,12 +550,41 @@ pub fn run(args: Args) -> Result<i32> {
     if locs.len() < 2 {
         bail!("need at least one source and a destination");
     }
-    let (dst, srcs) = locs.split_last().unwrap();
-    for s in srcs {
-        if !s.same_host(&srcs[0]) {
+    let (_, raw_source_operands) = args.paths.split_last().unwrap();
+    let (dst, original_srcs) = locs.split_last().unwrap();
+    let source_operand_count = args
+        .direct_source_operand_count
+        .unwrap_or(raw_source_operands.len());
+    if source_operand_count < original_srcs.len() {
+        bail!("invalid direct source-operand count");
+    }
+    for s in original_srcs {
+        if !s.same_host(&original_srcs[0]) {
             bail!("all sources must be on the same host");
         }
     }
+    if args.files_from.is_some() && source_operand_count > 1 {
+        bail!("--files-from takes exactly one source directory");
+    }
+    // Rsync's file-list cleanup collapses an exactly repeated source. Key that
+    // decision on the raw operands, before parsing has normalized spellings,
+    // while retaining original multiplicity for destination placement:
+    // `file file new-dest` still creates a directory like other multi-source
+    // commands.
+    let multiple_source_operands = source_operand_count > 1;
+    let srcs: Vec<Location> = if args.direct_sources_prededuplicated {
+        original_srcs.to_vec()
+    } else {
+        let mut seen_sources = std::collections::HashSet::new();
+        raw_source_operands
+            .iter()
+            .zip(original_srcs)
+            .filter(|(raw, _)| seen_sources.insert(raw.as_str()))
+            .map(|(_, source)| source.clone())
+            .collect()
+    };
+    let srcs = srcs.as_slice();
+    let multiple_distinct_sources = srcs.len() > 1;
     if let Some(checkpoint) = args.checkpoint.as_deref() {
         let checkpoint = crate::fsops::normalize(std::path::Path::new(checkpoint));
         for source in srcs.iter().filter(|source| !source.is_remote()) {
@@ -610,7 +639,9 @@ pub fn run(args: Args) -> Result<i32> {
     }
     if src_ep.is_remote() && dst_ep.is_remote() {
         if !args.relay {
-            return crate::direct::run(&args, srcs, dst);
+            // Let the remote orchestrator observe the original source count so
+            // repeated file sources keep multi-source destination semantics.
+            return crate::direct::run(&args, srcs, dst, source_operand_count);
         }
         if !args.quiet {
             eprintln!("syq: remote-to-remote transfer: relaying data through this machine");
@@ -643,10 +674,6 @@ pub fn run(args: Args) -> Result<i32> {
         max_size,
         min_size,
     });
-    if args.files_from.is_some() && srcs.len() > 1 {
-        bail!("--files-from takes exactly one source directory");
-    }
-
     let show_progress = !args.no_progress && !args.quiet && !args.dry_run;
     let progress = Progress::new(
         args.connections,
@@ -910,11 +937,11 @@ pub fn run(args: Args) -> Result<i32> {
     let dst_existed = dst_root_entry.is_some();
     let dst_is_dir = match &dst_root_entry {
         Some(e) if e.kind == Kind::Dir => true,
-        Some(_) if srcs.len() > 1 => {
+        Some(_) if multiple_source_operands => {
             bail!("destination must be a directory when copying multiple sources")
         }
         Some(_) => false,
-        None => srcs.len() > 1 || dst.copies_contents() || args.files_from.is_some(),
+        None => multiple_source_operands || dst.copies_contents() || args.files_from.is_some(),
     };
     if args.files_from.is_some() {
         if let Some(e) = dst_root_entry.as_ref().filter(|e| e.kind != Kind::Dir) {
@@ -999,7 +1026,7 @@ pub fn run(args: Args) -> Result<i32> {
         && !args.existing;
     let dry_run_creates_root =
         args.dry_run && dst_root_entry.is_none() && dst_is_dir && !args.existing;
-    if create_root && srcs.len() == 1 {
+    if create_root && !multiple_distinct_sources {
         mkdir_root(&mut *dst_ctl, &dst_root)?;
     }
 
@@ -1041,12 +1068,12 @@ pub fn run(args: Args) -> Result<i32> {
         scan_warned: false,
         max_delete_hit: false,
         delete_walk_failed: false,
-        buffer: if srcs.len() > 1 {
+        buffer: if multiple_distinct_sources {
             Some(Vec::new())
         } else {
             None
         },
-        create_root: if create_root && srcs.len() > 1 {
+        create_root: if create_root && multiple_distinct_sources {
             Some(dst_root.clone())
         } else {
             None

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -2240,6 +2240,74 @@ fn duplicate_destination_rejected() {
 }
 
 #[test]
+fn exactly_repeated_sources_are_deduplicated_without_changing_placement() {
+    let t = Tmp::new();
+    write(&t.path("tree/name1"), b"data");
+    std::os::unix::fs::symlink("name1", t.path("tree/name2")).unwrap();
+    let tree = t.s("tree/");
+    let so = run_ok(&["-avv", &tree, &tree, &tree, &t.s("tree-dest/")]);
+    assert_eq!(transferred(&so), 1, "{so}");
+    assert_eq!(read(&t.path("tree-dest/name1")), b"data");
+    assert_eq!(
+        fs::read_link(t.path("tree-dest/name2")).unwrap(),
+        std::path::Path::new("name1")
+    );
+
+    // Deduplicating the work must not turn an originally multi-source command
+    // into single-source placement: repeated files still land inside a
+    // directory destination, including when that destination is missing.
+    write(&t.path("one/file"), b"one");
+    let file = t.s("one/file");
+    run_ok(&["-a", &file, &file, &t.s("file-dest")]);
+    assert!(t.path("file-dest").is_dir());
+    assert_eq!(read(&t.path("file-dest/file")), b"one");
+}
+
+#[test]
+fn direct_remote_dedup_uses_raw_operands_and_preserves_original_placement() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    write(&t.path("source-file"), b"payload");
+
+    let source = format!("fake:{}", t.s("source-file"));
+    let destination = format!("fake:{}", t.s("deduplicated"));
+    let repeated = remote_syq(
+        &t,
+        &rsh,
+        &["-a", "--no-bootstrap", &source, &source, &destination],
+    );
+    assert_output_ok(&repeated);
+    assert!(t.path("deduplicated").is_dir());
+    assert_eq!(read(&t.path("deduplicated/source-file")), b"payload");
+
+    // Bracket removal makes these Locations equal after parsing, but the raw
+    // operands are distinct and must still reach collision detection on the
+    // source-side orchestrator.
+    let bracketed_source = format!("[fake]:{}", t.s("source-file"));
+    let conflicting_destination = format!("fake:{}", t.s("conflict"));
+    let distinct = remote_syq(
+        &t,
+        &rsh,
+        &[
+            "-a",
+            "--no-bootstrap",
+            &source,
+            &bracketed_source,
+            &conflicting_destination,
+        ],
+    );
+    assert!(!distinct.status.success());
+    assert!(
+        stderr_of(&distinct).contains("two sources named"),
+        "{}",
+        stderr_of(&distinct)
+    );
+    assert!(!t.path("conflict").exists());
+}
+
+#[test]
 fn checksum_repair_shrinks_longer_destination() {
     let t = Tmp::new();
     write(&t.path("src"), b"abc");

--- a/tests/rsync-compat/LEDGER.md
+++ b/tests/rsync-compat/LEDGER.md
@@ -55,7 +55,7 @@ The baseline is the last reviewed observation, not a claim that rsync's behavior
 | security | `symlink-race-dest` | fail | Unimplemented | unmodified upstream | platform=linux; run-as=root; root; a second uid; symlinks | SYQ follows an attacker-owned symlink in an operator-named absolute destination path. |
 | security | `symlink-race-relative-dest` | fail | Unimplemented | unmodified upstream | platform=linux; run-as=root; root; a second uid; symlinks | SYQ follows an attacker-owned symlink in an operator-named relative destination path. |
 | security | `symlink-race-source` | pass | Compatible | unmodified upstream | platform=linux; symlinks; C compiler; renameat2 | A raced source parent cannot make SYQ read file contents from outside the source tree. |
-| source-mapping | `duplicates` | fail | Policy open | unmodified upstream | platform=linux; symlinks | SYQ still treats repeated identical sources as destination collisions. |
+| source-mapping | `duplicates` | pass | Compatible | unmodified upstream | platform=linux; symlinks | Exactly repeated source operands are scanned and copied once while retaining multi-source destination placement. |
 | special-files | `nested-socket-specials` | pass | Compatible | unmodified upstream | platform=linux; Unix-domain sockets | Archive mode handles a nested socket without losing ordinary files. |
 | symlinks | `links` | pass | Compatible | subset adaptation (links-preserve-subset) | platform=linux; symlinks | -l preserves both file and directory symlinks several levels deep; unsupported -L and -k cases are omitted. |
 | symlinks | `symlink-ignore` | pass | Compatible | unmodified upstream | platform=linux; symlinks | Without -l/-L/-a, omit symlinks while copying referent files. |

--- a/tests/rsync-compat/manifest.toml
+++ b/tests/rsync-compat/manifest.toml
@@ -63,12 +63,12 @@ note = "Honor setgid inheritance when creating destination directories."
 name = "duplicates"
 classification = "conformance"
 area = "source-mapping"
-position = "policy-open"
-baseline = "fail"
+position = "compatible"
+baseline = "pass"
 platforms = ["linux"]
-tags = ["local", "sources", "known-gap"]
+tags = ["local", "sources"]
 requirements = ["symlinks"]
-note = "SYQ still treats repeated identical sources as destination collisions."
+note = "Exactly repeated source operands are scanned and copied once while retaining multi-source destination placement."
 
 [[tests]]
 name = "files-from-path-clamp"


### PR DESCRIPTION
## Summary

- deduplicate exactly repeated source operands before planning transfers
- preserve original multi-source destination placement semantics
- keep direct remote-to-remote behavior consistent by deduplicating on the remote orchestrator
- mark the upstream rsync duplicate-source case compatible

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (291 passed)
- rsync compatibility harness unit tests (16 passed)
- full non-root rsync compatibility run (33 passed, 1 expected policy-open failure: `files-from-path-clamp`)
