### PR TITLE
Publish release sources to crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,11 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
       - run: cargo test --locked --all-targets
+      - run: scripts/test-cargo-package.sh
       - run: scripts/test-installer.sh
       - run: scripts/test-release-tools.sh
       - run: scripts/test-secret-tools.sh
-      - run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-homebrew-formula.sh scripts/test-secret-tools.sh
+      - run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-homebrew-formula.sh scripts/test-secret-tools.sh
 
   # The release workflow builds on this runner; libc field types differ from
   # x86-64 (st_nlink is u32 here), so check it before a tag can fail.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 # Build all supported targets, assemble one complete signed release, attest its
-# contents, publish it draft-first, then update the project-owned Homebrew tap.
+# contents, publish it draft-first, publish the source crate, then update the
+# project-owned Homebrew tap.
 name: release
 
 on:
@@ -190,6 +191,44 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" dist/*
           scripts/verify-release-assets.sh "$GITHUB_REF_NAME" dist
           gh release edit "$GITHUB_REF_NAME" --draft=false
+      - name: Package the source crate
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          test "$GITHUB_REF_NAME" = "v$version"
+          cargo package --locked
+          test -f "target/package/syq-$version.crate"
+      - name: Check whether crates.io already has this exact package
+        id: crates_io_state
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=${GITHUB_REF_NAME#v}
+          if scripts/verify-crates-io-package.sh \
+            "$version" "target/package/syq-$version.crate"; then
+            echo 'published=true' >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            test "$status" -eq 3
+            echo 'published=false' >> "$GITHUB_OUTPUT"
+          fi
+      - name: Authenticate to crates.io
+        if: steps.crates_io_state.outputs.published != 'true'
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+      - name: Publish the source crate
+        if: steps.crates_io_state.outputs.published != 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        run: cargo publish --locked
+      - name: Verify the published source crate
+        if: steps.crates_io_state.outputs.published != 'true'
+        shell: bash
+        run: |
+          version=${GITHUB_REF_NAME#v}
+          scripts/verify-crates-io-package.sh \
+            "$version" "target/package/syq-$version.crate"
       - name: Carry the verified published formula to the tap job
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Parallel file copy with an explicit native CLI and rsync compatib
 license = "MIT"
 repository = "https://github.com/greaber/syq"
 readme = "README.md"
+publish = ["crates-io"]
 keywords = ["copy", "rsync", "ssh", "parallel", "transfer"]
 categories = ["command-line-utilities", "filesystem"]
 include = [
@@ -49,6 +50,9 @@ signal-hook = "0.4.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 socket2 = "0.6"
+
+[build-dependencies]
+serde_json = "1"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -57,12 +57,18 @@ cargo build --release          # binary at target/release/syq
 cargo install --locked --path . # or: put it on your PATH
 ```
 
-Registry and checkout builds carry a source-revision identity and deliberately
-do not claim to be an immutable release. Managed remote bootstrap is therefore
-available only in official release binaries. To use a source build remotely,
-install the same locked source revision there and pass
-`--syq-path /path/to/syq` (or put it on the remote `PATH` and use
-`--no-bootstrap`).
+Checkout builds carry a source-revision identity. The crates.io 0.1.5 package
+predates stable identities for packaged source: two independent
+`cargo install --locked syq` builds receive different identities and cannot
+connect as remote peers. To use a 0.1.5 Cargo installation remotely, copy the
+exact installed executable to the remote and pass `--syq-path /path/to/syq`
+(or put it on the remote `PATH` and use `--no-bootstrap`).
+
+A later crate release containing packaged-source identity support will carry
+the package's source revision, allowing independent locked installations of
+that same version to connect. Source builds deliberately do not claim to be an
+immutable release, so managed remote bootstrap remains available only in
+official release binaries.
 
 Standalone installs download and verify one signed release manifest at most
 once a day after a successful interactive command. When a newer release is

--- a/README.md
+++ b/README.md
@@ -44,18 +44,25 @@ Homebrew is also supported through the project-owned tap:
 brew install greaber/tap/syq
 ```
 
-Or build from source with the pinned Rust toolchain:
+Rust users can instead compile and install the published source package:
+
+```sh
+cargo install --locked syq
+```
+
+Or build a checkout with the pinned Rust toolchain:
 
 ```sh
 cargo build --release          # binary at target/release/syq
 cargo install --locked --path . # or: put it on your PATH
 ```
 
-Source builds carry a Git-derived build identity and deliberately do not claim
-to be an immutable release. Managed remote bootstrap is therefore available
-only in official release binaries. To use a source build remotely, install the
-same build there and pass `--syq-path /path/to/syq` (or put it on the remote
-`PATH` and use `--no-bootstrap`).
+Registry and checkout builds carry a source-revision identity and deliberately
+do not claim to be an immutable release. Managed remote bootstrap is therefore
+available only in official release binaries. To use a source build remotely,
+install the same locked source revision there and pass
+`--syq-path /path/to/syq` (or put it on the remote `PATH` and use
+`--no-bootstrap`).
 
 Standalone installs download and verify one signed release manifest at most
 once a day after a successful interactive command. When a newer release is

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,12 @@ releases setting so published assets and tags cannot be changed afterward.
    `v*` tags to release maintainers. GitHub's ruleset signature rule applies to
    commits, not annotated tag-object signatures; the release workflow checks
    the latter explicitly through GitHub's tag verification API.
-4. The encrypted inventory initializer generates a dedicated SSH deploy key
+4. Publish the first `syq` version to crates.io manually, then add a GitHub
+   trusted publisher for repository `greaber/syq`, workflow `release.yml`, and
+   environment `release`. Do not put a long-lived crates.io token in GitHub
+   secrets. After the first automated publication succeeds, enable
+   trusted-publishing-only mode on crates.io and revoke the bootstrap token.
+5. The encrypted inventory initializer generates a dedicated SSH deploy key
    for `greaber/homebrew-tap`. The sync installs its public half on that
    repository with write access and places only its private half in the
    protected `release` environment. It has no access to the syq repository or
@@ -137,8 +142,9 @@ connection, so enable it only for a trusted release host rather than globally.
    binaries and native macOS Apple Silicon/Intel binaries, embeds an Ed25519
    signature over the manifest's RFC 8785 canonical JSON, verifies the exact
    asset inventory, creates provenance attestations, uploads a draft, checks
-   every uploaded byte, publishes it, and finally updates the tap.
-4. Verify one or more downloaded artifacts and exercise both install paths:
+   every uploaded byte, publishes it, publishes the matching source package to
+   crates.io with a short-lived OIDC credential, and finally updates the tap.
+4. Verify one or more downloaded artifacts and exercise all install paths:
 
    ```sh
    gh attestation verify syq-linux-x86_64 --repo greaber/syq
@@ -146,13 +152,16 @@ connection, so enable it only for a trusted release host rather than globally.
    less install.sh
    sh install.sh --bin-dir "$(mktemp -d)"
    brew install greaber/tap/syq
+   cargo install --locked syq --root "$(mktemp -d)"
    ```
 
 If a job stops after creating a draft, inspect that draft rather than
 overwriting it. The workflow refuses to reuse drafts. It may safely be rerun
 after a fully published release: it downloads every published asset and
 requires byte-for-byte equality with the rebuilt release before forwarding the
-formula to the tap job.
+formula to the tap job. The same rerun packages the source crate again and
+requires its SHA-256 to match the immutable crates.io version; a missing
+version is published, while a divergent version fails closed.
 
 The release workflow sets `SYQ_RELEASE_BUILD=1`, which makes each platform
 binary report the tag (for example `v0.2.0`) as its build identity. Ordinary

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs;
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -25,6 +26,7 @@ fn main() {
 }
 
 fn register_inputs() {
+    println!("cargo::rerun-if-changed=.cargo_vcs_info.json");
     if let Ok(output) = Command::new("git")
         .args([
             "ls-files",
@@ -59,13 +61,28 @@ fn register_inputs() {
 }
 
 fn development_identity(release_identity: &str) -> String {
-    let revision = git(&["rev-parse", "--short=12", "HEAD"])
+    let revision = packaged_revision()
+        .or_else(|| git(&["rev-parse", "--short=12", "HEAD"]))
         .filter(|value| value.len() == 12 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
         .unwrap_or_else(|| format!("source.{}", build_nonce()));
     let dirty = working_tree_hash()
         .map(|hash| format!(".dirty.{hash}"))
         .unwrap_or_default();
     format!("{release_identity}+dev.{revision}{dirty}")
+}
+
+/// Cargo puts the source commit in every registry package. Prefer that value
+/// over a surrounding checkout so an extracted package has the same identity
+/// wherever it is compiled.
+fn packaged_revision() -> Option<String> {
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR")?);
+    let bytes = fs::read(manifest_dir.join(".cargo_vcs_info.json")).ok()?;
+    let metadata: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let revision = metadata.get("git")?.get("sha1")?.as_str()?;
+    if revision.len() != 40 || !revision.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(revision[..12].to_ascii_lowercase())
 }
 
 fn git(args: &[&str]) -> Option<String> {

--- a/scripts/test-cargo-package.sh
+++ b/scripts/test-cargo-package.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Build the registry package outside the checkout and require Cargo's VCS
+# metadata to produce a stable source identity.
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_dir=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$repo_dir/Cargo.toml" | head -1)
+target_dir=$(cargo metadata --no-deps --format-version 1 \
+  --manifest-path "$repo_dir/Cargo.toml" | jq -r .target_directory)
+
+cargo package --locked --manifest-path "$repo_dir/Cargo.toml"
+package="$target_dir/package/syq-$version.crate"
+if [ ! -f "$package" ] || [ -L "$package" ]; then
+  echo "cargo did not create $package" >&2
+  exit 1
+fi
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-cargo-package.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+tar -xzf "$package" -C "$work"
+source_dir="$work/syq-$version"
+revision=$(jq -er '.git.sha1 | select(test("^[0-9a-fA-F]{40}$"))' \
+  "$source_dir/.cargo_vcs_info.json")
+expected="v$version+dev.${revision:0:12}"
+
+CARGO_TARGET_DIR="$work/target" cargo build --locked \
+  --manifest-path "$source_dir/Cargo.toml" --bin syq
+actual=$("$work/target/debug/syq" --build-identity)
+[ "$actual" = "$expected" ] || {
+  echo "packaged source identity is $actual, expected $expected" >&2
+  exit 1
+}
+
+echo "cargo package source identity is stable at $expected"

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -85,6 +85,34 @@ expect_failure 'release directory contains missing or unexpected files' \
 expect_failure 'does not match Cargo.toml version' \
   "$script_dir/package-release.sh" v99.99.99 "$first"
 
+# crates.io reruns accept only the exact package checksum, distinguish a
+# missing version with exit 3, and fail closed on registry errors.
+source_crate="$work/syq-0.1.0.crate"
+printf 'source crate\n' > "$source_crate"
+source_checksum=$(sha256sum "$source_crate" | awk '{print $1}')
+crate_response="$work/crate-response.json"
+jq -n --arg checksum "$source_checksum" \
+  '{version:{num:"0.1.0",checksum:$checksum}}' > "$crate_response"
+SYQ_TEST_CRATES_IO_RESPONSE="$crate_response" SYQ_TEST_CRATES_IO_STATUS=200 \
+  "$script_dir/verify-crates-io-package.sh" 0.1.0 "$source_crate" >/dev/null
+
+set +e
+SYQ_TEST_CRATES_IO_RESPONSE="$crate_response" SYQ_TEST_CRATES_IO_STATUS=404 \
+  "$script_dir/verify-crates-io-package.sh" 0.1.0 "$source_crate" \
+  > "$work/crate-missing.out" 2>&1
+missing_status=$?
+set -e
+test "$missing_status" -eq 3
+grep -F 'is not published on crates.io' "$work/crate-missing.out" >/dev/null
+
+jq -n '{version:{num:"0.1.0",checksum:("a" * 64)}}' > "$crate_response"
+expect_failure 'differs from the package assembled from this tag' env \
+  SYQ_TEST_CRATES_IO_RESPONSE="$crate_response" SYQ_TEST_CRATES_IO_STATUS=200 \
+  "$script_dir/verify-crates-io-package.sh" 0.1.0 "$source_crate"
+expect_failure 'returned HTTP 500' env \
+  SYQ_TEST_CRATES_IO_RESPONSE="$crate_response" SYQ_TEST_CRATES_IO_STATUS=500 \
+  "$script_dir/verify-crates-io-package.sh" 0.1.0 "$source_crate"
+
 # Run the same signing operation used by the release workflow, verify the
 # result independently, and prove that a mismatched configured public key is
 # rejected without modifying the manifest.

--- a/scripts/verify-crates-io-package.sh
+++ b/scripts/verify-crates-io-package.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Require a published crates.io version to be the exact package assembled from
+# the release tag. Exit 3 means that the version has not been published yet.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 VERSION CRATE_FILE" >&2
+  exit 2
+fi
+
+version=$1
+package=$2
+if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.+-]+)?$ ]]; then
+  echo "invalid crate version: $version" >&2
+  exit 2
+fi
+if [ ! -f "$package" ] || [ -L "$package" ]; then
+  echo "missing regular crate package: $package" >&2
+  exit 1
+fi
+command -v jq >/dev/null || { echo 'crate verification needs jq' >&2; exit 1; }
+command -v sha256sum >/dev/null || { echo 'crate verification needs sha256sum' >&2; exit 1; }
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-crates-io.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+response="$work/response.json"
+
+if [ -n "${SYQ_TEST_CRATES_IO_RESPONSE:-}" ]; then
+  [ -n "${SYQ_TEST_CRATES_IO_STATUS:-}" ] || {
+    echo 'SYQ_TEST_CRATES_IO_RESPONSE requires SYQ_TEST_CRATES_IO_STATUS' >&2
+    exit 2
+  }
+  cp "$SYQ_TEST_CRATES_IO_RESPONSE" "$response"
+  status=$SYQ_TEST_CRATES_IO_STATUS
+else
+  command -v curl >/dev/null || { echo 'crate verification needs curl' >&2; exit 1; }
+  status=$(curl --silent --show-error --proto '=https' \
+    --user-agent 'syq-release-verifier (https://github.com/greaber/syq)' \
+    --output "$response" --write-out '%{http_code}' \
+    "https://crates.io/api/v1/crates/syq/$version")
+fi
+
+case "$status" in
+  200) ;;
+  404)
+    echo "syq $version is not published on crates.io"
+    exit 3
+    ;;
+  *)
+    echo "crates.io returned HTTP $status for syq $version" >&2
+    jq -r '.errors[]?.detail // empty' "$response" >&2 || true
+    exit 1
+    ;;
+esac
+
+published_version=$(jq -er '.version.num' "$response") || {
+  echo 'crates.io response has no version number' >&2
+  exit 1
+}
+published_checksum=$(jq -er '.version.checksum' "$response") || {
+  echo 'crates.io response has no package checksum' >&2
+  exit 1
+}
+[ "$published_version" = "$version" ] || {
+  echo "crates.io returned version $published_version, expected $version" >&2
+  exit 1
+}
+
+local_checksum=$(sha256sum "$package" | awk '{print $1}')
+[ "$published_checksum" = "$local_checksum" ] || {
+  echo "crates.io syq $version differs from the package assembled from this tag" >&2
+  echo "published: $published_checksum" >&2
+  echo "local:     $local_checksum" >&2
+  exit 1
+}
+
+echo "crates.io syq $version is byte-for-byte identical to this package"


### PR DESCRIPTION
## Summary

- publish source crates after the signed GitHub release using crates.io trusted publishing and the protected release environment
- make release reruns compare the locally packaged crate against the immutable registry checksum
- give crates.io source builds a stable commit-derived peer identity
- document cargo installation and add package/release-tool coverage

## One-time setup completed

- published syq 0.1.3 and 0.1.5 manually from their exact released tags
- registered greaber/syq, release.yml, and the release environment as the trusted publisher

## Verification

- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets
- scripts/test-release-tools.sh
- scripts/test-cargo-package.sh
- cargo publish --dry-run --locked
- live byte-for-byte registry verification for syq 0.1.3 and 0.1.5
