### PR TITLE
Expand native selector and operational parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ syq cp project --to server --into /backup       # named object → /backup/proje
 syq cp --src-src project --to server --into /app # project contents → /app
 syq cp --from server --cwd /data --src a --src b --into ./data
 syq cp --src-file report --src-dir assets --into /backup
+syq cp --src-files a.txt b.txt --src-dirs images fonts --into /archive
 syq cp report --to server --as-new /reports/final
 syq cp-prune --src-src build --to server --into-existing /srv/app
 syq rm cache old-output
@@ -175,11 +176,12 @@ directory, while `--src-dir DIR` requires a directory; on a match they copy
 exactly like `--src`, including copying a selected symlink rather than following
 it. These typed selectors are available to `cp`, `cp-prune`, and `rm`.
 `--src-src DIR` selects a directory's contents and merges them directly into
-the target container. `--srcs PATH...` and `--src-srcs DIR...` are bulk
-conveniences for those two canonical selectors. Symlinks found while traversing
-a directory are copied as symlinks and are never followed. Singular selector
-options consume their next argument even when it begins with `-`, so every Unix
-filename is expressible without losing raw path bytes.
+the target container. `--srcs PATH...`, `--src-srcs DIR...`, `--src-files
+PATH...`, and `--src-dirs DIR...` are bulk conveniences for the corresponding
+singular selectors. Symlinks found while traversing a directory are copied as
+symlinks and are never followed. Singular selector options consume their next
+argument even when it begins with `-`, so every Unix filename is expressible
+without losing raw path bytes.
 
 Placement is always explicit in this initial native surface:
 
@@ -251,16 +253,20 @@ hard links, ACLs, xattrs, filtering, comparison policy, and the automation API
 are intentionally not frozen by this first grammar. Use `syq rsync` when the
 current compatibility options for those capabilities are needed.
 
-The native commands accept only `-n`/`--dry-run`, `-v`/`--verbose`,
-`-q`/`--quiet`, and `-j`/`--connections` in addition to the endpoint,
-selector, cwd, and placement options above. `cp-prune` additionally accepts
-`--max-delete`; `rm` additionally accepts `--root` and `--follow` plus its
-endpoint-side removal semantics. Preservation policies, filters, comparison
-controls, progress interfaces, and SSH/transport configuration remain available
-only through `syq rsync`; sharing the transfer engine does not expose those
-options in native mode. Remote-to-remote copies still use the ordinary
-automatic transport. Native raw path bytes are relayed through syq's protocol
-when they cannot be represented in a direct remote shell command.
+All native commands accept `-n`/`--dry-run`, `-v`/`--verbose`, `-q`/`--quiet`,
+`-j`/`--connections`, `--progress`/`--no-progress`, and `--progress-json` in
+addition to their endpoint and selector options. `cp` and `cp-prune` also
+accept `--bwlimit RATE` and `--stats`; the bandwidth limit applies only to file
+data, not scanning, hashing, metadata, or pruning. `cp-prune` additionally
+accepts `--max-delete`; `rm` additionally accepts `--root` and `--follow` plus
+its endpoint-side removal semantics.
+
+Preservation policies, filters, comparison controls, low-level transfer tuning,
+and SSH/transport configuration remain available only through `syq rsync`;
+sharing the transfer engine does not expose those options in native mode.
+Remote-to-remote copies still use the ordinary automatic transport. Native raw
+path bytes are relayed through syq's protocol when they cannot be represented
+in a direct remote shell command.
 
 ## Rsync compatibility
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ target placement in separate arguments:
 syq cp project --to server --into /backup       # named object → /backup/project
 syq cp --src-src project --to server --into /app # project contents → /app
 syq cp --from server --cwd /data --src a --src b --into ./data
+syq cp --src-file report --src-dir assets --into /backup
 syq cp report --to server --as-new /reports/final
 syq cp-prune --src-src build --to server --into-existing /srv/app
 syq rm cache old-output
@@ -169,6 +170,10 @@ any `.` or `..` component.
 Bare paths and repeatable `--src PATH` select named objects. A named directory
 keeps its basename at the target; a named symlink is copied as a symlink. A
 trailing slash is ordinary path spelling and has no semantic effect.
+`--src-file PATH` adds the precondition that the named object is not a
+directory, while `--src-dir DIR` requires a directory; on a match they copy
+exactly like `--src`, including copying a selected symlink rather than following
+it. These typed selectors are available to `cp`, `cp-prune`, and `rm`.
 `--src-src DIR` selects a directory's contents and merges them directly into
 the target container. `--srcs PATH...` and `--src-srcs DIR...` are bulk
 conveniences for those two canonical selectors. Symlinks found while traversing
@@ -225,7 +230,7 @@ would leave it, even if later components would re-enter. `--cwd` is not a
 containment boundary when `--follow` is used.
 
 For removal, `--src PATH` and bare paths accept either a terminal file or
-directory and remove that object, recursively for a directory.
+directory and remove that object, recursively for a directory. As with copy,
 `--src-file PATH` requires a non-directory terminal object, while
 `--src-dir DIR` requires a directory and removes its entire tree.
 `--src-src DIR` requires a directory, removes its contents, and retains the
@@ -250,12 +255,12 @@ The native commands accept only `-n`/`--dry-run`, `-v`/`--verbose`,
 `-q`/`--quiet`, and `-j`/`--connections` in addition to the endpoint,
 selector, cwd, and placement options above. `cp-prune` additionally accepts
 `--max-delete`; `rm` additionally accepts `--root` and `--follow` plus its
-typed selectors. Preservation policies, filters, comparison controls, progress
-interfaces, and SSH/transport configuration remain available only through
-`syq rsync`; sharing the transfer engine does not expose those options in
-native mode. Remote-to-remote copies still use the ordinary automatic
-transport. Native raw path bytes are relayed through syq's protocol when they
-cannot be represented in a direct remote shell command.
+endpoint-side removal semantics. Preservation policies, filters, comparison
+controls, progress interfaces, and SSH/transport configuration remain available
+only through `syq rsync`; sharing the transfer engine does not expose those
+options in native mode. Remote-to-remote copies still use the ordinary
+automatic transport. Native raw path bytes are relayed through syq's protocol
+when they cannot be represented in a direct remote shell command.
 
 ## Rsync compatibility
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -518,6 +518,12 @@ struct NativeSelectionArgs {
     /// Select a directory's contents (repeatable)
     #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
     src_src: Vec<OsString>,
+    /// Select a named non-directory source object (repeatable)
+    #[arg(long, value_name = "PATH", allow_hyphen_values = true)]
+    src_file: Vec<OsString>,
+    /// Select a named source directory (repeatable)
+    #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
+    src_dir: Vec<OsString>,
     /// Select several named source objects
     #[arg(long, value_name = "PATH", num_args = 1..)]
     srcs: Vec<OsString>,
@@ -653,7 +659,7 @@ struct NativeCopyFields {
     version,
     about = "Copy selected objects with explicit endpoint and placement syntax",
     long_about = "Copy selected objects with explicit endpoint and placement syntax.\n\nNative copies use fixed rsync -rlt behavior: recursive traversal, symlinks copied as symlinks, and modification times preserved. Permissions, owner, group, devices, and special files are not preserved.",
-    override_usage = "syq cp [OPTIONS] [--src PATH | --src-src DIR | PATH]... PLACEMENT"
+    override_usage = "syq cp [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]... PLACEMENT"
 )]
 struct NativeCopyCommand {
     #[command(flatten)]
@@ -666,7 +672,7 @@ struct NativeCopyCommand {
     version,
     about = "Copy selected objects, then remove target-only objects in mapped scopes",
     long_about = "Copy selected objects, then remove target-only objects in mapped scopes.\n\nCopying uses fixed rsync -rlt behavior: recursive traversal, symlinks copied as symlinks, and modification times preserved. Permissions, owner, group, devices, and special files are not preserved. Removal uses the current post-transfer deletion scopes and guards.",
-    override_usage = "syq cp-prune [OPTIONS] [--src PATH | --src-src DIR | PATH]... PLACEMENT"
+    override_usage = "syq cp-prune [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]... PLACEMENT"
 )]
 struct NativeCopyPruneCommand {
     #[command(flatten)]
@@ -733,22 +739,11 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
             command_label(interface)
         );
     };
-    if placement == Placement::As
-        && (locations.len() != 1
-            || !matches!(
-                locations[0].selection,
-                SourceSelection::Named | SourceSelection::NamedNoFollow
-            ))
-    {
+    if placement == Placement::As && (locations.len() != 1 || locations[0].copies_contents()) {
         bail!("--as, --as-new, and --as-existing require exactly one ordinary source object");
     }
     if placement == Placement::Into {
-        for source in locations.iter().filter(|source| {
-            matches!(
-                source.selection,
-                SourceSelection::Named | SourceSelection::NamedNoFollow
-            )
-        }) {
+        for source in locations.iter().filter(|source| !source.copies_contents()) {
             if native_basename(&source.path).is_none() {
                 bail!(
                     "named source {:?} has no target basename; use --src-src to select directory contents",
@@ -864,6 +859,8 @@ fn lower_native_selection(
         ("srcs", SourceSelection::NamedNoFollow, &parsed.srcs),
         ("src_src", SourceSelection::Contents, &parsed.src_src),
         ("src_srcs", SourceSelection::Contents, &parsed.src_srcs),
+        ("src_file", SourceSelection::File, &parsed.src_file),
+        ("src_dir", SourceSelection::Directory, &parsed.src_dir),
     ] {
         if let Some(indices) = matches.indices_of(id) {
             ordered.extend(
@@ -1462,21 +1459,13 @@ impl Location {
         }
     }
 
-    /// Native contents selectors must name directories; rsync's trailing-slash
-    /// spelling keeps its existing scan-time behavior.
-    pub fn requires_directory(&self) -> bool {
-        matches!(
-            self.selection,
-            SourceSelection::Contents | SourceSelection::Directory
-        )
-    }
-
     pub fn follows_root(&self) -> bool {
         match self.selection {
             SourceSelection::Named => true,
             SourceSelection::Contents => true,
-            SourceSelection::NamedNoFollow => false,
-            SourceSelection::File | SourceSelection::Directory => true,
+            SourceSelection::NamedNoFollow | SourceSelection::File | SourceSelection::Directory => {
+                false
+            }
             SourceSelection::Rsync => self.copies_contents(),
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -524,6 +524,12 @@ struct NativeSelectionArgs {
     /// Select a named source directory (repeatable)
     #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
     src_dir: Vec<OsString>,
+    /// Select several named non-directory source objects
+    #[arg(long, value_name = "PATH", num_args = 1..)]
+    src_files: Vec<OsString>,
+    /// Select several named source directories
+    #[arg(long, value_name = "DIR", num_args = 1..)]
+    src_dirs: Vec<OsString>,
     /// Select several named source objects
     #[arg(long, value_name = "PATH", num_args = 1..)]
     srcs: Vec<OsString>,
@@ -567,6 +573,12 @@ struct NativeRmSelectionArgs {
     /// Select a directory tree (repeatable)
     #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
     src_dir: Vec<OsString>,
+    /// Select several non-directory terminal objects
+    #[arg(long, value_name = "PATH", num_args = 1..)]
+    src_files: Vec<OsString>,
+    /// Select several directory trees
+    #[arg(long, value_name = "DIR", num_args = 1..)]
+    src_dirs: Vec<OsString>,
     /// Select several objects without constraining their terminal type
     #[arg(long, value_name = "PATH", num_args = 1..)]
     srcs: Vec<OsString>,
@@ -592,6 +604,27 @@ struct NativeOperationalArgs {
     /// Use a fixed number of parallel connections/workers
     #[arg(short = 'j', long = "connections", value_name = "N")]
     connections: Option<usize>,
+    /// Show progress even when stderr is not a terminal
+    #[arg(long, overrides_with = "no_progress")]
+    progress: bool,
+    /// Never show the human progress display
+    #[arg(long)]
+    no_progress: bool,
+    /// Emit machine-readable progress lines (JSON) on stderr
+    #[arg(long)]
+    progress_json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+struct NativeCopyOperationalArgs {
+    #[command(flatten)]
+    common: NativeOperationalArgs,
+    /// Limit aggregate file-data throughput (default unit: KiB/s; 0 disables)
+    #[arg(long, value_name = "RATE")]
+    bwlimit: Option<String>,
+    /// Print transfer statistics at the end
+    #[arg(long)]
+    stats: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -650,7 +683,7 @@ struct NativeCopyFields {
     )]
     as_existing: Option<OsString>,
     #[command(flatten)]
-    operational: NativeOperationalArgs,
+    operational: NativeCopyOperationalArgs,
 }
 
 #[derive(Parser, Debug)]
@@ -770,7 +803,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     args.locations = locations;
     args.delete = interface == Interface::NativeCpPrune;
     args.max_delete = max_delete;
-    apply_native_operational(&mut args, parsed.operational);
+    apply_native_copy_operational(&mut args, parsed.operational)?;
     apply_internal_native_direct(&mut args)?;
     Ok(args)
 }
@@ -814,6 +847,16 @@ fn parse_native_rm(argv: &[OsString]) -> Result<Args> {
             "src_dir",
             SourceSelection::Directory,
             &parsed.selection.src_dir,
+        ),
+        (
+            "src_files",
+            SourceSelection::File,
+            &parsed.selection.src_files,
+        ),
+        (
+            "src_dirs",
+            SourceSelection::Directory,
+            &parsed.selection.src_dirs,
         ),
     ] {
         if let Some(indices) = matches.indices_of(id) {
@@ -861,6 +904,8 @@ fn lower_native_selection(
         ("src_srcs", SourceSelection::Contents, &parsed.src_srcs),
         ("src_file", SourceSelection::File, &parsed.src_file),
         ("src_dir", SourceSelection::Directory, &parsed.src_dir),
+        ("src_files", SourceSelection::File, &parsed.src_files),
+        ("src_dirs", SourceSelection::Directory, &parsed.src_dirs),
     ] {
         if let Some(indices) = matches.indices_of(id) {
             ordered.extend(
@@ -905,6 +950,29 @@ fn apply_native_operational(args: &mut Args, operational: NativeOperationalArgs)
     args.verbose = operational.verbose;
     args.quiet = operational.quiet;
     args.connections_opt = operational.connections;
+    args.progress = operational.progress;
+    args.no_progress = operational.no_progress;
+    args.progress_json = operational.progress_json;
+}
+
+fn apply_native_copy_operational(
+    args: &mut Args,
+    operational: NativeCopyOperationalArgs,
+) -> Result<()> {
+    let NativeCopyOperationalArgs {
+        common,
+        bwlimit,
+        stats,
+    } = operational;
+    args.bwlimit_bytes = bwlimit
+        .as_deref()
+        .map(crate::bwlimit::parse_rate)
+        .transpose()?
+        .unwrap_or(0);
+    args.bwlimit = bwlimit;
+    args.stats = stats;
+    apply_native_operational(args, common);
+    Ok(())
 }
 
 /// Direct remote-to-remote execution needs a few automatically derived engine

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -375,9 +375,6 @@ pub fn run(
     if args.interface == Interface::Rsync {
         remote.push(format!("--block-size={}", args.block_size));
         remote.push(format!("--min-split={}", args.min_split));
-        if let Some(rate) = &args.bwlimit {
-            remote.push(format!("--bwlimit={rate}"));
-        }
         if args.verify_only {
             remote.push("--verify-only".into());
         }
@@ -415,7 +412,10 @@ pub fn run(
             remote.push(format!("--ignore={line}"));
         }
     }
-    if args.interface == Interface::Rsync && args.stats {
+    if let Some(rate) = &args.bwlimit {
+        remote.push(format!("--bwlimit={rate}"));
+    }
+    if args.stats {
         remote.push("--stats".into());
     }
     if let Some(n) = args.max_delete {
@@ -438,9 +438,6 @@ pub fn run(
             remote.push(format!("--tcp-congestion={algorithm}"));
         }
         remote.push(format!("--tcp-ports={}", args.tcp_ports));
-        if args.progress_json && !args.quiet {
-            remote.push("--progress-json".into());
-        }
         if args.dry_run {
             remote.push(format!("--plan-source-host={src_target}"));
         }
@@ -448,12 +445,6 @@ pub fn run(
             "--direct-source-operand-count={source_operand_count}"
         ));
         remote.push("--direct-sources-prededuplicated".into());
-        if args.no_progress || args.quiet {
-            remote.push("--no-progress".into());
-        } else if std::io::stderr().is_terminal() {
-            remote.push("--progress".into());
-            remote.push(format!("--width={}", crate::progress::term_width()));
-        }
         if let Some(p) = &args.syq_path {
             remote.push(format!("--syq-path={p}"));
         }
@@ -466,6 +457,17 @@ pub fn run(
             remote.push("-e".into());
             remote.push(e);
         }
+    }
+    if args.progress_json && !args.quiet {
+        remote.push("--progress-json".into());
+    }
+    if args.no_progress || args.quiet {
+        remote.push("--no-progress".into());
+    } else if args.progress {
+        remote.push("--progress".into());
+    } else if args.interface == Interface::Rsync && std::io::stderr().is_terminal() {
+        remote.push("--progress".into());
+        remote.push(format!("--width={}", crate::progress::term_width()));
     }
 
     if args.interface == Interface::Rsync {
@@ -567,7 +569,7 @@ pub fn run(
         ) {
             internal_environment.push(("SYQ_INTERNAL_NATIVE_RSH", rsh));
         }
-        if !args.quiet && std::io::stderr().is_terminal() {
+        if !args.no_progress && !args.quiet && std::io::stderr().is_terminal() {
             internal_environment.push((
                 "SYQ_INTERNAL_NATIVE_PROGRESS_WIDTH",
                 crate::progress::term_width().to_string(),

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1,7 +1,9 @@
 //! The orchestrator: scan, diff, schedule, and the per-worker transfer loop.
 
 use crate::bwlimit::BandwidthLimit;
-use crate::cli::{parse_rsh, parse_size, Args, Existence, Interface, Location, Placement};
+use crate::cli::{
+    parse_rsh, parse_size, Args, Existence, Interface, Location, Placement, SourceSelection,
+};
 use crate::conn::{
     ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, TcpCandidate, TcpPairStats,
 };
@@ -505,8 +507,28 @@ struct DestinationRoot<'a> {
 struct SourceMapping<'a> {
     follow_root: bool,
     contents: bool,
-    require_directory: bool,
+    selection: SourceSelection,
     sub: &'a [u8],
+}
+
+fn validate_native_source_type(path: &[u8], selection: SourceSelection, kind: Kind) -> Result<()> {
+    match selection {
+        SourceSelection::Contents if kind != Kind::Dir => {
+            bail!("contents selector {} is not a directory", display(path))
+        }
+        SourceSelection::Directory if kind != Kind::Dir => {
+            bail!("--src-dir selector {} is not a directory", display(path))
+        }
+        SourceSelection::File if kind == Kind::Dir => {
+            bail!("--src-file selector {} is a directory", display(path))
+        }
+        SourceSelection::Rsync
+        | SourceSelection::Named
+        | SourceSelection::NamedNoFollow
+        | SourceSelection::File
+        | SourceSelection::Directory
+        | SourceSelection::Contents => Ok(()),
+    }
 }
 
 fn copy_identity(
@@ -1245,13 +1267,9 @@ pub fn run(args: Args) -> Result<i32> {
         // their root and additionally require it to resolve to a directory.
         for source in srcs {
             match stat_one(&mut *src_ctl, &source.path, source.follows_root())? {
-                Some(entry) if source.requires_directory() && entry.kind != Kind::Dir => {
-                    bail!(
-                        "contents selector {} is not a directory",
-                        display(&source.path)
-                    )
+                Some(entry) => {
+                    validate_native_source_type(&source.path, source.selection, entry.kind)?
                 }
-                Some(_) => {}
                 None => bail!("source {} does not exist", display(&source.path)),
             }
         }
@@ -1573,7 +1591,7 @@ pub fn run(args: Args) -> Result<i32> {
             SourceMapping {
                 follow_root,
                 contents,
-                require_directory: src.requires_directory(),
+                selection: src.selection,
                 sub: &sub,
             },
             DestinationRoot {
@@ -2753,7 +2771,7 @@ impl Planner<'_> {
         let SourceMapping {
             follow_root,
             contents,
-            require_directory,
+            selection,
             sub,
         } = source;
         let dst_root = destination.path;
@@ -2771,9 +2789,7 @@ impl Planner<'_> {
             if first {
                 first = false;
                 if let Some(root) = batch.first() {
-                    if require_directory && root.kind != Kind::Dir {
-                        bail!("contents selector {} is not a directory", display(src_root));
-                    }
+                    validate_native_source_type(src_root, selection, root.kind)?;
                     if destination.exact && destination.entry_is_dir && root.kind != Kind::Dir {
                         bail!(
                             "destination {} is an existing directory; cannot replace it with non-directory source {}",

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -460,6 +460,46 @@ fn native_cp_prune_checks_all_typed_sources_before_mutation() {
 }
 
 #[test]
+fn native_copy_accepts_copy_only_operational_controls() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--src-file",
+            &t.s("src/file"),
+            "--as-new",
+            &t.s("copied"),
+            "--bwlimit",
+            "1G",
+            "--stats",
+            "--no-progress",
+        ])
+        .run()
+        .unwrap();
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("copied")), b"payload");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("scanned entries:"),
+        "{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let invalid = native_syq(&[
+        "cp",
+        &t.s("src/file"),
+        "--as-new",
+        &t.s("invalid"),
+        "--bwlimit",
+        "fast",
+    ]);
+    assert_eq!(invalid.status.code(), Some(2));
+    assert!(stderr_of(&invalid).contains("bad --bwlimit"));
+    assert!(!t.path("invalid").exists());
+}
+
+#[test]
 fn native_copy_named_selector_preserves_a_root_symlink() {
     use std::os::unix::fs::symlink;
 
@@ -852,6 +892,30 @@ fn native_rm_typed_selectors_check_every_type_before_mutation() {
     ]);
     assert!(!t.path("file").exists());
     assert!(!t.path("directory").exists());
+}
+
+#[test]
+fn native_rm_accepts_bulk_typed_selectors() {
+    let t = Tmp::new();
+    write(&t.path("base/file-a"), b"a");
+    write(&t.path("base/file-b"), b"b");
+    write(&t.path("base/dir-a/child"), b"a");
+    write(&t.path("base/dir-b/child"), b"b");
+
+    run_native_ok(&[
+        "rm",
+        "--cwd",
+        &t.s("base"),
+        "--src-files",
+        "file-a",
+        "file-b",
+        "--src-dirs",
+        "dir-a",
+        "dir-b",
+        "--progress-json",
+        "--no-progress",
+    ]);
+    assert!(listing(&t.path("base")).is_empty());
 }
 
 #[test]
@@ -3907,6 +3971,10 @@ fn native_selectors_support_bulk_mixing_and_late_modifiers() {
     write(&t.path("sources/a"), b"a");
     write(&t.path("sources/tree/f"), b"tree");
     write(&t.path("sources/contents/b"), b"b");
+    write(&t.path("sources/file-a"), b"file-a");
+    write(&t.path("sources/file-b"), b"file-b");
+    write(&t.path("sources/dir-a/c"), b"dir-a");
+    write(&t.path("sources/dir-b/d"), b"dir-b");
     write(&t.path("sources/z"), b"z");
 
     run_native_ok(&[
@@ -3916,6 +3984,12 @@ fn native_selectors_support_bulk_mixing_and_late_modifiers() {
         "tree",
         "--src-srcs",
         "contents",
+        "--src-files",
+        "file-a",
+        "file-b",
+        "--src-dirs",
+        "dir-a",
+        "dir-b",
         "--src",
         "z",
         "--cwd",
@@ -3926,7 +4000,13 @@ fn native_selectors_support_bulk_mixing_and_late_modifiers() {
         &t.s("dest"),
     ]);
 
-    assert_eq!(listing(&t.path("dest")), ["a", "b", "tree", "tree/f", "z"]);
+    assert_eq!(
+        listing(&t.path("dest")),
+        [
+            "a", "b", "dir-a", "dir-a/c", "dir-b", "dir-b/d", "file-a", "file-b", "tree", "tree/f",
+            "z",
+        ]
+    );
 }
 
 #[test]
@@ -3950,6 +4030,8 @@ fn native_rejects_positional_destinations_implicit_verbs_and_compat_flags() {
         ["cp", "-a", "source", "--into", "dest"].as_slice(),
         ["cp", "--delete", "source", "--into", "dest"].as_slice(),
         ["rm", "--no-tcp", "source", "", ""].as_slice(),
+        ["rm", "--bwlimit", "1M", "source", ""].as_slice(),
+        ["rm", "--stats", "source", "", ""].as_slice(),
     ] {
         let args: Vec<_> = args.iter().copied().filter(|arg| !arg.is_empty()).collect();
         let out = native_syq(&args);

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -376,6 +376,90 @@ fn native_copy_uses_explicit_endpoints_cwd_and_option_safe_selectors() {
 }
 
 #[test]
+fn native_copy_typed_selectors_are_source_preconditions() {
+    use std::os::unix::fs::symlink;
+
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"file");
+    write(&t.path("src/dir/child"), b"child");
+    symlink("dir", t.path("src/link")).unwrap();
+
+    run_native_ok(&[
+        "cp",
+        "--cwd",
+        &t.s("src"),
+        "--src-file",
+        "file",
+        "--src-dir",
+        "dir",
+        "--src-file",
+        "link",
+        "--into-new",
+        &t.s("copied"),
+    ]);
+    assert_eq!(read(&t.path("copied/file")), b"file");
+    assert_eq!(read(&t.path("copied/dir/child")), b"child");
+    assert_eq!(
+        fs::read_link(t.path("copied/link")).unwrap(),
+        Path::new("dir")
+    );
+
+    run_native_ok(&[
+        "cp",
+        "--src-file",
+        &t.s("src/file"),
+        "--as-new",
+        &t.s("exact"),
+    ]);
+    assert_eq!(read(&t.path("exact")), b"file");
+
+    let wrong_directory = native_syq(&[
+        "cp",
+        "--src-dir",
+        &t.s("src/file"),
+        "--into-new",
+        &t.s("wrong-directory"),
+    ]);
+    assert!(!wrong_directory.status.success());
+    assert!(stderr_of(&wrong_directory).contains("--src-dir selector"));
+    assert!(!t.path("wrong-directory").exists());
+
+    let followed_link = native_syq(&[
+        "cp",
+        "--src-dir",
+        &t.s("src/link"),
+        "--into-new",
+        &t.s("followed-link"),
+    ]);
+    assert!(!followed_link.status.success());
+    assert!(stderr_of(&followed_link).contains("--src-dir selector"));
+    assert!(!t.path("followed-link").exists());
+}
+
+#[test]
+fn native_cp_prune_checks_all_typed_sources_before_mutation() {
+    let t = Tmp::new();
+    write(&t.path("src/good"), b"new");
+    write(&t.path("src/not-a-file/child"), b"child");
+    write(&t.path("dst/good"), b"old");
+    write(&t.path("dst/extra"), b"keep");
+
+    let output = native_syq(&[
+        "cp-prune",
+        "--src-file",
+        &t.s("src/good"),
+        "--src-file",
+        &t.s("src/not-a-file"),
+        "--into-existing",
+        &t.s("dst"),
+    ]);
+    assert!(!output.status.success());
+    assert!(stderr_of(&output).contains("--src-file selector"));
+    assert_eq!(read(&t.path("dst/good")), b"old");
+    assert_eq!(read(&t.path("dst/extra")), b"keep");
+}
+
+#[test]
 fn native_copy_named_selector_preserves_a_root_symlink() {
     use std::os::unix::fs::symlink;
 


### PR DESCRIPTION
## Summary

- add `--src-file` and `--src-dir` to native `cp` and `cp-prune` as pure source-type preconditions
- add bulk `--src-files` and `--src-dirs` selectors to `cp`, `cp-prune`, and `rm`
- expose `--progress`, `--no-progress`, and `--progress-json` on every native command
- expose `--bwlimit` and `--stats` on native copy commands and forward them to direct remote orchestrators
- keep `--bwlimit` and transfer statistics out of `rm`, where they have no defined removal meaning
- update native CLI documentation and integration coverage

Typed copy selectors retain ordinary `--src` behavior on a type match, including not following a selected symlink. Type mismatches are checked before target mutation and again on the first scan batch. This PR deliberately does not generalize native `rm`'s `--root`/`--follow` or descriptor-pinned resolution model to copying.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (476 tests)