### PR TITLE
Refuse to release a commit whose CI checks did not succeed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           scripts/verify-release-tag.sh \
-            "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_SHA" master
+            "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_SHA" master \
+            rust,macos,linux-arm64
 
   build:
     name: build (${{ matrix.name }})

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -137,8 +137,12 @@ connection, so enable it only for a trusted release host rather than globally.
 3. Approve the protected `release` environment for the publishing job, then
    approve it again when the separate Homebrew tap job is ready. The workflow
    first verifies that the annotated tag's signature is valid and that it
-   directly targets the workflow commit, and that this commit is reachable
-   from protected `master`. It then builds static GNU Linux x86-64/ARM64
+   directly targets the workflow commit, that this commit is reachable
+   from protected `master`, and that the `rust`, `macos`, and `linux-arm64`
+   checks all succeeded on that exact commit. Pull requests are checked
+   against their own head rather than the merged result, so wait for the
+   post-merge `ci` run on `master` to finish before tagging; a red or
+   still-running `master` cannot be released. It then builds static GNU Linux x86-64/ARM64
    binaries and native macOS Apple Silicon/Intel binaries, embeds an Ed25519
    signature over the manifest's RFC 8785 canonical JSON, verifies the exact
    asset inventory, creates provenance attestations, uploads a draft, checks

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -125,9 +125,19 @@ connection, so enable it only for a trusted release host rather than globally.
    release notes and merge through the protected branch. Peer compatibility is
    the immutable release identity, so there is no separate protocol number to
    maintain.
-2. Create and push a signed annotated tag matching the package version. Its
-   signing key and email must be configured on your GitHub account so GitHub
-   reports the tag-object signature as verified:
+2. Wait for the post-merge `ci` run on `master` to succeed for the release
+   commit. Pull requests are checked against their own head rather than the
+   merged result, and the release workflow refuses a commit whose `rust`,
+   `macos`, and `linux-arm64` checks have not all succeeded, so tagging a
+   red or still-running `master` only produces a failed release run:
+
+   ```sh
+   gh run watch --exit-status "$(gh run list --workflow ci.yml --branch master --commit "$(git rev-parse master)" --json databaseId --jq '.[0].databaseId')"
+   ```
+
+   Then create and push a signed annotated tag matching the package version.
+   Its signing key and email must be configured on your GitHub account so
+   GitHub reports the tag-object signature as verified:
 
    ```sh
    git tag -s v0.1.0 -m 'syq 0.1.0'
@@ -139,10 +149,7 @@ connection, so enable it only for a trusted release host rather than globally.
    first verifies that the annotated tag's signature is valid and that it
    directly targets the workflow commit, that this commit is reachable
    from protected `master`, and that the `rust`, `macos`, and `linux-arm64`
-   checks all succeeded on that exact commit. Pull requests are checked
-   against their own head rather than the merged result, so wait for the
-   post-merge `ci` run on `master` to finish before tagging; a red or
-   still-running `master` cannot be released. It then builds static GNU Linux x86-64/ARM64
+   checks all succeeded on that exact commit. It then builds static GNU Linux x86-64/ARM64
    binaries and native macOS Apple Silicon/Intel binaries, embeds an Ed25519
    signature over the manifest's RFC 8785 canonical JSON, verifies the exact
    asset inventory, creates provenance attestations, uploads a draft, checks

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -154,6 +154,7 @@ case "$1:$2" in
   api:*/git/ref/tags/*) printf '%s\n' "$SYQ_TEST_REF_JSON" ;;
   api:*/git/tags/*) printf '%s\n' "$SYQ_TEST_TAG_JSON" ;;
   api:*/compare/*) printf '%s\n' "$SYQ_TEST_COMPARE_JSON" ;;
+  api:*/check-runs*) printf '%s\n' "$SYQ_TEST_CHECKS_JSON" ;;
   release:download)
     shift 2
     destination=
@@ -177,30 +178,58 @@ tag_json=$(jq -cn --arg commit "$commit" '
    verification:{verified:true,reason:"valid"}}')
 compare_json=$(jq -cn --arg commit "$commit" \
   '{base_commit:{sha:$commit},merge_base_commit:{sha:$commit}}')
+checks_json=$(jq -cn '{check_runs:[
+  {name:"rust",status:"completed",conclusion:"success"},
+  {name:"macos",status:"completed",conclusion:"success"},
+  {name:"verify signed release tag",status:"in_progress",conclusion:null}]}')
 SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
-  SYQ_TEST_COMPARE_JSON="$compare_json" PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master >/dev/null
+  SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$checks_json" \
+  PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos >/dev/null
 
 lightweight=$(jq -cn --arg sha "$commit" '{object:{type:"commit",sha:$sha}}')
 expect_failure 'is lightweight' env \
   SYQ_TEST_REF_JSON="$lightweight" SYQ_TEST_TAG_JSON="$tag_json" PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
 unsigned=$(jq -cn --arg commit "$commit" '
   {tag:"v0.1.0",object:{type:"commit",sha:$commit},
    verification:{verified:false,reason:"unsigned"}}')
 expect_failure 'reason: unsigned' env \
   SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$unsigned" PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
 expect_failure 'not workflow commit' env \
   SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" PATH="$fakebin:$PATH" \
   "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 \
-  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa master
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa master rust,macos
 unmerged_compare=$(jq -cn --arg commit "$commit" \
   '{base_commit:{sha:$commit},merge_base_commit:{sha:("b"*40)}}')
 expect_failure 'not reachable from protected branch master' env \
   SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
   SYQ_TEST_COMPARE_JSON="$unmerged_compare" PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
+# A red, pending, or absent required check on the tagged commit blocks the
+# release even when the tag itself is valid and merged.
+failed_checks=$(jq -cn '{check_runs:[
+  {name:"rust",status:"completed",conclusion:"failure"},
+  {name:"macos",status:"completed",conclusion:"success"}]}')
+expect_failure 'required check rust is failure' env \
+  SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
+  SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$failed_checks" \
+  PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
+pending_checks=$(jq -cn '{check_runs:[
+  {name:"rust",status:"in_progress",conclusion:null},
+  {name:"macos",status:"completed",conclusion:"success"}]}')
+expect_failure 'required check rust is pending' env \
+  SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
+  SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$pending_checks" \
+  PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
+expect_failure 'required check linux-arm64 is missing' env \
+  SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
+  SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$checks_json" \
+  PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos,linux-arm64
 
 # Published-release reruns compare content, not just asset names.
 local_assets="$work/local-assets"

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 # Require a GitHub-verified annotated tag that directly names the commit being
-# built by this release workflow and is reachable from the protected branch.
+# built by this release workflow, is reachable from the protected branch, and
+# has every named CI check concluded successfully. Pull requests are checked
+# against their own head, not against the branch they land on, so a merge can
+# leave the branch red; the tagged commit's own check runs are what prove it.
 set -euo pipefail
 
-if [ "$#" -ne 4 ]; then
-  echo "usage: $0 OWNER/REPOSITORY TAG EXPECTED_COMMIT PROTECTED_BRANCH" >&2
+if [ "$#" -ne 5 ]; then
+  echo "usage: $0 OWNER/REPOSITORY TAG EXPECTED_COMMIT PROTECTED_BRANCH REQUIRED_CHECKS" >&2
+  echo "REQUIRED_CHECKS is a comma-separated list of check run names" >&2
   exit 2
 fi
 repository=$1
 tag=$2
 expected_commit=$3
 protected_branch=$4
+required_checks=$5
 case "$repository" in
   */*) ;;
   *) echo "invalid GitHub repository: $repository" >&2; exit 2 ;;
@@ -23,6 +28,9 @@ case "$expected_commit" in
 esac
 case "$protected_branch" in
   ''|*[!A-Za-z0-9._/-]*) echo "unsafe protected branch: $protected_branch" >&2; exit 2 ;;
+esac
+case "$required_checks" in
+  ''|*[!A-Za-z0-9._,-]*) echo "unsafe required check list: $required_checks" >&2; exit 2 ;;
 esac
 command -v gh >/dev/null || { echo 'tag verification needs gh' >&2; exit 1; }
 command -v jq >/dev/null || { echo 'tag verification needs jq' >&2; exit 1; }
@@ -66,4 +74,16 @@ if [ "$base_commit" != "$target_commit" ] || [ "$merge_base" != "$target_commit"
   exit 1
 fi
 
-echo "verified signed annotated tag $tag at $target_commit on $protected_branch"
+check_runs=$(gh api "repos/$repository/commits/$target_commit/check-runs?filter=latest&per_page=100")
+IFS=, read -ra check_names <<<"$required_checks"
+for check_name in "${check_names[@]}"; do
+  conclusion=$(jq -r --arg name "$check_name" '
+    [.check_runs[] | select(.name == $name)] | if length == 0 then "missing"
+    elif length > 1 then "ambiguous" else .[0].conclusion // "pending" end' <<<"$check_runs")
+  test "$conclusion" = success || {
+    echo "required check $check_name is $conclusion on release commit $target_commit" >&2
+    exit 1
+  }
+done
+
+echo "verified signed annotated tag $tag at $target_commit on $protected_branch with checks $required_checks"


### PR DESCRIPTION
Branch protection on `master` no longer requires PR heads to be up to date with the base (turned off today to stop the update-branch churn between concurrent sessions). That means a merge can leave `master` red until its post-merge `ci` run reports, and a broken master is acceptable while a broken release is not.

- `scripts/verify-release-tag.sh` takes a fifth argument, a comma-separated list of check run names, and requires each to have concluded `success` on the exact tagged commit (latest run per name). Failed, pending, duplicated, or missing checks all fail the verify job before any binary is built.
- `release.yml` passes `rust,macos,linux-arm64`, the same set branch protection requires.
- `scripts/test-release-tools.sh` extends the fake `gh` with a `check-runs` response and adds failure cases for a failed, a pending, and a missing check.
- `RELEASING.md` says to wait for the post-merge `ci` run on `master` before tagging.

Verified: `shellcheck` on both scripts, `scripts/test-release-tools.sh` passes, and the verifier run against the live API accepts the real v0.1.5 tag at `4c0301c` with `rust,macos,linux-arm64` and rejects the same tag when a nonexistent check name is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWkfrRvnVgBgWCM7wznkfL
