### PR TITLE
Release syq 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Version bump for the 0.1.4 release. Since 0.1.3: the auto-tuner duplicate-worker fix and same-host copy speedups from #66, plus the merged work in between (see the compare link GitHub generates on the release).

Locked checks in the release worktree: `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, and `cargo test --locked --all-targets` (214 unit, 249 local integration, 9 update tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWkfrRvnVgBgWCM7wznkfL
