### PR TITLE
Automatically optimize single-file writes to NFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1254,10 +1254,13 @@ When source and destination are on the same machine, syq copies each file with
 does a reflink or a straight in-kernel copy, and on NFS 4.2 the *server* copies
 the file internally (no client round trip). Measured: a single 8 GB file
 /raid→/raid at 24.8 GB/s vs 2.5 GB/s for `cp`; NFS→NFS at 3.3 GB/s vs 0.4.
-If the kernel cannot offload a cross-mount copy *into NFS*, the receiver uses
-one sequential reader/writer for that file. That avoids both per-inode NFS
-write contention and needless transport framing and hashing. An unsupported
-non-NFS destination retains the parallel, hash-resumable streaming fallback.
+If the kernel cannot offload a cross-mount copy from a recognized local disk
+filesystem into an ordinary asynchronous NFS mount, the receiver automatically
+uses one sequential reader/writer for that file. That avoids both per-inode NFS
+write contention and needless transport framing and hashing. NFS-to-NFS copies,
+other source filesystem types, synchronous NFS destinations, an explicit fixed
+worker count above one, and unsupported non-NFS destinations retain the
+parallel, hash-resumable streaming fallback.
 `-c`, any existing partial, and `--bwlimit` disable the receiver-side shortcut.
 Small new bwlimited files that fit in one paced transfer block retain the
 `PutSmall` exception described above.
@@ -1268,11 +1271,14 @@ Local↔NFS copies are a local→local syq run (`syq rsync -a -j16 /raid/x /mnt/
 and benefit from parallelism across files and on reads: measured on a 20 Gbit
 NFSv4.2 mount, reads of one 4 GB file reached 858 MiB/s with `-j8` vs ~400 MB/s
 for `cp`, and 20,000 small files were written in 28 s vs 72 s for `cp -r`.
-Writes into one NFS inode are instead serialized by the receiver when the
-kernel cannot offload them. On a fresh 4 GiB `/raid`→NFS copy, that changed syq
-from 21.44 s with 32 range writers to a 9.93 s median with one sequential
-receiver-side writer, versus a 10.94 s median for `cp` (two interleaved runs).
-The reciprocal NFS→`/raid` copy retained parallel range reads at 1.13 GiB/s.
+Writes from a recognized local disk filesystem into one asynchronous NFS inode
+are instead serialized automatically by the receiver when the kernel cannot
+offload them.
+On a fresh 4 GiB `/raid`→NFS copy, that changed syq from 21.44 s with 32 range
+writers to a 9.93 s median with one sequential receiver-side writer, versus a
+10.94 s median for `cp` (two interleaved runs). Synchronous destinations and
+NFS sources retain the adaptive parallel path; the reciprocal NFS→`/raid` copy
+reached 1.13 GiB/s with parallel range reads.
 Separate files still run concurrently and have reached ~650 MB/s in aggregate.
 Mounting with `nconnect=8` (NFS 4.1+; needs an unmount/mount, not a remount) can
 add headroom for those concurrent files and other NFS traffic.

--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ Git-derived identity when an explicit source-built helper is used.
   `cargo build --release` (needs the Xcode command-line tools, `xcode-select
   --install`, for the bundled zstd C library). The tool is otherwise pure Rust
   and uses only POSIX calls; Linux-only optimizations (`fallocate`,
-  glibc `mallopt`) are compiled out automatically. copy_file_range's local
-  fast path is Linux-only; on macOS same-machine copies use the normal path.
+  glibc `mallopt`) are compiled out automatically. The receiver-side
+  same-machine copy fast path is Linux-only; on macOS those copies use the
+  normal path.
 - For a manually installed binary that is portable across distributions (for
   example, a host with an older glibc), build a static binary:
   `RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target x86_64-unknown-linux-gnu`
@@ -1246,30 +1247,35 @@ NFS, where every unlink is a round trip, `-j32` removed 20,000 files in 2.5 s
 versus 9.7 s for `rm -rf`; on a local SSD `rm -rf` is already fast and syq is
 no faster.
 
-## Same-machine copies (copy_file_range)
+## Same-machine copies (copy_file_range and NFS)
 
 When source and destination are on the same machine, syq copies each file with
 `copy_file_range(2)` instead of streaming bytes through userspace: the kernel
 does a reflink or a straight in-kernel copy, and on NFS 4.2 the *server* copies
 the file internally (no client round trip). Measured: a single 8 GB file
 /raid→/raid at 24.8 GB/s vs 2.5 GB/s for `cp`; NFS→NFS at 3.3 GB/s vs 0.4.
-Hashing is skipped on this path (there's no wire to corrupt it); `-c`, any
-existing partial, and `--bwlimit` disable this shortcut. Existing partials and
-larger bwlimited files use the hash-resumable streaming path. Small new
-bwlimited files that fit in one paced transfer block retain the `PutSmall`
-exception described above.
+If the kernel cannot offload a cross-mount copy *into NFS*, the receiver uses
+one sequential reader/writer for that file. That avoids both per-inode NFS
+write contention and needless transport framing and hashing. An unsupported
+non-NFS destination retains the parallel, hash-resumable streaming fallback.
+`-c`, any existing partial, and `--bwlimit` disable the receiver-side shortcut.
+Small new bwlimited files that fit in one paced transfer block retain the
+`PutSmall` exception described above.
 
 ## NFS
 
 Local↔NFS copies are a local→local syq run (`syq rsync -a -j16 /raid/x /mnt/nfs/x`)
-and benefit from the same parallelism: measured on a 20 Gbit NFSv4.2 mount,
-reads of one 4 GB file 858 MiB/s with `-j8` vs ~400 MB/s for `cp`; 20,000
-small files written in 28 s vs 72 s for `cp -r`. Writes of a *single* file
-were capped at ~250 MB/s regardless of `-j`, while eight files written in
-parallel reached ~650 MB/s: the per-file limit comes from the NFS client's one
-TCP connection and per-inode write serialization. Mounting with
-`nconnect=8` (NFS 4.1+; needs an unmount/mount, not a remount) is the usual
-fix for that.
+and benefit from parallelism across files and on reads: measured on a 20 Gbit
+NFSv4.2 mount, reads of one 4 GB file reached 858 MiB/s with `-j8` vs ~400 MB/s
+for `cp`, and 20,000 small files were written in 28 s vs 72 s for `cp -r`.
+Writes into one NFS inode are instead serialized by the receiver when the
+kernel cannot offload them. On a fresh 4 GiB `/raid`→NFS copy, that changed syq
+from 21.44 s with 32 range writers to a 9.93 s median with one sequential
+receiver-side writer, versus a 10.94 s median for `cp` (two interleaved runs).
+The reciprocal NFS→`/raid` copy retained parallel range reads at 1.13 GiB/s.
+Separate files still run concurrently and have reached ~650 MB/s in aggregate.
+Mounting with `nconnect=8` (NFS 4.1+; needs an unmount/mount, not a remount) can
+add headroom for those concurrent files and other NFS traffic.
 
 ## Performance notes
 

--- a/SERVER-TUNING.md
+++ b/SERVER-TUNING.md
@@ -205,10 +205,12 @@ drops with `ip -s link` and the vendor's tools.
   tuner can reduce active workers during longer runs, but short jobs may finish
   before it measures the slowdown.
 - NVMe, RAID, NFS, and other high-latency filesystems often benefit from
-  parallelism across files. A same-machine copy into one NFS file is the
-  exception: when kernel offload is unavailable, syq uses one sequential
-  receiver-side writer to avoid per-inode contention. NFS mount choices such
-  as `nconnect` are client and server policy; see the
+  parallelism across files. A same-machine copy from a recognized local disk
+  filesystem into one asynchronous NFS file is the exception: when kernel
+  offload is unavailable, syq automatically uses one sequential receiver-side
+  writer to avoid per-inode contention. Other source types and synchronous NFS
+  destinations keep the adaptive parallel path. NFS mount choices such as
+  `nconnect` are client and server policy; see the
   [NFS notes](README.md#nfs) and test with disposable data.
 - Compression trades network bytes for CPU. Compare with and without `-z` when
   either the link or CPU is near saturation.

--- a/SERVER-TUNING.md
+++ b/SERVER-TUNING.md
@@ -205,8 +205,11 @@ drops with `ip -s link` and the vendor's tools.
   tuner can reduce active workers during longer runs, but short jobs may finish
   before it measures the slowdown.
 - NVMe, RAID, NFS, and other high-latency filesystems often benefit from
-  parallelism. NFS mount choices such as `nconnect` are client and server
-  policy; see the [NFS notes](README.md#nfs) and test with disposable data.
+  parallelism across files. A same-machine copy into one NFS file is the
+  exception: when kernel offload is unavailable, syq uses one sequential
+  receiver-side writer to avoid per-inode contention. NFS mount choices such
+  as `nconnect` are client and server policy; see the
+  [NFS notes](README.md#nfs) and test with disposable data.
 - Compression trades network bytes for CPU. Compare with and without `-z` when
   either the link or CPU is near saturation.
 - `--bwlimit` is the appropriate control when the goal is coexistence with

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -8,6 +8,8 @@ use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
+#[cfg(target_os = "linux")]
+use std::io::Write;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
@@ -21,6 +23,15 @@ const FD_CACHE_MAX: usize = 16;
 const COMMON_NAME_MAX: usize = 255;
 const COMPACT_HASH_BYTES: usize = 10;
 const NAME_MAX_CACHE_CAP: usize = 1024;
+
+#[cfg(target_os = "linux")]
+fn is_nfs_file(file: &File) -> bool {
+    let mut stats = std::mem::MaybeUninit::<libc::statfs>::uninit();
+    unsafe {
+        libc::fstatfs(file.as_raw_fd(), stats.as_mut_ptr()) == 0
+            && stats.assume_init().f_type as u32 == libc::NFS_SUPER_MAGIC as u32
+    }
+}
 
 #[cfg(target_os = "linux")]
 const MODE_DIR: u32 = libc::S_IFDIR;
@@ -2496,10 +2507,10 @@ impl FsOps {
         Ok(())
     }
 
-    /// Copy a whole file in the kernel via copy_file_range. Falls back with a
-    /// distinct "EXDEV" error when the kernel can't offload (different mounts
-    /// without server-side copy, or an unsupported filesystem) so the caller
-    /// can use the normal streaming path.
+    /// Copy a whole same-machine file without routing its bytes through the
+    /// transport. Prefer copy_file_range; when a cross-mount copy into NFS
+    /// cannot be offloaded, use one sequential userspace writer instead. Other
+    /// unsupported filesystems return "EXDEV" for the parallel streaming path.
     #[cfg(target_os = "linux")]
     pub fn copy_local(
         &mut self,
@@ -2553,15 +2564,22 @@ impl FsOps {
             }
             d
         };
+        let destination_is_nfs = is_nfs_file(&d)
+            || cfg!(debug_assertions) && std::env::var_os("SYQ_TEST_COPY_LOCAL_NFS").is_some();
+        let mut userspace_fallback = false;
         #[cfg(debug_assertions)]
         if !inplace && std::env::var_os("SYQ_TEST_COPY_LOCAL_EXDEV").is_some() {
-            drop(d);
-            fs::remove_file(&target).with_context(|| format!("remove {}", target.display()))?;
-            bail!("EXDEV");
+            if destination_is_nfs {
+                userspace_fallback = true;
+            } else {
+                drop(d);
+                fs::remove_file(&target).with_context(|| format!("remove {}", target.display()))?;
+                bail!("EXDEV");
+            }
         }
         let mut off: i64 = 0;
         let mut remaining = size;
-        while remaining > 0 {
+        while remaining > 0 && !userspace_fallback {
             let n = unsafe {
                 libc::copy_file_range(
                     s.as_raw_fd(),
@@ -2582,6 +2600,10 @@ impl FsOps {
                         libc::EXDEV | libc::ENOSYS | libc::EOPNOTSUPP | libc::EINVAL
                     )
                 {
+                    if destination_is_nfs {
+                        userspace_fallback = true;
+                        continue;
+                    }
                     if inplace {
                         drop(d);
                         let _ = fs::remove_file(&target);
@@ -2606,6 +2628,28 @@ impl FsOps {
                 break; // source shorter than expected; finalize what we have
             }
             remaining -= n as u64;
+        }
+        if userspace_fallback {
+            let mut source = &s;
+            let mut destination = &d;
+            source.seek(SeekFrom::Start(0))?;
+            destination.seek(SeekFrom::Start(0))?;
+            let mut buffer = vec![0u8; 1 << 20];
+            let mut remaining = size;
+            while remaining > 0 {
+                let want = remaining.min(buffer.len() as u64) as usize;
+                let n = source
+                    .read(&mut buffer[..want])
+                    .with_context(|| format!("read {}", sp.display()))?;
+                if n == 0 {
+                    bail!("source shortened while copying {}", sp.display());
+                }
+                destination
+                    .write_all(&buffer[..n])
+                    .with_context(|| format!("write {}", target.display()))?;
+                remaining -= n as u64;
+            }
+            d.set_len(size)?;
         }
         Ok(())
     }
@@ -2736,6 +2780,10 @@ impl FsOps {
         off: u64,
         len: u32,
     ) -> Result<Response> {
+        #[cfg(debug_assertions)]
+        if std::env::var_os("SYQ_TEST_FAIL_READ_RANGE").is_some() {
+            bail!("test read-range failure");
+        }
         let p = resolve(path);
         let f = self.cached(&p, false, attempt, false)?;
         let mut data = vec![0u8; len as usize];

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -25,11 +25,49 @@ const COMPACT_HASH_BYTES: usize = 10;
 const NAME_MAX_CACHE_CAP: usize = 1024;
 
 #[cfg(target_os = "linux")]
-fn is_nfs_file(file: &File) -> bool {
+#[derive(Clone, Copy, Default)]
+struct FileSystemTraits {
+    is_nfs: bool,
+    synchronous: bool,
+    measured_local_source: bool,
+}
+
+#[derive(Clone, Copy)]
+struct CopyLocalPolicy {
+    inplace: bool,
+    allow_sequential_nfs_fallback: bool,
+}
+
+#[cfg(target_os = "linux")]
+fn file_system_traits(file: &File) -> FileSystemTraits {
     let mut stats = std::mem::MaybeUninit::<libc::statfs>::uninit();
     unsafe {
-        libc::fstatfs(file.as_raw_fd(), stats.as_mut_ptr()) == 0
-            && stats.assume_init().f_type as u32 == libc::NFS_SUPER_MAGIC as u32
+        if libc::fstatfs(file.as_raw_fd(), stats.as_mut_ptr()) != 0 {
+            return FileSystemTraits::default();
+        }
+        let stats = stats.assume_init();
+        let file_system_type = stats.f_type as u32;
+        let mut mount_stats = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+        // Unknown mount flags are treated as synchronous so a metadata-query
+        // failure cannot opt an unmeasured topology into the shortcut.
+        let synchronous = if libc::fstatvfs(file.as_raw_fd(), mount_stats.as_mut_ptr()) == 0 {
+            mount_stats.assume_init().f_flag & libc::ST_SYNCHRONOUS != 0
+        } else {
+            true
+        };
+        FileSystemTraits {
+            is_nfs: file_system_type == libc::NFS_SUPER_MAGIC as u32,
+            synchronous,
+            // Keep the automatic optimization confined to the source
+            // filesystems actually exercised by the ext-family and XFS NFS
+            // benchmarks. Unknown or network-backed sources retain adaptive
+            // range reads until measured independently.
+            measured_local_source: matches!(
+                file_system_type,
+                t if t == libc::EXT4_SUPER_MAGIC as u32
+                    || t == libc::XFS_SUPER_MAGIC as u32
+            ),
+        }
     }
 }
 
@@ -2512,15 +2550,19 @@ impl FsOps {
     /// cannot be offloaded, use one sequential userspace writer instead. Other
     /// unsupported filesystems return "EXDEV" for the parallel streaming path.
     #[cfg(target_os = "linux")]
-    pub fn copy_local(
+    fn copy_local(
         &mut self,
         src: &[u8],
         dst: &[u8],
-        inplace: bool,
+        policy: CopyLocalPolicy,
         partial_id: &PartialId,
         size: u64,
         mode: u32,
     ) -> Result<()> {
+        let CopyLocalPolicy {
+            inplace,
+            allow_sequential_nfs_fallback,
+        } = policy;
         let sp = resolve(src);
         let s = open_existing_regular(&sp, false)?;
         // The kernel copy reads the source through the page cache, so the
@@ -2564,12 +2606,36 @@ impl FsOps {
             }
             d
         };
-        let destination_is_nfs = is_nfs_file(&d)
-            || cfg!(debug_assertions) && std::env::var_os("SYQ_TEST_COPY_LOCAL_NFS").is_some();
+        let source_fs = file_system_traits(&s);
+        let destination_fs = file_system_traits(&d);
+        #[cfg(debug_assertions)]
+        let source_fs = FileSystemTraits {
+            is_nfs: source_fs.is_nfs
+                || std::env::var_os("SYQ_TEST_COPY_LOCAL_SOURCE_NFS").is_some(),
+            measured_local_source: source_fs.measured_local_source
+                || std::env::var_os("SYQ_TEST_COPY_LOCAL_SOURCE_DISK").is_some(),
+            ..source_fs
+        };
+        #[cfg(debug_assertions)]
+        let destination_fs = FileSystemTraits {
+            is_nfs: destination_fs.is_nfs || std::env::var_os("SYQ_TEST_COPY_LOCAL_NFS").is_some(),
+            synchronous: destination_fs.synchronous
+                || std::env::var_os("SYQ_TEST_COPY_LOCAL_NFS_SYNC").is_some(),
+            ..destination_fs
+        };
+        // The measured fast path is a local filesystem feeding an ordinary
+        // asynchronous NFS mount. NFS reads can benefit from parallelism, and
+        // a synchronous destination makes every write syscall wait for the
+        // server, so let the normal adaptive range path handle either case.
+        let use_sequential_nfs_fallback = allow_sequential_nfs_fallback
+            && !source_fs.is_nfs
+            && source_fs.measured_local_source
+            && destination_fs.is_nfs
+            && !destination_fs.synchronous;
         let mut userspace_fallback = false;
         #[cfg(debug_assertions)]
         if !inplace && std::env::var_os("SYQ_TEST_COPY_LOCAL_EXDEV").is_some() {
-            if destination_is_nfs {
+            if use_sequential_nfs_fallback {
                 userspace_fallback = true;
             } else {
                 drop(d);
@@ -2600,7 +2666,7 @@ impl FsOps {
                         libc::EXDEV | libc::ENOSYS | libc::EOPNOTSUPP | libc::EINVAL
                     )
                 {
-                    if destination_is_nfs {
+                    if use_sequential_nfs_fallback {
                         userspace_fallback = true;
                         continue;
                     }
@@ -2655,11 +2721,11 @@ impl FsOps {
     }
 
     #[cfg(not(target_os = "linux"))]
-    pub fn copy_local(
+    fn copy_local(
         &mut self,
         _src: &[u8],
         _dst: &[u8],
-        _inplace: bool,
+        _policy: CopyLocalPolicy,
         _partial_id: &PartialId,
         _size: u64,
         _mode: u32,
@@ -3118,11 +3184,22 @@ impl FsOps {
                 src,
                 dst,
                 inplace,
+                allow_sequential_nfs_fallback,
                 partial_id,
                 size,
                 mode,
             } => self
-                .copy_local(src, dst, *inplace, partial_id, *size, *mode)
+                .copy_local(
+                    src,
+                    dst,
+                    CopyLocalPolicy {
+                        inplace: *inplace,
+                        allow_sequential_nfs_fallback: *allow_sequential_nfs_fallback,
+                    },
+                    partial_id,
+                    *size,
+                    *mode,
+                )
                 .map(|_| Response::Ok),
             Request::PutSmallBatch(puts) => Ok(Response::Applied(
                 puts.iter()

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -390,9 +390,9 @@ pub enum Request {
         len: u64,
         guard: Option<ContainerGuard>,
     },
-    /// In-kernel copy of a same-machine file (copy_file_range: reflink / NFS
-    /// server-side copy when possible). Err("EXDEV") tells the caller to fall
-    /// back to the normal read/write path.
+    /// Receiver-side copy of a same-machine file (copy_file_range when
+    /// possible, sequential userspace fallback for an NFS destination).
+    /// Err("EXDEV") tells the caller to use the normal streaming path.
     CopyLocal {
         src: PathBytes,
         dst: PathBytes,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -391,12 +391,14 @@ pub enum Request {
         guard: Option<ContainerGuard>,
     },
     /// Receiver-side copy of a same-machine file (copy_file_range when
-    /// possible, sequential userspace fallback for an NFS destination).
-    /// Err("EXDEV") tells the caller to use the normal streaming path.
+    /// possible, optionally a sequential userspace fallback for a local
+    /// source and asynchronous NFS destination). Err("EXDEV") tells the
+    /// caller to use the normal streaming path.
     CopyLocal {
         src: PathBytes,
         dst: PathBytes,
         inplace: bool,
+        allow_sequential_nfs_fallback: bool,
         partial_id: PartialId,
         size: u64,
         mode: u32,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -53,6 +53,9 @@ pub struct Opts {
     pub verify_only: bool,
     pub inplace: bool,
     pub same_host: bool,
+    /// Automatic copies and explicit -j1 may use one direct userspace writer
+    /// for the proven local-filesystem -> asynchronous-NFS topology.
+    pub allow_sequential_nfs_fallback: bool,
     pub dst_remote: bool,
     pub restricted_receiver: bool,
     pub dry_run: bool,
@@ -846,6 +849,7 @@ pub fn run(args: Args) -> Result<i32> {
         verify_only: args.verify_only,
         inplace: args.inplace,
         same_host: !src_ep.is_remote() && !dst_ep.is_remote(),
+        allow_sequential_nfs_fallback: args.connections_default || args.connections == 1,
         dst_remote: dst_ep.is_remote(),
         restricted_receiver: args.restricted_grant.is_some(),
         dry_run: args.dry_run,
@@ -5323,6 +5327,7 @@ impl Worker {
             src: job.src.clone(),
             dst: job.dst.clone(),
             inplace,
+            allow_sequential_nfs_fallback: self.opts.allow_sequential_nfs_fallback,
             partial_id: self.partial_id(),
             size: job.entry.size,
             mode,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -5115,8 +5115,9 @@ impl Worker {
                 }
             }
         };
-        // Same-machine copy: let the kernel move the bytes (reflink / NFS
-        // server-side copy) instead of streaming them through userspace.
+        // Same-machine copy: let the receiver move the bytes directly (kernel
+        // offload, or one sequential writer for cross-mount NFS) instead of
+        // framing, hashing and scheduling them through the transport.
         // copy_file_range cannot be paced, so a limited same-machine transfer
         // uses the regular userspace path (also useful for mounted NFS paths).
         if self.opts.same_host
@@ -5304,13 +5305,15 @@ impl Worker {
         self.sched.jobs.lock().unwrap()[idx].inplace = v;
     }
 
-    /// Attempt an in-kernel same-host copy. Ok(true) = done; Ok(false) =
-    /// kernel can't offload, caller should stream; Err = real failure.
+    /// Attempt a receiver-side same-host copy. Ok(true) = done; Ok(false) =
+    /// receiver cannot use its direct path, so the caller should stream;
+    /// Err = real failure.
     /// The caller owns scheduler probing bookkeeping for every terminal result.
     fn try_copy_local(&mut self, idx: usize, job: &FileJob) -> Result<bool> {
         // Write to a partial and let finish_file rename it, so an interrupted
-        // copy_file_range never leaves a final-named file the quick check could
-        // mistake for complete. Only --inplace writes the final path directly.
+        // A receiver-side copy never leaves a final-named file the quick check
+        // could mistake for complete. Only --inplace writes the final path
+        // directly.
         let inplace = self.opts.inplace
             && job.target_condition == TargetCondition::Any
             && job.container_guard.is_none();

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -6342,12 +6342,49 @@ fn copy_local_nfs_exdev_uses_sequential_receiver_fallback() {
         .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
         .env("SYQ_TEST_COPY_LOCAL_NFS", "1")
+        .env("SYQ_TEST_COPY_LOCAL_SOURCE_DISK", "1")
         .env("SYQ_TEST_FAIL_READ_RANGE", "1")
         .run()
         .unwrap();
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), contents);
     assert!(partial_files(&t.0).is_empty());
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_nfs_exdev_keeps_automatic_parallel_cases() {
+    let cases: &[(&[&str], Option<&str>)] = &[
+        (&[], Some("SYQ_TEST_COPY_LOCAL_SOURCE_NFS")),
+        (&[], Some("SYQ_TEST_COPY_LOCAL_NFS_SYNC")),
+        (&["-j", "2"], None),
+    ];
+    for (extra_args, extra_env) in cases {
+        let t = Tmp::new();
+        let contents = vec![b'x'; 8 * 1024 * 1024];
+        write(&t.path("src"), &contents);
+        let src = t.s("src");
+        let dst = t.s("dst");
+        let mut command = compat_command();
+        command
+            .args(["-a", "--no-progress"])
+            .args(*extra_args)
+            .args([&src, &dst])
+            .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .env("SYQ_TEST_COPY_LOCAL_NFS", "1")
+            .env("SYQ_TEST_COPY_LOCAL_SOURCE_DISK", "1")
+            .env("SYQ_TEST_FAIL_READ_RANGE", "1");
+        if let Some(name) = extra_env {
+            command.env(name, "1");
+        }
+        let out = command.run().unwrap();
+        assert!(!out.status.success(), "case unexpectedly used one writer");
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains("test read-range failure"),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
 }
 
 #[cfg(debug_assertions)]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -6331,6 +6331,25 @@ fn copy_local_exdev_fallback_leaves_no_partial() {
     assert!(partial_files(&t.0).is_empty());
 }
 
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_nfs_exdev_uses_sequential_receiver_fallback() {
+    let t = Tmp::new();
+    let contents = vec![b'x'; 8 * 1024 * 1024];
+    write(&t.path("src"), &contents);
+
+    let out = compat_command()
+        .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_NFS", "1")
+        .env("SYQ_TEST_FAIL_READ_RANGE", "1")
+        .run()
+        .unwrap();
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), contents);
+    assert!(partial_files(&t.0).is_empty());
+}
+
 #[cfg(debug_assertions)]
 #[test]
 fn long_basename_partial_is_truncated_and_resumed() {


### PR DESCRIPTION
## Summary

- always attempt `copy_file_range` first, preserving reflinks and NFS server-side copy
- when cross-mount offload is unavailable, automatically use one sequential 1 MiB receiver writer only for measured ext-family/XFS sources into an asynchronous NFS destination
- inspect both opened files plus `ST_SYNCHRONOUS`; NFS sources, synchronous/unknown mounts, and unmeasured source filesystem types retain the adaptive parallel range path
- honor an explicitly fixed worker count above one without requiring any option for the optimized default
- document the automatic selection and test the local-disk, cross-NFS, synchronous-NFS, and fixed-parallel branches

## Performance

Original live 4 GiB reproduction on j5:

- previous auto-32 syq: 21.44 s
- previous `-j 1`: 14.65 s
- `cp`: 10.89 / 10.99 s (10.94 s median)
- initial branch: 9.05 / 10.81 s (9.93 s median)

Fresh zero-option review run at `bf968cb`, XFS -> asynchronous NFSv4.2:

- `syq rsync -a`: 12.31 / 11.35 s (11.83 s median)
- `cp -a`: 11.49 / 12.18 s (11.84 s median)

All four outputs were byte-for-byte verified. The reciprocal NFS -> XFS copy remains on the parallel path; the earlier live run completed in 3.70 s at 1.13 GiB/s and was also verified.

## Review response

The first version selected only from destination NFS type. This revision confines the default shortcut to the two measured local source filesystem families and an asynchronous NFS destination. `fstatvfs` failure is conservative. Cross-NFS and synchronous NFS therefore keep their previous behavior rather than inheriting an untested one-writer assumption.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (214 unit, 251 local integration, 9 update)
- live interleaved 4 GiB automatic syq/cp benchmark with byte verification

Head: `bf968cb`
