### PR TITLE
Add per-socket TCP congestion control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1074,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2",
  "shell-words",
+ "socket2",
  "ureq",
  "xxhash-rust",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ semver = "1"
 sha2 = "0.11"
 ureq = { version = "3", default-features = false, features = ["rustls"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+socket2 = "0.6"
+
 [profile.release]
 opt-level = 3
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ syq -a --checkpoint ./copy.state src host:dst # keep completed-file state for la
 | `--no-tcp` | Send data over the ssh connection instead of separate TCP sockets |
 | `--tcp-plain` | TCP data connections without encryption (trusted networks only) |
 | `--tcp-ports LO-HI` | Port range the remote listens on for TCP data (default 47600-47699) |
+| `--tcp-congestion ALGO` | Linux: use `ALGO` on both ends of direct TCP data sockets; the host default is unchanged |
 | `-i PATTERN`, `--ignore PATTERN` | Skip paths matching a gitignore-style pattern (repeatable; see below) |
 | `--ignore-from FILE` | Read ignore patterns from a file (repeatable, stacks with `-i`) |
 | `--delete` | Remove destination paths the source doesn't have (see below); `--delete-after`/`--delete-delay` are synonyms |
@@ -663,14 +664,33 @@ AES-256-GCM records keyed by a secret exchanged over the ssh session
 reached — a firewall, typically — syq says so once and falls back to ssh data
 connections, so the default is always safe.
 
+On Linux, `--tcp-congestion ALGO` requests a congestion-control algorithm for
+both ends of every direct TCP data connection. The connecting socket is
+configured before `connect`, and the remote listener is configured before its
+port is advertised, so accepted sockets inherit the same algorithm. This is a
+per-socket override: syq does not change sysctls, load kernel modules, or alter
+queueing disciplines. Without the option, every socket keeps its host's
+default. An explicit override that either kernel rejects is a fatal error with
+the affected host and kernel error; syq never silently substitutes another
+algorithm. If the TCP route itself is unreachable, the normal warned SSH
+fallback still applies and says that the requested algorithm was not used.
+
+The algorithm must be registered on both Linux hosts and available to the syq
+process. Unprivileged processes may choose only entries in
+`net.ipv4.tcp_allowed_congestion_control`; inspect host prerequisites and qdisc
+state as described in [SERVER-TUNING.md](SERVER-TUNING.md). Congestion control
+is sender-side, so setting it only on a download server does not also select it
+for uploads from a client. syq can cover both directions because it owns the
+data socket on each endpoint.
+
 With `--stats`, direct TCP copies also report the kernel counters available on
-both socket ends: retransmitted packets and bytes (a packet-loss signal),
-current/minimum RTT, congestion window and delivery rate, receive-window and
-send-buffer limited time, and ECN CE deliveries. These are diagnostic telemetry
-only and do not change the tuning cache key. Unsupported fields are labeled
-unavailable rather than displayed as zero. SSH does not expose per-data-
-connection TCP counters to syq, so the statistics say they are unavailable
-when the data transport is SSH.
+both socket ends: the effective congestion-control algorithm, retransmitted
+packets and bytes (a packet-loss signal), current/minimum RTT, congestion window
+and delivery rate, receive-window and send-buffer limited time, and ECN CE
+deliveries. These are diagnostic telemetry only and do not change the tuning
+cache key. Unsupported fields are labeled unavailable rather than displayed as
+zero. SSH does not expose per-data-connection TCP counters to syq, so the
+statistics say they are unavailable when the data transport is SSH.
 
 The remote advertises every address it has (the one your ssh session arrived
 on first, then private LAN, then public, then CGNAT/Tailscale); the client

--- a/README.md
+++ b/README.md
@@ -673,7 +673,8 @@ queueing disciplines. Without the option, every socket keeps its host's
 default. An explicit override that either kernel rejects is a fatal error with
 the affected host and kernel error; syq never silently substitutes another
 algorithm. If the TCP route itself is unreachable, the normal warned SSH
-fallback still applies and says that the requested algorithm was not used.
+fallback still applies and says that the requested algorithm is not used by
+the SSH fallback.
 
 The algorithm must be registered on both Linux hosts and available to the syq
 process. Unprivileged processes may choose only entries in

--- a/SERVER-TUNING.md
+++ b/SERVER-TUNING.md
@@ -146,12 +146,13 @@ The kernel's [IP sysctl documentation][ip-sysctl] describes `tcp_rmem`,
 `tcp_wmem`, and the global socket limits. Kernel and distribution defaults
 change, which is another reason to inspect the running host.
 
-## 4. Treat congestion control and queueing as host policy
+## 4. Keep host defaults separate from per-transfer congestion experiments
 
 Inspect what the kernel supports and currently uses:
 
 ```sh
 sysctl net.ipv4.tcp_available_congestion_control
+sysctl net.ipv4.tcp_allowed_congestion_control
 sysctl net.ipv4.tcp_congestion_control
 sysctl net.core.default_qdisc
 tc qdisc show
@@ -159,10 +160,25 @@ tc qdisc show
 
 BBR with fair queueing can help some long-distance or lossy paths, but it is
 not an syq requirement and is not automatically faster on a clean LAN. Changing
-the congestion-control algorithm affects new TCP connections from every
-application. Changing `net.core.default_qdisc` alone may not replace qdiscs
-already attached to live interfaces, and virtual or multiqueue devices can have
-different behavior.
+`net.ipv4.tcp_congestion_control` affects new TCP connections from every
+application. If both endpoints already default to the wanted algorithm, syq's
+new direct TCP sockets inherit it and no application option is needed.
+
+For a scoped comparison on Linux, `syq --tcp-congestion ALGO` selects an
+algorithm only for syq's direct TCP data sockets, on both the connecting and
+listening hosts. It does not change the host default. Both kernels must have
+the algorithm registered, and an unprivileged syq process may choose only an
+entry in `net.ipv4.tcp_allowed_congestion_control`. A rejected explicit request
+stops the transfer rather than silently changing the experiment. Use a fixed
+connection count such as `-j 1` when comparing algorithms, repeat and alternate
+the runs, and inspect the effective algorithms and loss/window telemetry with
+`--stats`.
+
+Congestion control is sender-side: the server setting governs bulk downloads,
+while the uploading client setting governs bulk uploads. The per-socket option
+does not attach or replace a queueing discipline. Changing
+`net.core.default_qdisc` alone may not replace qdiscs already attached to live
+interfaces, and virtual or multiqueue devices can have different behavior.
 
 Only test these settings when network measurements point to congestion, loss,
 or queueing rather than CPU or storage. Confirm kernel support, follow the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -475,20 +475,13 @@ fn reject_unsupported_rsync_flags(argv: &[String]) -> Result<()> {
 fn parse_tcp_congestion(value: &str) -> std::result::Result<String, String> {
     // Linux's TCP_CA_NAME_MAX is 16 including the terminating NUL. Keep this
     // validation platform-independent so a forwarded command fails the same
-    // way on every orchestrator.
+    // way on every orchestrator. The kernel otherwise looks up the registered
+    // name exactly, without imposing a character whitelist.
     if value.is_empty() {
         return Err("congestion-control algorithm cannot be empty".into());
     }
     if value.len() >= 16 {
         return Err("congestion-control algorithm must be at most 15 bytes".into());
-    }
-    if !value
-        .bytes()
-        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
-    {
-        return Err(
-            "congestion-control algorithm may contain only ASCII letters, digits, and `_`".into(),
-        );
     }
     Ok(value.to_string())
 }
@@ -619,7 +612,13 @@ mod tests {
             args(&["--tcp-congestion", "bbr"]).tcp_congestion.as_deref(),
             Some("bbr")
         );
-        for value in ["", "not-an-algo", "1234567890123456"] {
+        assert_eq!(
+            args(&["--tcp-congestion", "foo-bar"])
+                .tcp_congestion
+                .as_deref(),
+            Some("foo-bar")
+        );
+        for value in ["", "1234567890123456"] {
             let parsed = Args::try_parse_from(["syq", "--tcp-congestion", value, "src", "dst"]);
             assert!(parsed.is_err(), "accepted {value:?}");
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -155,6 +155,14 @@ pub struct Args {
     /// Port range the remote listens on for TCP data connections
     #[arg(long, default_value = "47600-47699", value_name = "LO-HI")]
     pub tcp_ports: String,
+    /// Use this congestion-control algorithm for direct TCP data sockets (Linux only)
+    #[arg(
+        long,
+        value_name = "ALGO",
+        value_parser = parse_tcp_congestion,
+        conflicts_with_all = ["no_tcp", "rm", "follow"]
+    )]
+    pub tcp_congestion: Option<String>,
     /// Remote-to-remote: start the transfer detached on the source host (survives losing this
     /// ssh session) and return; progress goes to a log you can watch with --follow
     #[arg(long)]
@@ -438,6 +446,7 @@ fn reject_unsupported_rsync_flags(argv: &[String]) -> Result<()> {
         "--max-delete",
         "--checkpoint",
         "--tcp-ports",
+        "--tcp-congestion",
         "--syq-path",
         "--width",
     ];
@@ -461,6 +470,27 @@ fn reject_unsupported_rsync_flags(argv: &[String]) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn parse_tcp_congestion(value: &str) -> std::result::Result<String, String> {
+    // Linux's TCP_CA_NAME_MAX is 16 including the terminating NUL. Keep this
+    // validation platform-independent so a forwarded command fails the same
+    // way on every orchestrator.
+    if value.is_empty() {
+        return Err("congestion-control algorithm cannot be empty".into());
+    }
+    if value.len() >= 16 {
+        return Err("congestion-control algorithm must be at most 15 bytes".into());
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        return Err(
+            "congestion-control algorithm may contain only ASCII letters, digits, and `_`".into(),
+        );
+    }
+    Ok(value.to_string())
 }
 
 fn unsupported_message(tok: &str) -> Option<String> {
@@ -581,6 +611,22 @@ mod tests {
         // As with other clap overrides, the last spelling wins.
         assert!(!args(&["-z", "--no-compress"]).compress);
         assert!(args(&["--no-compress", "-z"]).compress);
+    }
+
+    #[test]
+    fn tcp_congestion_names_are_validated() {
+        assert_eq!(
+            args(&["--tcp-congestion", "bbr"]).tcp_congestion.as_deref(),
+            Some("bbr")
+        );
+        for value in ["", "not-an-algo", "1234567890123456"] {
+            let parsed = Args::try_parse_from(["syq", "--tcp-congestion", value, "src", "dst"]);
+            assert!(parsed.is_err(), "accepted {value:?}");
+        }
+        assert!(Args::try_parse_from(
+            ["syq", "--tcp-congestion", "bbr", "--no-tcp", "src", "dst",]
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -80,6 +80,12 @@ pub(crate) fn is_tcp_congestion_error(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| cause.is::<TcpCongestionError>())
 }
 
+pub(crate) fn tcp_congestion_fallback_note(requested: Option<&str>) -> String {
+    requested
+        .map(|algorithm| format!("; requested congestion control {algorithm} was not used"))
+        .unwrap_or_default()
+}
+
 #[cfg(target_os = "linux")]
 fn tcp_congestion_control<S: AsRawFd>(socket: &S) -> std::io::Result<String> {
     // Linux currently caps names at TCP_CA_NAME_MAX (16 including NUL). Leave
@@ -1019,7 +1025,12 @@ impl RemoteSpec {
                         break;
                     }
                     Err(error) if is_tcp_congestion_error(&error) => {
-                        return Err(error).with_context(|| self.label())
+                        return Err(error).with_context(|| {
+                            format!(
+                                "local/orchestrating host could not configure the connecting data socket to {}",
+                                self.label()
+                            )
+                        })
                     }
                     Err(e) => last = anyhow!("{addr}:{}: {e}", info.port),
                 }
@@ -1637,7 +1648,10 @@ impl Endpoint {
                                     i.failed = true;
                                     i.failure = Some(format!("{e:#}"));
                                     if !spec.quiet || crate::transfer::debug() {
-                                        eprintln!("syq: {}: data over ssh (TCP port {} stopped answering: {e:#})", spec.label(), info.port);
+                                        let congestion_note = tcp_congestion_fallback_note(
+                                            info.congestion_control.as_deref(),
+                                        );
+                                        eprintln!("syq: {}: data over ssh (TCP port {} stopped answering: {e:#}{congestion_note})", spec.label(), info.port);
                                     }
                                 }
                             }
@@ -1733,6 +1747,51 @@ mod tests {
         let error = configure_tcp_congestion(&listener, Some("syq_missing_cc")).unwrap_err();
         assert!(is_tcp_congestion_error(&error));
         assert!(error.to_string().contains("kernel rejected"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn connecting_socket_congestion_rejection_is_attributed_locally() {
+        let spec = RemoteSpec {
+            user: None,
+            host: "remote.example".into(),
+            rsh: vec!["ssh".into()],
+            syq_path: None,
+            auto_helper: false,
+            helper_install: Default::default(),
+            quiet: false,
+            tcp: Default::default(),
+            diagnostics: Default::default(),
+        };
+        let info = TcpInfo {
+            addrs: vec!["127.0.0.1".into()],
+            port: 9,
+            key: None,
+            token: Vec::new(),
+            congestion_control: Some("syq_missing_cc".into()),
+            failed: false,
+            failure: None,
+            next: Default::default(),
+        };
+
+        let error = spec
+            .connect_tcp(&info, false)
+            .err()
+            .expect("unregistered congestion control should fail locally");
+        let message = format!("{error:#}");
+        assert!(is_tcp_congestion_error(&error));
+        assert!(message.contains(
+            "local/orchestrating host could not configure the connecting data socket to remote.example"
+        ));
+    }
+
+    #[test]
+    fn tcp_fallback_note_reports_an_unused_override() {
+        assert_eq!(tcp_congestion_fallback_note(None), "");
+        assert_eq!(
+            tcp_congestion_fallback_note(Some("reno")),
+            "; requested congestion control reno was not used"
+        );
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -9,7 +9,7 @@ use crate::remote_helper::{self, Target};
 use anyhow::{anyhow, bail, Context, Result};
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::os::fd::AsRawFd;
 use std::process::{Child, Command, Stdio};
 
@@ -62,6 +62,139 @@ pub struct TcpPairStats {
     pub peer: Option<TcpSocketStats>,
 }
 
+/// Marker for an explicit per-socket congestion-control request that could
+/// not be honored. Callers use this to distinguish a bad experiment setup
+/// from ordinary TCP reachability failures, which may fall back to SSH.
+#[derive(Debug)]
+pub(crate) struct TcpCongestionError(String);
+
+impl std::fmt::Display for TcpCongestionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for TcpCongestionError {}
+
+pub(crate) fn is_tcp_congestion_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| cause.is::<TcpCongestionError>())
+}
+
+#[cfg(target_os = "linux")]
+fn tcp_congestion_control<S: AsRawFd>(socket: &S) -> std::io::Result<String> {
+    // Linux currently caps names at TCP_CA_NAME_MAX (16 including NUL). Leave
+    // extra room so this remains safe if the kernel raises that limit.
+    let mut name = [0u8; 64];
+    let mut len = name.len() as libc::socklen_t;
+    let result = unsafe {
+        libc::getsockopt(
+            socket.as_raw_fd(),
+            libc::IPPROTO_TCP,
+            libc::TCP_CONGESTION,
+            name.as_mut_ptr().cast(),
+            &mut len,
+        )
+    };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let len = (len as usize).min(name.len());
+    let end = name[..len]
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(len);
+    std::str::from_utf8(&name[..end])
+        .map(str::to_owned)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+/// Apply an explicit Linux TCP_CONGESTION override and read it back. With no
+/// override this is observational only: an unavailable getter returns None
+/// and never changes normal socket behavior.
+pub(crate) fn configure_tcp_congestion<S: AsRawFd>(
+    socket: &S,
+    requested: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(requested) = requested else {
+        #[cfg(target_os = "linux")]
+        return Ok(tcp_congestion_control(socket).ok());
+        #[cfg(not(target_os = "linux"))]
+        return Ok(None);
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    return Err(TcpCongestionError(format!(
+        "TCP congestion control {requested:?} was requested, but per-socket selection is supported only on Linux"
+    ))
+    .into());
+
+    #[cfg(target_os = "linux")]
+    {
+        let result = unsafe {
+            libc::setsockopt(
+                socket.as_raw_fd(),
+                libc::IPPROTO_TCP,
+                libc::TCP_CONGESTION,
+                requested.as_ptr().cast(),
+                requested.len() as libc::socklen_t,
+            )
+        };
+        if result != 0 {
+            let error = std::io::Error::last_os_error();
+            return Err(TcpCongestionError(format!(
+                "kernel rejected TCP congestion control {requested:?}: {error}; check net.ipv4.tcp_available_congestion_control and net.ipv4.tcp_allowed_congestion_control on this host"
+            ))
+            .into());
+        }
+        let actual = tcp_congestion_control(socket).map_err(|error| {
+            TcpCongestionError(format!(
+                "could not verify TCP congestion control {requested:?}: {error}"
+            ))
+        })?;
+        if actual != requested {
+            return Err(TcpCongestionError(format!(
+                "requested TCP congestion control {requested:?}, but the socket reports {actual:?}"
+            ))
+            .into());
+        }
+        Ok(Some(actual))
+    }
+}
+
+fn connect_tcp_stream(
+    address: &SocketAddr,
+    timeout: std::time::Duration,
+    congestion_control: Option<&str>,
+) -> Result<TcpStream> {
+    let Some(congestion_control) = congestion_control else {
+        return TcpStream::connect_timeout(address, timeout).map_err(Into::into);
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (address, timeout);
+        return Err(TcpCongestionError(format!(
+            "TCP congestion control {congestion_control:?} was requested, but per-socket selection is supported only on Linux"
+        ))
+        .into());
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+
+        let domain = if address.is_ipv4() {
+            Domain::IPV4
+        } else {
+            Domain::IPV6
+        };
+        let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+        configure_tcp_congestion(&socket, Some(congestion_control))?;
+        socket.connect_timeout(&SockAddr::from(*address), timeout)?;
+        Ok(socket.into())
+    }
+}
+
 #[cfg(target_os = "linux")]
 pub(crate) fn tcp_socket_stats(stream: &TcpStream) -> Option<TcpSocketStats> {
     let mut info: libc::tcp_info = unsafe { std::mem::zeroed() };
@@ -86,6 +219,7 @@ pub(crate) fn tcp_socket_stats(stream: &TcpStream) -> Option<TcpSocketStats> {
         };
     }
     Some(TcpSocketStats {
+        congestion_control: tcp_congestion_control(stream).ok(),
         bytes_sent: field!(tcpi_bytes_sent, info.tcpi_bytes_sent),
         bytes_retransmitted: field!(tcpi_bytes_retrans, info.tcpi_bytes_retrans),
         segments_sent: field!(tcpi_segs_out, info.tcpi_segs_out.into()),
@@ -131,6 +265,7 @@ pub(crate) fn tcp_socket_stats(stream: &TcpStream) -> Option<TcpSocketStats> {
         };
     }
     Some(TcpSocketStats {
+        congestion_control: None,
         bytes_sent: field!(tcpi_txbytes, info.tcpi_txbytes),
         bytes_retransmitted: field!(tcpi_txretransmitbytes, info.tcpi_txretransmitbytes),
         segments_sent: field!(tcpi_txpackets, info.tcpi_txpackets),
@@ -473,6 +608,8 @@ pub struct TcpCandidate {
 pub struct TcpProbe {
     pub port: u16,
     pub encrypted: bool,
+    /// Effective algorithm read back from the remote listener, when exposed.
+    pub congestion_control: Option<String>,
     pub candidates: Vec<TcpCandidate>,
 }
 
@@ -690,21 +827,33 @@ impl RemoteSpec {
 
     /// Ask the remote (over the control connection) to accept TCP data
     /// connections; records how to reach it for later `connect` calls.
-    pub fn setup_tcp(&self, ctl: &mut dyn Conn, plain: bool, ports: (u16, u16)) -> Result<()> {
+    pub fn setup_tcp(
+        &self,
+        ctl: &mut dyn Conn,
+        plain: bool,
+        ports: (u16, u16),
+        congestion_control: Option<&str>,
+    ) -> Result<()> {
         *self.tcp.lock().unwrap() = None;
         {
             let mut diagnostics = self.diagnostics.lock().unwrap();
             diagnostics.tcp_probe = None;
             diagnostics.tcp_setup_error = None;
         }
-        let result = self.setup_tcp_inner(ctl, plain, ports);
+        let result = self.setup_tcp_inner(ctl, plain, ports, congestion_control);
         if let Err(error) = &result {
             self.diagnostics.lock().unwrap().tcp_setup_error = Some(format!("{error:#}"));
         }
         result
     }
 
-    fn setup_tcp_inner(&self, ctl: &mut dyn Conn, plain: bool, ports: (u16, u16)) -> Result<()> {
+    fn setup_tcp_inner(
+        &self,
+        ctl: &mut dyn Conn,
+        plain: bool,
+        ports: (u16, u16),
+        congestion_control: Option<&str>,
+    ) -> Result<()> {
         let key = if plain {
             None
         } else {
@@ -716,10 +865,18 @@ impl RemoteSpec {
             token: token.clone(),
             port_lo: ports.0,
             port_hi: ports.1,
+            congestion_control: congestion_control.map(str::to_owned),
         })?;
-        let (port, advertised) = match ok(resp, "tcp listen")? {
-            Response::TcpListening { port, addrs } => (port, addrs),
-            other => bail!("unexpected response {other:?}"),
+        let (port, advertised, remote_congestion_control) = match resp {
+            Response::TcpCongestionRejected(error) => return Err(TcpCongestionError(error).into()),
+            response => match ok(response, "tcp listen")? {
+                Response::TcpListening {
+                    port,
+                    addrs,
+                    congestion_control,
+                } => (port, addrs, congestion_control),
+                other => bail!("unexpected response {other:?}"),
+            },
         };
         let mut candidates: Vec<TcpCandidate> = advertised
             .into_iter()
@@ -781,6 +938,7 @@ impl RemoteSpec {
         self.diagnostics.lock().unwrap().tcp_probe = Some(TcpProbe {
             port,
             encrypted: key.is_some(),
+            congestion_control: remote_congestion_control,
             candidates: candidates.clone(),
         });
         let addrs: Vec<String> = candidates
@@ -804,6 +962,7 @@ impl RemoteSpec {
             port,
             key,
             token,
+            congestion_control: congestion_control.map(str::to_owned),
             failed: false,
             failure: None,
             next: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -850,10 +1009,17 @@ impl RemoteSpec {
             // unreachable family first).
             let mut got = None;
             for sa in &resolved {
-                match TcpStream::connect_timeout(sa, std::time::Duration::from_secs(4)) {
+                match connect_tcp_stream(
+                    sa,
+                    std::time::Duration::from_secs(4),
+                    info.congestion_control.as_deref(),
+                ) {
                     Ok(s) => {
                         got = Some(s);
                         break;
+                    }
+                    Err(error) if is_tcp_congestion_error(&error) => {
+                        return Err(error).with_context(|| self.label())
                     }
                     Err(e) => last = anyhow!("{addr}:{}: {e}", info.port),
                 }
@@ -986,6 +1152,9 @@ pub struct TcpInfo {
     pub port: u16,
     pub key: Option<Vec<u8>>,
     pub token: Vec<u8>,
+    /// Explicit algorithm requested for each outgoing data socket. None keeps
+    /// the host default.
+    pub congestion_control: Option<String>,
     /// Set once a connect attempt failed; later connections use ssh.
     pub failed: bool,
     pub failure: Option<String>,
@@ -1460,6 +1629,7 @@ impl Endpoint {
                 if let Some(info) = info.filter(|i| !i.failed) {
                     match spec.connect_tcp(&info, compress) {
                         Ok(c) => return Ok(Box::new(c)),
+                        Err(e) if is_tcp_congestion_error(&e) => return Err(e),
                         Err(e) => {
                             let mut g = spec.tcp.lock().unwrap();
                             if let Some(i) = g.as_mut() {
@@ -1530,6 +1700,39 @@ mod tests {
             server_stats.segments_sent.is_some_and(|value| value > 0)
                 || server_stats.bytes_sent.is_some_and(|value| value > 0)
         );
+        #[cfg(target_os = "linux")]
+        {
+            assert!(client_stats.congestion_control.is_some());
+            assert!(server_stats.congestion_control.is_some());
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn explicit_tcp_congestion_is_set_before_connect_and_inherited_on_accept() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        assert_eq!(
+            configure_tcp_congestion(&listener, Some("reno")).unwrap(),
+            Some("reno".into())
+        );
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            tcp_congestion_control(&socket).unwrap()
+        });
+        let client =
+            connect_tcp_stream(&address, std::time::Duration::from_secs(1), Some("reno")).unwrap();
+        assert_eq!(tcp_congestion_control(&client).unwrap(), "reno");
+        assert_eq!(server.join().unwrap(), "reno");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn rejected_tcp_congestion_is_classified_separately() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let error = configure_tcp_congestion(&listener, Some("syq_missing_cc")).unwrap_err();
+        assert!(is_tcp_congestion_error(&error));
+        assert!(error.to_string().contains("kernel rejected"));
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -82,7 +82,9 @@ pub(crate) fn is_tcp_congestion_error(error: &anyhow::Error) -> bool {
 
 pub(crate) fn tcp_congestion_fallback_note(requested: Option<&str>) -> String {
     requested
-        .map(|algorithm| format!("; requested congestion control {algorithm} was not used"))
+        .map(|algorithm| {
+            format!("; requested congestion control {algorithm} is not used by the SSH fallback")
+        })
         .unwrap_or_default()
 }
 
@@ -1786,11 +1788,11 @@ mod tests {
     }
 
     #[test]
-    fn tcp_fallback_note_reports_an_unused_override() {
+    fn tcp_fallback_note_scopes_the_unused_override_to_ssh() {
         assert_eq!(tcp_congestion_fallback_note(None), "");
         assert_eq!(
             tcp_congestion_fallback_note(Some("reno")),
-            "; requested congestion control reno was not used"
+            "; requested congestion control reno is not used by the SSH fallback"
         );
     }
 

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -135,6 +135,9 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     if args.tcp_plain {
         remote.push("--tcp-plain".into());
     }
+    if let Some(algorithm) = &args.tcp_congestion {
+        remote.push(format!("--tcp-congestion={algorithm}"));
+    }
     remote.push(format!("--tcp-ports={}", args.tcp_ports));
     if args.progress_json && !args.quiet {
         remote.push("--progress-json".into());

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -109,8 +109,9 @@ pub mod flags {
 /// Best-effort kernel counters for one end of a TCP data socket. `None` means
 /// the platform or returned kernel structure does not expose that field; a
 /// reported zero is therefore a genuine measurement.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct TcpSocketStats {
+    pub congestion_control: Option<String>,
     pub bytes_sent: Option<u64>,
     pub bytes_retransmitted: Option<u64>,
     pub segments_sent: Option<u64>,
@@ -193,6 +194,7 @@ pub enum Request {
         token: Vec<u8>,
         port_lo: u16,
         port_hi: u16,
+        congestion_control: Option<String>,
     },
     /// `ignore`: gitignore-style patterns relative to `root` (see scan.rs).
     /// `report_ignored`: also send the paths the patterns pruned (ScanIgnored).
@@ -332,7 +334,12 @@ pub enum Response {
     TcpListening {
         port: u16,
         addrs: Vec<(String, u32)>,
+        congestion_control: Option<String>,
     },
+    /// The peer understood the requested per-socket override but its kernel
+    /// could not honor it. Keep this distinct from ordinary TCP reachability
+    /// failures, for which the orchestrator may safely fall back to SSH.
+    TcpCongestionRejected(String),
     ScanBatch(Vec<Entry>),
     ScanWarn(String),
     /// Paths (relative to the root) pruned by the ignore patterns.

--- a/src/server.rs
+++ b/src/server.rs
@@ -163,6 +163,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 token,
                 port_lo,
                 port_hi,
+                congestion_control,
             } => {
                 if !over_ssh {
                     w.write_msg(&Response::Err(
@@ -170,11 +171,23 @@ fn serve<R: Read + Send + 'static, W: Write>(
                     ))?;
                     continue;
                 }
-                match tcp_listen(key, token, port_lo, port_hi, debug, w.compress) {
-                    Ok(port) => w.write_msg(&Response::TcpListening {
+                match tcp_listen(
+                    key,
+                    token,
+                    port_lo,
+                    port_hi,
+                    debug,
+                    w.compress,
+                    congestion_control.as_deref(),
+                ) {
+                    Ok((port, congestion_control)) => w.write_msg(&Response::TcpListening {
                         port,
                         addrs: local_addrs(),
+                        congestion_control,
                     })?,
+                    Err(e) if crate::conn::is_tcp_congestion_error(&e) => {
+                        w.write_msg(&Response::TcpCongestionRejected(format!("{e:#}")))?
+                    }
                     Err(e) => w.write_msg(&Response::Err(format!("{e:#}")))?,
                 }
             }
@@ -312,7 +325,8 @@ fn tcp_listen(
     hi: u16,
     debug: bool,
     compress: bool,
-) -> Result<u16> {
+    congestion_control: Option<&str>,
+) -> Result<(u16, Option<String>)> {
     let mut listener = None;
     for port in lo..=hi.max(lo) {
         if let Ok(l) = TcpListener::bind(("0.0.0.0", port)) {
@@ -323,6 +337,10 @@ fn tcp_listen(
     let Some(listener) = listener else {
         bail!("no free port in {lo}-{hi}");
     };
+    // Passive connections inherit the listener's congestion controller. Set
+    // and verify it before advertising the port so even handshake-time
+    // behavior uses the requested algorithm.
+    let congestion_control = crate::conn::configure_tcp_congestion(&listener, congestion_control)?;
     let port = listener.local_addr()?.port();
     let next_id = Arc::new(AtomicU32::new(1));
     // Bound in-flight data connections (a peer shouldn't be able to spawn
@@ -354,7 +372,7 @@ fn tcp_listen(
             });
         }
     });
-    Ok(port)
+    Ok((port, congestion_control))
 }
 
 fn serve_tcp(

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -209,6 +209,13 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
                 candidate_status(candidate, fastest)
             );
         }
+        let remote = probe.congestion_control.as_deref().unwrap_or("unavailable");
+        match &args.tcp_congestion {
+            Some(requested) => eprintln!(
+                "  congestion control: remote listener {remote}; local data sockets request {requested}"
+            ),
+            None => eprintln!("  congestion control: remote listener {remote} (host default)"),
+        }
     }
 
     let route_state = if args.dry_run {
@@ -286,9 +293,13 @@ fn print_transport_diagnostics(args: &Args, src: &Endpoint, dst: &Endpoint) {
 }
 
 fn format_tcp_stats(pairs: &[TcpPairStats], has_ssh_data: bool) -> String {
-    let sockets: Vec<TcpSocketStats> = pairs
+    let sockets: Vec<&TcpSocketStats> = pairs
         .iter()
-        .flat_map(|pair| [pair.local, pair.peer].into_iter().flatten())
+        .flat_map(|pair| {
+            [pair.local.as_ref(), pair.peer.as_ref()]
+                .into_iter()
+                .flatten()
+        })
         .collect();
     if sockets.is_empty() {
         return if has_ssh_data {
@@ -299,10 +310,17 @@ fn format_tcp_stats(pairs: &[TcpPairStats], has_ssh_data: bool) -> String {
     }
     // Aggregates are meaningful only when every sampled socket exposes the
     // field. Do not turn an unsupported end into a genuine zero.
-    let sum =
-        |field: fn(&TcpSocketStats) -> Option<u64>| sockets.iter().map(field).sum::<Option<u64>>();
+    let sum = |field: fn(&TcpSocketStats) -> Option<u64>| {
+        sockets
+            .iter()
+            .map(|stats| field(stats))
+            .sum::<Option<u64>>()
+    };
     let values = |field: fn(&TcpSocketStats) -> Option<u64>| {
-        sockets.iter().map(field).collect::<Option<Vec<u64>>>()
+        sockets
+            .iter()
+            .map(|stats| field(stats))
+            .collect::<Option<Vec<u64>>>()
     };
     let bytes_sent = sum(|stats| stats.bytes_sent);
     let bytes_retransmitted = sum(|stats| stats.bytes_retransmitted);
@@ -339,11 +357,30 @@ fn format_tcp_stats(pairs: &[TcpPairStats], has_ssh_data: bool) -> String {
         .map(|pair| pair.label.as_str())
         .collect::<std::collections::BTreeSet<_>>()
         .len();
+    let mut congestion_controls = std::collections::BTreeMap::<&str, usize>::new();
+    let mut unavailable_congestion_controls = 0usize;
+    for socket in &sockets {
+        match socket.congestion_control.as_deref() {
+            Some(algorithm) => *congestion_controls.entry(algorithm).or_default() += 1,
+            None => unavailable_congestion_controls += 1,
+        }
+    }
+    let mut congestion_control = congestion_controls
+        .into_iter()
+        .map(|(algorithm, count)| format!("{algorithm} ({count} socket ends)"))
+        .collect::<Vec<_>>();
+    if unavailable_congestion_controls > 0 {
+        congestion_control.push(format!(
+            "unavailable ({unavailable_congestion_controls} socket ends)"
+        ));
+    }
+    let congestion_control = congestion_control.join(", ");
     let mut output = format!(
-        "\n  tcp connection lifetimes sampled: {} across {} path(s) ({} socket ends)\n  tcp retransmissions (loss signal): {} packets, {} bytes\n  tcp RTT: current average {}, minimum {}\n  tcp congestion: average send window {}, aggregate delivery rate {}\n  tcp window-limited time: receive {}, send-buffer {}\n  tcp ECN CE deliveries: {}",
+        "\n  tcp connection lifetimes sampled: {} across {} path(s) ({} socket ends)\n  tcp congestion control: {}\n  tcp retransmissions (loss signal): {} packets, {} bytes\n  tcp RTT: current average {}, minimum {}\n  tcp congestion: average send window {}, aggregate delivery rate {}\n  tcp window-limited time: receive {}, send-buffer {}\n  tcp ECN CE deliveries: {}",
         pairs.len(),
         paths,
         sockets.len(),
+        congestion_control,
         loss(retransmissions, segments_sent),
         loss(bytes_retransmitted, bytes_sent),
         average_rtt.map_or_else(|| "unavailable".into(), |value| format!("{:.2} ms", value as f64 / 1000.0)),
@@ -616,6 +653,9 @@ pub fn run(args: Args) -> Result<i32> {
     }
     let src_ep = endpoint(&srcs[0], &args)?;
     let dst_ep = endpoint(dst, &args)?;
+    if args.tcp_congestion.is_some() && !src_ep.is_remote() && !dst_ep.is_remote() {
+        bail!("--tcp-congestion applies only to copies with a remote endpoint");
+    }
     // TCP data connections are the default (auto-selecting the fastest reachable
     // NIC and falling back to ssh if unreachable); --no-tcp forces ssh data.
     // Local<->local needs no data plane at all.
@@ -637,6 +677,12 @@ pub fn run(args: Args) -> Result<i32> {
         if !args.quiet {
             eprintln!("syq: remote-to-remote transfer: relaying data through this machine");
         }
+    }
+    #[cfg(not(target_os = "linux"))]
+    if let Some(algorithm) = &args.tcp_congestion {
+        bail!(
+            "--tcp-congestion {algorithm} requires a Linux transfer orchestrator and Linux remote endpoints"
+        );
     }
 
     let opts = Arc::new(Opts {
@@ -740,6 +786,10 @@ pub fn run(args: Args) -> Result<i32> {
                         .and_then(|src| Ok((src, dst_ep.connect(compress)?)));
                     let (src, dst) = match conns {
                         Ok(conns) => conns,
+                        Err(error) if crate::conn::is_tcp_congestion_error(&error) => {
+                            gate.mark_failed(id);
+                            return Err(error);
+                        }
                         Err(error) => {
                             failures += 1;
                             if failures >= CONNECTION_RECOVERY_ATTEMPTS {
@@ -863,10 +913,31 @@ pub fn run(args: Args) -> Result<i32> {
         let ports = parse_ports(&args.tcp_ports)?;
         for (ep, ctl) in [(&src_ep, &mut src_ctl), (&dst_ep, &mut dst_ctl)] {
             if let Endpoint::Remote(spec) = ep {
-                if let Err(e) = spec.setup_tcp(&mut **ctl, args.tcp_plain, ports) {
+                if let Err(e) = spec.setup_tcp(
+                    &mut **ctl,
+                    args.tcp_plain,
+                    ports,
+                    args.tcp_congestion.as_deref(),
+                ) {
+                    if crate::conn::is_tcp_congestion_error(&e) {
+                        return Err(e).with_context(|| {
+                            format!(
+                                "{} could not apply --tcp-congestion {}",
+                                spec.label(),
+                                args.tcp_congestion.as_deref().unwrap_or_default()
+                            )
+                        });
+                    }
                     if !args.quiet || debug() {
+                        let congestion_note = args
+                            .tcp_congestion
+                            .as_deref()
+                            .map(|algorithm| {
+                                format!("; requested congestion control {algorithm} was not used")
+                            })
+                            .unwrap_or_default();
                         eprintln!(
-                            "syq: {}: data over ssh (TCP ports {}-{} not reachable: {e:#}); a Tailscale address or an open port is faster",
+                            "syq: {}: data over ssh (TCP ports {}-{} not reachable: {e:#}{congestion_note}); a Tailscale address or an open port is faster",
                             spec.label(),
                             ports.0,
                             ports.1

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -929,13 +929,9 @@ pub fn run(args: Args) -> Result<i32> {
                         });
                     }
                     if !args.quiet || debug() {
-                        let congestion_note = args
-                            .tcp_congestion
-                            .as_deref()
-                            .map(|algorithm| {
-                                format!("; requested congestion control {algorithm} was not used")
-                            })
-                            .unwrap_or_default();
+                        let congestion_note = crate::conn::tcp_congestion_fallback_note(
+                            args.tcp_congestion.as_deref(),
+                        );
                         eprintln!(
                             "syq: {}: data over ssh (TCP ports {}-{} not reachable: {e:#}{congestion_note}); a Tailscale address or an open port is faster",
                             spec.label(),

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1051,6 +1051,7 @@ mod tests {
                 port: 1,
                 key: Some(vec![0; 32]),
                 token: vec![],
+                congestion_control: None,
                 failed: false,
                 failure: None,
                 next: Default::default(),

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1145,7 +1145,7 @@ fn ordinary_tcp_setup_failure_still_falls_back_with_congestion_notice() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("data over ssh"), "{stderr}");
     assert!(
-        stderr.contains("requested congestion control reno was not used"),
+        stderr.contains("requested congestion control reno is not used by the SSH fallback"),
         "{stderr}"
     );
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1023,6 +1023,178 @@ fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
     );
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn tcp_congestion_override_is_applied_on_both_socket_ends_and_reported() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"per-socket congestion control");
+    let remote = format!("127.0.0.1:{}", t.s("dst"));
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "--tcp-plain",
+            "--tcp-congestion=reno",
+            "--stats",
+            "-avv",
+            "-j",
+            "1",
+        ])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .output()
+        .expect("run syq with a per-socket TCP congestion override");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"per-socket congestion control");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("tcp congestion control: reno (2 socket ends)"),
+        "{stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr
+            .contains("congestion control: remote listener reno; local data sockets request reno"),
+        "{stderr}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn rejected_tcp_congestion_override_is_fatal_instead_of_falling_back() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"must not silently fall back");
+    let remote = format!("127.0.0.1:{}", t.s("dst"));
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args(["--tcp-congestion=syq_missing_cc", "-a", "-j", "1"])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .output()
+        .expect("run syq with an unavailable TCP congestion override");
+
+    assert!(!out.status.success());
+    assert!(!t.path("dst").exists());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("could not apply --tcp-congestion syq_missing_cc"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("kernel rejected"), "{stderr}");
+    assert!(
+        stderr.contains("tcp_allowed_congestion_control"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("data over ssh"), "{stderr}");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn ordinary_tcp_setup_failure_still_falls_back_with_congestion_notice() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"fallback remains available");
+    let remote = format!("127.0.0.1:{}", t.s("dst"));
+    let held_port = std::net::TcpListener::bind(("0.0.0.0", 0)).unwrap();
+    let port = held_port.local_addr().unwrap().port();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "--tcp-congestion=reno",
+            &format!("--tcp-ports={port}-{port}"),
+            "-a",
+            "-j",
+            "1",
+        ])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .output()
+        .expect("run syq when the requested direct TCP port is occupied");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"fallback remains available");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("data over ssh"), "{stderr}");
+    assert!(
+        stderr.contains("requested congestion control reno was not used"),
+        "{stderr}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn direct_remote_to_remote_forwards_tcp_congestion_override() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"direct forwarding");
+    let src = format!("hostA:{}", t.s("src"));
+    let dst = format!("hostB:{}", t.s("dst"));
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args(["--tcp-congestion=reno", "--dry-run", "-avv", "-j", "1"])
+        .arg(&src)
+        .arg(&dst)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .output()
+        .expect("run direct remote-to-remote dry-run with TCP congestion override");
+
+    assert_output_ok(&out);
+    assert!(!t.path("dst").exists());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("remote-to-remote: running on hostA"),
+        "{stderr}"
+    );
+    assert!(
+        stderr
+            .contains("congestion control: remote listener reno; local data sockets request reno"),
+        "{stderr}"
+    );
+    assert!(
+        fs::read_to_string(t.path("rsh.log"))
+            .unwrap()
+            .contains("--tcp-congestion=reno"),
+        "the source-side orchestrator did not receive the override"
+    );
+}
+
 #[test]
 fn remembered_path_count_seeds_auto_tuning_but_fixed_count_does_not_rewrite_it() {
     let t = Tmp::new();


### PR DESCRIPTION
Summary:
- add a Linux-only --tcp-congestion ALGO option for direct TCP data sockets
- apply and verify the override before outbound connect and on remote listeners, while keeping ordinary SSH fallback distinct from rejected overrides
- report effective algorithms in verbose diagnostics and --stats, and document host prerequisites and benchmarking guidance

Verification:
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets (91 unit, 203 local integration, 9 update tests)