### PR TITLE
Fix duplicate worker storm in auto-tuning and slow same-host file copies

### DIFF
--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -2512,6 +2512,13 @@ impl FsOps {
     ) -> Result<()> {
         let sp = resolve(src);
         let s = open_existing_regular(&sp, false)?;
+        // The kernel copy reads the source through the page cache, so the
+        // larger readahead window this hint enables is what keeps a cold
+        // source disk streaming (cp does the same; measured 10-20 % faster
+        // on a cold 4 GiB file). Advisory only: a failure changes nothing.
+        unsafe {
+            libc::posix_fadvise(s.as_raw_fd(), 0, 0, libc::POSIX_FADV_SEQUENTIAL);
+        }
         let dp = resolve(dst);
         // Never truncate the source: if the destination resolves to the same
         // file (same path, a hardlink, or a symlink pointing back), refuse.
@@ -2536,7 +2543,14 @@ impl FsOps {
             open_regular_write(&target, mode, true)?
         } else {
             let (d, _) = self.open_private_partial(&target)?;
-            d.set_len(0)?;
+            // Only discard stale content. ext4 treats any truncate to zero,
+            // even of an empty file, as "replace via truncate" and then
+            // flushes every dirty page of the file on close (auto_da_alloc),
+            // which put the whole writeback of a 4 GiB copy (about 1.8 s on
+            // NVMe) on the critical path before the rename.
+            if d.metadata()?.len() > 0 {
+                d.set_len(0)?;
+            }
             d
         };
         #[cfg(debug_assertions)]

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -683,6 +683,17 @@ pub struct Gate {
     cv: Condvar,
 }
 
+/// Extend the slot table so `id`s below `n` exist. Slots are never dropped:
+/// `Vec::resize_with` would truncate a longer table, and a worker that marked
+/// itself ready after a higher-numbered one would then erase that worker's
+/// slot. The tuner would read the erased slots as absent and spawn duplicate
+/// workers for ids that are still running.
+fn grow_to(slots: &mut Vec<Slot>, n: usize) {
+    if slots.len() < n {
+        slots.resize_with(n, Slot::default);
+    }
+}
+
 impl Gate {
     pub fn new(active: usize) -> Arc<Self> {
         Arc::new(Gate {
@@ -717,7 +728,7 @@ impl Gate {
     /// Claim absent slots through `n` for connection setup.
     pub fn begin_warming(&self, n: usize) -> Vec<usize> {
         let mut slots = self.slots.lock().unwrap();
-        slots.resize_with(n, Slot::default);
+        grow_to(&mut slots, n);
         let mut ids = Vec::new();
         for (id, slot) in slots.iter_mut().take(n).enumerate() {
             if slot.phase == SlotPhase::Absent {
@@ -730,14 +741,14 @@ impl Gate {
 
     pub fn mark_ready(&self, id: usize) {
         let mut slots = self.slots.lock().unwrap();
-        slots.resize_with(id + 1, Slot::default);
+        grow_to(&mut slots, id + 1);
         slots[id].phase = SlotPhase::Ready;
         self.cv.notify_all();
     }
 
     pub fn mark_warming(&self, id: usize) {
         let mut slots = self.slots.lock().unwrap();
-        slots.resize_with(id + 1, Slot::default);
+        grow_to(&mut slots, id + 1);
         slots[id].phase = SlotPhase::Warming;
         self.cv.notify_all();
     }
@@ -745,7 +756,7 @@ impl Gate {
     /// Mark a cleanly retired worker reusable immediately.
     pub fn mark_absent(&self, id: usize) {
         let mut slots = self.slots.lock().unwrap();
-        slots.resize_with(id + 1, Slot::default);
+        grow_to(&mut slots, id + 1);
         slots[id] = Slot::default();
         self.cv.notify_all();
     }
@@ -753,7 +764,7 @@ impl Gate {
     /// Mark setup or repeated connection loss after bounded retries.
     pub fn mark_failed(&self, id: usize) {
         let mut slots = self.slots.lock().unwrap();
-        slots.resize_with(id + 1, Slot::default);
+        grow_to(&mut slots, id + 1);
         slots[id].phase = SlotPhase::Failed;
         self.cv.notify_all();
     }
@@ -1389,5 +1400,30 @@ mod tests {
         gate.clear_failed_from(2);
         assert_eq!(gate.begin_warming(3), vec![2]);
         assert!(gate.ready_through(2));
+    }
+
+    #[test]
+    fn out_of_order_readiness_keeps_every_warming_slot() {
+        // Workers connect in any order. A lower id reporting ready after a
+        // higher one must not erase the higher slots, or the tuner's healing
+        // poll would respawn duplicates of workers that are still running.
+        let gate = Gate::new(4);
+        assert_eq!(gate.begin_warming(4), vec![0, 1, 2, 3]);
+        gate.mark_ready(3);
+        gate.mark_ready(0);
+        gate.mark_warming(2);
+        gate.mark_ready(1);
+        gate.mark_ready(2);
+        assert!(gate.ready_through(4));
+        assert!(gate.begin_warming(4).is_empty());
+
+        // Shrinking the warming target must not forget higher candidates.
+        gate.set_retain(6);
+        assert_eq!(gate.begin_warming(6), vec![4, 5]);
+        gate.mark_ready(5);
+        assert!(gate.begin_warming(4).is_empty());
+        gate.mark_ready(4);
+        assert!(gate.ready_through(6));
+        assert!(gate.begin_warming(6).is_empty());
     }
 }


### PR DESCRIPTION
Two same-host performance problems found by syq-bench (`local-2026-09-01` and `local-sweep-2026-09-01` results) on a 96-core NVMe box. Both reproduce on `master` and are fixed at `0310073`.

## Auto-tuned runs spawned duplicate workers

100,000 small files: auto took 7–11 s at 62–74 cores while a fixed `-j 32` took 1.9 s at 16 cores, and `--stats` reported `settled at 32 (path 32, peak 32)`. Debug output showed 138–272 worker connections for 32 slots.

Every `Gate::mark_*` method grew the slot table with `Vec::resize_with(id + 1)`, which truncates when the table is already longer. Workers connect in any order, so a lower id reporting ready after a higher one erased the higher slots. The tuner's 250 ms healing poll read them as absent and spawned duplicates for ids still running, and each duplicate's own out-of-order `mark_ready` repeated the cycle. The table now only grows; a unit test covers out-of-order readiness and a shrinking warming target and fails on the old code.

After: 32 connections, 2.0 s, on the same fixture.

## Same-host single 4 GiB file: 7.5–8.3 s vs cp 4.6–5.0 s

Same `copy_file_range` calls in both. Two causes in `copy_local`:

- The fresh partial was truncated to zero before the copy. ext4 treats any truncate to zero, even of an empty file, as "replace via truncate" and flushes all dirty pages on close (`auto_da_alloc`), putting the whole 1.8 s writeback on the critical path before the rename. This was never a durability guarantee (syq does not fsync transfer data, as the README says); the bench's "+fsync 0.00 s" for syq was this heuristic. The partial is now truncated only when it holds stale bytes.
- No readahead hint on the source. `POSIX_FADV_SEQUENTIAL`, which cp also sets, made the kernel copy 10–20 % faster on a cold source.

After, cold source cache: syq 4.8–5.1 s vs cp 4.6–4.8 s, identical flush left behind.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`: pass.
- `cargo test --all-targets`: 214 unit tests pass; `tests/local.rs` had one different failure in each of two runs (`direct_remote_to_remote_forwards_receiver_policy_opt_outs`, then `rsync_subcommand_wrapper_can_start_the_remote_server` with `Text file busy` from the fake remote helper). Both pass alone, and a run of the suite on clean `master` also failed one unrelated test, so this is pre-existing harness flakiness under a 96-way parallel run, not this change.
- Remote, TCP and macOS paths not exercised; the fsops change is inside the Linux-only `copy_local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWkfrRvnVgBgWCM7wznkfL
