### PR TITLE
Reduce WAN small-file setup latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,7 +718,11 @@ source's mode with `-p`.
 
 One control connection per endpoint does the scan (a parallel walk on each
 side, streamed in batches), the diff, directory creation and metadata.
-Workers connect after the mapped payload/sidecar namespace preflight completes.
+Workers receive no file work until the mapped payload/sidecar namespace
+preflight completes. For a fresh remote destination with a selected TCP route,
+they begin connecting as soon as a source batch proves that file work exists,
+overlapping authentication with sidecar resolution and directory creation;
+an empty tree opens no worker connection.
 The data connections — by default separate TCP sockets carrying AES-256-GCM
 records — carry only "read range" / "write range" requests. When data uses SSH
 (through `--no-tcp` or TCP fallback), a transfer consisting entirely of fresh
@@ -1077,7 +1081,11 @@ ssh (silenced by `-q`). When several NICs of
 comparable speed are reachable (e.g. an 8-rail RoCE fabric), syq spreads its
 data connections across all of them (multipath) — it keeps only paths within
 2x of the fastest, so it never drags a fast transfer down by mixing in a slow
-link. Single-homed hosts and laptops use the one best path, unchanged. With ufw:
+link. Every candidate still gets its complete bounded probe window, but those
+independent probes run while the control connection prepares the destination.
+Worker Hello and destination anchoring are likewise sent in one
+pipelined setup turn. Single-homed hosts and laptops use the one best path,
+unchanged. With ufw:
 
 ```sh
 sudo ufw allow from 192.0.2.0/24  to any port 47600:47699 proto tcp   # example LAN

--- a/README.md
+++ b/README.md
@@ -718,14 +718,17 @@ source's mode with `-p`.
 
 One control connection per endpoint does the scan (a parallel walk on each
 side, streamed in batches), the diff, directory creation and metadata.
-Workers connect while the source is scanned but begin file data only after
-the mapped payload/sidecar namespace preflight completes.
+Workers connect after the mapped payload/sidecar namespace preflight completes.
 The data connections — by default separate TCP sockets carrying AES-256-GCM
-records (under `--no-tcp`, separate `ssh` processes instead), each its own flow
-and cipher — carry only "read range" / "write range" requests. Files go
-onto a largest-first queue; when a worker runs dry it steals the back half of
-the remaining range of whichever file has the most left, so the tail of a
-transfer stays parallel without pre-deciding chunk counts.
+records — carry only "read range" / "write range" requests. When data uses SSH
+(through `--no-tcp` or TCP fallback), a transfer consisting entirely of fresh
+small files opens worker sessions over the already-authenticated OpenSSH control
+connection; larger or mixed workloads retain separate `ssh` processes, TCP
+flows, and cipher processes. A custom `-e` command keeps its own SSH
+multiplexing policy. Files go onto a largest-first queue; when a worker runs dry
+it steals the back half of the remaining range of whichever file has the most
+left, so the tail of a transfer stays parallel without pre-deciding chunk
+counts.
 
 On the receiving side a file that needs content changes is written beside its
 destination as `.name.syq-part.<job-id>` (preallocated with `fallocate`,
@@ -1013,6 +1016,12 @@ connections (where each stream is capped by OpenSSH's 2 MB window) it
 reaches line rate (~110 MB/s, where a fixed `-j 8` managed 44) about 30 s
 after the connections are up.
 
+On the same kind of long path (262 ms), a fresh 2,000-file / 8 MiB tree over
+`--no-tcp` took 11.29 s in two verified runs after fresh-small-file workers
+began reusing the authenticated control connection, versus 16.85 s with eight
+independently authenticated worker connections. Larger and mixed workloads
+still use independent SSH connections so they retain multi-flow throughput.
+
 `-j N` fixes the count and disables tuning. Use it when you know better (a
 spinning disk that must not be read in parallel: `-j 1`), or to be polite on
 a shared link.
@@ -1294,8 +1303,10 @@ fix for that.
   server sheds one — sshd's `MaxStartups` (default 10) randomly rejects
   sessions beyond 10 being set up at once — syq halves that number for the
   rest of the run and retries. Raising `MaxStartups` can reduce setup time for
-  ssh data connections, but increases the resources available to
-  unauthenticated clients; see [Server performance tuning](SERVER-TUNING.md).
+  independent ssh data connections; fresh-small-file workers using default ssh
+  reuse the authenticated control connection instead. A higher limit increases
+  the resources available to unauthenticated clients; see
+  [Server performance tuning](SERVER-TUNING.md).
   Auto-tuning starts at 16 for TCP data, or 8 for ssh data, and only opens more
   once they have been shown to pay.
 - Preferred direct remote→remote uses one enrollment-key authentication for the

--- a/SERVER-TUNING.md
+++ b/SERVER-TUNING.md
@@ -60,21 +60,24 @@ per-transfer token and is encrypted unless `--tcp-plain` was requested.
 Trade-offs:
 
 - A reachable TCP path avoids ssh's per-channel flow-control and cipher-process
-  limits and avoids starting one ssh process per data worker.
+  limits. Fresh-small-file workers using default ssh reuse the authenticated
+  control connection; larger and mixed SSH workloads start independent data
+  processes so they can use multiple flows and cipher processes.
 - A firewall exception increases reachable attack surface. A private LAN, VPN,
   or narrowly scoped source rule is preferable to a public allow rule.
 - `--tcp-plain` saves encryption work but removes data confidentiality and
   integrity. Use it only on a network whose trust boundary you understand.
-- `--no-tcp` requires no additional inbound ports, at the cost of using ssh for
-  every data connection.
+- `--no-tcp` requires no additional inbound ports, at the cost of using SSH for
+  the data transport.
 
 ## 2. Raise sshd `MaxStartups` only after observed drops
 
-This setting matters when data falls back to ssh. It limits concurrent
-*unauthenticated* ssh connections; it does not limit established sessions and
-does not apply to syq workers using the TCP data path. syq already retries shed
-connections and reduces the number of simultaneous handshakes, so the default
-is functional but can make connection setup slower.
+This setting matters when data falls back to independent ssh connections. It
+limits concurrent *unauthenticated* ssh connections; it does not limit
+established sessions, fresh-small-file workers multiplexed over default ssh, or
+workers using the TCP data path. syq already retries shed connections and
+reduces the number of simultaneous handshakes, so the default is functional but
+can make connection setup slower.
 
 Inspect the effective value rather than assuming the distribution default:
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -11,7 +11,9 @@ use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::os::fd::AsRawFd;
+use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 pub trait Conn: Send {
     fn send(&mut self, req: Request) -> Result<()>;
@@ -705,6 +707,43 @@ pub enum DataTransport {
     PlaintextTcp,
 }
 
+#[derive(Debug)]
+pub(crate) struct SshMultiplexer {
+    _directory: tempfile::TempDir,
+    path: PathBuf,
+    reuse_for_workers: AtomicBool,
+}
+
+impl SshMultiplexer {
+    pub(crate) fn new() -> Result<Self> {
+        let directory = tempfile::Builder::new()
+            .prefix("syq-ssh-")
+            .tempdir()
+            .context("create private SSH control directory")?;
+        let path = directory.path().join("socket");
+        Ok(Self {
+            _directory: directory,
+            path,
+            reuse_for_workers: AtomicBool::new(false),
+        })
+    }
+
+    fn set_reuse_for_workers(&self, reuse: bool) {
+        self.reuse_for_workers.store(reuse, Ordering::Relaxed);
+    }
+
+    fn reuse_for_workers(&self) -> bool {
+        self.reuse_for_workers.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum SshConnection {
+    Independent,
+    Control,
+    Worker,
+}
+
 #[derive(Clone, Debug)]
 pub struct RemoteSpec {
     /// Run the receiver helper as a local child. This gives local copies the
@@ -723,6 +762,10 @@ pub struct RemoteSpec {
     pub restricted_grant: Option<String>,
     /// Serializes a first-use install across control and worker clones.
     pub helper_install: std::sync::Arc<std::sync::Mutex<bool>>,
+    /// A private OpenSSH control socket. The control session is always capable
+    /// of multiplexing, but workers use it only after the completed plan shows
+    /// that every payload is a fresh small file.
+    pub(crate) ssh_multiplexer: Option<std::sync::Arc<SshMultiplexer>>,
     /// `-q`: suppress the "falling back to ssh" notice.
     pub quiet: bool,
     /// Shared across clones so workers see the TCP setup done on the control connection.
@@ -742,6 +785,7 @@ impl RemoteSpec {
             auto_helper: false,
             restricted_grant: None,
             helper_install: Default::default(),
+            ssh_multiplexer: None,
             quiet,
             tcp: Default::default(),
             diagnostics: Default::default(),
@@ -770,6 +814,12 @@ impl RemoteSpec {
         }
     }
 
+    pub fn set_ssh_multiplexing(&self, reuse: bool) {
+        if let Some(multiplexer) = &self.ssh_multiplexer {
+            multiplexer.set_reuse_for_workers(reuse);
+        }
+    }
+
     pub fn remote_shell_name(&self) -> String {
         std::path::Path::new(&self.rsh[0])
             .file_name()
@@ -784,22 +834,44 @@ impl RemoteSpec {
         }
     }
 
-    fn ssh_command(&self) -> Command {
+    fn ssh_command(&self, connection: SshConnection) -> Command {
         let mut cmd = Command::new(&self.rsh[0]);
         cmd.args(&self.rsh[1..]);
         if self.rsh[0].ends_with("ssh") {
-            // Data connections must not share one TCP stream / cipher process,
-            // and AES-GCM is much faster than OpenSSH's default chacha20 on
-            // CPUs with AES-NI. The list still includes the defaults so
-            // negotiation never fails.
-            cmd.args([
-                "-o",
-                "ControlMaster=no",
-                "-o",
-                "ControlPath=none",
-                "-o",
-                CIPHERS,
-            ]);
+            let multiplex = match (connection, &self.ssh_multiplexer) {
+                (SshConnection::Control, Some(multiplexer)) => Some((multiplexer, true)),
+                (SshConnection::Worker, Some(multiplexer)) if multiplexer.reuse_for_workers() => {
+                    Some((multiplexer, false))
+                }
+                _ => None,
+            };
+            if let Some((multiplexer, master)) = multiplex {
+                if master {
+                    // A failed control command can leave its socket briefly
+                    // behind while OpenSSH exits. This path is private to this
+                    // transfer, so clearing that stale inode before a retry is
+                    // safe and prevents the next master from refusing it.
+                    let _ = std::fs::remove_file(&multiplexer.path);
+                }
+                cmd.arg("-o")
+                    .arg(format!(
+                        "ControlMaster={}",
+                        if master { "yes" } else { "no" }
+                    ))
+                    .arg("-o")
+                    .arg(format!("ControlPath={}", multiplexer.path.display()))
+                    .arg("-o")
+                    .arg("ControlPersist=no");
+            } else {
+                // Large-file data connections need independent TCP streams and
+                // cipher processes. Custom remote-shell commands also keep
+                // their existing policy.
+                cmd.args(["-o", "ControlMaster=no", "-o", "ControlPath=none"]);
+            }
+            // AES-GCM is much faster than OpenSSH's default chacha20 on CPUs
+            // with AES-NI. The list still includes the defaults so negotiation
+            // never fails.
+            cmd.args(["-o", CIPHERS]);
             if let Some(u) = &self.user {
                 cmd.args(["-l", u]);
             }
@@ -859,7 +931,7 @@ impl RemoteSpec {
         let mut last = None;
         for attempt in 0..6 {
             let _slot = limited.then(connect_slot);
-            match self.connect_once(compress) {
+            match self.connect_once(compress, limited) {
                 Ok(c) => return Ok(c),
                 // Don't retry what won't change: a missing binary (127) or a
                 // build identity mismatch.
@@ -903,7 +975,7 @@ impl RemoteSpec {
         Err(last.unwrap())
     }
 
-    fn connect_once(&self, compress: bool) -> Result<RemoteConn> {
+    fn connect_once(&self, compress: bool, limited: bool) -> Result<RemoteConn> {
         let mut server_args = vec!["--server".into()];
         if let Some(grant) = &self.restricted_grant {
             server_args.push(format!("--restricted-grant={grant}"));
@@ -913,7 +985,11 @@ impl RemoteSpec {
             command.args(&server_args);
             command
         } else {
-            let mut command = self.ssh_command();
+            let mut command = self.ssh_command(if limited {
+                SshConnection::Worker
+            } else {
+                SshConnection::Control
+            });
             let remote_command = if self.restricted_grant.is_some() {
                 // This text is inspected by the forced receiver through
                 // SSH_ORIGINAL_COMMAND; sshd replaces the requested executable.
@@ -1366,7 +1442,7 @@ impl RemoteSpec {
     }
 
     fn remote_bootstrap(&self) -> Result<RemoteBootstrap> {
-        let mut cmd = self.ssh_command();
+        let mut cmd = self.ssh_command(SshConnection::Independent);
         cmd.arg(remote_helper::probe_command())
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -1455,7 +1531,7 @@ impl RemoteSpec {
 
     fn try_direct_helper(&self, target: Target) -> Result<DirectHelper> {
         let script = remote_helper::download_script(target);
-        let mut cmd = self.ssh_command();
+        let mut cmd = self.ssh_command(SshConnection::Independent);
         cmd.arg(format!("sh -c {}", shell_words::quote(&script)))
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -1577,7 +1653,7 @@ impl RemoteSpec {
 
     fn upload_helper(&self, target: Target, binary: &[u8]) -> Result<()> {
         let script = remote_helper::upload_script(target);
-        let mut cmd = self.ssh_command();
+        let mut cmd = self.ssh_command(SshConnection::Independent);
         cmd.arg(format!("sh -c {}", shell_words::quote(&script)))
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -1900,6 +1976,7 @@ mod tests {
             auto_helper: false,
             restricted_grant: None,
             helper_install: Default::default(),
+            ssh_multiplexer: None,
             quiet: false,
             tcp: Default::default(),
             diagnostics: Default::default(),
@@ -2098,11 +2175,12 @@ mod tests {
             auto_helper: false,
             restricted_grant: None,
             helper_install: Default::default(),
+            ssh_multiplexer: None,
             quiet: false,
             tcp: Default::default(),
             diagnostics: Default::default(),
         };
-        let command = spec.ssh_command();
+        let command = spec.ssh_command(SshConnection::Independent);
         assert!(!command
             .get_args()
             .any(|arg| arg.to_string_lossy().starts_with("StrictHostKeyChecking=")));
@@ -2114,8 +2192,52 @@ mod tests {
             "StrictHostKeyChecking=yes".to_string(),
         ];
         assert!(configured
-            .ssh_command()
+            .ssh_command(SshConnection::Independent)
             .get_args()
             .any(|arg| arg == OsStr::new("StrictHostKeyChecking=yes")));
+    }
+
+    #[test]
+    fn ssh_workers_reuse_the_private_control_socket_only_when_enabled() {
+        let multiplexer = std::sync::Arc::new(SshMultiplexer::new().unwrap());
+        let control_path = format!("ControlPath={}", multiplexer.path.display());
+        let spec = RemoteSpec {
+            local_process: false,
+            user: None,
+            host: "example".into(),
+            rsh: vec!["ssh".into()],
+            syq_path: None,
+            auto_helper: false,
+            restricted_grant: None,
+            helper_install: Default::default(),
+            ssh_multiplexer: Some(multiplexer),
+            quiet: false,
+            tcp: Default::default(),
+            diagnostics: Default::default(),
+        };
+        let args = |connection| {
+            spec.ssh_command(connection)
+                .get_args()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+        };
+
+        let control = args(SshConnection::Control);
+        assert!(control.iter().any(|arg| arg == "ControlMaster=yes"));
+        assert!(control.iter().any(|arg| arg == &control_path));
+        assert!(control.iter().any(|arg| arg == "ControlPersist=no"));
+
+        let worker = args(SshConnection::Worker);
+        assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
+        assert!(worker.iter().any(|arg| arg == "ControlPath=none"));
+
+        spec.set_ssh_multiplexing(true);
+        let worker = args(SshConnection::Worker);
+        assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
+        assert!(worker.iter().any(|arg| arg == &control_path));
+        assert!(!worker.iter().any(|arg| arg == "ControlPath=none"));
+
+        let independent = args(SshConnection::Independent);
+        assert!(independent.iter().any(|arg| arg == "ControlPath=none"));
     }
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2162,6 +2162,65 @@ mod tests {
     }
 
     #[test]
+    fn hello_sends_worker_initialization_before_waiting_for_its_response() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            socket
+                .set_read_timeout(Some(std::time::Duration::from_secs(1)))
+                .unwrap();
+            let mut reader = FrameReader::new(socket.try_clone().unwrap());
+            assert!(matches!(
+                reader.read_msg::<Request>().unwrap(),
+                Request::Hello { .. }
+            ));
+            assert!(matches!(
+                reader.read_msg::<Request>().unwrap(),
+                Request::AnchorDestination { .. }
+            ));
+
+            let mut writer = FrameWriter::new(socket, false);
+            writer
+                .write_msg(&Response::HelloOk {
+                    identity: crate::identity::build().to_string(),
+                    platform: crate::identity::platform(),
+                })
+                .unwrap();
+            writer.write_msg(&Response::Ok).unwrap();
+        });
+
+        let socket = TcpStream::connect(address).unwrap();
+        let (rx, reader) = spawn_reader(Box::new(socket.try_clone().unwrap()));
+        let conn = RemoteConn {
+            child: None,
+            w: FrameWriter::new(Box::new(socket), false),
+            rx: Some(rx),
+            reader: Some(reader),
+            label: "pipelined hello test".into(),
+            dead: false,
+            peer: None,
+            tcp_socket: None,
+        };
+        let conn = hello(
+            conn,
+            false,
+            Vec::new(),
+            Some(Request::AnchorDestination {
+                path: Some(b"destination".to_vec()),
+                expected_dev: 1,
+                expected_ino: 2,
+                request_prefix: b"destination".to_vec(),
+                insecure_links: false,
+            }),
+        )
+        .unwrap();
+        assert!(conn.peer.is_some());
+        drop(conn);
+        server.join().unwrap();
+    }
+
+    #[test]
     fn transport_stats_response_wait_has_a_deadline() {
         let (_sender, receiver) = std::sync::mpsc::sync_channel(1);
         let timeout = std::time::Duration::from_millis(20);

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -121,6 +121,26 @@ pub(crate) fn is_worker_initialization_error(error: &anyhow::Error) -> bool {
         .any(|cause| cause.is::<WorkerInitializationError>())
 }
 
+/// OpenSSH accepted the control connection but rejected a multiplexed worker
+/// session. Independent SSH connections may still be permitted (for example,
+/// with `MaxSessions 1`), so callers can safely disable reuse and retry.
+#[derive(Debug)]
+struct MultiplexedSshSessionError(String);
+
+impl std::fmt::Display for MultiplexedSshSessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for MultiplexedSshSessionError {}
+
+fn is_multiplexed_ssh_session_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.is::<MultiplexedSshSessionError>())
+}
+
 fn worker_initialization_response(response: Response) -> Result<()> {
     match response {
         Response::Ok => Ok(()),
@@ -431,6 +451,7 @@ pub struct RemoteConn {
     dead: bool,
     peer: Option<PeerInfo>,
     tcp_socket: Option<TcpStream>,
+    multiplexed_ssh: bool,
 }
 
 const READ_AHEAD: usize = 4;
@@ -523,6 +544,13 @@ impl RemoteConn {
         if let Some(child) = &mut self.child {
             for _ in 0..20 {
                 if let Ok(Some(status)) = child.try_wait() {
+                    if self.multiplexed_ssh && status.code() == Some(255) {
+                        return MultiplexedSshSessionError(format!(
+                            "{}: multiplexed SSH session was rejected ({status})",
+                            self.label
+                        ))
+                        .into();
+                    }
                     return anyhow!("{}: remote syq exited ({status})", self.label);
                 }
                 std::thread::sleep(std::time::Duration::from_millis(10));
@@ -782,7 +810,7 @@ impl SshMultiplexer {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum SshConnection {
     Independent,
     Control,
@@ -885,9 +913,7 @@ impl RemoteSpec {
         if self.rsh[0].ends_with("ssh") {
             let multiplex = match (connection, &self.ssh_multiplexer) {
                 (SshConnection::Control, Some(multiplexer)) => Some((multiplexer, true)),
-                (SshConnection::Worker, Some(multiplexer)) if multiplexer.reuse_for_workers() => {
-                    Some((multiplexer, false))
-                }
+                (SshConnection::Worker, Some(multiplexer)) => Some((multiplexer, false)),
                 _ => None,
             };
             if let Some((multiplexer, master)) = multiplex {
@@ -926,6 +952,20 @@ impl RemoteSpec {
         }
         cmd.arg(&self.host);
         cmd
+    }
+
+    fn ssh_connection(&self, limited: bool) -> SshConnection {
+        if !limited {
+            SshConnection::Control
+        } else if self
+            .ssh_multiplexer
+            .as_ref()
+            .is_some_and(|multiplexer| multiplexer.reuse_for_workers())
+        {
+            SshConnection::Worker
+        } else {
+            SshConnection::Independent
+        }
     }
 
     /// A shell command that runs syq with `args` on this host.  Automatic mode
@@ -991,20 +1031,39 @@ impl RemoteSpec {
         let mut last = None;
         for attempt in 0..6 {
             let _slot = limited.then(connect_slot);
-            match self.connect_once(compress, limited, initial_request.clone()) {
+            let ssh_connection = self.ssh_connection(limited);
+            match self.connect_once(compress, ssh_connection, initial_request.clone()) {
                 Ok(c) => return Ok(c),
+                Err(e)
+                    if ssh_connection == SshConnection::Worker
+                        && is_multiplexed_ssh_session_error(&e) =>
+                {
+                    // MaxSessions can reject a new channel on an otherwise
+                    // healthy control connection while still allowing a new
+                    // independently authenticated SSH connection. Disable
+                    // reuse for every later worker and retry immediately.
+                    self.set_ssh_multiplexing(false);
+                    if crate::transfer::debug() {
+                        eprintln!(
+                            "syq: {}: multiplexed SSH worker rejected; using independent SSH connections",
+                            self.label()
+                        );
+                    }
+                    last = Some(e);
+                    continue;
+                }
                 // Don't retry what won't change: a missing binary (127) or a
                 // build identity mismatch.
                 Err(e)
                     if attempt == 5
-                        || e.to_string().contains("build identity mismatch")
+                        || format!("{e:#}").contains("build identity mismatch")
                         || is_worker_initialization_error(&e)
-                        || e.to_string().contains("exit status: 127")
-                        || e.to_string().contains(&format!(
+                        || format!("{e:#}").contains("exit status: 127")
+                        || format!("{e:#}").contains(&format!(
                             "exit status: {}",
                             remote_helper::HELPER_MISSING_EXIT
                         ))
-                        || e.to_string().contains(&format!(
+                        || format!("{e:#}").contains(&format!(
                             "exit status: {}",
                             remote_helper::HELPER_NOT_EXECUTABLE_EXIT
                         )) =>
@@ -1039,7 +1098,7 @@ impl RemoteSpec {
     fn connect_once(
         &self,
         compress: bool,
-        limited: bool,
+        ssh_connection: SshConnection,
         initial_request: Option<Request>,
     ) -> Result<RemoteConn> {
         let mut server_args = vec!["--server".into()];
@@ -1051,11 +1110,7 @@ impl RemoteSpec {
             command.args(&server_args);
             command
         } else {
-            let mut command = self.ssh_command(if limited {
-                SshConnection::Worker
-            } else {
-                SshConnection::Control
-            });
+            let mut command = self.ssh_command(ssh_connection);
             let remote_command = if self.restricted_grant.is_some() {
                 // This text is inspected by the forced receiver through
                 // SSH_ORIGINAL_COMMAND; sshd replaces the requested executable.
@@ -1088,6 +1143,7 @@ impl RemoteSpec {
             dead: false,
             peer: None,
             tcp_socket: None,
+            multiplexed_ssh: ssh_connection == SshConnection::Worker,
         };
         let conn = hello(conn, compress, Vec::new(), initial_request)?;
         self.record_peer(&conn);
@@ -1374,6 +1430,7 @@ impl RemoteSpec {
                 dead: false,
                 peer: None,
                 tcp_socket: Some(tcp_socket),
+                multiplexed_ssh: false,
             };
             let conn = hello(conn, compress, info.token.clone(), initial_request.clone())?;
             self.record_peer(&conn);
@@ -1384,7 +1441,7 @@ impl RemoteSpec {
 }
 
 fn helper_needs_install(e: &anyhow::Error) -> bool {
-    let message = e.to_string();
+    let message = format!("{e:#}");
     message.contains(&format!(
         "exit status: {}",
         remote_helper::HELPER_MISSING_EXIT
@@ -1519,7 +1576,10 @@ fn hello(
         }
         Ok(Response::Err(e)) => bail!("{}: {e}", conn.label),
         Ok(other) => bail!("{}: unexpected handshake response {other:?}", conn.label),
-        Err(e) => bail!("{e}\ncould not start the remote syq on {}", conn.label),
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("could not start the remote syq on {}", conn.label))
+        }
     }
     if initial_request.is_some() {
         worker_initialization_response(conn.recv()?)?;
@@ -2201,6 +2261,7 @@ mod tests {
             dead: false,
             peer: None,
             tcp_socket: None,
+            multiplexed_ssh: false,
         };
         let conn = hello(
             conn,
@@ -2263,6 +2324,7 @@ mod tests {
                 dead: false,
                 peer: None,
                 tcp_socket: Some(tcp_socket),
+                multiplexed_ssh: false,
             };
             let timeout = std::time::Duration::from_millis(5);
             let start = std::time::Instant::now();
@@ -2435,12 +2497,12 @@ mod tests {
         assert!(control.iter().any(|arg| arg == &control_path));
         assert!(control.iter().any(|arg| arg == "ControlPersist=no"));
 
-        let worker = args(SshConnection::Worker);
+        let worker = args(spec.ssh_connection(true));
         assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
         assert!(worker.iter().any(|arg| arg == "ControlPath=none"));
 
         spec.set_ssh_multiplexing(true);
-        let worker = args(SshConnection::Worker);
+        let worker = args(spec.ssh_connection(true));
         assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
         assert!(worker.iter().any(|arg| arg == &control_path));
         assert!(!worker.iter().any(|arg| arg == "ControlPath=none"));

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -102,6 +102,36 @@ pub(crate) fn tcp_congestion_fallback_note(requested: Option<&str>) -> String {
         .unwrap_or_default()
 }
 
+/// A worker reached the receiver, but its destination anchor was rejected.
+/// Retrying or changing transports cannot repair a failed identity check.
+#[derive(Debug)]
+struct WorkerInitializationError(String);
+
+impl std::fmt::Display for WorkerInitializationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for WorkerInitializationError {}
+
+pub(crate) fn is_worker_initialization_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.is::<WorkerInitializationError>())
+}
+
+fn worker_initialization_response(response: Response) -> Result<()> {
+    match response {
+        Response::Ok => Ok(()),
+        Response::Err(error) => Err(WorkerInitializationError(error).into()),
+        other => Err(WorkerInitializationError(format!(
+            "unexpected worker initialization response {other:?}"
+        ))
+        .into()),
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn tcp_congestion_control<S: AsRawFd>(socket: &S) -> std::io::Result<String> {
     // Linux currently caps names at TCP_CA_NAME_MAX (16 including NUL). Leave
@@ -693,6 +723,21 @@ pub struct TcpProbe {
     pub candidates: Vec<TcpCandidate>,
 }
 
+/// TCP listener state whose route probes are running in the background.
+///
+/// The listener must be requested over the authenticated control connection,
+/// but probing its advertised addresses does not use that connection. Keeping
+/// the probe join handle here lets destination preflight cover the bounded
+/// reachability window without weakening route selection.
+pub(crate) struct PendingTcpSetup {
+    port: u16,
+    key: Option<Vec<u8>>,
+    token: Vec<u8>,
+    congestion_control: Option<String>,
+    remote_congestion_control: Option<String>,
+    probe: std::thread::JoinHandle<Vec<TcpCandidate>>,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct RemoteDiagnostics {
     pub peer: Option<PeerInfo>,
@@ -900,7 +945,7 @@ impl RemoteSpec {
     /// connections at random when many are being set up at once, so we also
     /// limit how many connects are in flight.
     pub fn connect(&self, compress: bool) -> Result<RemoteConn> {
-        self.connect_with(compress, true)
+        self.connect_with_request(compress, true, None)
     }
 
     /// `limited`: take a connect slot (data connections). The control
@@ -908,7 +953,16 @@ impl RemoteSpec {
     /// queue behind workers. In managed mode the release helper is installed
     /// on first use if the remote lacks it.
     pub fn connect_with(&self, compress: bool, limited: bool) -> Result<RemoteConn> {
-        let first = self.connect_retried(compress, limited);
+        self.connect_with_request(compress, limited, None)
+    }
+
+    fn connect_with_request(
+        &self,
+        compress: bool,
+        limited: bool,
+        initial_request: Option<Request>,
+    ) -> Result<RemoteConn> {
+        let first = self.connect_retried(compress, limited, initial_request.clone());
         let Err(first_error) = first else {
             return first;
         };
@@ -917,27 +971,34 @@ impl RemoteSpec {
         }
 
         self.install_helper()?;
-        self.connect_retried(compress, limited).with_context(|| {
-            format!(
-                "could not start the {} helper installed on {}",
-                remote_helper::helper_identity(),
-                self.label()
-            )
-        })
+        self.connect_retried(compress, limited, initial_request)
+            .with_context(|| {
+                format!(
+                    "could not start the {} helper installed on {}",
+                    remote_helper::helper_identity(),
+                    self.label()
+                )
+            })
     }
 
-    fn connect_retried(&self, compress: bool, limited: bool) -> Result<RemoteConn> {
+    fn connect_retried(
+        &self,
+        compress: bool,
+        limited: bool,
+        initial_request: Option<Request>,
+    ) -> Result<RemoteConn> {
         let mut delay = std::time::Duration::from_millis(200);
         let mut last = None;
         for attempt in 0..6 {
             let _slot = limited.then(connect_slot);
-            match self.connect_once(compress, limited) {
+            match self.connect_once(compress, limited, initial_request.clone()) {
                 Ok(c) => return Ok(c),
                 // Don't retry what won't change: a missing binary (127) or a
                 // build identity mismatch.
                 Err(e)
                     if attempt == 5
                         || e.to_string().contains("build identity mismatch")
+                        || is_worker_initialization_error(&e)
                         || e.to_string().contains("exit status: 127")
                         || e.to_string().contains(&format!(
                             "exit status: {}",
@@ -975,7 +1036,12 @@ impl RemoteSpec {
         Err(last.unwrap())
     }
 
-    fn connect_once(&self, compress: bool, limited: bool) -> Result<RemoteConn> {
+    fn connect_once(
+        &self,
+        compress: bool,
+        limited: bool,
+        initial_request: Option<Request>,
+    ) -> Result<RemoteConn> {
         let mut server_args = vec!["--server".into()];
         if let Some(grant) = &self.restricted_grant {
             server_args.push(format!("--restricted-grant={grant}"));
@@ -1023,40 +1089,50 @@ impl RemoteSpec {
             peer: None,
             tcp_socket: None,
         };
-        let conn = hello(conn, compress, Vec::new())?;
+        let conn = hello(conn, compress, Vec::new(), initial_request)?;
         self.record_peer(&conn);
         Ok(conn)
     }
 
     /// Ask the remote (over the control connection) to accept TCP data
-    /// connections; records how to reach it for later `connect` calls.
-    pub fn setup_tcp(
+    /// connections, then begin probing the advertised routes in the
+    /// background. The caller must finish the setup before opening workers.
+    pub(crate) fn begin_tcp_setup(
         &self,
         ctl: &mut dyn Conn,
         plain: bool,
         ports: (u16, u16),
         congestion_control: Option<&str>,
-    ) -> Result<()> {
+    ) -> Result<PendingTcpSetup> {
         *self.tcp.lock().unwrap() = None;
         {
             let mut diagnostics = self.diagnostics.lock().unwrap();
             diagnostics.tcp_probe = None;
             diagnostics.tcp_setup_error = None;
         }
-        let result = self.setup_tcp_inner(ctl, plain, ports, congestion_control);
+        let result = self.begin_tcp_setup_inner(ctl, plain, ports, congestion_control);
         if let Err(error) = &result {
             self.diagnostics.lock().unwrap().tcp_setup_error = Some(format!("{error:#}"));
         }
         result
     }
 
-    fn setup_tcp_inner(
+    /// Join background route probes and record the selected TCP data paths.
+    pub(crate) fn finish_tcp_setup(&self, pending: PendingTcpSetup) -> Result<()> {
+        let result = self.finish_tcp_setup_inner(pending);
+        if let Err(error) = &result {
+            self.diagnostics.lock().unwrap().tcp_setup_error = Some(format!("{error:#}"));
+        }
+        result
+    }
+
+    fn begin_tcp_setup_inner(
         &self,
         ctl: &mut dyn Conn,
         plain: bool,
         ports: (u16, u16),
         congestion_control: Option<&str>,
-    ) -> Result<()> {
+    ) -> Result<PendingTcpSetup> {
         let key = if plain {
             None
         } else {
@@ -1115,8 +1191,35 @@ impl RemoteSpec {
                 );
             }
         }
-        // Probe which advertised addresses this client can actually reach.
-        probe_reachable(&mut candidates, port);
+        // Probing is independent of the authenticated control stream. Let the
+        // orchestrator do destination preflight and plan payloads while every
+        // candidate receives its complete bounded probe window.
+        let probe = std::thread::spawn(move || {
+            probe_reachable(&mut candidates, port);
+            candidates
+        });
+        Ok(PendingTcpSetup {
+            port,
+            key,
+            token,
+            congestion_control: congestion_control.map(str::to_owned),
+            remote_congestion_control,
+            probe,
+        })
+    }
+
+    fn finish_tcp_setup_inner(&self, pending: PendingTcpSetup) -> Result<()> {
+        let PendingTcpSetup {
+            port,
+            key,
+            token,
+            congestion_control,
+            remote_congestion_control,
+            probe,
+        } = pending;
+        let mut candidates = probe
+            .join()
+            .map_err(|_| anyhow!("TCP route probe thread panicked"))?;
         // Multipath only across comparable-speed NICs: keep those within 2x of
         // the fastest reachable one. Mixing a fast and a slow path (a rail and
         // Tailscale, say) would drag the transfer down, so we don't.
@@ -1165,7 +1268,7 @@ impl RemoteSpec {
             port,
             key,
             token,
-            congestion_control: congestion_control.map(str::to_owned),
+            congestion_control,
             failed: false,
             failure: None,
             next: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -1195,7 +1298,12 @@ impl RemoteSpec {
     /// reachable data addresses (multipath). Addresses were already probed and
     /// speed-filtered in setup_tcp, so we just round-robin and fall through on
     /// the rare transient failure.
-    fn connect_tcp(&self, info: &TcpInfo, compress: bool) -> Result<RemoteConn> {
+    fn connect_tcp(
+        &self,
+        info: &TcpInfo,
+        compress: bool,
+        initial_request: Option<Request>,
+    ) -> Result<RemoteConn> {
         let n = info.addrs.len();
         let start = info.next.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % n;
         let mut last = anyhow!("no data address");
@@ -1267,7 +1375,7 @@ impl RemoteSpec {
                 peer: None,
                 tcp_socket: Some(tcp_socket),
             };
-            let conn = hello(conn, compress, info.token.clone())?;
+            let conn = hello(conn, compress, info.token.clone(), initial_request.clone())?;
             self.record_peer(&conn);
             return Ok(conn);
         }
@@ -1380,33 +1488,43 @@ impl std::fmt::Debug for TcpInfo {
     }
 }
 
-fn hello(mut conn: RemoteConn, compress: bool, token: Vec<u8>) -> Result<RemoteConn> {
-    {
-        conn.send(Request::Hello {
-            identity: crate::identity::build().to_string(),
-            compress,
-            debug: crate::transfer::debug(),
-            token,
-        })?;
-        match conn.recv() {
-            Ok(Response::HelloOk { identity, platform })
-                if identity == crate::identity::build() =>
-            {
-                conn.peer = Some(PeerInfo { identity, platform });
-                Ok(conn)
-            }
-            Ok(Response::HelloOk { identity, .. }) => {
-                bail!(
-                    "{}: build identity mismatch (remote {identity}, local {})",
-                    conn.label,
-                    crate::identity::build()
-                )
-            }
-            Ok(Response::Err(e)) => bail!("{}: {e}", conn.label),
-            Ok(other) => bail!("{}: unexpected handshake response {other:?}", conn.label),
-            Err(e) => bail!("{e}\ncould not start the remote syq on {}", conn.label),
-        }
+fn hello(
+    mut conn: RemoteConn,
+    compress: bool,
+    token: Vec<u8>,
+    initial_request: Option<Request>,
+) -> Result<RemoteConn> {
+    conn.send(Request::Hello {
+        identity: crate::identity::build().to_string(),
+        compress,
+        debug: crate::transfer::debug(),
+        token,
+    })?;
+    // Worker destination anchoring is independent of the Hello response. Put
+    // it on the wire immediately so the receiver can authenticate, anchor,
+    // and acknowledge within one WAN turn while preserving response order.
+    if let Some(request) = initial_request.as_ref() {
+        conn.send(request.clone())?;
     }
+    match conn.recv() {
+        Ok(Response::HelloOk { identity, platform }) if identity == crate::identity::build() => {
+            conn.peer = Some(PeerInfo { identity, platform });
+        }
+        Ok(Response::HelloOk { identity, .. }) => {
+            bail!(
+                "{}: build identity mismatch (remote {identity}, local {})",
+                conn.label,
+                crate::identity::build()
+            )
+        }
+        Ok(Response::Err(e)) => bail!("{}: {e}", conn.label),
+        Ok(other) => bail!("{}: unexpected handshake response {other:?}", conn.label),
+        Err(e) => bail!("{e}\ncould not start the remote syq on {}", conn.label),
+    }
+    if initial_request.is_some() {
+        worker_initialization_response(conn.recv()?)?;
+    }
+    Ok(conn)
 }
 
 impl RemoteSpec {
@@ -1834,14 +1952,33 @@ impl Endpoint {
     }
 
     pub fn connect(&self, compress: bool) -> Result<Box<dyn Conn>> {
+        self.connect_with_request(compress, None)
+    }
+
+    pub(crate) fn connect_with_request(
+        &self,
+        compress: bool,
+        initial_request: Option<Request>,
+    ) -> Result<Box<dyn Conn>> {
         match self {
-            Endpoint::Local => Ok(Box::new(LocalConn::new())),
+            Endpoint::Local => {
+                let mut conn = LocalConn::new();
+                if let Some(request) = initial_request {
+                    worker_initialization_response(conn.call(request)?)?;
+                }
+                Ok(Box::new(conn))
+            }
             Endpoint::Remote(spec) => {
                 let info = spec.tcp.lock().unwrap().clone();
                 if let Some(info) = info.filter(|i| !i.failed) {
-                    match spec.connect_tcp(&info, compress) {
+                    match spec.connect_tcp(&info, compress, initial_request.clone()) {
                         Ok(c) => return Ok(Box::new(c)),
-                        Err(e) if is_tcp_congestion_error(&e) => return Err(e),
+                        Err(e)
+                            if is_tcp_congestion_error(&e)
+                                || is_worker_initialization_error(&e) =>
+                        {
+                            return Err(e)
+                        }
                         Err(e) => {
                             if spec.restricted_grant.is_some() {
                                 return Err(e).with_context(|| {
@@ -1873,7 +2010,11 @@ impl Endpoint {
                         spec.label()
                     );
                 }
-                Ok(Box::new(spec.connect(compress)?))
+                Ok(Box::new(spec.connect_with_request(
+                    compress,
+                    true,
+                    initial_request,
+                )?))
             }
         }
     }
@@ -1993,7 +2134,7 @@ mod tests {
         };
 
         let error = spec
-            .connect_tcp(&info, false)
+            .connect_tcp(&info, false, None)
             .err()
             .expect("unregistered congestion control should fail locally");
         let message = format!("{error:#}");
@@ -2010,6 +2151,14 @@ mod tests {
             tcp_congestion_fallback_note(Some("reno")),
             "; requested congestion control reno is not used by the SSH fallback"
         );
+    }
+
+    #[test]
+    fn rejected_worker_initialization_is_not_a_retryable_transport_error() {
+        let error = worker_initialization_response(Response::Err("destination changed".into()))
+            .unwrap_err();
+        assert!(is_worker_initialization_error(&error));
+        assert!(!is_tcp_congestion_error(&error));
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -321,6 +321,7 @@ pub fn run(
         auto_helper: args.syq_path.is_none() && !args.no_bootstrap,
         restricted_grant: None,
         helper_install: Default::default(),
+        ssh_multiplexer: None,
         quiet: args.quiet,
         tcp: Default::default(),
         diagnostics: Default::default(),

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -56,6 +56,9 @@ struct Inner {
     fast_probing: usize,
     /// Workers currently processing one pipelined small-file batch.
     fast_batches: usize,
+    /// Planning has observed at least one regular file, before destination
+    /// namespace checks and directory creation make it runnable.
+    file_work_anticipated: bool,
     scan_done: bool,
     abort: bool,
 }
@@ -81,6 +84,7 @@ impl Sched {
                 probing: 0,
                 fast_probing: 0,
                 fast_batches: 0,
+                file_work_anticipated: false,
                 scan_done: false,
                 abort: false,
             }),
@@ -101,6 +105,28 @@ impl Sched {
         self.inner.lock().unwrap().files.push((size, Reverse(idx)));
         self.cv.notify_one();
         idx
+    }
+
+    /// Let speculative TCP workers warm while the planner performs remote
+    /// namespace and directory work for a batch that contains regular files.
+    pub fn anticipate_file_work(&self) {
+        self.inner.lock().unwrap().file_work_anticipated = true;
+        self.cv.notify_all();
+    }
+
+    /// Wait to learn whether planning found any regular files. False means the
+    /// scan ended or aborted without one, so an eager worker need not connect.
+    pub fn wait_for_anticipated_file_work(&self) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        loop {
+            if inner.file_work_anticipated {
+                return true;
+            }
+            if inner.scan_done || inner.abort {
+                return false;
+            }
+            inner = self.cv.wait(inner).unwrap();
+        }
     }
 
     pub fn requeue(&self, idx: usize) {
@@ -386,6 +412,25 @@ impl Sched {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn eager_connections_wait_for_a_planned_file_and_skip_empty_scans() {
+        let with_file = Arc::new(Sched::new(64, 128));
+        let waiter = {
+            let sched = with_file.clone();
+            std::thread::spawn(move || sched.wait_for_anticipated_file_work())
+        };
+        with_file.anticipate_file_work();
+        assert!(waiter.join().unwrap());
+
+        let empty = Arc::new(Sched::new(64, 128));
+        let waiter = {
+            let sched = empty.clone();
+            std::thread::spawn(move || sched.wait_for_anticipated_file_work())
+        };
+        empty.scan_done();
+        assert!(!waiter.join().unwrap());
+    }
 
     #[test]
     fn tail_gate_combines_bytes_file_credit_and_duration_requirement() {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -16,7 +16,7 @@ use crate::tune::{self, Gate};
 use anyhow::{bail, Context, Result};
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
-use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
 use std::sync::Arc;
 use std::sync::Mutex;
 use xxhash_rust::xxh3::xxh3_64;
@@ -690,6 +690,48 @@ fn read_umask() -> u32 {
     }
 }
 
+fn handle_tcp_setup_error(
+    args: &Args,
+    spec: &RemoteSpec,
+    ports: (u16, u16),
+    error: anyhow::Error,
+    sched: &Sched,
+    progress: &Progress,
+) -> Result<()> {
+    if crate::conn::is_tcp_congestion_error(&error) {
+        sched.abort();
+        progress.stop();
+        return Err(error).with_context(|| {
+            format!(
+                "{} could not apply --tcp-congestion {}",
+                spec.label(),
+                args.tcp_congestion.as_deref().unwrap_or_default()
+            )
+        });
+    }
+    if spec.restricted_grant.is_some() {
+        sched.abort();
+        progress.stop();
+        return Err(error).with_context(|| {
+            format!(
+                "{}: a signed receiver uses its one SSH authorization for the control connection, so encrypted TCP data connections are required",
+                spec.label()
+            )
+        });
+    }
+    if !args.quiet || debug() {
+        let congestion_note =
+            crate::conn::tcp_congestion_fallback_note(args.tcp_congestion.as_deref());
+        eprintln!(
+            "syq: {}: data over ssh (TCP ports {}-{} not reachable: {error:#}{congestion_note}); a Tailscale address or an open port is faster",
+            spec.label(),
+            ports.0,
+            ports.1
+        );
+    }
+    Ok(())
+}
+
 pub fn run(args: Args) -> Result<i32> {
     let mut args = args;
     // A block becomes one WriteRange frame, so it must stay well under MAX_FRAME.
@@ -923,6 +965,7 @@ pub fn run(args: Args) -> Result<i32> {
     let destination_anchor_required = args.restricted_grant.is_none();
     let workers: Arc<Mutex<Vec<std::thread::JoinHandle<Result<()>>>>> =
         Arc::new(Mutex::new(Vec::new()));
+    let connect_after_file_plan = Arc::new(AtomicBool::new(false));
     let transport_stats: Arc<Mutex<Vec<TcpPairStats>>> = Arc::new(Mutex::new(Vec::new()));
     let spawn_worker: Arc<dyn Fn(usize) + Send + Sync> = {
         let (
@@ -937,6 +980,7 @@ pub fn run(args: Args) -> Result<i32> {
             destination_anchor,
             bwlimit,
             transport_stats,
+            connect_after_file_plan,
         ) = (
             src_ep.clone(),
             dst_ep.clone(),
@@ -949,6 +993,7 @@ pub fn run(args: Args) -> Result<i32> {
             destination_anchor.clone(),
             bwlimit.clone(),
             transport_stats.clone(),
+            connect_after_file_plan.clone(),
         );
         let compress = args.compress;
         let collect_tcp_stats = args.stats;
@@ -964,6 +1009,7 @@ pub fn run(args: Args) -> Result<i32> {
                 destination_anchor,
                 bwlimit,
                 transport_stats,
+                connect_after_file_plan,
             ) = (
                 src_ep.clone(),
                 dst_ep.clone(),
@@ -975,8 +1021,23 @@ pub fn run(args: Args) -> Result<i32> {
                 destination_anchor.clone(),
                 bwlimit.clone(),
                 transport_stats.clone(),
+                connect_after_file_plan.clone(),
             );
             let h = std::thread::spawn(move || -> Result<()> {
+                if connect_after_file_plan.load(Relaxed) && !sched.wait_for_anticipated_file_work()
+                {
+                    gate.mark_absent(id);
+                    return Ok(());
+                }
+                let initial_destination = if destination_anchor_required {
+                    Some(worker_destination_request(
+                        destination_anchor
+                            .get()
+                            .context("destination root was not anchored before workers started")?,
+                    ))
+                } else {
+                    None
+                };
                 let mut failures = 0u32;
                 loop {
                     if !gate.retained(id) {
@@ -984,12 +1045,18 @@ pub fn run(args: Args) -> Result<i32> {
                         return Ok(());
                     }
                     let t0 = std::time::Instant::now();
-                    let conns = src_ep
-                        .connect(compress)
-                        .and_then(|src| Ok((src, dst_ep.connect(compress)?)));
-                    let (src, mut dst) = match conns {
+                    let conns = src_ep.connect(compress).and_then(|src| {
+                        Ok((
+                            src,
+                            dst_ep.connect_with_request(compress, initial_destination.clone())?,
+                        ))
+                    });
+                    let (src, dst) = match conns {
                         Ok(conns) => conns,
-                        Err(error) if crate::conn::is_tcp_congestion_error(&error) => {
+                        Err(error)
+                            if crate::conn::is_tcp_congestion_error(&error)
+                                || crate::conn::is_worker_initialization_error(&error) =>
+                        {
                             gate.mark_failed(id);
                             return Err(error);
                         }
@@ -1010,15 +1077,6 @@ pub fn run(args: Args) -> Result<i32> {
                             continue;
                         }
                     };
-                    if destination_anchor_required {
-                        let anchor = destination_anchor
-                            .get()
-                            .context("destination root was not anchored before workers started")?;
-                        if let Err(error) = anchor_worker_destination(&mut *dst, anchor) {
-                            gate.mark_failed(id);
-                            return Err(error);
-                        }
-                    }
                     gate.mark_ready(id);
                     let remote_ssh_data = [&src_ep, &dst_ep]
                         .into_iter()
@@ -1125,89 +1183,30 @@ pub fn run(args: Args) -> Result<i32> {
             t0.elapsed().as_secs_f64()
         );
     }
-    if use_tcp {
-        let ports = parse_ports(&args.tcp_ports)?;
+    let tcp_ports = use_tcp.then(|| parse_ports(&args.tcp_ports)).transpose()?;
+    let mut pending_tcp_setups = Vec::new();
+    if let Some(ports) = tcp_ports {
         for (ep, ctl) in [(&src_ep, &mut src_ctl), (&dst_ep, &mut dst_ctl)] {
             if let Endpoint::Remote(spec) = ep {
-                if let Err(e) = spec.setup_tcp(
+                match spec.begin_tcp_setup(
                     &mut **ctl,
                     args.tcp_plain,
                     ports,
                     args.tcp_congestion.as_deref(),
                 ) {
-                    if crate::conn::is_tcp_congestion_error(&e) {
-                        return Err(e).with_context(|| {
-                            format!(
-                                "{} could not apply --tcp-congestion {}",
-                                spec.label(),
-                                args.tcp_congestion.as_deref().unwrap_or_default()
-                            )
-                        });
+                    Ok(pending) => pending_tcp_setups.push((spec.clone(), pending)),
+                    Err(error) => {
+                        handle_tcp_setup_error(&args, spec, ports, error, &sched, &progress)?;
                     }
-                    if spec.restricted_grant.is_some() {
-                        sched.abort();
-                        progress.stop();
-                        return Err(e).with_context(|| {
-                            format!(
-                                "{}: a signed receiver uses its one SSH authorization for the control connection, so encrypted TCP data connections are required",
-                                spec.label()
-                            )
-                        });
-                    }
-                    if !args.quiet || debug() {
-                        let congestion_note = crate::conn::tcp_congestion_fallback_note(
-                            args.tcp_congestion.as_deref(),
-                        );
-                        eprintln!(
-                            "syq: {}: data over ssh (TCP ports {}-{} not reachable: {e:#}{congestion_note}); a Tailscale address or an open port is faster",
-                            spec.label(),
-                            ports.0,
-                            ports.1
-                        );
-                    }
-                    continue;
-                }
-                if debug() {
-                    eprintln!(
-                        "syq: {}: tcp data port {:?}",
-                        spec.label(),
-                        spec.tcp
-                            .lock()
-                            .unwrap()
-                            .as_ref()
-                            .map(|i| (i.addrs.clone(), i.port))
-                    );
                 }
             }
         }
     }
-    let all_remote_endpoints_use_tcp = use_tcp
-        && [&src_ep, &dst_ep].into_iter().all(|ep| match ep {
-            Endpoint::Local => true,
-            Endpoint::Remote(spec) => spec
-                .tcp
-                .lock()
-                .unwrap()
-                .as_ref()
-                .is_some_and(|info| !info.failed),
-        });
-    if autotune && all_remote_endpoints_use_tcp && (src_ep.is_remote() || dst_ep.is_remote()) {
-        args.connections = tune::START_TCP;
-        gate.set_active(args.connections);
-    }
-    let tuning_key = autotune.then(|| tune::path_key(&src_ep, &dst_ep)).flatten();
-    let remembered_start = tuning_key.as_deref().and_then(tune::cached);
-    if let Some(remembered) = remembered_start {
-        args.connections = remembered;
-        gate.set_active(remembered);
-    }
-    print_transport_diagnostics(&args, &src_ep, &dst_ep);
-    if args.verbose >= 2 {
-        if let Some(remembered) = remembered_start {
-            eprintln!(
-                "syq: auto-tuning: starting with {remembered} connections remembered for this path"
-            );
-        }
+    if debug() {
+        eprintln!(
+            "syq: TCP route probes started at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
     }
     // One spelling for the destination root: every derived key — claims,
     // delete roots, destination-walk paths, receiver-computed sidecar names —
@@ -1227,6 +1226,12 @@ pub fn run(args: Args) -> Result<i32> {
     // so ordinary in-tree symlinks can still be replaced instead of followed.
     let (dst_root, mut dst_root_entry) =
         follow_dir_symlink(&mut *dst_ctl, &operator_dst_root, dst_root_entry)?;
+    if debug() {
+        eprintln!(
+            "syq: destination stat complete at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
     let mut dst_initially_missing = dst_root_entry.is_none();
     let mut dst_existed = dst_root_entry.is_some();
     let mut dst_entry_is_dir = dst_root_entry
@@ -1329,6 +1334,12 @@ pub fn run(args: Args) -> Result<i32> {
     } else {
         None
     };
+    if debug() {
+        eprintln!(
+            "syq: destination selection complete at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
     if use_operator_anchor && dst_is_dir {
         let planned_identity = dst_root_entry.as_ref().map(|entry| (entry.dev, entry.ino));
         let selected_identity = directory_selection
@@ -1427,6 +1438,12 @@ pub fn run(args: Args) -> Result<i32> {
     opts.partial_id
         .set(crate::checkpoint::partial_id(&identity))
         .expect("partial identity set once");
+    if debug() {
+        eprintln!(
+            "syq: copy identity complete at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
 
     let checkpoint_state = checkpoint_setup(
         &args,
@@ -1441,6 +1458,28 @@ pub fn run(args: Args) -> Result<i32> {
         &mut *dst_ctl,
         &identity,
     )?;
+
+    // A signed receiver cannot fall back to replaying its one-time SSH grant.
+    // Settle its TCP reachability before any destination creation, preserving
+    // the pre-mutation failure boundary even though ordinary route probes may
+    // overlap the rest of destination preflight.
+    if pending_tcp_setups
+        .iter()
+        .any(|(spec, _)| spec.restricted_grant.is_some())
+    {
+        for (spec, pending) in std::mem::take(&mut pending_tcp_setups) {
+            if let Err(error) = spec.finish_tcp_setup(pending) {
+                handle_tcp_setup_error(
+                    &args,
+                    &spec,
+                    tcp_ports.expect("pending TCP setup has a port range"),
+                    error,
+                    &sched,
+                    &progress,
+                )?;
+            }
+        }
+    }
 
     // Create a missing directory destination — never in the read-only modes,
     // and never under --existing. With several sources this waits until
@@ -1515,6 +1554,92 @@ pub fn run(args: Args) -> Result<i32> {
             checkpoint: Some(checkpoint.clone()),
         });
     }
+    if debug() {
+        eprintln!(
+            "syq: destination preflight complete at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
+
+    for (spec, pending) in pending_tcp_setups {
+        if let Err(error) = spec.finish_tcp_setup(pending) {
+            handle_tcp_setup_error(
+                &args,
+                &spec,
+                tcp_ports.expect("pending TCP setup has a port range"),
+                error,
+                &sched,
+                &progress,
+            )?;
+        }
+        if debug() {
+            eprintln!(
+                "syq: {}: tcp data port {:?}",
+                spec.label(),
+                spec.tcp
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .map(|info| (info.addrs.clone(), info.port))
+            );
+        }
+    }
+    if debug() {
+        eprintln!(
+            "syq: data transport setup complete at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
+    let all_remote_endpoints_use_tcp = use_tcp
+        && [&src_ep, &dst_ep]
+            .into_iter()
+            .all(|endpoint| match endpoint {
+                Endpoint::Local => true,
+                Endpoint::Remote(spec) => spec
+                    .tcp
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .is_some_and(|info| !info.failed),
+            });
+    if autotune && all_remote_endpoints_use_tcp && (src_ep.is_remote() || dst_ep.is_remote()) {
+        args.connections = tune::START_TCP;
+        gate.set_active(args.connections);
+    }
+    let tuning_key = autotune.then(|| tune::path_key(&src_ep, &dst_ep)).flatten();
+    let remembered_start = tuning_key.as_deref().and_then(tune::cached);
+    if let Some(remembered) = remembered_start {
+        args.connections = remembered;
+        gate.set_active(remembered);
+    }
+    print_transport_diagnostics(&args, &src_ep, &dst_ep);
+    if args.verbose >= 2 {
+        if let Some(remembered) = remembered_start {
+            eprintln!(
+                "syq: auto-tuning: starting with {remembered} connections remembered for this path"
+            );
+        }
+    }
+    let destination_tree_known_missing = dst.is_remote()
+        && dst_initially_missing
+        && !opts.ignore_existing
+        && !opts.update
+        && !opts.checksum;
+    let mut workers_started = false;
+    if all_remote_endpoints_use_tcp
+        && destination_tree_known_missing
+        && !opts.dry_run
+        && !opts.verify_only
+        && (!destination_anchor_required || destination_anchor.get().is_some())
+    {
+        // The planner signals as soon as a source batch contains regular files,
+        // before remote sidecar resolution and directory creation. Empty trees
+        // therefore open no data connections, while fresh file trees cover TCP
+        // authentication with work the control connection must do anyway.
+        connect_after_file_plan.store(true, Relaxed);
+        spawn_workers(args.connections);
+        workers_started = true;
+    }
 
     let ticker = progress.spawn_ticker();
 
@@ -1525,11 +1650,7 @@ pub fn run(args: Args) -> Result<i32> {
         opts: &opts,
         completed: checkpoint_completed,
         checkpoint: checkpoint_writer,
-        destination_tree_known_missing: dst.is_remote()
-            && dst_initially_missing
-            && !opts.ignore_existing
-            && !opts.update
-            && !opts.checksum,
+        destination_tree_known_missing,
         dst_seen: std::collections::HashMap::new(),
         missing_dirs: std::collections::HashSet::new(),
         dry_run_replaced_dirs: std::collections::HashSet::new(),
@@ -1635,6 +1756,12 @@ pub fn run(args: Args) -> Result<i32> {
             scan_err = Some(e);
         }
     }
+    if debug() {
+        eprintln!(
+            "syq: payload planning complete at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
     if st.source_partials > 0 && !args.quiet && scan_err.is_none() && !st.collision {
         let count = st.source_partials;
         progress.warning(
@@ -1679,7 +1806,9 @@ pub fn run(args: Args) -> Result<i32> {
                         spec.set_ssh_multiplexing(true);
                     }
                 }
-                spawn_workers(args.connections);
+                if !workers_started {
+                    spawn_workers(args.connections);
+                }
             }
         }
         // No worker opens a sidecar until every payload/sidecar namespace
@@ -1724,6 +1853,12 @@ pub fn run(args: Args) -> Result<i32> {
         },
         None => None,
     };
+    if debug() {
+        eprintln!(
+            "syq: file workers complete at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
 
     let aborted = sched.is_aborted();
     let mut deleted = 0u64;
@@ -1761,6 +1896,12 @@ pub fn run(args: Args) -> Result<i32> {
     }
     if !aborted && !opts.dry_run && !opts.verify_only {
         st.apply_deferred()?;
+    }
+    if debug() {
+        eprintln!(
+            "syq: deferred metadata complete at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
     }
     let max_delete_hit = st.max_delete_hit;
     let dry_run_changes = std::mem::take(&mut st.dry_run_changes);
@@ -2170,19 +2311,13 @@ fn activate_control_destination(
     }
 }
 
-fn anchor_worker_destination(conn: &mut dyn Conn, anchor: &DestinationAnchor) -> Result<()> {
-    match ok(
-        conn.call(Request::AnchorDestination {
-            path: Some(anchor.operator_path.clone()),
-            expected_dev: anchor.dev,
-            expected_ino: anchor.ino,
-            request_prefix: anchor.request_prefix.clone(),
-            insecure_links: anchor.insecure_links,
-        })?,
-        "anchor worker destination root",
-    )? {
-        Response::Ok => Ok(()),
-        other => bail!("unexpected response {other:?}"),
+fn worker_destination_request(anchor: &DestinationAnchor) -> Request {
+    Request::AnchorDestination {
+        path: Some(anchor.operator_path.clone()),
+        expected_dev: anchor.dev,
+        expected_ino: anchor.ino,
+        request_prefix: anchor.request_prefix.clone(),
+        insecure_links: anchor.insecure_links,
     }
 }
 
@@ -3103,6 +3238,9 @@ impl Planner<'_> {
         dst_root: &[u8],
     ) -> Result<()> {
         let namespace_files = self.collect_namespace_files(&batch, src_root, sub, dst_root);
+        if !namespace_files.is_empty() {
+            self.sched.anticipate_file_work();
+        }
         if self.collision {
             return Ok(());
         }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -5,7 +5,8 @@ use crate::cli::{
     parse_rsh, parse_size, Args, Existence, Interface, Location, Placement, SourceSelection,
 };
 use crate::conn::{
-    ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, TcpCandidate, TcpPairStats,
+    ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, SshMultiplexer, TcpCandidate,
+    TcpPairStats,
 };
 use crate::fsops::{is_partial_name, join};
 use crate::progress::{commas, human, Progress, WorkerStatus};
@@ -26,17 +27,23 @@ pub const LOCAL_DEFAULT_CONNECTIONS: usize = 32;
 const FAST_BATCH_FILES: usize = 128;
 // Larger batches trade filesystem overlap for fewer request/ack turns. On the
 // measured 262 ms path, 4,096 one-byte files at eight workers improved from a
-// 9.68 s to an 8.72 s median at 512; keep the change confined to high RTT TCP.
+// 9.68 s to an 8.72 s median at 512. Direct TCP exposes its RTT; remote SSH
+// does not, but needs the same amortization and remains bounded by bytes below.
 const HIGH_RTT_FAST_BATCH_FILES: usize = 512;
 const HIGH_RTT_US: u64 = 100_000;
 const FAST_BATCH_BYTES: u64 = 16 << 20;
 const CONNECTION_RECOVERY_ATTEMPTS: u32 = 3;
 
-fn fast_batch_file_limit(src_rtt_us: Option<u64>, dst_rtt_us: Option<u64>) -> usize {
-    if src_rtt_us
-        .into_iter()
-        .chain(dst_rtt_us)
-        .any(|rtt| rtt >= HIGH_RTT_US)
+fn fast_batch_file_limit(
+    src_rtt_us: Option<u64>,
+    dst_rtt_us: Option<u64>,
+    remote_ssh_data: bool,
+) -> usize {
+    if remote_ssh_data
+        || src_rtt_us
+            .into_iter()
+            .chain(dst_rtt_us)
+            .any(|rtt| rtt >= HIGH_RTT_US)
     {
         HIGH_RTT_FAST_BATCH_FILES
     } else {
@@ -86,21 +93,31 @@ pub struct Opts {
 pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
     Ok(match &loc.host {
         None => Endpoint::Local,
-        Some(h) => Endpoint::Remote(RemoteSpec {
-            local_process: false,
-            user: loc.user.clone(),
-            host: h.clone(),
-            rsh: parse_rsh(&args.rsh)?,
-            syq_path: args.syq_path.clone(),
-            auto_helper: args.restricted_grant.is_none()
-                && args.syq_path.is_none()
-                && !args.no_bootstrap,
-            restricted_grant: args.restricted_grant.clone(),
-            helper_install: Default::default(),
-            quiet: args.quiet,
-            tcp: Default::default(),
-            diagnostics: Default::default(),
-        }),
+        Some(h) => {
+            let rsh = parse_rsh(&args.rsh)?;
+            let ssh_multiplexer = args
+                .rsh
+                .is_none()
+                .then(SshMultiplexer::new)
+                .transpose()?
+                .map(Arc::new);
+            Endpoint::Remote(RemoteSpec {
+                local_process: false,
+                user: loc.user.clone(),
+                host: h.clone(),
+                rsh,
+                syq_path: args.syq_path.clone(),
+                auto_helper: args.restricted_grant.is_none()
+                    && args.syq_path.is_none()
+                    && !args.no_bootstrap,
+                restricted_grant: args.restricted_grant.clone(),
+                helper_install: Default::default(),
+                ssh_multiplexer,
+                quiet: args.quiet,
+                tcp: Default::default(),
+                diagnostics: Default::default(),
+            })
+        }
     })
 }
 
@@ -1003,8 +1020,12 @@ pub fn run(args: Args) -> Result<i32> {
                         }
                     }
                     gate.mark_ready(id);
+                    let remote_ssh_data = [&src_ep, &dst_ep]
+                        .into_iter()
+                        .filter_map(real_remote_spec)
+                        .any(|spec| spec.data_transport() == DataTransport::Ssh);
                     let fast_batch_files =
-                        fast_batch_file_limit(src.tcp_rtt_us(), dst.tcp_rtt_us());
+                        fast_batch_file_limit(src.tcp_rtt_us(), dst.tcp_rtt_us(), remote_ssh_data);
                     let mut worker = Worker {
                         id,
                         src,
@@ -1640,6 +1661,24 @@ pub fn run(args: Args) -> Result<i32> {
                 progress.error("syq: destination root is missing and cannot be anchored");
                 sched.abort();
             } else {
+                let multiplex_small_files = !opts.verify_only
+                    && !opts.inplace
+                    && bwlimit.is_none()
+                    && sched
+                        .jobs
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .all(|job| job.entry.size <= opts.block && job.dst_entry.is_none());
+                if multiplex_small_files {
+                    for spec in [&src_ep, &dst_ep]
+                        .into_iter()
+                        .filter_map(real_remote_spec)
+                        .filter(|spec| spec.data_transport() == DataTransport::Ssh)
+                    {
+                        spec.set_ssh_multiplexing(true);
+                    }
+                }
                 spawn_workers(args.connections);
             }
         }
@@ -5851,15 +5890,22 @@ mod tests {
     }
 
     #[test]
-    fn fast_batch_ceiling_only_grows_on_high_rtt_tcp() {
-        assert_eq!(fast_batch_file_limit(None, None), FAST_BATCH_FILES);
-        assert_eq!(fast_batch_file_limit(Some(99_999), None), FAST_BATCH_FILES);
+    fn fast_batch_ceiling_grows_on_high_rtt_tcp_or_remote_ssh() {
+        assert_eq!(fast_batch_file_limit(None, None, false), FAST_BATCH_FILES);
         assert_eq!(
-            fast_batch_file_limit(None, Some(HIGH_RTT_US)),
+            fast_batch_file_limit(Some(99_999), None, false),
+            FAST_BATCH_FILES
+        );
+        assert_eq!(
+            fast_batch_file_limit(None, Some(HIGH_RTT_US), false),
             HIGH_RTT_FAST_BATCH_FILES
         );
         assert_eq!(
-            fast_batch_file_limit(Some(262_000), Some(1_000)),
+            fast_batch_file_limit(Some(262_000), Some(1_000), false),
+            HIGH_RTT_FAST_BATCH_FILES
+        );
+        assert_eq!(
+            fast_batch_file_limit(None, None, true),
             HIGH_RTT_FAST_BATCH_FILES
         );
     }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1629,6 +1629,7 @@ pub fn run(args: Args) -> Result<i32> {
     if all_remote_endpoints_use_tcp
         && destination_tree_known_missing
         && !opts.dry_run
+        && !opts.inplace
         && !opts.verify_only
         && (!destination_anchor_required || destination_anchor.get().is_some())
     {

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1060,6 +1060,7 @@ mod tests {
             auto_helper: false,
             restricted_grant: None,
             helper_install: Default::default(),
+            ssh_multiplexer: None,
             quiet: true,
             tcp: std::sync::Arc::new(std::sync::Mutex::new(tcp.then(|| crate::conn::TcpInfo {
                 addrs: vec!["127.0.0.1".into()],

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1074,6 +1074,52 @@ exec /bin/sh -c "$1"
     path
 }
 
+/// An ssh-shaped remote shell that accepts the control session, rejects every
+/// multiplexed worker like an sshd with `MaxSessions 1`, and accepts workers
+/// that disable `ControlPath`.
+fn fake_ssh_rejecting_multiplexed_workers(t: &Tmp) -> PathBuf {
+    let path = t.path("bin/ssh");
+    executable(
+        &path,
+        br#"#!/bin/sh
+control_master=unset
+control_path=unset
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            option=$2
+            shift 2
+            case "$option" in
+                ControlMaster=*) control_master=${option#ControlMaster=} ;;
+                ControlPath=*) control_path=${option#ControlPath=} ;;
+            esac
+            ;;
+        -l)
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            exit 98
+            ;;
+    esac
+done
+shift
+printf '%s|%s\n' "$control_master" "$control_path" >> "$FAKE_RSH_LOG"
+if [ "$control_master" = no ] && [ "$control_path" != none ]; then
+    exit 255
+fi
+HOME="$FAKE_REMOTE_HOME"
+PATH=/usr/bin:/bin
+export HOME PATH
+exec /bin/sh -c "$1"
+"#,
+    );
+    path
+}
+
 fn remote_syq_command(t: &Tmp, rsh: &Path, args: &[&str]) -> Command {
     let mut cmd = compat_command();
     cmd.args(["-e", rsh.to_str().unwrap(), "--no-tcp", "-j", "1"])
@@ -1963,6 +2009,76 @@ fn tcp_copy_auto_tuning_starts_with_sixteen_connections() {
     assert!(
         stderr.contains("concurrency: starting with 16 connections (auto-tuned)"),
         "{stderr}"
+    );
+}
+
+#[test]
+fn inplace_copy_to_missing_remote_destination_waits_for_planned_work() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"in-place over reachable TCP");
+    let remote = format!("127.0.0.1:{}", t.s("dst"));
+
+    let out = compat_command()
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args(["--tcp-plain", "--inplace", "-a", "-j", "1"])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_CACHE_HOME", t.path("cache"))
+        .run()
+        .expect("run in-place copy over reachable TCP");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"in-place over reachable TCP");
+}
+
+#[test]
+fn multiplexed_worker_refusal_falls_back_to_independent_ssh() {
+    let t = Tmp::new();
+    fake_ssh_rejecting_multiplexed_workers(&t);
+    write(&t.path("src"), b"independent SSH fallback");
+    let remote = format!("fake:{}", t.s("dst"));
+
+    let out = compat_command()
+        .arg("--syq-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args(["--no-tcp", "-a", "-j", "1"])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("PATH", format!("{}:/usr/bin:/bin", t.s("bin")))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .run()
+        .expect("run copy when the SSH server rejects multiplexed workers");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"independent SSH fallback");
+    let invocations = fs::read_to_string(t.path("rsh.log")).unwrap();
+    assert!(
+        invocations
+            .lines()
+            .any(|line| line.starts_with("yes|") && !line.ends_with("|none")),
+        "control connection did not enable its private socket:\n{invocations}"
+    );
+    assert!(
+        invocations
+            .lines()
+            .any(|line| line.starts_with("no|") && !line.ends_with("|none")),
+        "no multiplexed worker was attempted:\n{invocations}"
+    );
+    assert!(
+        invocations.lines().any(|line| line == "no|none"),
+        "no independent worker fallback was attempted:\n{invocations}"
     );
 }
 


### PR DESCRIPTION
## Summary

- reuse a private OpenSSH control connection for proven fresh-small-file workloads, while keeping independent SSH connections for large, mixed, resumed, bandwidth-limited, and custom-shell copies
- overlap TCP route probing, destination preflight, planning, and worker startup
- pipeline the worker Hello and destination-anchor requests to remove a WAN round trip
- raise the bounded small-file batch ceiling on high-latency TCP and remote SSH paths
- add phase diagnostics, protocol tests, scheduler tests, and user-facing tuning documentation

Destination identity is still authenticated and completed before mutation. Worker initialization failures remain fatal rather than falling back after a possibly mutating attempt.

## WAN benchmark

Germany to Japan, approximately 262 ms RTT, fresh tree of 2,000 files / 8 MiB:

| Path | Before | This branch |
| --- | ---: | ---: |
| ordinary encrypted TCP, forward | 11.34 s (v0.1.5) | 9.71 s, 9.43 s (median 9.57 s) |
| `--no-tcp`, forward | 16.85-17.00 s | 10.81 s |
| ordinary encrypted TCP, reverse | — | 10.08 s, 10.70 s (median 10.39 s) |
| `--no-tcp`, reverse | — | 10.42 s |

The exact measured transfer commit was `00cf53e`. It was then rebased onto `master` after release-only commits landed; the PR head is `33e90fa`, with identical transfer code. Every result was checked against the 2,000-file fixture; the two TCP forward runs also passed full `--verify-only --checksum`.

For reference, the same forward fixture measured rsync at 8.91 s and tar at 7.86 s.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (218 unit, 249 local integration, 9 update)
- live copies and byte verification in both directions over TCP and `--no-tcp`
- large/mixed `--no-tcp -j2` retained independent SSH worker connections
