### PR TITLE
Fix st_nlink type on AArch64 Linux and check that target in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,16 @@ jobs:
       - run: scripts/test-secret-tools.sh
       - run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-homebrew-formula.sh scripts/test-secret-tools.sh
 
+  # The release workflow builds on this runner; libc field types differ from
+  # x86-64 (st_nlink is u32 here), so check it before a tag can fail.
+  linux-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: cargo check --locked --all-targets
+
   macos:
     runs-on: macos-14
     steps:

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -904,9 +904,11 @@ fn stat_mode(stat: &libc::stat) -> u32 {
     stat.st_mode as u32
 }
 
-#[cfg(target_os = "linux")]
+/// `st_nlink` is `u64` on x86-64 Linux, `u32` on AArch64 Linux, and `u16`
+/// on macOS, so the cast is only redundant on one of the release targets.
+#[allow(clippy::unnecessary_cast)]
 fn stat_nlink(stat: &libc::stat) -> u64 {
-    stat.st_nlink
+    stat.st_nlink as u64
 }
 
 #[cfg(target_os = "linux")]
@@ -917,11 +919,6 @@ fn stat_rdev(stat: &libc::stat) -> u64 {
 #[cfg(not(target_os = "linux"))]
 fn stat_rdev(stat: &libc::stat) -> u64 {
     stat.st_rdev as u64
-}
-
-#[cfg(not(target_os = "linux"))]
-fn stat_nlink(stat: &libc::stat) -> u64 {
-    stat.st_nlink as u64
 }
 
 fn unlink_at(parent: RawFd, name: &CString, flags: libc::c_int) -> io::Result<()> {


### PR DESCRIPTION
The v0.1.4 release run ([33557561925](https://github.com/greaber/syq/actions/runs/33557561925)) failed in `build (syq-linux-aarch64)`: `src/rooted.rs` returned `stat.st_nlink` as `u64`, but libc declares it `u32` on AArch64 Linux (`u64` on x86-64, `u16` on macOS). Pre-existing on `master` since #64's container binding; `ci` never built that target.

- Fold both `stat_nlink` cfg variants into one casting helper.
- Add a `linux-arm64` job on `ubuntu-24.04-arm`, the runner the release workflow uses, running `cargo check --locked --all-targets`.

Verified locally on x86-64: fmt, clippy with warnings denied, and `cargo test --locked --all-targets` all pass. The AArch64 build itself could not be completed locally (no ARM C toolchain for the ring and zstd build scripts); the new CI job is the verification for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWkfrRvnVgBgWCM7wznkfL
