### PR TITLE
Harden attached native rm behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,12 @@ removed by another selector is successful. Symlinks encountered while walking
 inside a selected directory are removed as entries and are never followed.
 
 By default, native `rm` follows no symlinks while resolving `--cwd` or a
-selector, including the selector's final component. Encountering one aborts
-the entire command before mutation. `--follow` explicitly enables full
-resolution of those symlinks. The terminal non-symlink file or directory is
-then removed while the symlinks used to reach it remain in place, usually
-dangling. Native `rm` therefore has no direct-root-symlink deletion mode; use
-ordinary `rm` over SSH when the link itself is the intended object.
+selector. A symlink selected by name is removed as a symlink without touching
+its referent. A symlink in `--cwd`, or in a selector before the selected name,
+would have to be traversed; encountering one therefore aborts the entire
+command before mutation. `--follow` explicitly enables that traversal. The
+resolved non-symlink file or directory is then removed while the symlinks used
+to reach it remain in place, usually dangling.
 
 `--root DIR` is mutually exclusive with `--cwd`. The root path itself must
 contain no symlink, even with `--follow`. Selector resolution is confined to
@@ -219,6 +219,12 @@ directory and remove that object, recursively for a directory.
 resolved directory itself. All type checks and selector resolution finish
 before deletion begins. `-vv` prints the base identity, symlink hops, and final
 device/inode resolution used for the operation's audit trail.
+
+Remote native `rm` is attached to its control connection. While work remains,
+the endpoint sends a result or liveness frame at least once per second. A
+detected write failure cancels queued work and stops directory scans from
+scheduling more removals; operations already completed or inside a filesystem
+call are not rolled back. Native `rm` has no detached mode.
 
 The first native fidelity default is exactly `-rlt`: it recurses through
 directories, copies symlinks as symlinks, and retains mtimes. Owner, group,
@@ -294,10 +300,10 @@ explicitly say otherwise.
 | `--tcp-plain` | TCP data connections without encryption (trusted networks only) |
 | `--tcp-ports LO-HI` | Port range the remote listens on for TCP data (default 47600-47699) |
 | `--tcp-congestion ALGO` | Linux: use `ALGO` on both ends of direct TCP data sockets; the host default is unchanged |
-| `-i PATTERN`, `--ignore PATTERN` | Skip paths matching a gitignore-style pattern (repeatable; see below) |
-| `--ignore-from FILE` | Read ignore patterns from a file (repeatable, stacks with `-i`) |
+| `--ignore PATTERN` | Skip paths matching a gitignore-style pattern (repeatable; see below) |
+| `--ignore-from FILE` | Read ignore patterns from a file (repeatable, stacks with `--ignore`) |
 | `--delete` | Remove destination paths the source doesn't have (see below); `--delete-after`/`--delete-delay` are synonyms |
-| `--delete-excluded` | With `--delete`, also remove destination paths the `-i` patterns exclude |
+| `--delete-excluded` | With `--delete`, also remove destination paths the `--ignore` patterns exclude |
 | `--max-delete N` | With `--delete`, delete nothing if more than N deletions are planned (exit 25) |
 | `-u`, `--update` | Skip files that are newer on the destination |
 | `--existing` | Only update files that already exist on the destination; create nothing |
@@ -889,7 +895,7 @@ strictly after the transfer (see below); hardlinks aren't implemented.
 `RSYNC-COMPAT.md` tracks rsync compatibility in full: what matches, what
 differs and why, what's missing, and the open issues. The short version:
 
-- rsync filter rules (`--exclude`/`--include`/`--filter`); use `-i` (gitignore
+- rsync filter rules (`--exclude`/`--include`/`--filter`); use `--ignore` (gitignore
   syntax) instead.
 - `--link-dest`, `--backup`.
 - `--delete-before`/`--delete-during` and `--force`. syq deletes only after
@@ -1080,20 +1086,20 @@ write still finishes with an atomic rename. When both ends are local, 32 workers
 are used. This costs one rename per file on NFS, but avoids exposing incomplete
 final-named files. `--inplace` is the explicit space/safety tradeoff.
 
-## Ignoring paths (`-i`, `--ignore-from`)
+## Ignoring paths (`--ignore`, `--ignore-from`)
 
 syq has one filter mechanism instead of rsync's include/exclude/filter rules:
-every `-i PATTERN` is a line of a virtual `.gitignore` anchored at each source
+every `--ignore PATTERN` is a line of a virtual `.gitignore` anchored at each source
 root, and `--ignore-from FILE` splices in the lines of a file. Patterns from
 both are applied in command-line order with gitignore semantics (last match
 wins, `!` re-includes), so anything you'd write in a `.gitignore` works here:
 
 ```sh
-syq rsync -a -i node_modules -i .git src/ host:dst/   # a name matches at any depth
-syq rsync -a -i '*.o' -i /build src/ host:dst/         # glob; leading / anchors to the root
-syq rsync -a -i 'logs/*' -i '!logs/keep/' src/ dst/    # everything in logs/ except keep/
-syq rsync -a --ignore-from .gitignore -i '!dist/' repo/ host:repo/
-syq rsync -a -i '*' -i '!*/' -i '!*.jpg' photos/ bak/  # copy only *.jpg
+syq rsync -a --ignore node_modules --ignore .git src/ host:dst/ # a name matches at any depth
+syq rsync -a --ignore '*.o' --ignore /build src/ host:dst/      # glob; leading / anchors to root
+syq rsync -a --ignore 'logs/*' --ignore '!logs/keep/' src/ dst/ # everything in logs/ except keep/
+syq rsync -a --ignore-from .gitignore --ignore '!dist/' repo/ host:repo/
+syq rsync -a --ignore '*' --ignore '!*/' --ignore '!*.jpg' photos/ bak/ # copy only *.jpg
 ```
 
 Rules of thumb (they're git's): `foo` matches a file or directory named `foo`
@@ -1104,7 +1110,7 @@ it is transferred or even scanned — which is why "only `*.jpg`" needs the
 (this is a filter on the walk, not git's notion of what's tracked). The source
 root itself is never ignored; with several sources each is filtered from its
 own root. `-n` previews the selected scope and intended changes. `--rm` does not
-take filters (it always removes the whole tree), so `-i` conflicts with it.
+take filters (it always removes the whole tree), so `--ignore` conflicts with it.
 
 As in git, a `!` rule cannot re-include something whose parent directory is
 ignored: `logs/**` prunes `logs/keep` itself, so `!logs/keep/**` after it has
@@ -1120,7 +1126,7 @@ have is removed. The rules are simpler than rsync's, deliberately:
 - **Scope.** Only inside directories the sources map onto: `syq rsync --delete a b
   dst/` cleans `dst/a` and `dst/b`, never `dst/c`. A single-file source deletes
   nothing.
-- **Ignored means out of scope, on both sides.** The `-i` patterns are applied
+- **Ignored means out of scope, on both sides.** The `--ignore` patterns are applied
   to the destination walk from the same roots, so an ignored entry is neither
   copied nor deleted, and a directory that holds one is kept (`not deleting
   keep/: it holds ignored paths`, on stderr, not an error). Patterns are
@@ -1212,7 +1218,7 @@ spell a literal comment-looking name as `./#name` or `./;name`. Leading `/` or
 the root itself are rejected. A listed path that doesn't exist is an error
 (exit 23) and the rest is still copied. The destination must be a directory (an
 existing file there is an error, never replaced). `--files-from` can't be
-combined with `-i`/`--ignore-from` or `--delete`; for a remote-to-remote copy
+combined with `--ignore`/`--ignore-from` or `--delete`; for a remote-to-remote copy
 it needs `--relay` (the list is read on this machine).
 
 ## Parallel removal (`--rm`)

--- a/RSYNC-COMPAT.md
+++ b/RSYNC-COMPAT.md
@@ -158,8 +158,9 @@ item.
    re-includes, while rsync applies the first matching include/exclude/filter
    rule and has sender/receiver-side modifiers, `protect`/`risk` rules, and
    per-directory merge files. gitignore is what most users already know; the
-   trade is that rsync filter files can't be reused. (The short `-i` alias is a
-   separate CLI problem — open issue 1.)
+   trade is that rsync filter files can't be reused. Filtering uses the
+   long-only `--ignore`; rsync's `-i` remains `--itemize-changes` and is
+   rejected with a specific explanation because itemized output is absent.
 2. **Any error while listing the source disables deletion** — the same idea
    as rsync's file-list I/O check. A directory we couldn't read would
    otherwise look like one whose contents vanished. A read failure *during
@@ -205,8 +206,8 @@ command says what to change.
 - `--link-dest`/`--compare-dest`/`--copy-dest`.
 - `--relative` (`-R`), `--partial-dir`.
 - `-A`/`--acls`, `-X`/`--xattrs`, `-S`/`--sparse`, `-x`/`--one-file-system`.
-- `-i`/`--itemize-changes` — and the short flag is currently taken, open
-  issue 1.
+- `-i`/`--itemize-changes` — rejected with a specific explanation; use the
+  long-only `--ignore` for syq's gitignore-style filtering.
 - `--size-only`, `--ignore-times`/`-I`, `--modify-window`, `--chmod`,
   `--log-file`.
 - rsync filter rules (`--exclude`/`--include`/`--filter`); use `--ignore`.
@@ -215,21 +216,15 @@ command says what to change.
 
 ## Open issues
 
-1. **`-i` means `--ignore` in syq and `--itemize-changes` in rsync.** Worse
-   than cosmetic: rsync's `-i` takes no value, so a pasted multi-source
-   command can consume a source argument as an ignore pattern. Plan: make
-   `--ignore`/`--ignore-from` long-only; reject a bare `-i` with a specific
-   explanation until itemized output exists. Don't pick another rsync short
-   letter for ignore (`-I` is `--ignore-times`).
-2. **The remaining `--files-from` entry parsing doesn't match rsync's**
+1. **The remaining `--files-from` entry parsing doesn't match rsync's**
    (measured on 3.2.7 and 3.5.0). Finish the related path rules as one change:
    normalize `..` and clamp it at the source root instead of rejecting;
    preserve a trailing slash (`dir/` selects the directory's immediate
    children without `-r`, `dir` only the directory); accept `.`/`/` as the root
    entry (children without `-r`); add `-0` as an alias of `--from0`.
-3. **`-h` alone should print help**, as rsync does, while staying
+2. **`-h` alone should print help**, as rsync does, while staying
    `--human-readable` inside a cluster (`-avh`). Essentially free.
-4. **`-u` for symlinks/devices** — measure rsync, then align or record.
+3. **`-u` for symlinks/devices** — measure rsync, then align or record.
 
 ## Resolved
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -276,13 +276,9 @@ pub struct Args {
     /// at the source root, `foo/` only directories, `!pat` re-includes). Repeatable; together
     /// with --ignore-from the patterns act like the lines of one .gitignore file, in
     /// command-line order, anchored at each source root. Skipping a directory skips its
-    /// whole subtree, so to copy only *.jpg use: -i '*' -i '!*/' -i '!*.jpg'
-    #[arg(
-        short = 'i',
-        long = "ignore",
-        value_name = "PATTERN",
-        allow_hyphen_values = true
-    )]
+    /// whole subtree, so to copy only *.jpg use: --ignore '*' --ignore '!*/'
+    /// --ignore '!*.jpg'
+    #[arg(long = "ignore", value_name = "PATTERN", allow_hyphen_values = true)]
     pub ignore: Vec<String>,
     /// Read ignore patterns from FILE (one per line, # comments); repeatable
     #[arg(long, value_name = "FILE")]
@@ -293,7 +289,7 @@ pub struct Args {
 
     /// Delete extraneous files from the destination directories (paths the source does not
     /// have). Deletion happens after the transfer and is skipped entirely if the source scan
-    /// reported any error. Ignored paths (-i) are protected on both sides. rsync's
+    /// reported any error. Ignored paths (--ignore) are protected on both sides. rsync's
     /// --delete-after and --delete-delay mean the same thing and are accepted. Cannot be combined
     /// with --verify-only or --files-from
     #[arg(
@@ -302,7 +298,7 @@ pub struct Args {
         conflicts_with_all = ["verify_only", "files_from"]
     )]
     pub delete: bool,
-    /// With --delete, also remove destination paths that the -i patterns exclude
+    /// With --delete, also remove destination paths that the --ignore patterns exclude
     #[arg(long, requires = "delete")]
     pub delete_excluded: bool,
     /// With --delete, refuse to delete anything if more than N deletions are planned (exit 25)
@@ -1124,7 +1120,7 @@ fn reject_unsupported_rsync_flags(argv: &[String]) -> Result<()> {
             break; // end of options; the rest are paths
         }
         if value_long.contains(&tok.as_str())
-            || (!tok.starts_with("--") && matches!(tok.as_str(), "-e" | "-i" | "-j"))
+            || (!tok.starts_with("--") && matches!(tok.as_str(), "-e" | "-j"))
         {
             skip_next = true;
             continue;
@@ -1158,7 +1154,7 @@ fn unsupported_message(tok: &str) -> Option<String> {
         // Bundled short flags (e.g. `-auHz`): stop at the first value-taking
         // short, since everything after it is that option's value.
         for c in cluster.chars() {
-            if matches!(c, 'e' | 'i' | 'j') {
+            if matches!(c, 'e' | 'j') {
                 break;
             }
             if let Some(m) = message_for_short(c) {
@@ -1169,12 +1165,14 @@ fn unsupported_message(tok: &str) -> Option<String> {
     None
 }
 
-const FILTER_MSG: &str = "syq has no --exclude/--include/--filter. Use -i/--ignore (or --ignore-from), which takes gitignore-style patterns: e.g. `--exclude node_modules` becomes `-i node_modules`. See the README's \"Ignoring paths\" section.";
+const FILTER_MSG: &str = "syq has no --exclude/--include/--filter. Use --ignore (or --ignore-from), which takes gitignore-style patterns: e.g. `--exclude node_modules` becomes `--ignore node_modules`. See the README's \"Ignoring paths\" section.";
+const ITEMIZE_MSG: &str = "syq does not implement rsync's -i/--itemize-changes. Filtering uses the long-only --ignore option.";
 const DELETE_MSG: &str = "syq deletes only after the transfer (--delete; --delete-after and --delete-delay are synonyms); --delete-before, --delete-during and --force are not supported.";
 
 fn message_for_long(base: &str) -> Option<&'static str> {
     Some(match base {
         "exclude" | "exclude-from" | "include" | "include-from" | "filter" => FILTER_MSG,
+        "itemize-changes" => ITEMIZE_MSG,
         "force" => DELETE_MSG,
         _ if base.starts_with("delete-")
             && !matches!(base, "delete-after" | "delete-delay" | "delete-excluded") =>
@@ -1204,6 +1202,7 @@ fn message_for_short(c: char) -> Option<&'static str> {
         'S' => "sparse",
         'x' => "one-file-system",
         'L' => "copy-links",
+        'i' => "itemize-changes",
         _ => return None,
     })
 }

--- a/src/native_rm.rs
+++ b/src/native_rm.rs
@@ -4,8 +4,9 @@
 //! is a component walk rooted at an already-open directory; it never produces
 //! a canonical pathname that is reopened later. The selected object and its
 //! parent directory remain pinned while an endpoint-local worker pool removes
-//! descendants relative to directory descriptors. Symlinks encountered below
-//! a selected directory are payload entries and are unlinked, never followed.
+//! descendants relative to directory descriptors. Without `--follow`, a
+//! selected symlink and symlinks encountered below a selected directory are
+//! unlinked as entries; neither is followed.
 
 use crate::proto::{NativeRemoveKind, NativeRemoveOutcome, NativeRemoveSelection, PathBytes};
 use anyhow::{bail, Context, Result};
@@ -16,12 +17,15 @@ use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const SYMLINK_LIMIT: usize = 40;
 const EVENT_BATCH: usize = 200;
+const EVENT_POLL: Duration = Duration::from_millis(100);
+const EVENT_FLUSH: Duration = Duration::from_millis(100);
+const ATTACHED_HEARTBEAT: Duration = Duration::from_secs(1);
 const RMDIR_RETRIES: usize = 3;
 
 #[cfg(target_os = "linux")]
@@ -76,7 +80,7 @@ impl PinnedParent {
 
 struct PinnedLeaf {
     name: PinnedName,
-    _object: File,
+    _object: Option<File>,
     label: PathBytes,
 }
 
@@ -191,13 +195,41 @@ impl Resolver {
                 }
             };
 
+            let final_component = components.is_empty();
             if identity.is_symlink() {
                 if !self.follow {
-                    bail!(
-                        "selector {:?} encounters symlink component {:?}; pass --follow to resolve symlinks",
-                        String::from_utf8_lossy(&selection.path),
-                        String::from_utf8_lossy(&component)
-                    );
+                    if !final_component {
+                        bail!(
+                            "selector {:?} encounters symlink component {:?}; pass --follow to resolve symlinks",
+                            String::from_utf8_lossy(&selection.path),
+                            String::from_utf8_lossy(&component)
+                        );
+                    }
+                    require_kind(selection.kind, identity, &label)?;
+                    traces.push(format!(
+                        "selector {:?} resolved to symlink {}:{}",
+                        String::from_utf8_lossy(&label),
+                        identity.dev,
+                        identity.ino
+                    ));
+                    return Ok(ResolvedSelection::Leaf(PinnedLeaf {
+                        name: PinnedName {
+                            parent: PinnedParent::File(
+                                current
+                                    .directory
+                                    .try_clone()
+                                    .context("pin selected symlink parent")?,
+                            ),
+                            name: component_cstring(&component)?,
+                            identity,
+                        },
+                        // Linux can hold an O_PATH descriptor for a symlink,
+                        // but macOS has no corresponding portable open mode.
+                        // The pinned parent/name plus identity check is the
+                        // same mechanism used for symlinks found in a tree.
+                        _object: None,
+                        label,
+                    }));
                 }
                 symlinks += 1;
                 if symlinks > SYMLINK_LIMIT {
@@ -231,7 +263,6 @@ impl Resolver {
                 continue;
             }
 
-            let terminal = components.is_empty();
             if identity.is_dir() {
                 let directory = open_directory_at(&current.directory, &component)
                     .with_context(|| format!("open directory component {:?}", bytes(&component)))?;
@@ -246,7 +277,7 @@ impl Resolver {
                     name: component_cstring(&component)?,
                     identity,
                 };
-                if terminal {
+                if final_component {
                     require_kind(selection.kind, identity, &label)?;
                     traces.push(format!(
                         "selector {:?} resolved to directory {}:{}",
@@ -268,7 +299,7 @@ impl Resolver {
                 continue;
             }
 
-            if !terminal {
+            if !final_component {
                 bail!(
                     "non-directory component {:?} in selector {:?}",
                     String::from_utf8_lossy(&component),
@@ -296,7 +327,7 @@ impl Resolver {
                     name: component_cstring(&component)?,
                     identity,
                 },
-                _object: object,
+                _object: Some(object),
                 label,
             }));
         }
@@ -495,6 +526,7 @@ struct Pool {
     pending: Mutex<usize>,
     events: mpsc::Sender<NativeRemoveOutcome>,
     dry_run: bool,
+    cancelled: AtomicBool,
 }
 
 impl Pool {
@@ -530,9 +562,32 @@ impl Pool {
         self.sender.lock().unwrap().take();
     }
 
-    fn outcome(&self, path: PathBytes, error: Option<String>) {
-        let _ = self.events.send(NativeRemoveOutcome { path, error });
+    fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
     }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+
+    fn outcome(&self, path: PathBytes, error: Option<String>) {
+        if !self.is_cancelled() {
+            let _ = self.events.send(NativeRemoveOutcome { path, error });
+        }
+    }
+}
+
+fn emit_attached(
+    pool: &Pool,
+    batch: &mut Vec<NativeRemoveOutcome>,
+    sink: &mut dyn FnMut(Vec<NativeRemoveOutcome>) -> Result<()>,
+) -> Result<()> {
+    let ready = std::mem::replace(batch, Vec::with_capacity(EVENT_BATCH));
+    if let Err(error) = sink(ready) {
+        pool.cancel();
+        return Err(error);
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -577,28 +632,25 @@ pub(crate) fn remove(
         trace(traces)?;
     }
 
-    let (task_tx, task_rx) = mpsc::sync_channel(workers.max(1).saturating_mul(4));
+    // Queue every resolved root before starting workers. Once workers run,
+    // only they may take the bounded-queue inline fallback; the coordinator
+    // remains available to flush results and detect connection failure.
+    let queue_capacity = workers.max(1).saturating_mul(4).max(resolved.len()).max(1);
+    let (task_tx, task_rx) = mpsc::sync_channel(queue_capacity);
     let (event_tx, event_rx) = mpsc::channel();
     let pool = Arc::new(Pool {
         sender: Mutex::new(Some(task_tx)),
         pending: Mutex::new(0),
         events: event_tx,
         dry_run,
+        cancelled: AtomicBool::new(false),
     });
-    let task_rx = Arc::new(Mutex::new(task_rx));
-    let mut threads = Vec::new();
-    for _ in 0..workers.max(1) {
-        let pool = pool.clone();
-        let task_rx = task_rx.clone();
-        threads.push(std::thread::spawn(move || worker_loop(pool, task_rx)));
-    }
-
     for selected in resolved {
         match selected {
             ResolvedSelection::Missing => unreachable!(),
             ResolvedSelection::Leaf(leaf) => pool.submit(Task::Leaf {
                 name: leaf.name,
-                _object: Some(leaf._object),
+                _object: leaf._object,
                 label: leaf.label,
                 parent: None,
             }),
@@ -615,34 +667,53 @@ pub(crate) fn remove(
         }
     }
 
+    let task_rx = Arc::new(Mutex::new(task_rx));
+    let mut threads = Vec::new();
+    for _ in 0..workers.max(1) {
+        let pool = pool.clone();
+        let task_rx = task_rx.clone();
+        threads.push(std::thread::spawn(move || worker_loop(pool, task_rx)));
+    }
+
     let mut batch = Vec::with_capacity(EVENT_BATCH);
     let mut sink_error = None;
+    let mut last_emit = Instant::now();
     while !pool.is_done() {
-        match event_rx.recv_timeout(Duration::from_millis(100)) {
+        match event_rx.recv_timeout(EVENT_POLL) {
             Ok(event) => {
-                batch.push(event);
-                if batch.len() >= EVENT_BATCH {
-                    let ready = std::mem::replace(&mut batch, Vec::with_capacity(EVENT_BATCH));
-                    if sink_error.is_none() {
-                        sink_error = sink(ready).err();
-                    }
+                if sink_error.is_none() {
+                    batch.push(event);
                 }
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {}
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
+        if sink_error.is_none()
+            && (batch.len() >= EVENT_BATCH
+                || (!batch.is_empty() && last_emit.elapsed() >= EVENT_FLUSH)
+                || last_emit.elapsed() >= ATTACHED_HEARTBEAT)
+        {
+            if let Err(error) = emit_attached(&pool, &mut batch, sink) {
+                sink_error = Some(error);
+            } else {
+                last_emit = Instant::now();
+            }
+        }
     }
     while let Ok(event) = event_rx.try_recv() {
-        batch.push(event);
-        if batch.len() >= EVENT_BATCH {
-            let ready = std::mem::replace(&mut batch, Vec::with_capacity(EVENT_BATCH));
-            if sink_error.is_none() {
-                sink_error = sink(ready).err();
+        if sink_error.is_none() {
+            batch.push(event);
+            if batch.len() >= EVENT_BATCH {
+                if let Err(error) = emit_attached(&pool, &mut batch, sink) {
+                    sink_error = Some(error);
+                }
             }
         }
     }
     if !batch.is_empty() && sink_error.is_none() {
-        sink_error = sink(batch).err();
+        if let Err(error) = emit_attached(&pool, &mut batch, sink) {
+            sink_error = Some(error);
+        }
     }
     pool.close();
     for thread in threads {
@@ -668,6 +739,17 @@ fn worker_loop(pool: Arc<Pool>, receiver: Arc<Mutex<mpsc::Receiver<Task>>>) {
 }
 
 fn process_task(pool: &Arc<Pool>, task: Task) {
+    if pool.is_cancelled() {
+        match task {
+            Task::Scan(job) | Task::Finish(job) => abandon_directory(pool, &job),
+            Task::Leaf { parent, .. } => {
+                if let Some(parent) = parent {
+                    directory_part_done(pool, parent);
+                }
+            }
+        }
+        return;
+    }
     match task {
         Task::Scan(job) => scan_directory(pool, job),
         Task::Leaf {
@@ -676,6 +758,12 @@ fn process_task(pool: &Arc<Pool>, task: Task) {
             label,
             parent,
         } => {
+            if pool.is_cancelled() {
+                if let Some(parent) = parent {
+                    directory_part_done(pool, parent);
+                }
+                return;
+            }
             let error = if pool.dry_run {
                 None
             } else {
@@ -702,6 +790,9 @@ fn scan_directory(pool: &Arc<Pool>, job: Arc<DirectoryJob>) {
         }
     };
     for component in names {
+        if pool.is_cancelled() {
+            break;
+        }
         let identity = match metadata_at(job.directory.as_raw_fd(), &component) {
             Ok(identity) => identity,
             Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
@@ -769,6 +860,10 @@ fn scan_directory(pool: &Arc<Pool>, job: Arc<DirectoryJob>) {
 }
 
 fn finish_directory(pool: &Arc<Pool>, job: Arc<DirectoryJob>) {
+    if pool.is_cancelled() {
+        abandon_directory(pool, &job);
+        return;
+    }
     let Some(removal) = &job.removal else {
         if let Some(parent) = &job.parent {
             directory_part_done(pool, parent.clone());
@@ -1197,7 +1292,7 @@ mod tests {
             None,
             &[
                 selector(b"victim", NativeRemoveKind::Any),
-                selector(b"link", NativeRemoveKind::Any),
+                selector(b"link/file", NativeRemoveKind::Any),
             ],
             false,
             false,
@@ -1211,6 +1306,76 @@ mod tests {
         assert!(result.is_err());
         assert!(temp.path().join("victim").exists());
         assert!(temp.path().join("real/file").exists());
+    }
+
+    #[test]
+    fn no_follow_unlinks_selected_symlink_and_preserves_referent() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::create_dir(temp.path().join("real")).unwrap();
+        fs::write(temp.path().join("real/file"), b"data").unwrap();
+        symlink("real", temp.path().join("link")).unwrap();
+        let mut outcomes = Vec::new();
+        remove(
+            Some(temp.path().as_os_str().as_bytes()),
+            None,
+            &[selector(b"link", NativeRemoveKind::File)],
+            false,
+            false,
+            2,
+            &mut |_| Ok(()),
+            &mut |batch| {
+                outcomes.extend(batch);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert!(!temp.path().join("link").is_symlink());
+        assert_eq!(fs::read(temp.path().join("real/file")).unwrap(), b"data");
+        assert_eq!(outcomes.len(), 1);
+        assert!(outcomes[0].error.is_none());
+    }
+
+    #[test]
+    fn failed_attached_emit_cancels_pending_mutation() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("victim"), b"data").unwrap();
+        let directory = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
+            .open(temp.path())
+            .unwrap();
+        let identity = metadata_at(directory.as_raw_fd(), b"victim").unwrap();
+        let (task_tx, _task_rx) = mpsc::sync_channel(1);
+        let (event_tx, _event_rx) = mpsc::channel();
+        let pool = Arc::new(Pool {
+            sender: Mutex::new(Some(task_tx)),
+            pending: Mutex::new(0),
+            events: event_tx,
+            dry_run: false,
+            cancelled: AtomicBool::new(false),
+        });
+
+        let mut heartbeat = Vec::new();
+        let error = emit_attached(&pool, &mut heartbeat, &mut |_| bail!("client disconnected"))
+            .unwrap_err();
+        assert!(error.to_string().contains("client disconnected"));
+        assert!(pool.is_cancelled());
+
+        process_task(
+            &pool,
+            Task::Leaf {
+                name: PinnedName {
+                    parent: PinnedParent::File(directory),
+                    name: component_cstring(b"victim").unwrap(),
+                    identity,
+                },
+                _object: None,
+                label: b"victim".to_vec(),
+                parent: None,
+            },
+        );
+        assert_eq!(fs::read(temp.path().join("victim")).unwrap(), b"data");
     }
 
     #[test]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -479,6 +479,7 @@ pub enum Response {
     ScanIgnored(Vec<PathBytes>),
     ScanDone,
     NativeRemoveTrace(Vec<String>),
+    /// An empty batch is an attached native-rm liveness frame.
     NativeRemoveBatch(Vec<NativeRemoveOutcome>),
     NativeRemoveDone,
     Stats(Vec<Option<Entry>>),

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -4257,7 +4257,7 @@ impl Planner<'_> {
             p.starts_with(r) && (r.ends_with(b"/") || p.get(r.len()) == Some(&b'/'))
         };
         for (root, sub) in roots.clone() {
-            // Every root is walked with its own -i anchoring. A root nested in
+            // Every root is walked with its own --ignore anchoring. A root nested in
             // this one (`syq rsync --delete a b/ dst`: dst/a inside dst) is left to
             // its own walk, so its patterns apply and nothing is deleted twice.
             let nested: Vec<PathBytes> = roots

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -402,7 +402,7 @@ fn native_rejects_transport_configuration() {
 }
 
 #[test]
-fn native_rm_refuses_a_symlink_before_mutating_any_selector() {
+fn native_rm_refuses_an_intermediate_symlink_before_mutating_any_selector() {
     use std::os::unix::fs::symlink;
 
     let t = Tmp::new();
@@ -410,9 +410,72 @@ fn native_rm_refuses_a_symlink_before_mutating_any_selector() {
     write(&t.path("victim"), b"keep");
     symlink("real", t.path("link")).unwrap();
 
-    let output = native_syq(&["rm", "--cwd", &t.s(""), "--src", "victim", "--src", "link"]);
+    let output = native_syq(&[
+        "rm",
+        "--cwd",
+        &t.s(""),
+        "--src",
+        "victim",
+        "--src",
+        "link/file",
+    ]);
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("pass --follow"));
+    assert_eq!(read(&t.path("victim")), b"keep");
+    assert_eq!(read(&t.path("real/file")), b"keep");
+    assert!(t.path("link").is_symlink());
+}
+
+#[test]
+fn native_rm_without_follow_unlinks_selected_symlinks_and_preserves_referents() {
+    use std::os::unix::fs::symlink;
+
+    let t = Tmp::new();
+    write(&t.path("real-dir/file"), b"keep");
+    write(&t.path("real-file"), b"keep");
+    symlink("real-dir", t.path("dir-link")).unwrap();
+    symlink("real-file", t.path("file-link")).unwrap();
+    symlink("missing", t.path("dangling-link")).unwrap();
+
+    run_native_ok(&[
+        "rm",
+        "--cwd",
+        &t.s(""),
+        "--src",
+        "dir-link",
+        "--src-file",
+        "file-link",
+        "--src",
+        "dangling-link",
+    ]);
+
+    assert!(!t.path("dir-link").is_symlink());
+    assert!(!t.path("file-link").is_symlink());
+    assert!(!t.path("dangling-link").is_symlink());
+    assert_eq!(read(&t.path("real-dir/file")), b"keep");
+    assert_eq!(read(&t.path("real-file")), b"keep");
+}
+
+#[test]
+fn native_rm_directory_selector_rejects_a_selected_symlink_before_mutation() {
+    use std::os::unix::fs::symlink;
+
+    let t = Tmp::new();
+    write(&t.path("real/file"), b"keep");
+    write(&t.path("victim"), b"keep");
+    symlink("real", t.path("link")).unwrap();
+
+    let output = native_syq(&[
+        "rm",
+        "--cwd",
+        &t.s(""),
+        "--src",
+        "victim",
+        "--src-dir",
+        "link",
+    ]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("must resolve to a directory"));
     assert_eq!(read(&t.path("victim")), b"keep");
     assert_eq!(read(&t.path("real/file")), b"keep");
     assert!(t.path("link").is_symlink());
@@ -2592,7 +2655,7 @@ fn dry_run_reports_typed_preflight_summary() {
         "--delete",
         "--max-size",
         "5",
-        "-i",
+        "--ignore",
         "*.log",
         &t.s("src/"),
         &t.s("dst"),
@@ -3768,11 +3831,11 @@ fn ignore_patterns_prune_dirs_and_files() {
     // `node_modules` at any depth, `*.o` anywhere, `/build` only at the root.
     run_ok(&[
         "-a",
-        "-i",
+        "--ignore",
         "node_modules",
-        "-i",
+        "--ignore",
         "*.o",
-        "-i",
+        "--ignore",
         "/build",
         &t.s("src/"),
         &t.s("dst"),
@@ -3803,11 +3866,11 @@ fn ignore_only_idiom_and_empty_dirs() {
     // The gitignore "only *.jpg" idiom: directories are still all created.
     run_ok(&[
         "-a",
-        "-i",
+        "--ignore",
         "*",
-        "-i",
+        "--ignore",
         "!*/",
-        "-i",
+        "--ignore",
         "!*.jpg",
         &t.s("src/"),
         &t.s("dst"),
@@ -3834,7 +3897,7 @@ fn ignore_from_file_and_later_negation_wins() {
         "-a",
         "--ignore-from",
         &t.s("pats"),
-        "-i",
+        "--ignore",
         "!x.o",
         &t.s("src/"),
         &t.s("dst"),
@@ -3842,14 +3905,14 @@ fn ignore_from_file_and_later_negation_wins() {
     let l = listing(&t.path("dst"));
     assert!(
         l.contains(&"x.o".to_string()),
-        "later -i '!x.o' must override file"
+        "later --ignore '!x.o' must override file"
     );
     assert!(!l.contains(&"a/y.o".to_string()));
     assert!(!l.iter().any(|p| p.contains("node_modules")));
     // And the other order: the file's `*.o` comes last, so x.o stays ignored.
     run_ok(&[
         "-a",
-        "-i",
+        "--ignore",
         "!x.o",
         "--ignore-from",
         &t.s("pats"),
@@ -3876,12 +3939,27 @@ fn ignore_applies_per_source_root_and_dry_run() {
     make_ignore_tree(&t.path("s2"));
     fs::create_dir(t.path("dst")).unwrap();
     // `/build` is anchored at each source's root, not the destination.
-    run_ok(&["-a", "-i", "/build", &t.s("s1"), &t.s("s2"), &t.s("dst")]);
+    run_ok(&[
+        "-a",
+        "--ignore",
+        "/build",
+        &t.s("s1"),
+        &t.s("s2"),
+        &t.s("dst"),
+    ]);
     assert!(!t.path("dst/s1/build").exists());
     assert!(!t.path("dst/s2/build").exists());
     assert!(t.path("dst/s1/a/build/out2").is_file());
     // Dry run with the root itself matching a pattern: the root is never ignored.
-    let out = run_ok(&["-an", "-i", "s1", "-i", "*.o", &t.s("s1"), &t.s("dst2")]);
+    let out = run_ok(&[
+        "-an",
+        "--ignore",
+        "s1",
+        "--ignore",
+        "*.o",
+        &t.s("s1"),
+        &t.s("dst2"),
+    ]);
     assert!(!t.path("dst2").exists());
     assert!(out.contains("in 9 files needing content work"), "{out}");
 }
@@ -3893,9 +3971,9 @@ fn ignore_reinclude_subdir_idiom() {
     // Everything directly under logs/ except the keep/ directory (git idiom).
     run_ok(&[
         "-a",
-        "-i",
+        "--ignore",
         "logs/*",
-        "-i",
+        "--ignore",
         "!logs/keep/",
         &t.s("src/"),
         &t.s("dst"),
@@ -3915,7 +3993,7 @@ fn ignore_from_strips_bom_and_hyphen_patterns_work() {
         "-a",
         "--ignore-from",
         &t.s("pats"),
-        "-i",
+        "--ignore",
         "-secret",
         &t.s("src/"),
         &t.s("dst"),
@@ -3932,8 +4010,8 @@ fn ignore_from_strips_bom_and_hyphen_patterns_work() {
 fn ignore_conflicts_with_rm() {
     let t = Tmp::new();
     make_ignore_tree(&t.path("tree"));
-    let out = syq(&["--rm", "-i", "keep", &t.s("tree")]);
-    assert!(!out.status.success(), "--rm with -i must be rejected");
+    let out = syq(&["--rm", "--ignore", "keep", &t.s("tree")]);
+    assert!(!out.status.success(), "--rm with --ignore must be rejected");
     assert!(
         t.path("tree/logs/keep/k").is_file(),
         "nothing may be removed"
@@ -3973,7 +4051,7 @@ fn delete_removes_extras_and_protects_ignored() {
         "-n",
         "-v",
         "--delete",
-        "-i",
+        "--ignore",
         "*.log",
         &t.s("src/"),
         &t.s("dst"),
@@ -4007,7 +4085,7 @@ fn delete_removes_extras_and_protects_ignored() {
         "-a",
         "-v",
         "--delete",
-        "-i",
+        "--ignore",
         "*.log",
         &t.s("src/"),
         &t.s("dst"),
@@ -4567,7 +4645,7 @@ fn delete_nested_roots_keep_their_own_anchored_ignores() {
         "-a",
         "-v",
         "--delete",
-        "-i",
+        "--ignore",
         "/foo",
         &t.s("src/"),
         &t.s("src2"),
@@ -4606,7 +4684,7 @@ fn delete_treats_partial_named_directory_as_ordinary_extra() {
         "-a",
         "-v",
         "--delete",
-        "-i",
+        "--ignore",
         "*.log",
         &t.s("src/"),
         &t.s("dst"),
@@ -6516,7 +6594,7 @@ fn checkpoint_records_metadata_only_reconcile() {
 }
 
 // Unsupported rsync flags get a helpful, specific error (not clap's generic
-// "unexpected argument"), and the filter family points at -i.
+// "unexpected argument"), and the filter family points at --ignore.
 #[test]
 fn unsupported_rsync_flags_explain_themselves() {
     let t = Tmp::new();
@@ -6531,8 +6609,21 @@ fn unsupported_rsync_flags_explain_themselves() {
     ]);
     assert!(!out.status.success());
     let err = String::from_utf8_lossy(&out.stderr);
-    assert!(err.contains("-i/--ignore"), "should point to -i: {err}");
+    assert!(err.contains("--ignore"), "should point to --ignore: {err}");
     assert!(err.contains("gitignore"), "should mention gitignore: {err}");
+
+    let out = syq(&["-a", "-i", &t.s("src/"), &t.s("itemized-dst/")]);
+    assert!(!out.status.success());
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("itemize-changes"),
+        "should explain rsync -i: {err}"
+    );
+    assert!(
+        err.contains("long-only --ignore"),
+        "should name filtering: {err}"
+    );
+    assert!(!t.path("itemized-dst").exists());
 
     let out = syq(&["-a", "--delete-during", &t.s("src/"), &t.s("dst/")]);
     assert!(!out.status.success());
@@ -6583,9 +6674,9 @@ fn rsync_compat_noops_are_accepted() {
 fn flag_like_ignore_pattern_is_not_rejected() {
     let t = Tmp::new();
     write(&t.path("src/keep"), b"k");
-    // `-i --exclude` means "ignore a pattern literally named --exclude"; it must
+    // `--ignore --exclude` means "ignore a pattern literally named --exclude"; it must
     // not trip the --exclude rejection.
-    run_ok(&["-a", "-i", "--exclude", &t.s("src/"), &t.s("dst/")]);
+    run_ok(&["-a", "--ignore", "--exclude", &t.s("src/"), &t.s("dst/")]);
     assert_eq!(read(&t.path("dst/keep")), b"k");
 }
 
@@ -6751,7 +6842,14 @@ fn delete_excluded_removes_ignored_destination_paths() {
     write(&t.path("dst/keep/k.log"), b"k");
     write(&t.path("dst/junk.log"), b"old");
     // Protected without the flag...
-    run_ok(&["-a", "--delete", "-i", "*.log", &t.s("src/"), &t.s("dst")]);
+    run_ok(&[
+        "-a",
+        "--delete",
+        "--ignore",
+        "*.log",
+        &t.s("src/"),
+        &t.s("dst"),
+    ]);
     assert_eq!(
         listing(&t.path("dst")),
         ["a", "junk.log", "keep", "keep/k.log"]
@@ -6761,7 +6859,7 @@ fn delete_excluded_removes_ignored_destination_paths() {
         "-a",
         "--delete",
         "--delete-excluded",
-        "-i",
+        "--ignore",
         "*.log",
         &t.s("src/"),
         &t.s("dst"),
@@ -6988,8 +7086,12 @@ fn files_from_rejections_and_stdin() {
     let out = child.wait_with_output().unwrap();
     assert!(out.status.success());
     assert_eq!(listing(&t.path("dst")), ["b"]);
-    // Cannot combine with -i / --ignore-from / --delete (clap-level errors).
-    for extra in [["-i", "x"], ["--ignore-from", "list"], ["--delete", "-v"]] {
+    // Cannot combine with --ignore / --ignore-from / --delete (clap-level errors).
+    for extra in [
+        ["--ignore", "x"],
+        ["--ignore-from", "list"],
+        ["--delete", "-v"],
+    ] {
         let out = syq(&[
             "-a",
             "--files-from",


### PR DESCRIPTION
## Summary

- keep the native-rm coordinator available for result flushing, emit liveness frames while an attached job is quiet, and cancel queued removal work after a detected control/result write failure
- unlink a selected symlink when `--follow` is absent while still rejecting any symlink that would need traversal; preserve referents and retain identity rechecks before unlink
- make rsync-mode filtering use long-only `--ignore`, and reject rsync `-i`/`--itemize-changes` with a specific explanation

Completed removals and filesystem calls already in flight are not rolled back after connection failure.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`
- `python3 tests/rsync-compat/harness_test.py`
- `python3 scripts/rsync-compat.py --ledger-only`