### PR TITLE
Release syq 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Version bump for the 0.1.5 release. The v0.1.4 tag (#67) never published: its release run failed to compile on AArch64 Linux, fixed in #68 together with a CI job for that target. 0.1.5 carries #66 (auto-tuner duplicate-worker fix, same-host copy speedups), #68, and the work merged since 0.1.3.

Locked checks in the release worktree: `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, and `cargo test --locked --all-targets` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWkfrRvnVgBgWCM7wznkfL
