### PR TITLE
Automate Python SDK release preparation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -42,7 +43,7 @@ jobs:
       - run: scripts/test-installer.sh
       - run: scripts/test-release-tools.sh
       - run: scripts/test-secret-tools.sh
-      - run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-homebrew-formula.sh scripts/test-secret-tools.sh
+      - run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh
 
   sdks:
     runs-on: ubuntu-latest
@@ -55,12 +56,28 @@ jobs:
           python-version: "3.10"
       - name: Install pinned Python tooling
         run: python -m pip install --disable-pip-version-check --no-deps uv==0.11.6
+      - name: Require the SDK mapping for the latest syq release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          latest_tag=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)
+          pinned_tag=$(jq -er .tag sdk/python/src/syq/syq-release-manifest.json)
+          test "$pinned_tag" = "$latest_tag" || {
+            echo "Python SDK pins $pinned_tag, but the latest syq release is $latest_tag" >&2
+            exit 1
+          }
+      - name: Build the candidate syq executable
+        run: cargo build --locked --bin syq
       - name: Test and reproducibly package Python SDK
         env:
           PYTHONPATH: sdk/python/src
+          SYQ_CANDIDATE_EXECUTABLE: ${{ github.workspace }}/target/debug/syq
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/syq-sdk-python
           XDG_CACHE_HOME: ${{ runner.temp }}/syq-sdk-cache
         run: |
+          SYQ_CANDIDATE_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          export SYQ_CANDIDATE_VERSION
+          scripts/test-python-sdk-release-tools.sh
           uv run --project sdk/python --frozen python -m unittest discover -s sdk/python/tests
           export SOURCE_DATE_EPOCH
           SOURCE_DATE_EPOCH=$(git show -s --format=%ct "$GITHUB_SHA")

--- a/.github/workflows/prepare-python-sdk.yml
+++ b/.github/workflows/prepare-python-sdk.yml
@@ -1,0 +1,117 @@
+name: prepare Python SDK release
+
+on:
+  workflow_run:
+    workflows: [release]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-python-sdk-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current master
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Install pinned Python tooling
+        run: python -m pip install --disable-pip-version-check --no-deps uv==0.11.6
+      - name: Validate and download the immutable syq release manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMIT: ${{ github.event.workflow_run.head_sha }}
+          RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          git fetch origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$RELEASE_COMMIT"
+          git merge-base --is-ancestor "$RELEASE_COMMIT" origin/master
+          test "$(gh release view "$RELEASE_TAG" --json tagName,isDraft,isImmutable \
+            --jq '[.tagName, .isDraft, .isImmutable] | @tsv')" = \
+            "$RELEASE_TAG"$'\tfalse\ttrue'
+          mkdir -p "$RUNNER_TEMP/syq-release"
+          gh release download "$RELEASE_TAG" \
+            --pattern syq-release-manifest.json \
+            --dir "$RUNNER_TEMP/syq-release"
+          test "$(jq -er .tag \
+            "$RUNNER_TEMP/syq-release/syq-release-manifest.json")" = \
+            "$RELEASE_TAG"
+      - name: Prepare the next Python SDK mapping
+        id: prepare
+        env:
+          RELEASE_MANIFEST: ${{ runner.temp }}/syq-release/syq-release-manifest.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/prepare-python-sdk-release.py \
+            --manifest "$RELEASE_MANIFEST"
+          uv lock --project sdk/python --offline
+          if git diff --quiet; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          scripts/test-python-sdk-release-tools.sh
+          PYTHONPATH=sdk/python/src \
+            uv run --project sdk/python --frozen \
+            python -m unittest discover -s sdk/python/tests
+          python_version=$(python3 -c \
+            'import tomllib; print(tomllib.load(open("sdk/python/pyproject.toml", "rb"))["project"]["version"])')
+          syq_version=$(jq -er .version "$RELEASE_MANIFEST")
+          echo 'changed=true' >> "$GITHUB_OUTPUT"
+          echo "python_version=$python_version" >> "$GITHUB_OUTPUT"
+          echo "syq_version=$syq_version" >> "$GITHUB_OUTPUT"
+      - name: Commit the prepared release and open a pull request
+        if: steps.prepare.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PYTHON_VERSION: ${{ steps.prepare.outputs.python_version }}
+          SYQ_VERSION: ${{ steps.prepare.outputs.syq_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="automation/python-sdk-v$SYQ_VERSION"
+          existing=$(gh pr list --head "$branch" --state open --json url --jq '.[0].url // empty')
+          if test -n "$existing"; then
+            echo "Python SDK update already exists: $existing"
+            exit 0
+          fi
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Remote branch $branch exists without an open pull request; refusing to overwrite it." >&2
+            exit 1
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -c "$branch"
+          git add sdk/README.md sdk/python sdk/RELEASING.md
+          git diff --cached --check
+          git commit -m "Pin Python SDK $PYTHON_VERSION to syq $SYQ_VERSION"
+          git push origin "$branch"
+          body=$(printf '%s\n\n%s\n%s\n%s\n\n%s' \
+            "Automated follow-up to the immutable syq v$SYQ_VERSION release." \
+            "- bumps the Python SDK to $PYTHON_VERSION" \
+            "- embeds the exact signed v$SYQ_VERSION release manifest" \
+            "- updates the documented SDK-to-syq mapping" \
+            "The SDK checks were dispatched explicitly because GitHub suppresses ordinary workflow events for branches and pull requests created by GITHUB_TOKEN. Review and merge this pull request normally; publication still requires the maintainer-signed tag sdk-python-v$PYTHON_VERSION and approval of the protected pypi environment.")
+          pr_url=$(gh pr create \
+            --base master \
+            --head "$branch" \
+            --title "Pin Python SDK $PYTHON_VERSION to syq $SYQ_VERSION" \
+            --body "$body")
+          echo "Created $pr_url"
+          gh workflow run ci.yml --ref "$branch"
+          gh workflow run rsync-compat.yml --ref "$branch"

--- a/.github/workflows/prepare-python-sdk.yml
+++ b/.github/workflows/prepare-python-sdk.yml
@@ -85,7 +85,12 @@ jobs:
         run: |
           set -euo pipefail
           branch="automation/python-sdk-v$SYQ_VERSION"
-          existing=$(gh pr list --head "$branch" --state open --json url --jq '.[0].url // empty')
+          existing=$(
+            gh pr list --head "$branch" --state open \
+              --json headRepository,url |
+              jq -r --arg repository "$GITHUB_REPOSITORY" \
+                -f scripts/select-trusted-pr.jq
+          )
           if test -n "$existing"; then
             echo "Python SDK update already exists: $existing"
             exit 0

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -27,7 +27,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           scripts/verify-release-tag.sh \
-            "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_SHA" master
+            "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_SHA" master sdks
 
   build-python:
     name: build Python SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           scripts/verify-release-tag.sh \
             "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_SHA" master \
-            rust,macos,linux-arm64
+            rust,sdks,macos,linux-arm64
 
   build:
     name: build (${{ matrix.name }})

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -131,8 +131,10 @@ connection, so enable it only for a trusted release host rather than globally.
 2. Wait for the post-merge `ci` run on `master` to succeed for the release
    commit. Pull requests are checked against their own head rather than the
    merged result, and the release workflow refuses a commit whose `rust`,
-   `macos`, and `linux-arm64` checks have not all succeeded, so tagging a
-   red or still-running `master` only produces a failed release run:
+   `sdks`, `macos`, and `linux-arm64` checks have not all succeeded. The `sdks`
+   check builds the candidate syq and exercises it through the Python adapter,
+   so tagging a red or still-running `master` only produces a failed release
+   run:
 
    ```sh
    gh run watch --exit-status "$(gh run list --workflow ci.yml --branch master --commit "$(git rev-parse master)" --json databaseId --jq '.[0].databaseId')"
@@ -151,13 +153,18 @@ connection, so enable it only for a trusted release host rather than globally.
    approve it again when the separate Homebrew tap job is ready. The workflow
    first verifies that the annotated tag's signature is valid and that it
    directly targets the workflow commit, that this commit is reachable
-   from protected `master`, and that the `rust`, `macos`, and `linux-arm64`
-   checks all succeeded on that exact commit. It then builds static GNU Linux x86-64/ARM64
+   from protected `master`, and that the `rust`, `sdks`, `macos`, and
+   `linux-arm64` checks all succeeded on that exact commit. It then builds
+   static GNU Linux x86-64/ARM64
    binaries and native macOS Apple Silicon/Intel binaries, embeds an Ed25519
    signature over the manifest's RFC 8785 canonical JSON, verifies the exact
    asset inventory, creates provenance attestations, uploads a draft, checks
    every uploaded byte, publishes it, publishes the matching source package to
    crates.io with a short-lived OIDC credential, and finally updates the tap.
+   Once the entire release workflow succeeds, the Python SDK preparation
+   workflow opens a pull request for the next SDK patch release using this
+   immutable syq manifest. PyPI publication remains a separate signed-tag and
+   protected-environment action, so a registry outage cannot block syq.
 4. Verify one or more downloaded artifacts and exercise all install paths:
 
    ```sh

--- a/scripts/prepare-python-sdk-release.py
+++ b/scripts/prepare-python-sdk-release.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Prepare a Python SDK patch release for one immutable syq manifest."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+SEMVER = re.compile(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)")
+EXPECTED_REPOSITORY = "https://github.com/greaber/syq"
+EXPECTED_TARGETS = {
+    "linux-aarch64",
+    "linux-x86_64",
+    "macos-arm64",
+    "macos-x86_64",
+}
+
+
+def version_tuple(value: str, *, label: str) -> tuple[int, int, int]:
+    match = SEMVER.fullmatch(value)
+    if match is None:
+        raise ValueError(f"{label} must be an X.Y.Z version, got {value!r}")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def digest(value: Any, *, label: str) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"manifest {label} is not a lowercase SHA-256 digest")
+    return value
+
+
+def positive_integer(value: Any, *, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"manifest {label} is not a positive integer")
+    return value
+
+
+def load_manifest(path: Path) -> tuple[bytes, dict[str, Any]]:
+    raw = path.read_bytes()
+    if len(raw) > 1024 * 1024:
+        raise ValueError("release manifest is unexpectedly large")
+    manifest = json.loads(raw)
+    if not isinstance(manifest, dict):
+        raise ValueError("release manifest is not an object")
+    if manifest.get("schema") != 1:
+        raise ValueError("release manifest schema is not 1")
+    if manifest.get("repository") != EXPECTED_REPOSITORY:
+        raise ValueError("release manifest repository is unexpected")
+    version = manifest.get("version")
+    if not isinstance(version, str) or manifest.get("tag") != f"v{version}":
+        raise ValueError("release manifest version and tag do not match")
+    version_tuple(version, label="syq release")
+    try:
+        signature = base64.b64decode(manifest["signature"], validate=True)
+    except (KeyError, TypeError, ValueError, binascii.Error) as error:
+        raise ValueError("release manifest has no valid base64 signature") from error
+    if len(signature) != 64:
+        raise ValueError("release manifest signature is not 64 bytes")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict) or set(artifacts) != EXPECTED_TARGETS:
+        raise ValueError("release manifest does not contain every SDK target")
+    for target, entry in artifacts.items():
+        if not isinstance(entry, dict):
+            raise ValueError(f"release manifest target {target} is not an object")
+        for kind in ("archive", "binary"):
+            artifact = entry.get(kind)
+            if not isinstance(artifact, dict):
+                raise ValueError(f"release manifest {target} {kind} is not an object")
+            name = artifact.get("name")
+            if not isinstance(name, str) or not name.startswith("syq-"):
+                raise ValueError(f"release manifest {target} {kind} name is invalid")
+            digest(artifact.get("sha256"), label=f"{target} {kind} digest")
+            positive_integer(artifact.get("size"), label=f"{target} {kind} size")
+    return raw, manifest
+
+
+def replace_once(text: str, old: str, new: str, *, label: str) -> str:
+    if text.count(old) != 1:
+        raise ValueError(f"expected exactly one {label} marker, found {text.count(old)}")
+    return text.replace(old, new)
+
+
+def prepare(root: Path, manifest_path: Path) -> bool:
+    raw_manifest, manifest = load_manifest(manifest_path)
+    new_syq_version = str(manifest["version"])
+    packaged_manifest = root / "sdk/python/src/syq/syq-release-manifest.json"
+    current_manifest = json.loads(packaged_manifest.read_bytes())
+    current_syq_version = str(current_manifest["version"])
+    if version_tuple(new_syq_version, label="new syq release") <= version_tuple(
+        current_syq_version, label="current syq release"
+    ):
+        print(
+            f"Python SDK already pins syq {current_syq_version}; "
+            f"not preparing {new_syq_version}"
+        )
+        return False
+
+    pyproject_path = root / "sdk/python/pyproject.toml"
+    pyproject = pyproject_path.read_text(encoding="utf-8")
+    version_match = re.search(r'^version = "([^"]+)"$', pyproject, re.MULTILINE)
+    if version_match is None:
+        raise ValueError("could not find the Python package version")
+    current_python_version = version_match.group(1)
+    major, minor, patch = version_tuple(
+        current_python_version, label="current Python SDK"
+    )
+    new_python_version = f"{major}.{minor}.{patch + 1}"
+    pyproject = replace_once(
+        pyproject,
+        f'version = "{current_python_version}"',
+        f'version = "{new_python_version}"',
+        label="Python package version",
+    )
+
+    python_readme_path = root / "sdk/python/README.md"
+    python_readme = python_readme_path.read_text(encoding="utf-8")
+    python_readme = replace_once(
+        python_readme,
+        f"For Python package `{current_python_version}`, that release is syq "
+        f"`{current_syq_version}`.",
+        f"For Python package `{new_python_version}`, that release is syq "
+        f"`{new_syq_version}`.",
+        label="Python README release mapping",
+    )
+    old_cache_path = f"syq/sdk/python/v{current_syq_version}/"
+    if python_readme.count(old_cache_path) != 2:
+        raise ValueError("expected two Python README cache-version markers")
+    python_readme = python_readme.replace(
+        old_cache_path,
+        f"syq/sdk/python/v{new_syq_version}/",
+    )
+    if old_cache_path in python_readme:
+        raise ValueError("the Python README retained the old cache version")
+
+    sdk_readme_path = root / "sdk/README.md"
+    sdk_readme = sdk_readme_path.read_text(encoding="utf-8")
+    current_row = f"| `{current_python_version}` | `{current_syq_version}` |"
+    new_row = f"| `{new_python_version}` | `{new_syq_version}` |"
+    sdk_readme = replace_once(
+        sdk_readme,
+        current_row,
+        f"{current_row}\n{new_row}",
+        label="SDK mapping table row",
+    )
+
+    pyproject_path.write_text(pyproject, encoding="utf-8")
+    python_readme_path.write_text(python_readme, encoding="utf-8")
+    sdk_readme_path.write_text(sdk_readme, encoding="utf-8")
+    packaged_manifest.write_bytes(raw_manifest)
+    print(
+        f"prepared Python SDK {new_python_version} for syq {new_syq_version}"
+    )
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+    )
+    arguments = parser.parse_args()
+    prepare(arguments.root.resolve(), arguments.manifest.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/select-trusted-pr.jq
+++ b/scripts/select-trusted-pr.jq
@@ -1,0 +1,6 @@
+map(select(.headRepository.nameWithOwner == $repository))
+| if length > 1 then
+    error("multiple open pull requests from the trusted repository use this branch")
+  else
+    .[0].url // empty
+  end

--- a/scripts/test-python-sdk-release-tools.sh
+++ b/scripts/test-python-sdk-release-tools.sh
@@ -54,4 +54,26 @@ if python3 "$script_dir/prepare-python-sdk-release.py" \
 fi
 grep -F 'release manifest has no valid base64 signature' "$work/invalid.out" >/dev/null
 
+trusted_pr='https://github.com/greaber/syq/pull/123'
+cat > "$work/pull-requests.json" <<EOF
+[
+  {
+    "headRepository": {"nameWithOwner": "attacker/syq"},
+    "url": "https://github.com/greaber/syq/pull/122"
+  },
+  {
+    "headRepository": {"nameWithOwner": "greaber/syq"},
+    "url": "$trusted_pr"
+  }
+]
+EOF
+selected_pr=$(jq -r --arg repository greaber/syq \
+  -f "$script_dir/select-trusted-pr.jq" "$work/pull-requests.json")
+test "$selected_pr" = "$trusted_pr"
+selected_pr=$(jq -r --arg repository greaber/syq \
+  -f "$script_dir/select-trusted-pr.jq" \
+  <(jq 'map(select(.headRepository.nameWithOwner != "greaber/syq"))' \
+    "$work/pull-requests.json"))
+test -z "$selected_pr"
+
 echo 'Python SDK release tool tests passed'

--- a/scripts/test-python-sdk-release-tools.sh
+++ b/scripts/test-python-sdk-release-tools.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_dir=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-python-sdk-release-test.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$work/sdk/python/src/syq"
+cp "$repo_dir/sdk/README.md" "$work/sdk/README.md"
+cp "$repo_dir/sdk/python/README.md" "$work/sdk/python/README.md"
+cp "$repo_dir/sdk/python/pyproject.toml" "$work/sdk/python/pyproject.toml"
+cp "$repo_dir/sdk/python/src/syq/syq-release-manifest.json" \
+  "$work/sdk/python/src/syq/syq-release-manifest.json"
+
+current_manifest="$repo_dir/sdk/python/src/syq/syq-release-manifest.json"
+current_syq_version=$(jq -er .version "$current_manifest")
+current_python_version=$(sed -n 's/^version = "\(.*\)"/\1/p' \
+  "$repo_dir/sdk/python/pyproject.toml")
+IFS=. read -r syq_major syq_minor syq_patch <<<"$current_syq_version"
+IFS=. read -r python_major python_minor python_patch <<<"$current_python_version"
+next_syq_version="$syq_major.$syq_minor.$((syq_patch + 1))"
+next_python_version="$python_major.$python_minor.$((python_patch + 1))"
+candidate="$work/candidate.json"
+jq --arg version "$next_syq_version" \
+  '.version = $version | .tag = ("v" + $version) | .helper_id = ("v" + $version + "-p0")' \
+  "$current_manifest" > "$candidate"
+python3 "$script_dir/prepare-python-sdk-release.py" \
+  --root "$work" --manifest "$candidate"
+
+grep -Fx "version = \"$next_python_version\"" \
+  "$work/sdk/python/pyproject.toml" >/dev/null
+grep -F "For Python package \`$next_python_version\`, that release is syq \`$next_syq_version\`." \
+  "$work/sdk/python/README.md" >/dev/null
+test "$(grep -Fc "syq/sdk/python/v$next_syq_version/" \
+  "$work/sdk/python/README.md")" -eq 2
+grep -Fx "| \`$next_python_version\` | \`$next_syq_version\` |" \
+  "$work/sdk/README.md" >/dev/null
+cmp "$candidate" "$work/sdk/python/src/syq/syq-release-manifest.json"
+
+before=$(find "$work/sdk" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)
+python3 "$script_dir/prepare-python-sdk-release.py" \
+  --root "$work" --manifest "$candidate"
+after=$(find "$work/sdk" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)
+test "$before" = "$after"
+
+invalid="$work/invalid.json"
+jq 'del(.signature)' "$candidate" > "$invalid"
+if python3 "$script_dir/prepare-python-sdk-release.py" \
+  --root "$work" --manifest "$invalid" > "$work/invalid.out" 2>&1; then
+  echo 'manifest without a signature unexpectedly succeeded' >&2
+  exit 1
+fi
+grep -F 'release manifest has no valid base64 signature' "$work/invalid.out" >/dev/null
+
+echo 'Python SDK release tool tests passed'

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -36,8 +36,9 @@ The current mapping is:
 The two version numbers do not need to match, but the mapping is immutable for
 a published SDK release. Multiple SDK releases may pin the same syq release.
 Moving to another syq release requires a new SDK release and its compatibility
-tests. A syq release does not require an SDK release unless the SDK is being
-moved to it.
+tests. Every successful official syq release automatically prepares a Python
+SDK patch-release pull request that pins its exact signed manifest. Maintainers
+review and merge that mapping before creating the signed Python SDK tag.
 
 Callers that need a local build, a newer syq, or an offline-provisioned binary
 may pass `executable=` explicitly. That opts out of the tested pairing; the

--- a/sdk/RELEASING.md
+++ b/sdk/RELEASING.md
@@ -7,7 +7,9 @@ immutable: never move a release tag or attempt to replace an uploaded package.
 
 ### PyPI
 
-In the existing PyPI account, create a pending GitHub trusted publisher with:
+The repository already has a protected GitHub environment named `pypi`. It
+requires maintainer approval and accepts only `sdk-python-v*` tags. In the
+existing PyPI account, create a pending GitHub trusted publisher with:
 
 - PyPI project name: `syq`
 - GitHub owner: `greaber`
@@ -15,10 +17,8 @@ In the existing PyPI account, create a pending GitHub trusted publisher with:
 - workflow: `publish-sdks.yml`
 - environment: `pypi`
 
-Create a protected GitHub environment named `pypi`, require a maintainer's
-approval, and restrict it to `sdk-python-v*` release tags. A pending publisher
-does not reserve the name; the first successful workflow run creates the
-project.
+The pending publisher is the remaining account-side setup. It does not reserve
+the name; the first successful workflow run creates the project.
 
 ### npm
 
@@ -57,10 +57,11 @@ Go has no publisher account or central name reservation. The module path in
 tag commits the project to `github.com/greaber/syq/sdk/go`; changing to a
 future vanity domain would create a different Go module.
 
-Extend the repository's release-tag ruleset to restrict creation, update, and
-deletion of `sdk-python-v*`, `sdk-js-v*`, and `sdk/go/v*` tags to release
-maintainers. Like binary releases, every SDK release uses a signed annotated
-tag whose signature GitHub recognizes.
+The repository's release-tag ruleset restricts creation, update, deletion, and
+non-fast-forward changes for `sdk-python-v*`, `sdk-js-v*`, and `sdk/go/v*` tags
+to the release maintainer, alongside the existing `v*` protection. Like binary
+releases, every SDK release uses a signed annotated tag whose signature GitHub
+recognizes.
 
 ## Release checks
 
@@ -84,18 +85,55 @@ git tag -s sdk-python-v0.0.1 -m 'Python SDK 0.0.1'
 git push origin sdk-python-v0.0.1
 ```
 
-After the manually published `0.0.1` package is byte-for-byte verified, create
-its tag and configure trusted publishing. Subsequent JavaScript tags use the
-version in `js/package.json` normally:
+The first Python tag uses the pending trusted publisher configured above; do
+not upload `0.0.1` locally. The protected workflow creates the PyPI project and
+publishes the already-tested distributions with OIDC. PyPI does not reserve the
+name until that workflow successfully publishes, so create the pending
+publisher immediately before the tag.
+
+JavaScript `0.0.1` is the package that requires the manual bootstrap publish.
+After those exact bytes are verified and its trusted publisher is configured,
+subsequent JavaScript tags use the version in `js/package.json` normally:
 
 ```sh
 git tag -s sdk-js-v0.0.1 -m 'JavaScript SDK 0.0.1'
 git push origin sdk-js-v0.0.1
 ```
 
-Those tags run `.github/workflows/publish-sdks.yml`, which verifies the tag,
-version, tests, package contents, pinned download, and executable identity
+Those tags run `.github/workflows/publish-sdks.yml`, which verifies that the
+signed tag targets a `master` commit whose `sdks` check passed, then verifies
+the version, tests, package contents, pinned download, and executable identity
 before entering the protected publishing environment.
+
+## Automated Python follow-up to a syq release
+
+The `sdks` CI job builds the syq executable from the commit under test and runs
+the Python adapter's candidate compatibility tests against it. These exercise
+the reported version, a real disposable local copy, argument boundaries, and
+failure retention. The syq release tag verifier requires `sdks` alongside the
+Rust and platform checks, so a failing adapter blocks publication of the syq
+release itself. The same job requires the packaged Python manifest to match the
+latest immutable syq release. Until the generated mapping pull request lands,
+subsequent development therefore cannot acquire a green release-eligible
+`sdks` check or consume the same next Python patch version.
+
+After `.github/workflows/release.yml` completes successfully and the GitHub
+release is immutable, `.github/workflows/prepare-python-sdk.yml` downloads its
+exact signed manifest and prepares the next Python patch version. It opens an
+`automation/python-sdk-vX.Y.Z` pull request containing the version, manifest,
+cache-path documentation, lockfile, and mapping-table updates, then explicitly
+dispatches the normal CI and compatibility workflows. GitHub intentionally
+suppresses ordinary workflow events caused by its own token, which is why the
+dispatch is explicit. The repository keeps the default workflow token read
+only, permits trusted Actions workflows to create pull requests, and grants
+write scopes only inside this preparation workflow.
+
+Review and merge that pull request normally. The final publication remains a
+deliberate release-authority action: create the signed annotated
+`sdk-python-v<version>` tag and approve the protected `pypi` environment. The
+tag then publishes through OIDC without a local upload or long-lived PyPI
+credential. Keeping the tag signature manual avoids placing maintainer signing
+authority in CI; PyPI availability cannot block publication of syq itself.
 
 Python distributions use a pinned interpreter and the tagged commit timestamp
 as `SOURCE_DATE_EPOCH`, and the source archive is repacked with normalized

--- a/sdk/python/tests/test_bootstrap.py
+++ b/sdk/python/tests/test_bootstrap.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gzip
 import hashlib
 import io
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -76,8 +77,10 @@ class BootstrapTests(unittest.TestCase):
             mock.patch.object(bootstrap, "_host_target", return_value="linux-x86_64"),
         )
 
-    def test_package_pins_syq_0_1_5(self) -> None:
-        self.assertEqual(syq.PINNED_SYQ_VERSION, "0.1.5")
+    def test_package_pin_matches_embedded_manifest(self) -> None:
+        manifest_path = Path(bootstrap.__file__).with_name("syq-release-manifest.json")
+        manifest = json.loads(manifest_path.read_bytes())
+        self.assertEqual(syq.PINNED_SYQ_VERSION, manifest["version"])
 
     def test_downloads_validates_and_reuses_the_exact_binary(self) -> None:
         manifest_patch, target_patch = self._patch_release()

--- a/sdk/python/tests/test_candidate.py
+++ b/sdk/python/tests/test_candidate.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import syq
+
+
+EXECUTABLE = os.environ.get("SYQ_CANDIDATE_EXECUTABLE")
+EXPECTED_VERSION = os.environ.get("SYQ_CANDIDATE_VERSION")
+
+
+@unittest.skipUnless(
+    EXECUTABLE and EXPECTED_VERSION,
+    "candidate compatibility requires SYQ_CANDIDATE_EXECUTABLE and version",
+)
+class CandidateCompatibilityTests(unittest.TestCase):
+    def test_candidate_version_and_local_copy(self) -> None:
+        assert EXECUTABLE is not None
+        assert EXPECTED_VERSION is not None
+        executable = Path(EXECUTABLE)
+        self.assertEqual(syq.version(executable=executable), EXPECTED_VERSION)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "source; $(not-a-command)"
+            destination = root / "destination"
+            source.write_bytes(b"candidate compatibility\n")
+
+            result = syq.run(
+                ["cp", source, "--as-new", destination, "--quiet"],
+                executable=executable,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+
+    def test_candidate_failure_is_retained(self) -> None:
+        assert EXECUTABLE is not None
+        result = syq.run(
+            ["not-a-syq-command"],
+            executable=EXECUTABLE,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- build each candidate syq in the `sdks` job and exercise it through the Python adapter with a real disposable local copy
- require the Python manifest to match the latest immutable syq release, preventing a second syq release from overtaking an unmerged SDK mapping
- require `sdks` alongside Rust/platform checks before a syq release tag can publish
- after a successful immutable syq release, validate and embed its exact signed manifest, bump the Python SDK patch version, update its lockfile/docs/mapping, and open a review PR
- explicitly dispatch CI for the bot-created PR because GitHub suppresses ordinary workflow events created by `GITHUB_TOKEN`
- fix the existing SDK publishing workflow's missing required-check argument so the first signed Python tag can actually build and publish
- document that Python `0.0.1` uses PyPI's pending trusted publisher rather than a manual local upload

## Repository configuration completed

- created protected GitHub environment `pypi`
- required maintainer approval and restricted it to `sdk-python-v*` tags
- extended release tag protection to Python, JavaScript, and Go SDK tags
- retained read-only default workflow permissions and enabled trusted workflows to create their update PR

The remaining account-side prerequisite is the pending PyPI publisher for project `syq`, owner `greaber`, repository `syq`, workflow `publish-sdks.yml`, environment `pypi`.

## Verification

At `3e2336f`:

- candidate Python SDK suite: 18 passed against source-built syq 0.1.5
- updater future-version, invalid-manifest, idempotency, and offline-lock simulations passed
- two Python distributions were byte-for-byte reproducible
- the isolated built wheel downloaded and ran pinned syq 0.1.5
- JavaScript tests/package dry-run and Go format/vet/tests passed
- all workflow YAML and embedded Bash parsed successfully
- shellcheck passed for the complete release-script inventory
- `cargo fmt --all -- --check` passed
- `cargo clippy --locked --all-targets --all-features -- -D warnings` passed
- `cargo test --locked --all-targets --quiet` passed (214 unit, 249 local integration, 9 update tests)
- release assembly/signing and Python release-tool tests passed
