### PR TITLE
Mappings: syq map, cp --mapping, and --results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,4 @@ strip = "symbols"
 
 [dev-dependencies]
 libc = "0.2"
+serde_json = "1"

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -282,6 +282,8 @@ set -o pipefail
 syq cp --mapping big.ndjson -C src --to nas --into /data --results r.ndjson
 jq -cs 'if (.[-1].type? // "") != "result"
         then "incomplete results stream (no terminal record)" | halt_error
+        elif (.[-1].status != "success" and .[-1].status != "partial")
+        then "run stopped early (status \(.[-1].status)); rerun it instead of retrying" | halt_error
         else .[] | select(.type == "operation_result"
                           and .disposition == "failed"
                           and .retryable != "no")
@@ -291,7 +293,9 @@ jq -cs 'if (.[-1].type? // "") != "result"
 
 The jq program first checks the stream's terminal record: a results
 file without one is from a run that did not finish (a crash, a kill),
-so entries the run never reached have no records at all and a retry
-built from the prefix would look complete while it is not. With the
+and a terminal status other than `success` or `partial` (an aborted
+run, say) means queued entries were never settled — in both cases
+entries may have no records at all, so a retry manifest built from
+what is there would look complete while it is not. With the
 terminal record present, the filter is what an exit code cannot
 express: which entries failed, and whether a retry could help.

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -66,6 +66,14 @@ Emission refuses names that are not valid UTF-8 (so published
 one-line transforms are safe by construction); mappings you author
 yourself may use the base64 form for such names.
 
+In this first version `syq map` reads a local source (`--from` is
+refused), and takes either `--src-src DIR` as the only selector or any
+number of relative named selectors. It never contacts a destination,
+so `--to` and `--into` do not change what is emitted and the
+`--into-new`/`--into-existing`/`--as-new`/`--as-existing` existence
+preconditions are refused; only `--as` changes the output, by renaming
+the single selected root.
+
 ## Transform in the middle
 
 Because a mapping is plain data, the pipeline
@@ -202,10 +210,11 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
   an exact single-path placement cannot host a manifest — each entry's
   `dst` already is its own `--as`. It is part of the native surface
   only; `syq rsync` is unchanged.
-- `syq map` accepts any `syq cp` invocation, including
-  `report --as /reports/final`, which emits that single resolved entry.
-  The typed `rm` selectors (`--src-dir`, `--src-file`) are not part of
-  the copy grammar.
+- `syq map` accepts the `syq cp` grammar, including `--as PATH`, which
+  emits the single selected root under the target's basename; see
+  "Emitting a mapping" for this version's restrictions. The typed `rm`
+  selectors (`--src-dir`, `--src-file`) are not part of the copy
+  grammar.
 - Fidelity is the native default (`-rlt`). There is no per-entry
   policy: preservation and comparison behavior stay global.
 - An entry claims exactly one object. A `dir` entry claims the

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -8,7 +8,8 @@ a mapping syq itself emits — and syq does what it always does:
 parallel transfer, delta, resume, verification, and conflict checking
 before a single byte moves.
 
-```sh
+```bash
+set -o pipefail
 syq map --src-src photos \
   | jq '.dst.value |= ascii_downcase' \
   | syq cp --mapping - -C photos --to nas --into /pub
@@ -83,16 +84,23 @@ Re-running any of these converges like an ordinary syq copy: what
 already landed is skipped.
 
 As in any shell pipeline, `syq cp` sees only the bytes that reach it:
-if a producer fails partway, use `set -o pipefail` so the pipeline's
-exit status reflects it. Nothing wrong is copied either way — a
-truncated manifest copies a valid prefix, and re-running after the fix
-completes the rest.
+the examples set `set -o pipefail` (Bash) so a failed producer fails
+the pipeline. Nothing wrong is copied either way — a truncated
+manifest copies only a valid prefix, and re-running the corrected
+pipeline converges. For stage-by-stage completion, materialize the
+manifest instead:
+
+```bash
+syq map --src-src src | jq '.dst.value |= ascii_downcase' > m.ndjson \
+  && syq cp --mapping m.ndjson -C src --to nas --into /pub
+```
 
 ### Lowercase every destination name
 
 A migration to a case-insensitive filesystem:
 
-```sh
+```bash
+set -o pipefail
 syq map --src-src src \
   | jq '.dst.value |= ascii_downcase' \
   | syq cp --mapping - -C src --to nas --into /pub
@@ -139,7 +147,8 @@ up around every run.
 
 ### Repartition into `YEAR/MM/` folders by modification time
 
-```sh
+```bash
+set -o pipefail
 syq map --src-src photos \
   | jq 'select(.kind == "file")
         | .dst.value = (.mtime | gmtime | strftime("%Y/%m")) + "/" + .dst.value' \
@@ -165,7 +174,8 @@ lifecycle (rebuild after changes, clean up after runs).
 
 ### Only files of at least 1 MiB
 
-```sh
+```bash
+set -o pipefail
 syq map --src-src data \
   | jq 'select(.kind != "file" or .size >= 1048576)' \
   | syq cp --mapping - -C data --to nas --into /big
@@ -229,28 +239,33 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
   symlink, and a destination path that would traverse a symlink inside
   the target container fails that entry. Resolve links yourself before
   emitting if you want targets instead.
-- An entry whose object the fixed `-rlt` fidelity does not copy (a FIFO
-  or device) is skipped, not failed: the run still succeeds, the entry
-  counts as excluded, and with `--results` it appears with disposition
-  `skipped` — the same class as a `--min-size` exclusion. Filter with
+- `kind: "special"` asserts the source's type; it does not override the
+  fixed `-rlt` fidelity, which copies no special files. Such an entry is
+  a policy exclusion like `--min-size`: the run still succeeds and the
+  entry appears only in the excluded aggregate. Filter with
   `jq 'select(.kind != "special")'` to drop such entries up front.
 - Mappings define no deletion region, so `--mapping` is not available
   on `cp-prune`.
 - Duplicate lines are errors, even identical ones: a duplicate almost
   always means a generator bug. Deduplicate in your generator if you
   union overlapping fragments.
-- `syq map` streams as it scans, and `syq cp --mapping -` starts work
-  before the stream ends; conflict checks are incremental. Exit codes
+- `syq cp --mapping` reads and validates the whole manifest before
+  copying anything: parse errors, duplicate destinations, and
+  declared-kind ancestor conflicts refuse the run before any entry is
+  applied (the `--into` container itself is created eagerly, as with
+  `--files-from`). The price is memory proportional to the manifest, as
+  in a multi-source copy. Execution then overlaps source stats and transfers.
+  Conflicts only observable at execution — an undeclared ancestor that
+  turns out not to be a directory, existing destination state — still
+  fail entries individually. `syq map` streams its output. Exit codes
   and output are the ordinary `syq cp` ones.
 
 ## Machine-readable results (preview)
 
 `syq cp --results FILE` (also `-` for stdout; combine that with `-q`)
 writes an NDJSON outcome stream beside the ordinary human output:
-a `run` record, one `operation_result` per settled mutation, per
-failed mapping entry, and per policy-skipped mapping entry
-(disposition `succeeded`, `failed`, or `skipped`), an `error` record
-per counted error, and exactly
+a `run` record, one `operation_result` per settled mutation and per
+failed mapping entry, an `error` record per counted error, and exactly
 one terminal `result` with the exit code and aggregate counts. The
 records carry `schema_version: 0` — an unstable preview of the planned
 automation interface; unchanged and excluded entries appear only in

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -107,11 +107,15 @@ That is a reasonable choice for a one-time transfer. Its limits:
   wins and one file's content is lost without warning.
 - Every run resends every byte: no delta, no resume, and an
   interrupted pipe leaves truncated files in place.
-- The data flows over one unverified connection.
+- The data moves over one connection, at single-stream ssh speed.
 - The transform sees only the name, so the mtime- and size-based
   examples below cannot be expressed.
 - Symlink targets are rewritten too by default, which breaks links
-  pointing outside the tree.
+  pointing outside the tree. (syq takes the opposite trade: target
+  text is copied verbatim, so out-of-tree links survive, but an
+  in-tree link does not follow the rename — harmless here because the
+  case-insensitive destination resolves `Notes.TXT` anyway, dangling
+  on a case-sensitive one.)
 
 rsync itself has no rename option. Keeping rsync's delta and resume
 means a symlink staging farm: `ln -sf` each file into a lowercased

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -231,3 +231,29 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
 - `syq map` streams as it scans, and `syq cp --mapping -` starts work
   before the stream ends; conflict checks are incremental. Exit codes
   and output are the ordinary `syq cp` ones.
+
+## Machine-readable results (preview)
+
+`syq cp --results FILE` (also `-` for stdout; combine that with `-q`)
+writes an NDJSON outcome stream beside the ordinary human output:
+a `run` record, one `operation_result` per settled mutation and per
+failed mapping entry, an `error` record per counted error, and exactly
+one terminal `result` with the exit code and aggregate counts. The
+records carry `schema_version: 0` — an unstable preview of the planned
+automation interface; unchanged and excluded entries appear only in
+the terminal aggregates, and metadata-only updates are not yet
+reported per operation. A missing terminal record means the run did
+not finish.
+
+Failed operation records carry `src`, `dst`, and `kind`, so a retry
+manifest is one filter away:
+
+```sh
+syq cp --mapping big.ndjson -C src --to nas --into /data --results r.ndjson
+jq -c 'select(.type == "operation_result" and .disposition == "failed"
+              and .retryable != "no") | {src, dst, kind}' r.ndjson \
+  | syq cp --mapping - -C src --to nas --into /data
+```
+
+The second line is what an exit code cannot express: which entries
+failed, and whether a retry could help.

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -16,9 +16,9 @@ syq map --src-src photos \
 
 rsync hardcodes single instances of this idea as flags (`--iconv` is a
 filename transform; `-R` with `/./` anchors is a placement transform).
-With a mapping, the transform is yours — any tool that can edit JSON
-lines — and syq refuses case-fold collisions that a hand-rolled rename
-loop would silently overwrite.
+With a mapping, any tool that can edit JSON lines can do the
+transform, and syq refuses case-fold collisions that a hand-rolled
+rename loop would silently overwrite.
 
 ## The format
 
@@ -101,18 +101,23 @@ For a one-shot copy, GNU tar can do this rename more simply:
 tar -C src -cf - --transform='s/.*/\L&/' . | ssh nas 'tar -C /pub -xf -'
 ```
 
-Use that when it fits. Where it stops fitting: the case-fold collision
-above extracts with exit 0 and the last writer silently wins (measured,
-not speculated); every run resends every byte, and an interrupted pipe
-leaves truncated files in place; the stream is one connection,
-unverified; the transform sees only the *name*, so the mtime- and
-size-based examples below are out of its reach; and it rewrites symlink
-targets by default, which breaks links pointing outside the tree.
-rsync itself has no rename option at all — keeping rsync's delta and
-resume means a symlink staging farm (`ln -sf` into a lowercased
-`staging/` tree, then `rsync -aL staging/ nas:/pub/`), where `-f`
-again resolves collisions silently and the farm must be rebuilt and
-cleaned up around every run.
+That is a reasonable choice for a one-time transfer. Its limits:
+
+- The case-fold collision above extracts with exit 0; the last writer
+  wins and one file's content is lost without warning.
+- Every run resends every byte: no delta, no resume, and an
+  interrupted pipe leaves truncated files in place.
+- The data flows over one unverified connection.
+- The transform sees only the name, so the mtime- and size-based
+  examples below cannot be expressed.
+- Symlink targets are rewritten too by default, which breaks links
+  pointing outside the tree.
+
+rsync itself has no rename option. Keeping rsync's delta and resume
+means a symlink staging farm: `ln -sf` each file into a lowercased
+`staging/` tree, then `rsync -aL staging/ nas:/pub/`. The `-f` again
+resolves collisions silently, and the farm must be rebuilt and cleaned
+up around every run.
 
 ### Repartition into `YEAR/MM/` folders by modification time
 
@@ -148,12 +153,11 @@ syq map --src-src data \
   | syq cp --mapping - -C data --to nas --into /big
 ```
 
-rsync spells this exact transform as a dedicated flag:
-`rsync -a --min-size=1M data/ nas:/big/`. That is the pattern in
-miniature: a few transforms earned rsync flags over the years
-(`--min-size`, `--iconv`); most never will — there is no
-`--lowercase` and no `--partition-by-date` — but as mapping transforms
-they are all the same one-line shape.
+rsync has a dedicated flag for this exact transform:
+`rsync -a --min-size=1M data/ nas:/big/`. A few transforms of this
+kind got rsync flags over the years (`--min-size`, `--iconv`); most,
+like lowercasing or date partitioning, never did. As mapping
+transforms they all have the same shape.
 
 ## Producing a mapping yourself
 

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -70,10 +70,13 @@ yourself may use the base64 form for such names.
 
 Because a mapping is plain data, the pipeline
 `syq map … | <transform> | syq cp --mapping - …` covers, as one-liners,
-things that otherwise need dedicated flags or custom copy scripts:
+things that otherwise need dedicated flags or custom copy scripts.
+Re-running any of these converges like an ordinary syq copy: what
+already landed is skipped.
 
-Lowercase every destination name (a migration to a case-insensitive
-filesystem — collisions refused, not overwritten):
+### Lowercase every destination name
+
+A migration to a case-insensitive filesystem:
 
 ```sh
 syq map --src-src src \
@@ -81,21 +84,72 @@ syq map --src-src src \
   | syq cp --mapping - -C src --to nas --into /pub
 ```
 
-Repartition into `YEAR/MM/` folders by modification time:
+```text
+src/                          nas:/pub/ afterwards
+├── Berlin/                   ├── berlin/
+│   ├── IMG_1234.JPG          │   ├── img_1234.jpg
+│   └── IMG_1235.JPG          │   └── img_1235.jpg
+└── Notes.TXT                 └── notes.txt
+```
+
+If `src` also contained `notes.TXT`, the run is refused before any
+transfer: two entries claim `notes.txt`.
+
+rsync has no rename option, so its closest equivalent is a symlink
+staging farm, dereferenced on the way out:
+
+```sh
+find src -type f | while read -r f; do
+  d="staging/$(printf %s "${f#src/}" | tr '[:upper:]' '[:lower:]')"
+  mkdir -p "$(dirname "$d")" && ln -sf "$(realpath "$f")" "$d"
+done
+rsync -aL staging/ nas:/pub/
+```
+
+— where `ln -sf` resolves the case-fold collision silently,
+last writer wins, and the farm must be rebuilt and cleaned up around
+every run.
+
+### Repartition into `YEAR/MM/` folders by modification time
 
 ```sh
 syq map --src-src photos \
-  | jq '.dst.value = (.mtime | gmtime | strftime("%Y/%m")) + "/" + .dst.value' \
+  | jq 'select(.kind == "file")
+        | .dst.value = (.mtime | gmtime | strftime("%Y/%m")) + "/" + .dst.value' \
   | syq cp --mapping - -C photos --to nas --into /archive
 ```
 
-Only files of at least 1 MiB:
+The `select` keeps only file entries; the `2024/07/` directories no
+entry names are created implicitly.
+
+```text
+photos/                          nas:/archive/ afterwards
+├── IMG_1234.JPG   (July 2024)   ├── 2024/
+├── IMG_8812.JPG   (Nov 2024)    │   ├── 07/IMG_1234.JPG
+└── clip.mp4       (Jan 2025)    │   └── 11/IMG_8812.JPG
+                                 └── 2025/
+                                     └── 01/clip.mp4
+```
+
+The rsync equivalent is a hardlink farm maintained beside the photos —
+`ln` each file into `farm/YEAR/MM/`, `rsync -a farm/ nas:/archive/` —
+which needs a writable staging tree on the same filesystem and its own
+lifecycle (rebuild after changes, clean up after runs).
+
+### Only files of at least 1 MiB
 
 ```sh
 syq map --src-src data \
   | jq 'select(.kind != "file" or .size >= 1048576)' \
   | syq cp --mapping - -C data --to nas --into /big
 ```
+
+rsync spells this exact transform as a dedicated flag:
+`rsync -a --min-size=1M data/ nas:/big/`. That is the pattern in
+miniature: a few transforms earned rsync flags over the years
+(`--min-size`, `--iconv`); most never will — there is no
+`--lowercase` and no `--partition-by-date` — but as mapping transforms
+they are all the same one-line shape.
 
 ## Producing a mapping yourself
 
@@ -114,6 +168,14 @@ up front:
 
 ```sh
 syq cp --mapping pairs.ndjson -C photos --to nas --into /archive
+```
+
+where `pairs.ndjson` is whatever your program emitted, one claim per
+line:
+
+```json
+{"src":{"encoding":"utf-8","value":"IMG_1234.JPG"},"dst":{"encoding":"utf-8","value":"2024/07/berlin/IMG_1234.JPG"}}
+{"src":{"encoding":"utf-8","value":"IMG_8812.JPG"},"dst":{"encoding":"utf-8","value":"2024/11/oslo/IMG_8812.JPG"}}
 ```
 
 For the patterns people build today with hardlink or symlink staging

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -1,0 +1,144 @@
+# Mappings: placement as data
+
+A mapping is a file (or stream) of explicit source→target claims that
+`syq cp` can execute: a generalized `--as` covering many entries at
+once, or a `--files-from` whose entries can also *re-place* each file.
+You author selection and placement — with a script, or by transforming
+a mapping syq itself emits — and syq does what it always does:
+parallel transfer, delta, resume, verification, and conflict checking
+before a single byte moves.
+
+```sh
+syq map --src-src photos \
+  | jq '.dst.value |= ascii_downcase' \
+  | syq cp --mapping - -C photos --to nas --into /pub
+```
+
+rsync hardcodes single instances of this idea as flags (`--iconv` is a
+filename transform; `-R` with `/./` anchors is a placement transform).
+With a mapping, the transform is yours — any tool that can edit JSON
+lines — and syq refuses case-fold collisions that a hand-rolled rename
+loop would silently overwrite.
+
+## The format
+
+One JSON object per line (NDJSON):
+
+```json
+{"src": {"encoding": "utf-8", "value": "IMG_1234.JPG"},
+ "dst": {"encoding": "utf-8", "value": "2024/07/img_1234.jpg"},
+ "kind": "file", "size": 4194304, "mtime": 1721900000}
+```
+
+- `src`, `dst` (required): paths relative to the source root (`-C DIR`,
+  default the working directory) and the target container (`--into
+  DIR`). Absolute paths, empty paths, and any `.` or `..` component are
+  rejected. Paths are tagged: `encoding` is `utf-8`, or `base64` for a
+  name that is not valid UTF-8 (`value` is then standard base64 of the
+  raw bytes).
+- `kind` (optional): `file`, `dir`, `symlink`, or `special`. This
+  disambiguates the request — mapping a file and mapping a directory
+  (non-recursively; entries are never recursive) are different
+  operations. If the object at `src` is not the declared kind, that
+  entry fails, exactly as if `src` did not exist. Without `kind`, the
+  entry maps whatever is there.
+- `size`, `mtime` (optional, informational): emitted by `syq map` for
+  transforms to filter on; execution ignores them. Unknown keys are
+  rejected, so a typo cannot be silently dropped.
+
+Duplicate destinations, and a destination claimed both as a file and as
+a directory ancestor of another entry, are conflicts — detected before
+any transfer begins, across the entire manifest. Destination ancestor
+directories no entry names are created implicitly, as with
+`--files-from`.
+
+## Emitting a mapping
+
+`syq map` takes the same selectors as `syq cp` and prints the resolved
+selection and placement as a mapping instead of copying:
+
+```sh
+syq map --src-src photos          # contents of photos/, dst == src
+syq map photos                    # named object: dst starts with photos/
+```
+
+Emission refuses names that are not valid UTF-8 (so published
+one-line transforms are safe by construction); mappings you author
+yourself may use the base64 form for such names.
+
+## Transform in the middle
+
+Because a mapping is plain data, the pipeline
+`syq map … | <transform> | syq cp --mapping - …` covers, as one-liners,
+things that otherwise need dedicated flags or custom copy scripts:
+
+Lowercase every destination name (a migration to a case-insensitive
+filesystem — collisions refused, not overwritten):
+
+```sh
+syq map --src-src src \
+  | jq '.dst.value |= ascii_downcase' \
+  | syq cp --mapping - -C src --to nas --into /pub
+```
+
+Repartition into `YEAR/MM/` folders by modification time:
+
+```sh
+syq map --src-src photos \
+  | jq '.dst.value = (.mtime | gmtime | strftime("%Y/%m")) + "/" + .dst.value' \
+  | syq cp --mapping - -C photos --to nas --into /archive
+```
+
+Only files of at least 1 MiB:
+
+```sh
+syq map --src-src data \
+  | jq 'select(.kind != "file" or .size >= 1048576)' \
+  | syq cp --mapping - -C data --to nas --into /big
+```
+
+## Producing a mapping yourself
+
+Any program that prints JSON lines can drive `syq cp --mapping`. The
+common before/after: a rename copy done today as one `rsync` per file,
+
+```sh
+# before: serial, no conflict checking, last writer wins
+while IFS=$'\t' read -r src dst; do
+  rsync -a "photos/$src" "nas:/archive/$dst"
+done < pairs.tsv
+```
+
+becomes a single parallel, resumable run whose conflicts are rejected
+up front:
+
+```sh
+syq cp --mapping pairs.ndjson -C photos --to nas --into /archive
+```
+
+For the patterns people build today with hardlink or symlink staging
+farms so that plain rsync can mirror a restructured tree — and where
+those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md).
+
+## Semantics and limits
+
+- `--mapping` replaces source selectors on `syq cp`; it composes with
+  `-C`, `--to`, `--into` (and the other `--into-*` placement
+  preconditions), `-n`, `-v`, `-q`, and `-j`. It is part of the native
+  surface only; `syq rsync` is unchanged.
+- Fidelity is the native default (`-rlt`). There is no per-entry
+  policy: preservation and comparison behavior stay global.
+- An entry claims exactly one object. A `dir` entry claims the
+  directory itself, without its contents.
+- Symlinks are never resolved in mapping handling: a symlink maps as a
+  symlink, and a destination path that would traverse a symlink inside
+  the target container fails that entry. Resolve links yourself before
+  emitting if you want targets instead.
+- Mappings define no deletion region, so `--mapping` is not available
+  on `cp-prune`.
+- Duplicate lines are errors, even identical ones: a duplicate almost
+  always means a generator bug. Deduplicate in your generator if you
+  union overlapping fragments.
+- `syq map` streams as it scans, and `syq cp --mapping -` starts work
+  before the stream ends; conflict checks are incremental. Exit codes
+  and output are the ordinary `syq cp` ones.

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -82,6 +82,12 @@ things that otherwise need dedicated flags or custom copy scripts.
 Re-running any of these converges like an ordinary syq copy: what
 already landed is skipped.
 
+As in any shell pipeline, `syq cp` sees only the bytes that reach it:
+if a producer fails partway, use `set -o pipefail` so the pipeline's
+exit status reflects it. Nothing wrong is copied either way — a
+truncated manifest copies a valid prefix, and re-running after the fix
+completes the rest.
+
 ### Lowercase every destination name
 
 A migration to a case-insensitive filesystem:
@@ -223,6 +229,11 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
   symlink, and a destination path that would traverse a symlink inside
   the target container fails that entry. Resolve links yourself before
   emitting if you want targets instead.
+- An entry whose object the fixed `-rlt` fidelity does not copy (a FIFO
+  or device) is skipped, not failed: the run still succeeds, the entry
+  counts as excluded, and with `--results` it appears with disposition
+  `skipped` — the same class as a `--min-size` exclusion. Filter with
+  `jq 'select(.kind != "special")'` to drop such entries up front.
 - Mappings define no deletion region, so `--mapping` is not available
   on `cp-prune`.
 - Duplicate lines are errors, even identical ones: a duplicate almost
@@ -236,8 +247,10 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
 
 `syq cp --results FILE` (also `-` for stdout; combine that with `-q`)
 writes an NDJSON outcome stream beside the ordinary human output:
-a `run` record, one `operation_result` per settled mutation and per
-failed mapping entry, an `error` record per counted error, and exactly
+a `run` record, one `operation_result` per settled mutation, per
+failed mapping entry, and per policy-skipped mapping entry
+(disposition `succeeded`, `failed`, or `skipped`), an `error` record
+per counted error, and exactly
 one terminal `result` with the exit code and aggregate counts. The
 records carry `schema_version: 0` — an unstable preview of the planned
 automation interface; unchanged and excluded entries appear only in

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -277,12 +277,21 @@ not finish.
 Failed operation records carry `src`, `dst`, and `kind`, so a retry
 manifest is one filter away:
 
-```sh
+```bash
+set -o pipefail
 syq cp --mapping big.ndjson -C src --to nas --into /data --results r.ndjson
-jq -c 'select(.type == "operation_result" and .disposition == "failed"
-              and .retryable != "no") | {src, dst, kind}' r.ndjson \
+jq -cs 'if (.[-1].type? // "") != "result"
+        then "incomplete results stream (no terminal record)" | halt_error
+        else .[] | select(.type == "operation_result"
+                          and .disposition == "failed"
+                          and .retryable != "no")
+             | {src, dst, kind} end' r.ndjson \
   | syq cp --mapping - -C src --to nas --into /data
 ```
 
-The second line is what an exit code cannot express: which entries
-failed, and whether a retry could help.
+The jq program first checks the stream's terminal record: a results
+file without one is from a run that did not finish (a crash, a kill),
+so entries the run never reached have no records at all and a retry
+built from the prefix would look complete while it is not. With the
+terminal record present, the filter is what an exit code cannot
+express: which entries failed, and whether a retry could help.

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -95,20 +95,24 @@ src/                          nas:/pub/ afterwards
 If `src` also contained `notes.TXT`, the run is refused before any
 transfer: two entries claim `notes.txt`.
 
-rsync has no rename option, so its closest equivalent is a symlink
-staging farm, dereferenced on the way out:
+For a one-shot copy, GNU tar can do this rename more simply:
 
 ```sh
-find src -type f | while read -r f; do
-  d="staging/$(printf %s "${f#src/}" | tr '[:upper:]' '[:lower:]')"
-  mkdir -p "$(dirname "$d")" && ln -sf "$(realpath "$f")" "$d"
-done
-rsync -aL staging/ nas:/pub/
+tar -C src -cf - --transform='s/.*/\L&/' . | ssh nas 'tar -C /pub -xf -'
 ```
 
-— where `ln -sf` resolves the case-fold collision silently,
-last writer wins, and the farm must be rebuilt and cleaned up around
-every run.
+Use that when it fits. Where it stops fitting: the case-fold collision
+above extracts with exit 0 and the last writer silently wins (measured,
+not speculated); every run resends every byte, and an interrupted pipe
+leaves truncated files in place; the stream is one connection,
+unverified; the transform sees only the *name*, so the mtime- and
+size-based examples below are out of its reach; and it rewrites symlink
+targets by default, which breaks links pointing outside the tree.
+rsync itself has no rename option at all — keeping rsync's delta and
+resume means a symlink staging farm (`ln -sf` into a lowercased
+`staging/` tree, then `rsync -aL staging/ nas:/pub/`), where `-f`
+again resolves collisions silently and the farm must be rebuilt and
+cleaned up around every run.
 
 ### Repartition into `YEAR/MM/` folders by modification time
 
@@ -186,8 +190,14 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
 
 - `--mapping` replaces source selectors on `syq cp`; it composes with
   `-C`, `--to`, `--into` (and the other `--into-*` placement
-  preconditions), `-n`, `-v`, `-q`, and `-j`. It is part of the native
-  surface only; `syq rsync` is unchanged.
+  preconditions), `-n`, `-v`, `-q`, and `-j`. It conflicts with `--as`:
+  an exact single-path placement cannot host a manifest — each entry's
+  `dst` already is its own `--as`. It is part of the native surface
+  only; `syq rsync` is unchanged.
+- `syq map` accepts any `syq cp` invocation, including
+  `report --as /reports/final`, which emits that single resolved entry.
+  The typed `rm` selectors (`--src-dir`, `--src-file`) are not part of
+  the copy grammar.
 - Fidelity is the native default (`-rlt`). There is no per-entry
   policy: preservation and comparison behavior stay global.
 - An entry claims exactly one object. A `dir` entry claims the

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -91,6 +91,7 @@ pipeline converges. For stage-by-stage completion, materialize the
 manifest instead:
 
 ```bash
+set -o pipefail
 syq map --src-src src | jq '.dst.value |= ascii_downcase' > m.ndjson \
   && syq cp --mapping m.ndjson -C src --to nas --into /pub
 ```
@@ -226,11 +227,11 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
   an exact single-path placement cannot host a manifest — each entry's
   `dst` already is its own `--as`. It is part of the native surface
   only; `syq rsync` is unchanged.
-- `syq map` accepts the `syq cp` grammar, including `--as PATH`, which
-  emits the single selected root under the target's basename; see
-  "Emitting a mapping" for this version's restrictions. The typed `rm`
-  selectors (`--src-dir`, `--src-file`) are not part of the copy
-  grammar.
+- `syq map` accepts the `syq cp` grammar, including `--as PATH` (which
+  emits the single selected root under the target's basename) and the
+  typed selectors `--src-file`/`--src-dir`, validated exactly as native
+  cp validates them; see "Emitting a mapping" for this version's
+  restrictions.
 - Fidelity is the native default (`-rlt`). There is no per-entry
   policy: preservation and comparison behavior stay global.
 - An entry claims exactly one object. A `dir` entry claims the
@@ -254,7 +255,7 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
   declared-kind ancestor conflicts refuse the run before any entry is
   applied (the `--into` container itself is created eagerly, as with
   `--files-from`). The price is memory proportional to the manifest, as
-  in a multi-source copy. Execution then overlaps source stats and transfers.
+  in a multi-source copy. Sources are then statted and planned in chunks, and transfers begin once planning completes.
   Conflicts only observable at execution — an undeclared ancestor that
   turns out not to be a directory, existing destination state — still
   fail entries individually. `syq map` streams its output. Exit codes

--- a/README.md
+++ b/README.md
@@ -257,6 +257,24 @@ native mode. Remote-to-remote copies still use the ordinary automatic
 transport. Native raw path bytes are relayed through syq's protocol when they
 cannot be represented in a direct remote shell command.
 
+## Mappings
+
+Placement can also be data instead of flags: `syq map` prints the resolved
+selection and placement of a command as JSON lines, and `syq cp --mapping`
+executes such a manifest — a generalized `--as` covering many entries, each
+with its own destination. Between the two, any tool that edits JSON can
+reshape a transfer:
+
+```sh
+syq map --src-src photos \
+  | jq '.dst.value |= ascii_downcase' \
+  | syq cp --mapping - -C photos --to nas --into /pub
+```
+
+Conflicting destinations are refused before any byte moves. See
+[MAPPINGS.md](MAPPINGS.md) for the format, more one-line transforms, and
+limits.
+
 ## Rsync compatibility
 
 The complete previous command surface remains available under `syq rsync`:
@@ -1232,7 +1250,9 @@ the root itself are rejected. A listed path that doesn't exist is an error
 (exit 23) and the rest is still copied. The destination must be a directory (an
 existing file there is an error, never replaced). `--files-from` can't be
 combined with `--ignore`/`--ignore-from` or `--delete`; for a remote-to-remote copy
-it needs `--relay` (the list is read on this machine).
+it needs `--relay` (the list is read on this machine). To also choose each
+entry's destination path, use a native mapping instead (see
+[MAPPINGS.md](MAPPINGS.md)).
 
 ## Parallel removal (`--rm`)
 

--- a/README.md
+++ b/README.md
@@ -460,7 +460,8 @@ The command-restricted path requires atomic staged publication and encrypted
 TCP data connections. `--inplace`, `--no-tcp`, `--tcp-plain`,
 `--tcp-congestion`, `--update`, `--existing`, `--ignore-existing`, native
 `--*-new`/`--*-existing`,
-`--ignore`/`--ignore-from`, `--files-from`, `--min-size`, a nonzero
+`--ignore`/`--ignore-from`, `--files-from`, `--mapping`, `--min-size`, a
+nonzero
 `--bwlimit`, `--syq-path`, and `--no-bootstrap` currently fail closed because
 the receiver cannot enforce those semantics independently of hostA.
 `--max-size` is enforced as a signed per-file limit, but is refused together

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ executes such a manifest — a generalized `--as` covering many entries, each
 with its own destination. Between the two, any tool that edits JSON can
 reshape a transfer:
 
-```sh
+```bash
+set -o pipefail
 syq map --src-src photos \
   | jq '.dst.value |= ascii_downcase' \
   | syq cp --mapping - -C photos --to nas --into /pub

--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ current compatibility options for those capabilities are needed.
 
 The native commands accept only `-n`/`--dry-run`, `-v`/`--verbose`,
 `-q`/`--quiet`, and `-j`/`--connections` in addition to the endpoint,
-selector, cwd, and placement options above. `cp-prune` additionally accepts
+selector, cwd, and placement options above. `cp` additionally accepts
+`--mapping` and `--results` (see [MAPPINGS.md](MAPPINGS.md)); `cp-prune`
+additionally accepts
 `--max-delete`; `rm` additionally accepts `--root` and `--follow` plus its
 typed selectors. Preservation policies, filters, comparison controls, progress
 interfaces, and SSH/transport configuration remain available only through

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -751,7 +751,7 @@ struct NativeCopyPruneCommand {
     version,
     about = "Print the resolved selection and placement of a copy as an NDJSON mapping",
     long_about = "Print the resolved selection and placement of a copy as an NDJSON mapping.\n\nOne JSON object per line: tagged src and dst paths (src relative to the source base, dst relative to the target container), the object kind, and size/mtime for regular files. Emission is local and read-only; it never contacts a destination. Names must be valid UTF-8.",
-    override_usage = "syq map [OPTIONS] [--src PATH | --src-src DIR | PATH]... [PLACEMENT]"
+    override_usage = "syq map [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]... [PLACEMENT]"
 )]
 struct NativeMapCommand {
     #[command(flatten)]
@@ -830,6 +830,10 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
             && parsed.selection.src_src.is_empty()
             && parsed.selection.srcs.is_empty()
             && parsed.selection.src_srcs.is_empty()
+            && parsed.selection.src_file.is_empty()
+            && parsed.selection.src_dir.is_empty()
+            && parsed.selection.src_files.is_empty()
+            && parsed.selection.src_dirs.is_empty()
             && parsed.selection.sources.is_empty());
         if has_selectors {
             bail!("--mapping replaces source selectors; do not combine them");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,9 @@ pub struct Args {
     /// (`-` reads stdin, streamed).
     #[arg(skip)]
     pub native_mapping: Option<Vec<u8>>,
+    /// `--results` NDJSON outcome stream for native cp (`-` writes stdout).
+    #[arg(skip)]
+    pub native_results: Option<Vec<u8>>,
 
     /// Print help
     #[arg(long, action = clap::ArgAction::Help)]
@@ -662,6 +665,11 @@ struct NativeCopyFields {
     /// dst paths are relative to the --into container
     #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
     mapping: Option<OsString>,
+    /// Write machine-readable NDJSON operation results to FILE (`-` writes
+    /// to stdout; combine with -q). Automation schema version 0, an
+    /// unstable preview
+    #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
+    results: Option<OsString>,
     #[command(flatten)]
     operational: NativeOperationalArgs,
 }
@@ -764,6 +772,10 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     let mapping = parsed.mapping.take();
     if mapping.is_some() && interface != Interface::NativeCp {
         bail!("--mapping is only available on syq cp");
+    }
+    let results = parsed.results.take();
+    if results.is_some() && interface != Interface::NativeCp {
+        bail!("--results is only available on syq cp");
     }
     let mut locations = if mapping.is_some() {
         let has_selectors = !(parsed.selection.src.is_empty()
@@ -911,6 +923,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     args.native_map_cwd = map_cwd;
     args.native_map_target = native_map_target;
     args.native_mapping = mapping.map(OsStringExt::into_vec);
+    args.native_results = results.map(OsStringExt::into_vec);
     if args.native_mapping.is_some() {
         // The manifest is read on this machine and its entries are stat'ed
         // through the source connection; a direct remote-to-remote copy has

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -777,6 +777,12 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     if results.is_some() && interface != Interface::NativeCp {
         bail!("--results is only available on syq cp");
     }
+    if results.is_some() && parsed.operational.dry_run {
+        // Dry-run trace output is a deliberately deferred automation
+        // feature; a version-0 results stream reusing the live counters
+        // would claim planned work as transferred.
+        bail!("--results does not support --dry-run yet");
+    }
     let mut locations = if mapping.is_some() {
         let has_selectors = !(parsed.selection.src.is_empty()
             && parsed.selection.src_src.is_empty()
@@ -807,7 +813,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
         if parsed.selection.from.is_some() {
             bail!("syq map with a remote source (--from) is not yet supported");
         }
-        for source in &locations {
+        for source in &mut locations {
             if source.path.starts_with(b"/")
                 || source.path == b"~"
                 || source.path.starts_with(b"~/")
@@ -817,6 +823,26 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
                     String::from_utf8_lossy(&source.path)
                 );
             }
+            // Normalize the way --files-from does — drop `.` and empty
+            // components, reject `..` — so emitted paths are always valid
+            // manifest paths.
+            let mut parts: Vec<&[u8]> = Vec::new();
+            for component in source.path.split(|&byte| byte == b'/') {
+                match component {
+                    b"" | b"." => {}
+                    b".." => bail!(
+                        "syq map selector {:?} contains a `..` component",
+                        String::from_utf8_lossy(&source.path)
+                    ),
+                    other => parts.push(other),
+                }
+            }
+            let normalized = parts.join(&b"/"[..]);
+            source.path = if normalized.is_empty() {
+                b".".to_vec()
+            } else {
+                normalized
+            };
         }
         if locations
             .iter()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,6 +79,10 @@ pub struct Args {
     /// `syq map` never contacts a destination.
     #[arg(skip)]
     pub native_map_target: Option<Vec<u8>>,
+    /// NDJSON mapping manifest consumed by native cp instead of selectors
+    /// (`-` reads stdin, streamed).
+    #[arg(skip)]
+    pub native_mapping: Option<Vec<u8>>,
 
     /// Print help
     #[arg(long, action = clap::ArgAction::Help)]
@@ -653,6 +657,11 @@ struct NativeCopyFields {
         allow_hyphen_values = true
     )]
     as_existing: Option<OsString>,
+    /// Copy the entries of an NDJSON mapping manifest (`-` reads stdin)
+    /// instead of selecting sources; entry src paths are relative to -C and
+    /// dst paths are relative to the --into container
+    #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
+    mapping: Option<OsString>,
     #[command(flatten)]
     operational: NativeOperationalArgs,
 }
@@ -752,7 +761,36 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     } else {
         None
     };
-    let mut locations = lower_native_selection(&parsed.selection, &matches)?;
+    let mapping = parsed.mapping.take();
+    if mapping.is_some() && interface != Interface::NativeCp {
+        bail!("--mapping is only available on syq cp");
+    }
+    let mut locations = if mapping.is_some() {
+        let has_selectors = !(parsed.selection.src.is_empty()
+            && parsed.selection.src_src.is_empty()
+            && parsed.selection.srcs.is_empty()
+            && parsed.selection.src_srcs.is_empty()
+            && parsed.selection.sources.is_empty());
+        if has_selectors {
+            bail!("--mapping replaces source selectors; do not combine them");
+        }
+        let endpoint = parse_native_endpoint(parsed.selection.from.as_deref())?;
+        let base = trim_native_trailing_slashes(
+            parsed
+                .selection
+                .cwd
+                .clone()
+                .map(OsStringExt::into_vec)
+                .unwrap_or_else(|| b".".to_vec()),
+        );
+        if base.is_empty() {
+            bail!("source base may not be empty");
+        }
+        // The manifest is the selection; its entries resolve against this root.
+        vec![Location::native(endpoint, base, SourceSelection::Contents)]
+    } else {
+        lower_native_selection(&parsed.selection, &matches)?
+    };
     if interface == Interface::NativeMap {
         if parsed.selection.from.is_some() {
             bail!("syq map with a remote source (--from) is not yet supported");
@@ -799,6 +837,9 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
             command_label(interface)
         ),
     };
+    if placement == Placement::As && mapping.is_some() {
+        bail!("--as conflicts with --mapping: each entry's dst is its own --as");
+    }
     if placement == Placement::As
         && (locations.len() != 1
             || !matches!(
@@ -869,6 +910,17 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     args.max_delete = max_delete;
     args.native_map_cwd = map_cwd;
     args.native_map_target = native_map_target;
+    args.native_mapping = mapping.map(OsStringExt::into_vec);
+    if args.native_mapping.is_some() {
+        // The manifest is read on this machine and its entries are stat'ed
+        // through the source connection; a direct remote-to-remote copy has
+        // no way to carry either.
+        let src_remote = args.locations.first().is_some_and(|l| l.host.is_some());
+        let dst_remote = args.locations.last().is_some_and(|l| l.host.is_some());
+        if src_remote && dst_remote {
+            bail!("--mapping with a remote-to-remote copy is not supported; one end must be local");
+        }
+    }
     apply_native_operational(&mut args, parsed.operational);
     apply_internal_native_direct(&mut args)?;
     Ok(args)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,6 +10,7 @@ pub enum Interface {
     NativeCp,
     NativeCpPrune,
     NativeRm,
+    NativeMap,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -70,6 +71,14 @@ pub struct Args {
     /// Permit symlinks while resolving the native removal base/selectors.
     #[arg(skip)]
     pub native_rm_follow: bool,
+    /// Source-side base for `syq map` selectors, joined at walk time so the
+    /// emitted `src` values stay relative to it.
+    #[arg(skip)]
+    pub native_map_cwd: Option<Vec<u8>>,
+    /// The placement target for `syq map`, kept only for `--as` renaming;
+    /// `syq map` never contacts a destination.
+    #[arg(skip)]
+    pub native_map_target: Option<Vec<u8>>,
 
     /// Print help
     #[arg(long, action = clap::ArgAction::Help)]
@@ -369,6 +378,7 @@ impl Args {
             "cp" => parse_native(&argv[1..], Interface::NativeCp),
             "cp-prune" => parse_native(&argv[1..], Interface::NativeCpPrune),
             "rm" => parse_native(&argv[1..], Interface::NativeRm),
+            "map" => parse_native(&argv[1..], Interface::NativeMap),
             "--help" | "-h" => {
                 print_root_help();
                 std::process::exit(0);
@@ -381,7 +391,7 @@ impl Args {
             // remain top-level. Internal helper switches are handled in main.
             "--self-update" | "--register-standalone-install" => Self::parse_rsync(&argv),
             _ => bail!(
-                "expected a command (`cp`, `cp-prune`, `rm`, or `rsync`); rsync-shaped syntax now starts with `syq rsync`"
+                "expected a command (`cp`, `cp-prune`, `rm`, `map`, or `rsync`); rsync-shaped syntax now starts with `syq rsync`"
             ),
         }
     }
@@ -500,7 +510,7 @@ fn finish_parse(mut args: Args, matches: &clap::ArgMatches) -> Result<Args> {
 
 fn print_root_help() {
     println!(
-        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects without removing target-only objects\n  cp-prune     Copy, then remove target-only objects in the mapped scope\n  rm           Remove explicitly selected object trees\n  rsync        Use the retained rsync-shaped command surface\n  enroll       Pre-enroll a command-restricted remote destination\n  enrollments  List local command-restricted enrollments\n  revoke       Revoke a command-restricted enrollment\n\nRun `syq <COMMAND> --help` for command-specific help."
+        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects without removing target-only objects\n  cp-prune     Copy, then remove target-only objects in the mapped scope\n  rm           Remove explicitly selected object trees\n  map          Print a copy's resolved selection and placement as NDJSON\n  rsync        Use the retained rsync-shaped command surface\n  enroll       Pre-enroll a command-restricted remote destination\n  enrollments  List local command-restricted enrollments\n  revoke       Revoke a command-restricted enrollment\n\nRun `syq <COMMAND> --help` for command-specific help."
     );
 }
 
@@ -678,6 +688,19 @@ struct NativeCopyPruneCommand {
 
 #[derive(Parser, Debug)]
 #[command(
+    name = "syq map",
+    version,
+    about = "Print the resolved selection and placement of a copy as an NDJSON mapping",
+    long_about = "Print the resolved selection and placement of a copy as an NDJSON mapping.\n\nOne JSON object per line: tagged src and dst paths (src relative to the source base, dst relative to the target container), the object kind, and size/mtime for regular files. Emission is local and read-only; it never contacts a destination. Names must be valid UTF-8.",
+    override_usage = "syq map [OPTIONS] [--src PATH | --src-src DIR | PATH]... [PLACEMENT]"
+)]
+struct NativeMapCommand {
+    #[command(flatten)]
+    copy: NativeCopyFields,
+}
+
+#[derive(Parser, Debug)]
+#[command(
     name = "syq rm",
     version,
     about = "Remove endpoint-resolved object trees without following symlinks by default",
@@ -692,7 +715,9 @@ struct NativeRmCommand {
 
 fn parse_native(argv: &[OsString], interface: Interface) -> Result<Args> {
     match interface {
-        Interface::NativeCp | Interface::NativeCpPrune => parse_native_copy(argv, interface),
+        Interface::NativeCp | Interface::NativeCpPrune | Interface::NativeMap => {
+            parse_native_copy(argv, interface)
+        }
         Interface::NativeRm => parse_native_rm(argv),
         Interface::Rsync => unreachable!(),
     }
@@ -701,12 +726,18 @@ fn parse_native(argv: &[OsString], interface: Interface) -> Result<Args> {
 fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     let mut full_argv = vec![OsString::from(command_label(interface))];
     full_argv.extend_from_slice(argv);
-    let (parsed, matches, max_delete) = if interface == Interface::NativeCpPrune {
+    let (mut parsed, matches, max_delete) = if interface == Interface::NativeCpPrune {
         let matches = NativeCopyPruneCommand::command()
             .try_get_matches_from(full_argv)
             .unwrap_or_else(|error| error.exit());
         let parsed = NativeCopyPruneCommand::from_arg_matches(&matches)?;
         (parsed.copy, matches, parsed.max_delete)
+    } else if interface == Interface::NativeMap {
+        let matches = NativeMapCommand::command()
+            .try_get_matches_from(full_argv)
+            .unwrap_or_else(|error| error.exit());
+        let parsed = NativeMapCommand::from_arg_matches(&matches)?;
+        (parsed.copy, matches, None)
     } else {
         let matches = NativeCopyCommand::command()
             .try_get_matches_from(full_argv)
@@ -714,7 +745,39 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
         let parsed = NativeCopyCommand::from_arg_matches(&matches)?;
         (parsed.copy, matches, None)
     };
+    // `syq map` keeps `-C` out of selector paths so emitted `src` values stay
+    // relative to it; the walk joins it back.
+    let map_cwd = if interface == Interface::NativeMap {
+        parsed.selection.cwd.take().map(OsStringExt::into_vec)
+    } else {
+        None
+    };
     let mut locations = lower_native_selection(&parsed.selection, &matches)?;
+    if interface == Interface::NativeMap {
+        if parsed.selection.from.is_some() {
+            bail!("syq map with a remote source (--from) is not yet supported");
+        }
+        for source in &locations {
+            if source.path.starts_with(b"/")
+                || source.path == b"~"
+                || source.path.starts_with(b"~/")
+            {
+                bail!(
+                    "syq map selector {:?} is absolute; mapping entries are root-relative (use -C to set the base)",
+                    String::from_utf8_lossy(&source.path)
+                );
+            }
+        }
+        if locations
+            .iter()
+            .any(|location| location.selection == SourceSelection::Contents)
+            && locations.len() > 1
+        {
+            bail!(
+                "syq map takes --src-src DIR as the only selector, or any number of named selectors"
+            );
+        }
+    }
 
     let placements = [
         (parsed.into, Placement::Into, Existence::Any),
@@ -724,14 +787,17 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
         (parsed.as_new, Placement::As, Existence::New),
         (parsed.as_existing, Placement::As, Existence::Existing),
     ];
-    let Some((target, placement, existence)) = placements
+    let (target, placement, existence) = match placements
         .into_iter()
         .find_map(|(path, placement, existence)| path.map(|path| (path, placement, existence)))
-    else {
-        bail!(
+    {
+        Some((path, placement, existence)) => (Some(path), placement, existence),
+        // `syq map` without placement emits the container-relative identity.
+        None if interface == Interface::NativeMap => (None, Placement::Into, Existence::Any),
+        None => bail!(
             "{} requires one of --into, --into-new, --into-existing, --as, --as-new, or --as-existing",
             command_label(interface)
-        );
+        ),
     };
     if placement == Placement::As
         && (locations.len() != 1
@@ -757,16 +823,42 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
             }
         }
     }
-    let target = trim_native_trailing_slashes(target.into_vec());
-    if target.is_empty() {
-        bail!("target paths may not be empty");
+    let target = match target {
+        Some(target) => {
+            let target = trim_native_trailing_slashes(target.into_vec());
+            if target.is_empty() {
+                bail!("target paths may not be empty");
+            }
+            Some(target)
+        }
+        None => None,
+    };
+    let mut native_map_target = None;
+    if interface == Interface::NativeMap {
+        if existence != Existence::Any {
+            bail!(
+                "syq map never contacts a destination and cannot check --into-new, --into-existing, --as-new, or --as-existing preconditions"
+            );
+        }
+        if placement == Placement::As {
+            let target = target.as_ref().expect("--as parsed with a target");
+            if native_basename(target).is_none() {
+                bail!(
+                    "--as target {:?} has no basename",
+                    String::from_utf8_lossy(target)
+                );
+            }
+        }
+        native_map_target = target;
+    } else {
+        let target = target.expect("copy placement parsed with a target");
+        let target_endpoint = parse_native_endpoint(parsed.to.as_deref())?;
+        locations.push(Location::native(
+            target_endpoint,
+            target,
+            SourceSelection::Named,
+        ));
     }
-    let target_endpoint = parse_native_endpoint(parsed.to.as_deref())?;
-    locations.push(Location::native(
-        target_endpoint,
-        target,
-        SourceSelection::Named,
-    ));
 
     let mut args = native_engine_defaults();
     args.interface = interface;
@@ -775,6 +867,8 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     args.locations = locations;
     args.delete = interface == Interface::NativeCpPrune;
     args.max_delete = max_delete;
+    args.native_map_cwd = map_cwd;
+    args.native_map_target = native_map_target;
     apply_native_operational(&mut args, parsed.operational);
     apply_internal_native_direct(&mut args)?;
     Ok(args)
@@ -944,6 +1038,7 @@ fn command_label(interface: Interface) -> &'static str {
         Interface::NativeCp => "syq cp",
         Interface::NativeCpPrune => "syq cp-prune",
         Interface::NativeRm => "syq rm",
+        Interface::NativeMap => "syq map",
     }
 }
 
@@ -989,7 +1084,7 @@ fn validate_native_rm_selector(path: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn native_basename(path: &[u8]) -> Option<&[u8]> {
+pub(crate) fn native_basename(path: &[u8]) -> Option<&[u8]> {
     let name = path.rsplit(|byte| *byte == b'/').next()?;
     (!name.is_empty() && name != b"." && name != b"..").then_some(name)
 }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -334,6 +334,7 @@ pub fn run(
         Interface::NativeCp => "cp",
         Interface::NativeCpPrune => "cp-prune",
         Interface::NativeRm => bail!("native rm cannot be a remote-to-remote transfer"),
+        Interface::NativeMap => bail!("syq map runs locally and is never remoted"),
     }
     .into()];
     let mut short = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod progress;
 mod proto;
 mod remote_helper;
 mod restricted;
+mod results;
 mod rm;
 #[allow(dead_code)]
 mod rooted;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ pub mod enrollment;
 mod fsops;
 mod identity;
 mod janky_cat;
+mod native_map;
 mod native_rm;
 mod progress;
 mod proto;
@@ -174,6 +175,8 @@ fn main() {
     let quiet = args.quiet;
     let result = if args.follow {
         direct::follow(&args)
+    } else if args.interface == cli::Interface::NativeMap {
+        native_map::run(&args)
     } else if args.rm {
         rm::run(args)
     } else {

--- a/src/native_map.rs
+++ b/src/native_map.rs
@@ -1,0 +1,175 @@
+//! `syq map`: print the resolved selection and placement of a native copy
+//! invocation as an NDJSON mapping, one JSON object per line.
+//!
+//! Emission is local and read-only, and destination-independent by design:
+//! `dst` values are relative to the target container, so the same manifest
+//! can be executed against any target with `syq cp --mapping`. Only `--as`
+//! changes emitted values, by renaming the single selected root. Names must
+//! be valid UTF-8; a non-UTF-8 name aborts emission with an error so that
+//! text transforms downstream cannot silently corrupt a base64 value.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Serialize;
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::fs::Metadata;
+use std::io::Write;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+use crate::cli::{native_basename, Args, Placement, SourceSelection};
+
+#[derive(Serialize)]
+struct TaggedPath<'a> {
+    encoding: &'static str,
+    value: &'a str,
+}
+
+#[derive(Serialize)]
+struct MapRecord<'a> {
+    src: TaggedPath<'a>,
+    dst: TaggedPath<'a>,
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mtime: Option<i64>,
+}
+
+pub fn run(args: &Args) -> Result<i32> {
+    let stdout = std::io::stdout();
+    let mut out = std::io::BufWriter::new(stdout.lock());
+    let mut top_level_dst: HashSet<Vec<u8>> = HashSet::new();
+    for location in &args.locations {
+        let full = full_path(args, &location.path);
+        if location.selection == SourceSelection::Contents {
+            // Contents selectors follow a root symlink, matching native cp.
+            let md = std::fs::metadata(&full)
+                .with_context(|| format!("--src-src {}", full.display()))?;
+            if !md.is_dir() {
+                bail!("--src-src {} is not a directory", full.display());
+            }
+            walk_children(&full, &location.path, b"", b"", &mut out)?;
+        } else {
+            // Named selectors never follow the selected symlink itself.
+            let md = std::fs::symlink_metadata(&full)
+                .with_context(|| format!("source {}", full.display()))?;
+            let dst_name = match (args.placement, &args.native_map_target) {
+                (Placement::As, Some(target)) => native_basename(target)
+                    .ok_or_else(|| anyhow!("--as target has no basename"))?
+                    .to_vec(),
+                _ => native_basename(&location.path)
+                    .expect("parse validated that named selectors have a basename")
+                    .to_vec(),
+            };
+            if !top_level_dst.insert(dst_name.clone()) {
+                bail!(
+                    "two selectors map to the same destination name {:?}",
+                    String::from_utf8_lossy(&dst_name)
+                );
+            }
+            emit(&mut out, &location.path, &dst_name, &md)?;
+            if md.is_dir() {
+                walk_children(&full, &location.path, &location.path, &dst_name, &mut out)?;
+            }
+        }
+    }
+    out.flush().context("writing mapping to stdout")?;
+    Ok(0)
+}
+
+/// Emit every descendant of `dir`, byte-sorted, parents before children.
+/// `sel` is the selector spelling used only in error messages; `src_prefix`
+/// and `dst_prefix` are the emitted relative prefixes (empty for a contents
+/// root).
+fn walk_children(
+    dir: &Path,
+    sel: &[u8],
+    src_prefix: &[u8],
+    dst_prefix: &[u8],
+    out: &mut impl Write,
+) -> Result<()> {
+    let mut names: Vec<Vec<u8>> = Vec::new();
+    for entry in std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("reading {}", dir.display()))?;
+        names.push(entry.file_name().as_bytes().to_vec());
+    }
+    names.sort();
+    for name in names {
+        let full = dir.join(OsStr::from_bytes(&name));
+        let md = std::fs::symlink_metadata(&full)
+            .with_context(|| format!("under {}", String::from_utf8_lossy(sel)))?;
+        let src_rel = join_rel(src_prefix, &name);
+        let dst_rel = join_rel(dst_prefix, &name);
+        emit(out, &src_rel, &dst_rel, &md)?;
+        if md.is_dir() {
+            walk_children(&full, sel, &src_rel, &dst_rel, out)?;
+        }
+    }
+    Ok(())
+}
+
+fn emit(out: &mut impl Write, src: &[u8], dst: &[u8], md: &Metadata) -> Result<()> {
+    let src = utf8(src)?;
+    let dst = utf8(dst)?;
+    let file_type = md.file_type();
+    let kind = if file_type.is_dir() {
+        "dir"
+    } else if file_type.is_file() {
+        "file"
+    } else if file_type.is_symlink() {
+        "symlink"
+    } else {
+        "special"
+    };
+    let (size, mtime) = if kind == "file" {
+        (Some(md.len()), Some(md.mtime()))
+    } else {
+        (None, None)
+    };
+    let record = MapRecord {
+        src: tagged(src),
+        dst: tagged(dst),
+        kind,
+        size,
+        mtime,
+    };
+    serde_json::to_writer(&mut *out, &record).context("writing mapping to stdout")?;
+    out.write_all(b"\n").context("writing mapping to stdout")?;
+    Ok(())
+}
+
+fn tagged(value: &str) -> TaggedPath<'_> {
+    TaggedPath {
+        encoding: "utf-8",
+        value,
+    }
+}
+
+fn utf8(path: &[u8]) -> Result<&str> {
+    std::str::from_utf8(path).map_err(|_| {
+        anyhow!(
+            "name {:?} is not valid UTF-8; syq map emits UTF-8 mappings only",
+            String::from_utf8_lossy(path)
+        )
+    })
+}
+
+fn join_rel(prefix: &[u8], name: &[u8]) -> Vec<u8> {
+    if prefix.is_empty() {
+        return name.to_vec();
+    }
+    let mut joined = prefix.to_vec();
+    joined.push(b'/');
+    joined.extend_from_slice(name);
+    joined
+}
+
+fn full_path(args: &Args, selector: &[u8]) -> PathBuf {
+    let full = match &args.native_map_cwd {
+        Some(cwd) => crate::fsops::join(cwd, selector),
+        None => selector.to_vec(),
+    };
+    PathBuf::from(OsStr::from_bytes(&full).to_os_string())
+}

--- a/src/native_map.rs
+++ b/src/native_map.rs
@@ -55,6 +55,11 @@ pub fn run(args: &Args) -> Result<i32> {
             // Named selectors never follow the selected symlink itself.
             let md = std::fs::symlink_metadata(&full)
                 .with_context(|| format!("source {}", full.display()))?;
+            crate::transfer::validate_native_source_type(
+                &location.path,
+                location.selection,
+                metadata_kind(&md),
+            )?;
             let dst_name = match (args.placement, &args.native_map_target) {
                 (Placement::As, Some(target)) => native_basename(target)
                     .ok_or_else(|| anyhow!("--as target has no basename"))?
@@ -164,6 +169,29 @@ fn join_rel(prefix: &[u8], name: &[u8]) -> Vec<u8> {
     joined.push(b'/');
     joined.extend_from_slice(name);
     joined
+}
+
+fn metadata_kind(md: &Metadata) -> crate::proto::Kind {
+    use crate::proto::Kind;
+    use std::os::unix::fs::FileTypeExt;
+    let file_type = md.file_type();
+    if file_type.is_dir() {
+        Kind::Dir
+    } else if file_type.is_file() {
+        Kind::File
+    } else if file_type.is_symlink() {
+        Kind::Symlink
+    } else if file_type.is_fifo() {
+        Kind::Fifo
+    } else if file_type.is_socket() {
+        Kind::Socket
+    } else if file_type.is_char_device() {
+        Kind::CharDev
+    } else if file_type.is_block_device() {
+        Kind::BlockDev
+    } else {
+        Kind::Other
+    }
 }
 
 fn full_path(args: &Args, selector: &[u8]) -> PathBuf {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -45,6 +45,9 @@ pub struct Progress {
     workers: Mutex<Vec<Option<WorkerStatus>>>,
     term: Mutex<TermState>,
     stop: AtomicBool,
+    /// `--results`: machine-readable NDJSON outcome stream, set once after
+    /// construction so workers and the planner reach it with no plumbing.
+    results: std::sync::OnceLock<Arc<crate::results::ResultsWriter>>,
 }
 
 struct TermState {
@@ -87,7 +90,16 @@ impl Progress {
                 last_json: None,
             }),
             stop: AtomicBool::new(false),
+            results: std::sync::OnceLock::new(),
         })
+    }
+
+    pub fn set_results(&self, writer: Arc<crate::results::ResultsWriter>) {
+        let _ = self.results.set(writer);
+    }
+
+    pub fn results_writer(&self) -> Option<&Arc<crate::results::ResultsWriter>> {
+        self.results.get()
     }
 
     pub fn set_worker(&self, id: usize, s: Option<WorkerStatus>) {
@@ -122,6 +134,9 @@ impl Progress {
     pub fn error(&self, line: &str) {
         self.errors.fetch_add(1, Relaxed);
         self.eprintln(line);
+        if let Some(results) = self.results.get() {
+            results.emit_error(line);
+        }
     }
 
     pub fn warning(&self, code: &str, count: u64, message: &str) {

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -1903,11 +1903,12 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
     if !args.ignore_lines.is_empty()
         || !args.files_from_lines.is_empty()
         || args.files_from.is_some()
+        || args.native_mapping.is_some()
         || args.min_size.is_some()
         || args.bwlimit_bytes != 0
     {
         bail!(
-            "--ignore/--ignore-from, --files-from, --min-size, and --bwlimit are not yet independently enforceable by the command-restricted receiver"
+            "--ignore/--ignore-from, --files-from, --mapping, --min-size, and --bwlimit are not yet independently enforceable by the command-restricted receiver"
         );
     }
     if args.syq_path.is_some() || args.no_bootstrap {

--- a/src/results.rs
+++ b/src/results.rs
@@ -136,12 +136,14 @@ impl ResultsWriter {
         if self.dead.load(Relaxed) {
             return;
         }
+        // Take the output lock before allocating the sequence number, so
+        // records land in the stream in seq order.
+        let mut out = self.out.lock().unwrap();
         let seq = self.seq.fetch_add(1, Relaxed);
         let object = record.as_object_mut().expect("record is an object");
         object.insert("schema".into(), SCHEMA.into());
         object.insert("schema_version".into(), SCHEMA_VERSION.into());
         object.insert("seq".into(), seq.into());
-        let mut out = self.out.lock().unwrap();
         let written = serde_json::to_writer(&mut *out, &record)
             .map_err(std::io::Error::from)
             .and_then(|()| out.write_all(b"\n"));

--- a/src/results.rs
+++ b/src/results.rs
@@ -1,0 +1,170 @@
+//! `--results`: an NDJSON stream of machine-readable operation outcomes for
+//! native cp. Automation schema version 0 — an explicitly unstable preview
+//! of the planned automation interface (`--output=ndjson` stays reserved for
+//! the stable contract). Human output is unchanged; records go to the named
+//! file, or to stdout with `-` (combine that with `-q`).
+//!
+//! Version-0 coverage: one `run` record first; one `operation_result` per
+//! settled mutation (file transfers, directory/symlink/special creation
+//! inside the target container) and per failed mapping entry; an `error`
+//! record for every counted error; exactly one terminal `result`. Unchanged
+//! and excluded entries are aggregated in the terminal record only, and
+//! metadata-only updates are not yet reported per operation.
+
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
+use std::sync::Mutex;
+
+pub const SCHEMA: &str = "syq.automation";
+pub const SCHEMA_VERSION: u64 = 0;
+
+pub struct ResultsWriter {
+    out: Mutex<Box<dyn Write + Send>>,
+    seq: AtomicU64,
+    /// A record failed to write: reported once on stderr, then nothing
+    /// further is written. The consumer sees the missing terminal record.
+    dead: AtomicBool,
+}
+
+/// One settled operation. `dst`/`src` are container/base-relative raw path
+/// bytes; together with `kind` a failed record round-trips as a mapping
+/// entry for retry.
+pub struct OperationRecord<'a> {
+    pub action: &'static str,
+    pub dst: &'a [u8],
+    pub src: Option<&'a [u8]>,
+    pub kind: &'static str,
+    pub disposition: &'static str,
+    pub bytes: Option<u64>,
+    pub attempts: Option<u64>,
+    pub retryable: Option<&'static str>,
+    pub message: Option<&'a str>,
+}
+
+pub struct ResultRecord {
+    pub status: &'static str,
+    pub exit_code: i32,
+    pub files_transferred: u64,
+    pub files_unchanged: u64,
+    pub files_excluded: u64,
+    pub directories_created: u64,
+    pub symlinks_created: u64,
+    pub specials_created: u64,
+    pub errors: u64,
+    pub bytes_transferred: u64,
+    pub bytes_unchanged: u64,
+    pub elapsed_ms: u64,
+}
+
+impl ResultsWriter {
+    pub fn new(out: Box<dyn Write + Send>) -> Self {
+        ResultsWriter {
+            out: Mutex::new(out),
+            seq: AtomicU64::new(0),
+            dead: AtomicBool::new(false),
+        }
+    }
+
+    pub fn emit_run(&self, mapping: bool) {
+        self.write(serde_json::json!({
+            "type": "run",
+            "syq_version": env!("CARGO_PKG_VERSION"),
+            "mode": "cp",
+            "mapping": mapping,
+        }));
+    }
+
+    pub fn emit_error(&self, message: &str) {
+        self.write(serde_json::json!({
+            "type": "error",
+            "message": message,
+        }));
+    }
+
+    pub fn emit_operation(&self, op: &OperationRecord) {
+        let mut record = serde_json::json!({
+            "type": "operation_result",
+            "action": op.action,
+            "dst": tagged(op.dst),
+            "kind": op.kind,
+            "disposition": op.disposition,
+        });
+        let object = record.as_object_mut().expect("record is an object");
+        if let Some(src) = op.src {
+            object.insert("src".into(), tagged(src));
+        }
+        if let Some(bytes) = op.bytes {
+            object.insert("bytes".into(), bytes.into());
+        }
+        if let Some(attempts) = op.attempts {
+            object.insert("attempts".into(), attempts.into());
+        }
+        if let Some(retryable) = op.retryable {
+            object.insert("retryable".into(), retryable.into());
+        }
+        if let Some(message) = op.message {
+            object.insert("message".into(), message.into());
+        }
+        self.write(record);
+    }
+
+    /// The terminal record; flushes the stream. Nothing may be written after.
+    pub fn emit_result(&self, result: &ResultRecord) {
+        self.write(serde_json::json!({
+            "type": "result",
+            "status": result.status,
+            "exit_code": result.exit_code,
+            "files_transferred": result.files_transferred,
+            "files_unchanged": result.files_unchanged,
+            "files_excluded": result.files_excluded,
+            "directories_created": result.directories_created,
+            "symlinks_created": result.symlinks_created,
+            "specials_created": result.specials_created,
+            "errors": result.errors,
+            "bytes_transferred": result.bytes_transferred,
+            "bytes_unchanged": result.bytes_unchanged,
+            "elapsed_ms": result.elapsed_ms,
+        }));
+        if !self.dead.load(Relaxed) {
+            if let Err(error) = self.out.lock().unwrap().flush() {
+                self.mark_dead(&error);
+            }
+        }
+    }
+
+    fn write(&self, mut record: serde_json::Value) {
+        if self.dead.load(Relaxed) {
+            return;
+        }
+        let seq = self.seq.fetch_add(1, Relaxed);
+        let object = record.as_object_mut().expect("record is an object");
+        object.insert("schema".into(), SCHEMA.into());
+        object.insert("schema_version".into(), SCHEMA_VERSION.into());
+        object.insert("seq".into(), seq.into());
+        let mut out = self.out.lock().unwrap();
+        let written = serde_json::to_writer(&mut *out, &record)
+            .map_err(std::io::Error::from)
+            .and_then(|()| out.write_all(b"\n"));
+        if let Err(error) = written {
+            drop(out);
+            self.mark_dead(&error);
+        }
+    }
+
+    fn mark_dead(&self, error: &std::io::Error) {
+        if !self.dead.swap(true, Relaxed) {
+            eprintln!("syq: warning: --results stream failed ({error}); further records are lost");
+        }
+    }
+}
+
+fn tagged(path: &[u8]) -> serde_json::Value {
+    use base64::Engine as _;
+    match std::str::from_utf8(path) {
+        Ok(value) => serde_json::json!({"encoding": "utf-8", "value": value}),
+        Err(_) => serde_json::json!({
+            "encoding": "base64",
+            "value": base64::engine::general_purpose::STANDARD.encode(path),
+        }),
+    }
+}

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -24,6 +24,9 @@ pub struct FileJob {
     pub inplace: bool,
     /// Destination-root-relative path, used as the checkpoint key.
     pub rel_bytes: PathBytes,
+    /// --mapping: the entry's source path relative to the source base, kept
+    /// so `--results` records round-trip as retry mapping entries.
+    pub src_rel: Option<PathBytes>,
 }
 
 pub struct RangeState {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -531,7 +531,11 @@ struct SourceMapping<'a> {
     sub: &'a [u8],
 }
 
-fn validate_native_source_type(path: &[u8], selection: SourceSelection, kind: Kind) -> Result<()> {
+pub(crate) fn validate_native_source_type(
+    path: &[u8],
+    selection: SourceSelection,
+    kind: Kind,
+) -> Result<()> {
     match selection {
         SourceSelection::Contents if kind != Kind::Dir => {
             bail!("contents selector {} is not a directory", display(path))
@@ -3318,8 +3322,8 @@ impl Planner<'_> {
         // destination state) still fail entries individually below.
         let entries = read_mapping_manifest(reader)?;
 
-        // Phase 2: stat sources and plan in chunks, overlapping with
-        // transfer work exactly like any other single-source scan. `emitted`
+        // Phase 2: stat sources and plan in chunks; as with any native
+        // copy, transfers begin once planning completes. `emitted`
         // is what the planner was given for each destination path;
         // `synthesized` are implicit ancestors an explicit entry may still
         // upgrade.

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1518,6 +1518,8 @@ pub fn run(args: Args) -> Result<i32> {
         } else {
             None
         },
+        src_overrides: std::collections::HashMap::new(),
+        implicit_dirs: std::collections::HashSet::new(),
         create_root: if create_root && multiple_distinct_sources {
             Some((dst_root.clone(), root_create_condition))
         } else {
@@ -1525,7 +1527,7 @@ pub fn run(args: Args) -> Result<i32> {
         },
         destination_anchor: &destination_anchor,
         use_operator_anchor,
-        keep_dirs: args.files_from.is_some(),
+        keep_dirs: args.files_from.is_some() || args.native_mapping.is_some(),
         delete_roots: Vec::new(),
         deletes: Deletes::default(),
         dry_run_changes: {
@@ -1539,7 +1541,28 @@ pub fn run(args: Args) -> Result<i32> {
 
     let mut scan_err = None;
     let mut dry_run_mappings = Vec::with_capacity(srcs.len());
-    if args.files_from.is_some() {
+    if let Some(mapping) = args.native_mapping.as_deref() {
+        let src = &srcs[0];
+        let open = || -> Result<Box<dyn std::io::BufRead>> {
+            if mapping == b"-" {
+                return Ok(Box::new(std::io::stdin().lock()));
+            }
+            let path = std::path::PathBuf::from(OsStr::from_bytes(mapping).to_os_string());
+            Ok(Box::new(std::io::BufReader::new(
+                std::fs::File::open(&path)
+                    .map_err(|e| anyhow::anyhow!("--mapping {}: {e}", path.display()))?,
+            )))
+        };
+        match open().and_then(|mut reader| {
+            st.scan_mapping(&mut *src_ctl, &src.path, &dst_root, &mut *reader)
+        }) {
+            Ok(()) => dry_run_mappings.push(DryRunMapping {
+                target: dst_root.clone(),
+                semantics: "entries selected by --mapping",
+            }),
+            Err(e) => scan_err = Some(e),
+        }
+    } else if args.files_from.is_some() {
         let src = &srcs[0];
         match st.scan_files_from(
             &mut *src_ctl,
@@ -1555,7 +1578,10 @@ pub fn run(args: Args) -> Result<i32> {
             Err(e) => scan_err = Some(e),
         }
     }
-    for src in srcs.iter().filter(|_| args.files_from.is_none()) {
+    for src in srcs
+        .iter()
+        .filter(|_| args.files_from.is_none() && args.native_mapping.is_none())
+    {
         let src_root = src.path.clone();
         let contents = src.copies_contents();
         let follow_root = src.follows_root();
@@ -2617,6 +2643,13 @@ struct Planner<'a> {
     /// Several sources: mapped batches waiting for all scans to finish
     /// (see `Mapped`). None with a single source, where batches stream.
     buffer: Option<Vec<Mapped>>,
+    /// --mapping: per-destination source override. A manifest entry's `path`
+    /// carries the destination-relative path so claims, ordering, and job
+    /// naming work unchanged; the read side looks the actual source up here.
+    src_overrides: std::collections::HashMap<PathBytes, PathBytes>,
+    /// --mapping: full destination paths of implicit ancestor directories no
+    /// entry names, created with default metadata (no deferred stamping).
+    implicit_dirs: std::collections::HashSet<PathBytes>,
     /// Placement root and receiver-enforced conditions for native operations.
     root_path: PathBytes,
     exact_condition: TargetCondition,
@@ -3009,6 +3042,156 @@ impl Planner<'_> {
         Ok(())
     }
 
+    /// Consume an NDJSON mapping manifest: each entry claims exactly one
+    /// source object (relative to `src_root`) at an explicit destination
+    /// (relative to `dst_root`). Entries stream: chunks are planned and
+    /// applied before the manifest ends, so `--mapping -` starts work long
+    /// before stdin closes. Destination ancestors no entry names are
+    /// synthesized as implicit directories with default metadata.
+    fn scan_mapping(
+        &mut self,
+        src: &mut dyn Conn,
+        src_root: &[u8],
+        dst_root: &[u8],
+        reader: &mut dyn std::io::BufRead,
+    ) -> Result<()> {
+        use std::collections::{HashMap, HashSet};
+        match stat_one(src, src_root, true)? {
+            Some(e) if e.kind == Kind::Dir => {}
+            Some(_) => bail!(
+                "--mapping: source base {} is not a directory",
+                display(src_root)
+            ),
+            None => bail!(
+                "--mapping: source base {} does not exist",
+                display(src_root)
+            ),
+        }
+        self.progress.scanned.fetch_add(1, Relaxed);
+
+        // Explicit destinations seen (duplicates are hard errors), what the
+        // planner was given for each destination path, and which of those
+        // were synthesized ancestors an explicit entry may still upgrade.
+        let mut manifest_dsts: HashSet<PathBytes> = HashSet::new();
+        let mut emitted: HashMap<PathBytes, Kind> = HashMap::new();
+        let mut synthesized: HashSet<PathBytes> = HashSet::new();
+        let mut line_number = 0u64;
+        let mut done = false;
+        while !done {
+            let mut chunk: Vec<(u64, ManifestEntry)> = Vec::new();
+            while chunk.len() < crate::scan::BATCH {
+                let mut line = String::new();
+                let n = reader
+                    .read_line(&mut line)
+                    .map_err(|e| anyhow::anyhow!("--mapping: read: {e}"))?;
+                if n == 0 {
+                    done = true;
+                    break;
+                }
+                line_number += 1;
+                let text = line.trim_end_matches('\n').trim_end_matches('\r');
+                if text.is_empty() {
+                    continue;
+                }
+                let entry = parse_manifest_entry(text)
+                    .map_err(|e| anyhow::anyhow!("--mapping line {line_number}: {e}"))?;
+                if !manifest_dsts.insert(entry.dst.clone()) {
+                    bail!(
+                        "--mapping line {line_number}: duplicate destination {} (duplicate entries are errors; deduplicate in the generator)",
+                        display(&entry.dst)
+                    );
+                }
+                chunk.push((line_number, entry));
+            }
+            if chunk.is_empty() {
+                continue;
+            }
+            let stats = stat_many(
+                src,
+                chunk.iter().map(|(_, m)| join(src_root, &m.src)).collect(),
+                false,
+            )?;
+            let mut batch: Vec<Entry> = Vec::new();
+            for ((line_number, m), st) in chunk.into_iter().zip(stats) {
+                let Some(e) = st else {
+                    self.progress.error(&format!(
+                        "syq: --mapping line {line_number}: source {} does not exist",
+                        display(&m.src)
+                    ));
+                    continue;
+                };
+                if let Some(declared) = m.kind {
+                    if !declared.matches(e.kind) {
+                        self.progress.error(&format!(
+                            "syq: --mapping line {line_number}: source {} is {}, not the declared {}",
+                            display(&m.src),
+                            kind_label(e.kind),
+                            declared.label(),
+                        ));
+                        continue;
+                    }
+                }
+                // Destination ancestors: consistent with what earlier entries
+                // established, with missing ones synthesized parent-first.
+                let mut conflict = false;
+                let mut chain: Vec<PathBytes> = Vec::new();
+                for (i, &byte) in m.dst.iter().enumerate() {
+                    if byte != b'/' {
+                        continue;
+                    }
+                    let anc = &m.dst[..i];
+                    match emitted.get(anc) {
+                        Some(Kind::Dir) => {}
+                        Some(_) => {
+                            self.progress.error(&format!(
+                                "syq: --mapping line {line_number}: destination ancestor {} was mapped as a non-directory",
+                                display(anc)
+                            ));
+                            conflict = true;
+                            break;
+                        }
+                        None => chain.push(anc.to_vec()),
+                    }
+                }
+                if conflict {
+                    continue;
+                }
+                match emitted.get(&m.dst) {
+                    None => {}
+                    Some(Kind::Dir) if e.kind == Kind::Dir && synthesized.remove(&m.dst) => {
+                        // An explicit directory entry for a path an earlier
+                        // entry implied: upgrade it from default metadata to
+                        // this entry's metadata.
+                        self.implicit_dirs.remove(&join(dst_root, &m.dst));
+                    }
+                    Some(_) => {
+                        self.progress.error(&format!(
+                            "syq: --mapping line {line_number}: destination {} was already used as a directory",
+                            display(&m.dst)
+                        ));
+                        continue;
+                    }
+                }
+                for anc in chain {
+                    self.implicit_dirs.insert(join(dst_root, &anc));
+                    emitted.insert(anc.clone(), Kind::Dir);
+                    synthesized.insert(anc.clone());
+                    batch.push(implicit_dir_entry(anc));
+                }
+                emitted.insert(m.dst.clone(), e.kind);
+                if m.src != m.dst {
+                    self.src_overrides.insert(m.dst.clone(), m.src);
+                }
+                let mut e = e;
+                e.path = m.dst;
+                batch.push(e);
+            }
+            self.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
+            self.handle_batch(batch, src_root, b"", dst_root)?;
+        }
+        Ok(())
+    }
+
     /// Walk `src_root/rel` and plan its entries under the same relative prefix.
     fn scan_subtree(
         &mut self,
@@ -3150,7 +3333,10 @@ impl Planner<'_> {
             let Some(contested) = self.claim_dst(&dst, &rel, claim) else {
                 continue;
             };
-            let src = join(src_root, &e.path);
+            let src = match self.src_overrides.get(&e.path) {
+                Some(actual) => join(src_root, actual),
+                None => join(src_root, &e.path),
+            };
             match claim {
                 Claim::Dir => dirs.push((dst, dst_rel, e)),
                 Claim::Weak if e.kind == Kind::Other => {
@@ -3385,7 +3571,10 @@ impl Planner<'_> {
                                 ));
                             }
                         }
-                        Some(d) if metadata_differs(e, d, meta_flags) => {
+                        Some(d)
+                            if metadata_differs(e, d, meta_flags)
+                                && !self.implicit_dirs.contains(p) =>
+                        {
                             self.dry_run_changes.metadata_directories.insert(p.clone());
                             if opts.verbose > 0 {
                                 self.progress.println(&format!(
@@ -3484,6 +3673,12 @@ impl Planner<'_> {
                     flags &= !flags::MODE;
                 }
                 for (p, _, e, s) in &planned {
+                    // Implicit --mapping ancestors keep the metadata their
+                    // creation gave them; only named entries stamp source
+                    // metadata.
+                    if self.implicit_dirs.contains(p) {
+                        continue;
+                    }
                     let depth = p.iter().filter(|&&c| c == b'/').count();
                     let mut meta = e.meta();
                     let mut flags = flags;
@@ -5960,5 +6155,145 @@ mod tests {
         assert!(output.contains("current average 1.00 ms, minimum unavailable"));
         assert!(output.contains("receive unavailable, send-buffer unavailable"));
         assert!(output.contains("tcp ECN CE deliveries: unavailable"));
+    }
+}
+
+/// One parsed `--mapping` manifest entry.
+struct ManifestEntry {
+    src: PathBytes,
+    dst: PathBytes,
+    kind: Option<DeclaredKind>,
+}
+
+/// The manifest's `kind` field: disambiguation of the request, not a
+/// precondition. A mismatch fails that entry the way a missing source does.
+#[derive(Clone, Copy)]
+enum DeclaredKind {
+    File,
+    Dir,
+    Symlink,
+    Special,
+}
+
+impl DeclaredKind {
+    fn matches(self, kind: Kind) -> bool {
+        match self {
+            DeclaredKind::File => kind == Kind::File,
+            DeclaredKind::Dir => kind == Kind::Dir,
+            DeclaredKind::Symlink => kind == Kind::Symlink,
+            DeclaredKind::Special => matches!(
+                kind,
+                Kind::Fifo | Kind::Socket | Kind::CharDev | Kind::BlockDev
+            ),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            DeclaredKind::File => "file",
+            DeclaredKind::Dir => "dir",
+            DeclaredKind::Symlink => "symlink",
+            DeclaredKind::Special => "special",
+        }
+    }
+}
+
+fn parse_manifest_entry(text: &str) -> Result<ManifestEntry> {
+    use base64::Engine as _;
+    // Unknown keys are rejected so a typo cannot be silently dropped; the
+    // known informational fields (`size`, `mtime`, a tagged path's `display`)
+    // are accepted and ignored so `syq map` output and future automation
+    // records round-trip.
+    #[derive(serde::Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct WirePath {
+        encoding: String,
+        value: String,
+        #[serde(default)]
+        #[allow(dead_code)]
+        display: Option<String>,
+    }
+    #[derive(serde::Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct WireEntry {
+        src: WirePath,
+        dst: WirePath,
+        #[serde(default)]
+        kind: Option<String>,
+        #[serde(default)]
+        #[allow(dead_code)]
+        size: Option<u64>,
+        #[serde(default)]
+        #[allow(dead_code)]
+        mtime: Option<i64>,
+    }
+    let entry: WireEntry = serde_json::from_str(text).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let decode = |path: WirePath, which: &str| -> Result<PathBytes> {
+        let bytes = match path.encoding.as_str() {
+            "utf-8" => path.value.into_bytes(),
+            "base64" => base64::engine::general_purpose::STANDARD
+                .decode(path.value.as_bytes())
+                .map_err(|e| anyhow::anyhow!("{which}: invalid base64 path: {e}"))?,
+            other => bail!("{which}: unknown path encoding {other:?}"),
+        };
+        validate_manifest_path(&bytes, which)?;
+        Ok(bytes)
+    };
+    let src = decode(entry.src, "src")?;
+    let dst = decode(entry.dst, "dst")?;
+    let kind = match entry.kind.as_deref() {
+        None => None,
+        Some("file") => Some(DeclaredKind::File),
+        Some("dir") => Some(DeclaredKind::Dir),
+        Some("symlink") => Some(DeclaredKind::Symlink),
+        Some("special") => Some(DeclaredKind::Special),
+        Some(other) => bail!("unknown kind {other:?}"),
+    };
+    Ok(ManifestEntry { src, dst, kind })
+}
+
+fn validate_manifest_path(path: &[u8], which: &str) -> Result<()> {
+    if path.is_empty() {
+        bail!("{which} path is empty");
+    }
+    if path[0] == b'/' {
+        bail!(
+            "{which} path {:?} is absolute; mapping entries are root-relative",
+            String::from_utf8_lossy(path)
+        );
+    }
+    if path.contains(&0) {
+        bail!("{which} path contains NUL");
+    }
+    for component in path.split(|&byte| byte == b'/') {
+        if component.is_empty() || component == b"." || component == b".." {
+            bail!(
+                "{which} path {:?} contains an empty, `.`, or `..` component",
+                String::from_utf8_lossy(path)
+            );
+        }
+    }
+    Ok(())
+}
+
+/// A destination ancestor directory no manifest entry names: created with
+/// default metadata (mode through the umask, natural mtime; see
+/// `Planner::implicit_dirs`).
+fn implicit_dir_entry(path: PathBytes) -> Entry {
+    Entry {
+        path,
+        kind: Kind::Dir,
+        size: 0,
+        mtime: 0,
+        mtime_nsec: 0,
+        mode: 0o755,
+        uid: 0,
+        gid: 0,
+        rdev: 0,
+        dev: 0,
+        ino: 0,
+        ctime: 0,
+        ctime_nsec: 0,
+        link: None,
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -3718,15 +3718,28 @@ impl Planner<'_> {
                             self.progress.results_writer(),
                             strip_dst_root(name, dst_root),
                         ) {
+                            // An implicit --mapping ancestor has no source and
+                            // is not independently retryable: the entries
+                            // beneath it carry the actionable retry records.
+                            let implicit = self.implicit_dirs.contains(name);
+                            let src = if implicit {
+                                None
+                            } else {
+                                self.mapping_source_rel(dst_rel)
+                            };
                             results.emit_operation(&crate::results::OperationRecord {
                                 action: "create_directory",
                                 dst: dst_rel,
-                                src: self.mapping_source_rel(dst_rel).as_deref(),
+                                src: src.as_deref(),
                                 kind: "dir",
                                 disposition: if created { "succeeded" } else { "failed" },
                                 bytes: None,
                                 attempts: None,
-                                retryable: (!created).then_some("unknown"),
+                                retryable: (!created).then_some(if implicit {
+                                    "no"
+                                } else {
+                                    "unknown"
+                                }),
                                 message: None,
                             });
                         }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -872,6 +872,20 @@ pub fn run(args: Args) -> Result<i32> {
         args.width,
         !args.quiet && args.progress_json,
     );
+    if let Some(results) = args.native_results.as_deref() {
+        let out: Box<dyn std::io::Write + Send> = if results == b"-" {
+            Box::new(std::io::stdout())
+        } else {
+            let path = std::path::PathBuf::from(OsStr::from_bytes(results).to_os_string());
+            Box::new(std::io::BufWriter::new(
+                std::fs::File::create(&path)
+                    .map_err(|e| anyhow::anyhow!("--results {}: {e}", path.display()))?,
+            ))
+        };
+        let writer = Arc::new(crate::results::ResultsWriter::new(out));
+        writer.emit_run(args.native_mapping.is_some());
+        progress.set_results(writer);
+    }
     let sched = Arc::new(Sched::new(block, min_split));
 
     // Workers connect on their own threads once the control connections are
@@ -1520,6 +1534,7 @@ pub fn run(args: Args) -> Result<i32> {
         },
         src_overrides: std::collections::HashMap::new(),
         implicit_dirs: std::collections::HashSet::new(),
+        mapping_mode: false,
         create_root: if create_root && multiple_distinct_sources {
             Some((dst_root.clone(), root_create_condition))
         } else {
@@ -1733,6 +1748,7 @@ pub fn run(args: Args) -> Result<i32> {
     }
     let max_delete_hit = st.max_delete_hit;
     let dry_run_changes = std::mem::take(&mut st.dry_run_changes);
+    let created_counts = (st.dirs_created, st.links_created, st.specials_created);
     drop(st);
 
     progress.stop();
@@ -1891,7 +1907,7 @@ pub fn run(args: Args) -> Result<i32> {
             );
         }
     }
-    Ok(if aborted {
+    let exit_code = if aborted {
         1
     } else if errors > 0 {
         23
@@ -1899,7 +1915,32 @@ pub fn run(args: Args) -> Result<i32> {
         25
     } else {
         0
-    })
+    };
+    if let Some(results) = progress.results_writer() {
+        results.emit_result(&crate::results::ResultRecord {
+            status: if aborted {
+                "aborted"
+            } else if max_delete_hit {
+                "refused"
+            } else if errors > 0 {
+                "partial"
+            } else {
+                "success"
+            },
+            exit_code,
+            files_transferred: progress.files_done.load(Relaxed),
+            files_unchanged: progress.files_skipped.load(Relaxed),
+            files_excluded: progress.files_excluded.load(Relaxed),
+            directories_created: created_counts.0,
+            symlinks_created: created_counts.1,
+            specials_created: created_counts.2,
+            errors,
+            bytes_transferred: progress.bytes_done.load(Relaxed),
+            bytes_unchanged: progress.bytes_skipped.load(Relaxed),
+            elapsed_ms: progress.start.elapsed().as_millis() as u64,
+        });
+    }
+    Ok(exit_code)
 }
 
 fn st_dirs(p: &Progress) -> u64 {
@@ -2650,6 +2691,8 @@ struct Planner<'a> {
     /// --mapping: full destination paths of implicit ancestor directories no
     /// entry names, created with default metadata (no deferred stamping).
     implicit_dirs: std::collections::HashSet<PathBytes>,
+    /// This run consumes a --mapping manifest (identity entries included).
+    mapping_mode: bool,
     /// Placement root and receiver-enforced conditions for native operations.
     root_path: PathBytes,
     exact_condition: TargetCondition,
@@ -3056,6 +3099,7 @@ impl Planner<'_> {
         reader: &mut dyn std::io::BufRead,
     ) -> Result<()> {
         use std::collections::{HashMap, HashSet};
+        self.mapping_mode = true;
         match stat_one(src, src_root, true)? {
             Some(e) if e.kind == Kind::Dir => {}
             Some(_) => bail!(
@@ -3114,20 +3158,24 @@ impl Planner<'_> {
             let mut batch: Vec<Entry> = Vec::new();
             for ((line_number, m), st) in chunk.into_iter().zip(stats) {
                 let Some(e) = st else {
-                    self.progress.error(&format!(
-                        "syq: --mapping line {line_number}: source {} does not exist",
+                    let message = format!(
+                        "--mapping line {line_number}: source {} does not exist",
                         display(&m.src)
-                    ));
+                    );
+                    self.progress.error(&format!("syq: {message}"));
+                    self.emit_mapping_entry_failed(&m, "unknown", &message);
                     continue;
                 };
                 if let Some(declared) = m.kind {
                     if !declared.matches(e.kind) {
-                        self.progress.error(&format!(
-                            "syq: --mapping line {line_number}: source {} is {}, not the declared {}",
+                        let message = format!(
+                            "--mapping line {line_number}: source {} is {}, not the declared {}",
                             display(&m.src),
                             kind_label(e.kind),
                             declared.label(),
-                        ));
+                        );
+                        self.progress.error(&format!("syq: {message}"));
+                        self.emit_mapping_entry_failed(&m, "no", &message);
                         continue;
                     }
                 }
@@ -3656,6 +3704,7 @@ impl Planner<'_> {
                     let errs = self.apply(new_dirs)?;
                     let mut failed = 0;
                     for ((name, condition), err) in op_info.iter().zip(errs) {
+                        let created = err.is_none();
                         if let Some(err) = err {
                             failed += 1;
                             self.progress.error(&format!("syq: {err}"));
@@ -3664,6 +3713,22 @@ impl Planner<'_> {
                             }
                         } else if opts.verbose > 0 {
                             self.progress.println(&format!("{}/", display(name)));
+                        }
+                        if let (Some(results), Some(dst_rel)) = (
+                            self.progress.results_writer(),
+                            strip_dst_root(name, dst_root),
+                        ) {
+                            results.emit_operation(&crate::results::OperationRecord {
+                                action: "create_directory",
+                                dst: dst_rel,
+                                src: self.mapping_source_rel(dst_rel).as_deref(),
+                                kind: "dir",
+                                disposition: if created { "succeeded" } else { "failed" },
+                                bytes: None,
+                                attempts: None,
+                                retryable: (!created).then_some("unknown"),
+                                message: None,
+                            });
                         }
                     }
                     self.dirs_created += (n - failed) as u64;
@@ -3755,7 +3820,7 @@ impl Planner<'_> {
             )?
         };
         let mut ops: Vec<Op> = Vec::new();
-        let mut op_names: Vec<String> = Vec::new();
+        let mut op_names: Vec<QueuedLeafOp> = Vec::new();
         // Metadata repairs for quick-check-identical files, each with the
         // checkpoint record once the repair has actually succeeded.
         let mut meta_fixes: Vec<(Op, Option<QuickCheckRecord>)> = Vec::new();
@@ -4021,7 +4086,12 @@ impl Planner<'_> {
                     if !self.invalidate_completion(&dst_rel) {
                         continue;
                     }
-                    op_names.push(format!("{rel} -> {}", display(&target)));
+                    op_names.push(QueuedLeafOp {
+                        dst_rel: dst_rel.clone(),
+                        action: "create_symlink",
+                        kind: "symlink",
+                        name: format!("{rel} -> {}", display(&target)),
+                    });
                     ops.push(Op::Symlink {
                         path: dst_path.clone(),
                         target,
@@ -4088,7 +4158,12 @@ impl Planner<'_> {
                     if !self.invalidate_completion(&dst_rel) {
                         continue;
                     }
-                    op_names.push(rel);
+                    op_names.push(QueuedLeafOp {
+                        dst_rel: dst_rel.clone(),
+                        action: "create_special",
+                        kind: "special",
+                        name: rel,
+                    });
                     ops.push(Op::Mknod {
                         path: dst_path.clone(),
                         mode: e.mode,
@@ -4129,13 +4204,35 @@ impl Planner<'_> {
         if !ops.is_empty() {
             let errs = self.apply(ops)?;
             // Two ops per item: creation then metadata.
-            for (i, name) in op_names.iter().enumerate() {
+            for (i, queued) in op_names.iter().enumerate() {
                 let e1 = errs.get(2 * i).cloned().flatten();
                 let e2 = errs.get(2 * i + 1).cloned().flatten();
-                if let Some(e) = e1.or(e2) {
+                let error = e1.or(e2);
+                if let Some(e) = &error {
                     self.progress.error(&format!("syq: {e}"));
+                    match queued.action {
+                        "create_symlink" => self.links_created -= 1,
+                        _ => self.specials_created -= 1,
+                    }
                 } else if opts.verbose > 0 {
-                    self.progress.println(name);
+                    self.progress.println(&queued.name);
+                }
+                if let Some(results) = self.progress.results_writer() {
+                    results.emit_operation(&crate::results::OperationRecord {
+                        action: queued.action,
+                        dst: &queued.dst_rel,
+                        src: self.mapping_source_rel(&queued.dst_rel).as_deref(),
+                        kind: queued.kind,
+                        disposition: if error.is_none() {
+                            "succeeded"
+                        } else {
+                            "failed"
+                        },
+                        bytes: None,
+                        attempts: None,
+                        retryable: error.is_some().then_some("unknown"),
+                        message: error.as_deref(),
+                    });
                 }
             }
         }
@@ -4314,6 +4411,51 @@ impl Planner<'_> {
 
     /// Display name for a source entry: its destination-relative path, or the
     /// source's basename when a single file is copied to an exact destination.
+    /// --mapping: the manifest source path (base-relative) for a destination,
+    /// so `--results` records round-trip as retry mapping entries. None
+    /// outside mapping mode, where no base-relative source spelling exists.
+    fn mapping_source_rel(&self, dst_rel: &[u8]) -> Option<PathBytes> {
+        if !self.mapping_mode {
+            return None;
+        }
+        Some(
+            self.src_overrides
+                .get(dst_rel)
+                .cloned()
+                .unwrap_or_else(|| dst_rel.to_vec()),
+        )
+    }
+
+    /// A mapping entry that failed before any job existed (missing source,
+    /// declared-kind mismatch): the error was already counted; this emits the
+    /// per-entry result record retry tooling filters on.
+    fn emit_mapping_entry_failed(
+        &self,
+        entry: &ManifestEntry,
+        retryable: &'static str,
+        message: &str,
+    ) {
+        if let Some(results) = self.progress.results_writer() {
+            let (action, kind) = match entry.kind {
+                Some(DeclaredKind::Dir) => ("create_directory", "dir"),
+                Some(DeclaredKind::Symlink) => ("create_symlink", "symlink"),
+                Some(DeclaredKind::Special) => ("create_special", "special"),
+                _ => ("transfer_file", "file"),
+            };
+            results.emit_operation(&crate::results::OperationRecord {
+                action,
+                dst: &entry.dst,
+                src: Some(&entry.src),
+                kind,
+                disposition: "failed",
+                bytes: None,
+                attempts: None,
+                retryable: Some(retryable),
+                message: Some(message),
+            });
+        }
+    }
+
     fn rel_name(&self, src_root: &[u8], sub_b: &[u8], path: &[u8]) -> String {
         let r = join(sub_b, path);
         if r.is_empty() {
@@ -4388,6 +4530,7 @@ impl Planner<'_> {
         dst_entry: Option<Entry>,
     ) {
         let target_condition = self.exact_condition_for(&dst);
+        let src_rel = self.mapping_source_rel(&rel_bytes);
         self.progress.files_total.fetch_add(1, Relaxed);
         self.progress.bytes_total.fetch_add(entry.size, Relaxed);
         self.sched.push_file(FileJob {
@@ -4402,6 +4545,7 @@ impl Planner<'_> {
             attempts: 0,
             done: Arc::new(AtomicU64::new(0)),
             inplace: false,
+            src_rel,
         });
     }
 
@@ -5188,7 +5332,9 @@ impl Worker {
             .zip(results.into_iter().zip(now.into_iter()))
         {
             if let Err(e) = res {
-                self.progress.error(&format!("syq: {}: {e:#}", j.rel));
+                let message = format!("{e:#}");
+                self.progress.error(&format!("syq: {}: {message}", j.rel));
+                self.emit_file_result_failed(j, "unknown", &message);
                 self.sched.fail_file(*idx);
                 continue;
             }
@@ -5230,6 +5376,11 @@ impl Worker {
                         "syq: {}: source changed during transfer (or vanished)",
                         j.rel
                     ));
+                    self.emit_file_result_failed(
+                        j,
+                        "yes",
+                        "source changed during transfer (or vanished)",
+                    );
                     self.sched.fail_file(*idx);
                 }
                 continue;
@@ -5237,6 +5388,19 @@ impl Worker {
             self.progress.add_bytes(j.entry.size);
             j.done.store(j.entry.size, Relaxed);
             self.progress.files_done.fetch_add(1, Relaxed);
+            if let Some(results) = self.progress.results_writer() {
+                results.emit_operation(&crate::results::OperationRecord {
+                    action: "transfer_file",
+                    dst: &j.rel_bytes,
+                    src: j.src_rel.as_deref(),
+                    kind: "file",
+                    disposition: "succeeded",
+                    bytes: Some(j.entry.size),
+                    attempts: Some(u64::from(j.attempts) + 1),
+                    retryable: None,
+                    message: None,
+                });
+            }
             self.record_done(&j.rel_bytes, &j.entry);
             if self.opts.verbose > 0 {
                 self.progress.println(&j.rel);
@@ -5251,11 +5415,31 @@ impl Worker {
             return Err(e);
         }
         if !self.sched.is_failed(idx) {
-            let rel = self.sched.jobs.lock().unwrap()[idx].rel.clone();
-            self.progress.error(&format!("syq: {rel}: {e:#}"));
+            let job = self.job(idx);
+            let message = format!("{e:#}");
+            self.progress.error(&format!("syq: {}: {message}", job.rel));
+            self.emit_file_result_failed(&job, "unknown", &message);
             self.sched.fail_file(idx);
         }
         Ok(())
+    }
+
+    /// One failed-transfer result record; the error itself was already
+    /// counted and printed by the caller.
+    fn emit_file_result_failed(&self, job: &FileJob, retryable: &'static str, message: &str) {
+        if let Some(results) = self.progress.results_writer() {
+            results.emit_operation(&crate::results::OperationRecord {
+                action: "transfer_file",
+                dst: &job.rel_bytes,
+                src: job.src_rel.as_deref(),
+                kind: "file",
+                disposition: "failed",
+                bytes: None,
+                attempts: Some(u64::from(job.attempts) + 1),
+                retryable: Some(retryable),
+                message: Some(message),
+            });
+        }
     }
 
     fn job(&self, idx: usize) -> FileJob {
@@ -5943,6 +6127,19 @@ impl Worker {
             self.progress.files_skipped.fetch_add(1, Relaxed);
         } else {
             self.progress.files_done.fetch_add(1, Relaxed);
+            if let Some(results) = self.progress.results_writer() {
+                results.emit_operation(&crate::results::OperationRecord {
+                    action: "transfer_file",
+                    dst: &job.rel_bytes,
+                    src: job.src_rel.as_deref(),
+                    kind: "file",
+                    disposition: "succeeded",
+                    bytes: Some(job.entry.size),
+                    attempts: Some(u64::from(job.attempts) + 1),
+                    retryable: None,
+                    message: None,
+                });
+            }
         }
         self.record_done(&job.rel_bytes, &job.entry);
         if !matched && self.opts.verbose > 0 {
@@ -6296,4 +6493,23 @@ fn implicit_dir_entry(path: PathBytes) -> Entry {
         ctime_nsec: 0,
         link: None,
     }
+}
+
+/// A queued symlink/special creation: the display string for -v plus the
+/// machine-readable identity `--results` records need.
+struct QueuedLeafOp {
+    dst_rel: PathBytes,
+    action: &'static str,
+    kind: &'static str,
+    name: String,
+}
+
+/// The container-relative spelling of a full destination path; None for the
+/// container itself.
+fn strip_dst_root<'p>(path: &'p [u8], dst_root: &[u8]) -> Option<&'p [u8]> {
+    if path == dst_root {
+        return None;
+    }
+    let rest = path.strip_prefix(dst_root)?;
+    Some(rest.strip_prefix(b"/").unwrap_or(rest))
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -3308,43 +3308,27 @@ impl Planner<'_> {
         }
         self.progress.scanned.fetch_add(1, Relaxed);
 
-        // Explicit destinations seen (duplicates are hard errors), what the
-        // planner was given for each destination path, and which of those
-        // were synthesized ancestors an explicit entry may still upgrade.
-        let mut manifest_dsts: HashSet<PathBytes> = HashSet::new();
+        // Phase 1: read and validate the whole manifest before any entry is
+        // applied. Parse errors, duplicate destinations, and declared-kind
+        // ancestor conflicts refuse the run (the --into container was
+        // already created, as with --files-from); the price is memory
+        // proportional to the manifest, which the multi-source preflight
+        // already accepts. Conflicts only observable
+        // at execution (an undeclared ancestor that is not a directory,
+        // destination state) still fail entries individually below.
+        let entries = read_mapping_manifest(reader)?;
+
+        // Phase 2: stat sources and plan in chunks, overlapping with
+        // transfer work exactly like any other single-source scan. `emitted`
+        // is what the planner was given for each destination path;
+        // `synthesized` are implicit ancestors an explicit entry may still
+        // upgrade.
         let mut emitted: HashMap<PathBytes, Kind> = HashMap::new();
         let mut synthesized: HashSet<PathBytes> = HashSet::new();
-        let mut line_number = 0u64;
-        let mut done = false;
-        while !done {
-            let mut chunk: Vec<(u64, ManifestEntry)> = Vec::new();
-            while chunk.len() < crate::scan::BATCH {
-                let mut line = String::new();
-                let n = reader
-                    .read_line(&mut line)
-                    .map_err(|e| anyhow::anyhow!("--mapping: read: {e}"))?;
-                if n == 0 {
-                    done = true;
-                    break;
-                }
-                line_number += 1;
-                let text = line.trim_end_matches('\n').trim_end_matches('\r');
-                if text.is_empty() {
-                    continue;
-                }
-                let entry = parse_manifest_entry(text)
-                    .map_err(|e| anyhow::anyhow!("--mapping line {line_number}: {e}"))?;
-                if !manifest_dsts.insert(entry.dst.clone()) {
-                    bail!(
-                        "--mapping line {line_number}: duplicate destination {} (duplicate entries are errors; deduplicate in the generator)",
-                        display(&entry.dst)
-                    );
-                }
-                chunk.push((line_number, entry));
-            }
-            if chunk.is_empty() {
-                continue;
-            }
+        let mut remaining = entries.into_iter().peekable();
+        while remaining.peek().is_some() {
+            let chunk: Vec<(u64, ManifestEntry)> =
+                remaining.by_ref().take(crate::scan::BATCH).collect();
             let stats = stat_many(
                 src,
                 chunk.iter().map(|(_, m)| join(src_root, &m.src)).collect(),
@@ -3588,7 +3572,6 @@ impl Planner<'_> {
                 Claim::Weak if e.kind == Kind::Other => {
                     // Unknown type: never transferred.
                     self.progress.files_excluded.fetch_add(1, Relaxed);
-                    self.emit_mapping_entry_skipped(&e, &dst_rel);
                 }
                 Claim::Weak => {
                     // Symlink without -l, special without -D.
@@ -3597,7 +3580,6 @@ impl Planner<'_> {
                             .eprintln(&format!("skipping non-regular file \"{rel}\""));
                     }
                     self.progress.files_excluded.fetch_add(1, Relaxed);
-                    self.emit_mapping_entry_skipped(&e, &dst_rel);
                 }
                 Claim::File { .. } | Claim::Leaf => others.push(Planned {
                     src,
@@ -4665,37 +4647,6 @@ impl Planner<'_> {
                 attempts: None,
                 retryable: Some(retryable),
                 message: Some(message),
-            });
-        }
-    }
-
-    /// A mapping entry excluded by policy (a special file or unknown type
-    /// under the fixed -rlt fidelity): visible in the results stream as a
-    /// skipped operation, not a failure — the same class as a --min-size
-    /// exclusion, and never selected by the retry filter.
-    fn emit_mapping_entry_skipped(&self, e: &Entry, dst_rel: &[u8]) {
-        if !self.mapping_mode {
-            return;
-        }
-        if let Some(results) = self.progress.results_writer() {
-            let (action, kind) = match e.kind {
-                Kind::Symlink => ("create_symlink", "symlink"),
-                Kind::Fifo | Kind::Socket | Kind::CharDev | Kind::BlockDev => {
-                    ("create_special", "special")
-                }
-                _ => ("transfer_file", "file"),
-            };
-            let src = self.mapping_source_rel(dst_rel);
-            results.emit_operation(&crate::results::OperationRecord {
-                action,
-                dst: dst_rel,
-                src: src.as_deref(),
-                kind,
-                disposition: "skipped",
-                bytes: None,
-                attempts: None,
-                retryable: None,
-                message: Some("not copied by native cp's fixed -rlt policy"),
             });
         }
     }
@@ -6767,4 +6718,58 @@ fn strip_dst_root<'p>(path: &'p [u8], dst_root: &[u8]) -> Option<&'p [u8]> {
     }
     let rest = path.strip_prefix(dst_root)?;
     Some(rest.strip_prefix(b"/").unwrap_or(rest))
+}
+
+/// Phase-1 manifest read for `--mapping`: parse every line and run the
+/// parse-level preflight (duplicate destinations; an entry whose destination
+/// is a strict ancestor of another entry's destination must not declare a
+/// non-directory kind) before anything is written. Whether an undeclared
+/// ancestor really is a directory is only knowable from the source and is
+/// checked during execution.
+fn read_mapping_manifest(reader: &mut dyn std::io::BufRead) -> Result<Vec<(u64, ManifestEntry)>> {
+    let mut entries: Vec<(u64, ManifestEntry)> = Vec::new();
+    let mut declared: std::collections::HashMap<PathBytes, Option<DeclaredKind>> =
+        std::collections::HashMap::new();
+    let mut line_number = 0u64;
+    loop {
+        let mut line = String::new();
+        let n = reader
+            .read_line(&mut line)
+            .map_err(|e| anyhow::anyhow!("--mapping: read: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        line_number += 1;
+        let text = line.trim_end_matches('\n').trim_end_matches('\r');
+        if text.is_empty() {
+            continue;
+        }
+        let entry = parse_manifest_entry(text)
+            .map_err(|e| anyhow::anyhow!("--mapping line {line_number}: {e}"))?;
+        if declared.insert(entry.dst.clone(), entry.kind).is_some() {
+            bail!(
+                "--mapping line {line_number}: duplicate destination {} (duplicate entries are errors; deduplicate in the generator)",
+                display(&entry.dst)
+            );
+        }
+        entries.push((line_number, entry));
+    }
+    for (line_number, entry) in &entries {
+        for (i, &byte) in entry.dst.iter().enumerate() {
+            if byte != b'/' {
+                continue;
+            }
+            if let Some(Some(kind)) = declared.get(&entry.dst[..i]) {
+                if !matches!(kind, DeclaredKind::Dir) {
+                    bail!(
+                        "--mapping line {line_number}: destination ancestor {} of {} is mapped with kind {:?}, not dir",
+                        display(&entry.dst[..i]),
+                        display(&entry.dst),
+                        kind.label()
+                    );
+                }
+            }
+        }
+    }
+    Ok(entries)
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -3588,6 +3588,7 @@ impl Planner<'_> {
                 Claim::Weak if e.kind == Kind::Other => {
                     // Unknown type: never transferred.
                     self.progress.files_excluded.fetch_add(1, Relaxed);
+                    self.emit_mapping_entry_skipped(&e, &dst_rel);
                 }
                 Claim::Weak => {
                     // Symlink without -l, special without -D.
@@ -3596,6 +3597,7 @@ impl Planner<'_> {
                             .eprintln(&format!("skipping non-regular file \"{rel}\""));
                     }
                     self.progress.files_excluded.fetch_add(1, Relaxed);
+                    self.emit_mapping_entry_skipped(&e, &dst_rel);
                 }
                 Claim::File { .. } | Claim::Leaf => others.push(Planned {
                     src,
@@ -4663,6 +4665,37 @@ impl Planner<'_> {
                 attempts: None,
                 retryable: Some(retryable),
                 message: Some(message),
+            });
+        }
+    }
+
+    /// A mapping entry excluded by policy (a special file or unknown type
+    /// under the fixed -rlt fidelity): visible in the results stream as a
+    /// skipped operation, not a failure — the same class as a --min-size
+    /// exclusion, and never selected by the retry filter.
+    fn emit_mapping_entry_skipped(&self, e: &Entry, dst_rel: &[u8]) {
+        if !self.mapping_mode {
+            return;
+        }
+        if let Some(results) = self.progress.results_writer() {
+            let (action, kind) = match e.kind {
+                Kind::Symlink => ("create_symlink", "symlink"),
+                Kind::Fifo | Kind::Socket | Kind::CharDev | Kind::BlockDev => {
+                    ("create_special", "special")
+                }
+                _ => ("transfer_file", "file"),
+            };
+            let src = self.mapping_source_rel(dst_rel);
+            results.emit_operation(&crate::results::OperationRecord {
+                action,
+                dst: dst_rel,
+                src: src.as_deref(),
+                kind,
+                disposition: "skipped",
+                bytes: None,
+                attempts: None,
+                retryable: None,
+                message: Some("not copied by native cp's fixed -rlt policy"),
             });
         }
     }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -8203,3 +8203,163 @@ fn native_cp_mapping_end_to_end_map_pipeline() {
     assert_eq!(read(&t.path("pub/berlin/img.jpg")), b"img");
     assert_eq!(read(&t.path("pub/notes.txt")), b"hello");
 }
+
+// ---- syq cp --results ----
+
+#[test]
+fn native_cp_results_stream_success_and_partial() {
+    let t = Tmp::new();
+    write(&t.path("src/a.txt"), b"abc");
+    std::os::unix::fs::symlink("a.txt", t.path("src/l")).unwrap();
+    let manifest = format!(
+        "{}{}{}",
+        entry_line("a.txt", "x/a.txt", Some("file")),
+        entry_line("l", "l", Some("symlink")),
+        entry_line("gone.txt", "g.txt", None),
+    );
+    let out = syq_cp_in(
+        &t.path(""),
+        &[
+            "--mapping",
+            "-",
+            "-C",
+            "src",
+            "--into",
+            "dst",
+            "--results",
+            "r.ndjson",
+            "-q",
+        ],
+        Some(manifest.as_bytes()),
+    );
+    assert_eq!(out.status.code(), Some(23));
+    let lines: Vec<serde_json::Value> = String::from_utf8(read(&t.path("r.ndjson")))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("results line is JSON"))
+        .collect();
+    // Envelope: schema v0, strictly increasing seq, run first, result last.
+    for (i, v) in lines.iter().enumerate() {
+        assert_eq!(v["schema"], "syq.automation");
+        assert_eq!(v["schema_version"], 0);
+        assert_eq!(v["seq"], i as u64);
+    }
+    assert_eq!(lines[0]["type"], "run");
+    assert_eq!(lines[0]["mapping"], true);
+    let last = lines.last().unwrap();
+    assert_eq!(last["type"], "result");
+    assert_eq!(last["status"], "partial");
+    assert_eq!(last["exit_code"], 23);
+    assert_eq!(last["files_transferred"], 1);
+    assert_eq!(last["symlinks_created"], 1);
+    assert!(last["directories_created"].as_u64().unwrap() >= 1);
+    assert_eq!(last["errors"], 1);
+    let ops: Vec<&serde_json::Value> = lines
+        .iter()
+        .filter(|v| v["type"] == "operation_result")
+        .collect();
+    let find = |dst: &str| {
+        *ops.iter()
+            .find(|v| v["dst"]["value"] == dst)
+            .unwrap_or_else(|| panic!("no operation_result for {dst}"))
+    };
+    let file = find("x/a.txt");
+    assert_eq!(file["action"], "transfer_file");
+    assert_eq!(file["disposition"], "succeeded");
+    assert_eq!(file["kind"], "file");
+    assert_eq!(file["bytes"], 3);
+    assert_eq!(file["src"]["value"], "a.txt");
+    let dir = find("x");
+    assert_eq!(dir["action"], "create_directory");
+    assert_eq!(dir["disposition"], "succeeded");
+    let link = find("l");
+    assert_eq!(link["action"], "create_symlink");
+    assert_eq!(link["disposition"], "succeeded");
+    let failed = find("g.txt");
+    assert_eq!(failed["disposition"], "failed");
+    assert_eq!(failed["retryable"], "unknown");
+    assert_eq!(failed["src"]["value"], "gone.txt");
+    // A failed record round-trips as a retry mapping entry.
+    let retry = format!(
+        "{{\"src\":{},\"dst\":{},\"kind\":{}}}\n",
+        failed["src"], failed["dst"], failed["kind"]
+    );
+    write(&t.path("src/gone.txt"), b"late");
+    let out = syq_cp_in(
+        &t.path(""),
+        &[
+            "--mapping",
+            "-",
+            "-C",
+            "src",
+            "--into",
+            "dst",
+            "--results",
+            "r2.ndjson",
+            "-q",
+        ],
+        Some(retry.as_bytes()),
+    );
+    assert!(
+        out.status.success(),
+        "retry failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(read(&t.path("dst/g.txt")), b"late");
+    let last: serde_json::Value = String::from_utf8(read(&t.path("r2.ndjson")))
+        .unwrap()
+        .lines()
+        .last()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .unwrap();
+    assert_eq!(last["status"], "success");
+    assert_eq!(last["exit_code"], 0);
+    // An error record accompanied the failure in the first run.
+    assert!(
+        lines
+            .iter()
+            .any(|v| v["type"] == "error"
+                && v["message"].as_str().unwrap().contains("does not exist"))
+    );
+}
+
+#[test]
+fn native_cp_results_without_mapping_and_refusals() {
+    let t = Tmp::new();
+    write(&t.path("src/f.txt"), b"data");
+    let out = syq_cp_in(
+        &t.path(""),
+        &[
+            "--src-src",
+            "src",
+            "--into",
+            "out",
+            "--results",
+            "r.ndjson",
+            "-q",
+        ],
+        None,
+    );
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let lines: Vec<serde_json::Value> = String::from_utf8(read(&t.path("r.ndjson")))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(lines[0]["mapping"], false);
+    let op = lines
+        .iter()
+        .find(|v| v["type"] == "operation_result" && v["dst"]["value"] == "f.txt")
+        .expect("transfer record");
+    assert_eq!(op["disposition"], "succeeded");
+    assert!(op.get("src").is_none(), "non-mapping records carry no src");
+    assert_eq!(lines.last().unwrap()["status"], "success");
+    // map and cp-prune refuse --results.
+    let out = syq_map_in(&t.path(""), &["--src-src", "src", "--results", "r.ndjson"]);
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("only available on syq cp"));
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -8886,3 +8886,41 @@ fn native_cp_mapping_whole_manifest_preflight_writes_nothing() {
     assert!(String::from_utf8_lossy(&out.stderr).contains("not dir"));
     assert_eq!(fs::read_dir(t.path("dst")).unwrap().count(), 0);
 }
+
+#[test]
+fn native_mapping_and_map_respect_typed_selectors() {
+    let t = Tmp::new();
+    write(&t.path("src/f.txt"), b"f");
+    fs::create_dir_all(t.path("src/d")).unwrap();
+    // --mapping rejects typed selectors instead of silently discarding them.
+    let out = syq_cp_in(
+        &t.path(""),
+        &[
+            "--mapping",
+            "-",
+            "--src-dir",
+            "absent",
+            "-C",
+            "src",
+            "--into",
+            "dst",
+        ],
+        Some(b""),
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("replaces source selectors"));
+    // syq map enforces typed-selector preconditions like native cp.
+    let out = syq_map_in(&t.path("src"), &["--src-file", "d"]);
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("is a directory"));
+    let out = syq_map_in(&t.path("src"), &["--src-dir", "f.txt"]);
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("is not a directory"));
+    // Happy paths still emit.
+    let lines = map_lines(&syq_map_in(
+        &t.path("src"),
+        &["--src-dir", "d", "--src-file", "f.txt"],
+    ));
+    let dsts: Vec<String> = lines.iter().map(|v| map_path(v, "dst")).collect();
+    assert_eq!(dsts, ["d", "f.txt"]);
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7881,3 +7881,116 @@ fn files_from_unwritable_destination_root_fails_and_is_left_alone() {
     assert_eq!(mode, 0o500, "the unlisted root keeps its mode");
     assert!(!t.path("dst/a").exists());
 }
+
+// ---- syq map ----
+
+fn syq_map_in(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("map")
+        .args(args)
+        .current_dir(dir)
+        .run()
+        .expect("run syq map")
+}
+
+fn map_lines(out: &Output) -> Vec<serde_json::Value> {
+    assert!(
+        out.status.success(),
+        "syq map failed: status {:?}\nstdout:\n{}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout.clone())
+        .expect("map output is UTF-8")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("map line is JSON"))
+        .collect()
+}
+
+fn map_path(value: &serde_json::Value, key: &str) -> String {
+    assert_eq!(value[key]["encoding"], "utf-8");
+    value[key]["value"]
+        .as_str()
+        .expect("tagged path value")
+        .to_string()
+}
+
+#[test]
+fn native_map_contents_emits_identity_parent_first() {
+    let t = Tmp::new();
+    write(&t.path("src/Berlin/IMG.JPG"), b"img");
+    write(&t.path("src/Notes.TXT"), b"hello");
+    std::os::unix::fs::symlink("Notes.TXT", t.path("src/Link.TXT")).unwrap();
+    let lines = map_lines(&syq_map_in(&t.path(""), &["--src-src", "src"]));
+    let dsts: Vec<String> = lines.iter().map(|v| map_path(v, "dst")).collect();
+    assert_eq!(dsts, ["Berlin", "Berlin/IMG.JPG", "Link.TXT", "Notes.TXT"]);
+    for v in &lines {
+        assert_eq!(map_path(v, "src"), map_path(v, "dst"));
+    }
+    assert_eq!(lines[0]["kind"], "dir");
+    assert!(lines[0].get("size").is_none());
+    assert_eq!(lines[1]["kind"], "file");
+    assert_eq!(lines[1]["size"], 3);
+    assert!(lines[1]["mtime"].is_i64());
+    assert_eq!(lines[2]["kind"], "symlink");
+    assert!(lines[2].get("size").is_none());
+    assert_eq!(lines[3]["kind"], "file");
+}
+
+#[test]
+fn native_map_named_cwd_and_as_rename() {
+    let t = Tmp::new();
+    write(&t.path("photos/x/a.jpg"), b"a");
+    // Named selector: dst gains the basename prefix.
+    let lines = map_lines(&syq_map_in(&t.path(""), &["photos"]));
+    let dsts: Vec<String> = lines.iter().map(|v| map_path(v, "dst")).collect();
+    assert_eq!(dsts, ["photos", "photos/x", "photos/x/a.jpg"]);
+    for v in &lines {
+        assert_eq!(map_path(v, "src"), map_path(v, "dst"));
+    }
+    // -C: emitted src stays relative to the base.
+    let lines = map_lines(&syq_map_in(&t.path(""), &["-C", "photos", "--src", "x"]));
+    let dsts: Vec<String> = lines.iter().map(|v| map_path(v, "dst")).collect();
+    assert_eq!(dsts, ["x", "x/a.jpg"]);
+    assert_eq!(map_path(&lines[0], "src"), "x");
+    // --as renames the single selected root; src spelling is unchanged.
+    let lines = map_lines(&syq_map_in(&t.path(""), &["photos", "--as", "album"]));
+    let dsts: Vec<String> = lines.iter().map(|v| map_path(v, "dst")).collect();
+    assert_eq!(dsts, ["album", "album/x", "album/x/a.jpg"]);
+    let srcs: Vec<String> = lines.iter().map(|v| map_path(v, "src")).collect();
+    assert_eq!(srcs, ["photos", "photos/x", "photos/x/a.jpg"]);
+}
+
+#[test]
+fn native_map_refusals() {
+    let t = Tmp::new();
+    write(&t.path("d1/n"), b"1");
+    write(&t.path("d2/n"), b"2");
+    let refuse = |args: &[&str], needle: &str| {
+        let out = syq_map_in(&t.path(""), args);
+        assert!(!out.status.success(), "expected failure for {args:?}");
+        let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+        assert!(stderr.contains(needle), "stderr for {args:?}: {stderr}");
+    };
+    refuse(&["/etc"], "root-relative");
+    refuse(&["--src-src", "d1", "--src-src", "d2"], "only selector");
+    refuse(&["--src-src", "d1", "d2"], "only selector");
+    refuse(&["d1/n", "d2/n"], "same destination name");
+    refuse(&["d1", "--into-new", "z"], "never contacts a destination");
+    refuse(&["d1", "--from", "remotehost"], "not yet supported");
+}
+
+#[test]
+fn native_map_refuses_non_utf8_names() {
+    let t = Tmp::new();
+    write(&t.path("src/ok.txt"), b"ok");
+    let bad = t
+        .path("src")
+        .join(std::ffi::OsString::from_vec(b"bad\xff.dat".to_vec()));
+    write(&bad, b"x");
+    let out = syq_map_in(&t.path(""), &["--src-src", "src"]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(stderr.contains("UTF-8"), "stderr: {stderr}");
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -8363,3 +8363,95 @@ fn native_cp_results_without_mapping_and_refusals() {
     assert!(!out.status.success());
     assert!(String::from_utf8_lossy(&out.stderr).contains("only available on syq cp"));
 }
+
+// ---- review-round fixes ----
+
+#[test]
+fn native_map_normalizes_dot_components_and_rejects_dotdot() {
+    let t = Tmp::new();
+    write(&t.path("photos/a.jpg"), b"a");
+    let lines = map_lines(&syq_map_in(&t.path(""), &["./photos"]));
+    let dsts: Vec<String> = lines.iter().map(|v| map_path(v, "dst")).collect();
+    assert_eq!(dsts, ["photos", "photos/a.jpg"]);
+    assert_eq!(map_path(&lines[0], "src"), "photos");
+    let out = syq_map_in(&t.path("photos"), &["--src", "../photos"]);
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("`..` component"));
+}
+
+#[test]
+fn native_cp_results_refuses_dry_run() {
+    let t = Tmp::new();
+    write(&t.path("src/f.txt"), b"x");
+    let out = syq_cp_in(
+        &t.path(""),
+        &[
+            "--src-src",
+            "src",
+            "--into",
+            "dst",
+            "--results",
+            "r.ndjson",
+            "-n",
+        ],
+        None,
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("does not support --dry-run"));
+}
+
+#[test]
+fn native_cp_results_implicit_dir_failure_is_not_a_retry_entry() {
+    let t = Tmp::new();
+    write(&t.path("src/a.txt"), b"abc");
+    fs::create_dir_all(t.path("dst")).unwrap();
+    fs::set_permissions(t.path("dst"), fs::Permissions::from_mode(0o555)).unwrap();
+    let manifest = entry_line("a.txt", "sub/a.txt", None);
+    let out = syq_cp_in(
+        &t.path(""),
+        &[
+            "--mapping",
+            "-",
+            "-C",
+            "src",
+            "--into",
+            "dst",
+            "--results",
+            "r.ndjson",
+            "-q",
+        ],
+        Some(manifest.as_bytes()),
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(23),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let lines: Vec<serde_json::Value> = String::from_utf8(read(&t.path("r.ndjson")))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let dir = lines
+        .iter()
+        .find(|v| v["type"] == "operation_result" && v["dst"]["value"] == "sub")
+        .expect("implicit dir record");
+    assert_eq!(dir["disposition"], "failed");
+    assert_eq!(dir["retryable"], "no");
+    assert!(dir.get("src").is_none(), "implicit dirs have no source");
+    // The documented retry filter selects only records that are valid
+    // mapping entries: failed, retryable, carrying a src.
+    let retryable: Vec<&serde_json::Value> = lines
+        .iter()
+        .filter(|v| {
+            v["type"] == "operation_result"
+                && v["disposition"] == "failed"
+                && v["retryable"] != "no"
+        })
+        .collect();
+    assert!(!retryable.is_empty(), "the file failure is retryable");
+    for v in &retryable {
+        assert!(v.get("src").is_some(), "retry candidates carry src: {v}");
+    }
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -8795,3 +8795,55 @@ fn native_cp_results_implicit_dir_failure_is_not_a_retry_entry() {
         assert!(v.get("src").is_some(), "retry candidates carry src: {v}");
     }
 }
+
+#[test]
+fn native_cp_mapping_specials_are_visible_skips_not_failures() {
+    let t = Tmp::new();
+    write(&t.path("src/a.txt"), b"abc");
+    fs::create_dir_all(t.path("src")).unwrap();
+    let fifo = t.path("src/pipe");
+    let c = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
+    assert_eq!(unsafe { libc::mkfifo(c.as_ptr(), 0o644) }, 0);
+    let manifest = format!(
+        "{}{}",
+        entry_line("a.txt", "a.txt", None),
+        entry_line("pipe", "pipe", Some("special")),
+    );
+    let out = syq_cp_in(
+        &t.path(""),
+        &[
+            "--mapping",
+            "-",
+            "-C",
+            "src",
+            "--into",
+            "dst",
+            "--results",
+            "r.ndjson",
+            "-q",
+        ],
+        Some(manifest.as_bytes()),
+    );
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(!t.path("dst/pipe").exists());
+    assert_eq!(read(&t.path("dst/a.txt")), b"abc");
+    let lines: Vec<serde_json::Value> = String::from_utf8(read(&t.path("r.ndjson")))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let skipped = lines
+        .iter()
+        .find(|v| v["type"] == "operation_result" && v["dst"]["value"] == "pipe")
+        .expect("skipped record");
+    assert_eq!(skipped["disposition"], "skipped");
+    assert_eq!(skipped["kind"], "special");
+    assert!(skipped.get("retryable").is_none());
+    let last = lines.last().unwrap();
+    assert_eq!(last["status"], "success");
+    assert_eq!(last["files_excluded"], 1);
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7994,3 +7994,212 @@ fn native_map_refuses_non_utf8_names() {
     let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
     assert!(stderr.contains("UTF-8"), "stderr: {stderr}");
 }
+
+// ---- syq cp --mapping ----
+
+fn syq_cp_in(dir: &Path, args: &[&str], stdin: Option<&[u8]>) -> Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_syq"));
+    cmd.arg("cp").args(args).current_dir(dir);
+    match stdin {
+        None => cmd.run().expect("run syq cp"),
+        Some(data) => {
+            cmd.stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            let mut child = cmd.spawn().expect("spawn syq cp");
+            child
+                .stdin
+                .take()
+                .expect("stdin")
+                .write_all(data)
+                .expect("write manifest");
+            child.wait_with_output().expect("wait syq cp")
+        }
+    }
+}
+
+fn entry_line(src: &str, dst: &str, kind: Option<&str>) -> String {
+    let kind = kind.map_or(String::new(), |k| format!(",\"kind\":\"{k}\""));
+    format!(
+        "{{\"src\":{{\"encoding\":\"utf-8\",\"value\":\"{src}\"}},\"dst\":{{\"encoding\":\"utf-8\",\"value\":\"{dst}\"}}{kind}}}\n"
+    )
+}
+
+#[test]
+fn native_cp_mapping_renames_creates_ancestors_and_streams_stdin() {
+    let t = Tmp::new();
+    write(&t.path("src/Berlin/IMG.JPG"), b"img");
+    write(&t.path("src/Notes.TXT"), b"hello");
+    write(&t.path("dst/unrelated.txt"), b"keep");
+    let manifest = format!(
+        "{}{}{}",
+        entry_line("Berlin", "berlin", Some("dir")),
+        entry_line("Berlin/IMG.JPG", "berlin/2024/07/img.jpg", Some("file")),
+        entry_line("Notes.TXT", "notes.txt", None),
+    );
+    // Dry run writes nothing.
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "-", "-C", "src", "--into", "dst", "-n", "-q"],
+        Some(manifest.as_bytes()),
+    );
+    assert!(
+        out.status.success(),
+        "dry-run failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(!t.path("dst/berlin").exists());
+    // Real run from stdin: renames, implicit 2024/07 ancestors, keeps extras.
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "-", "-C", "src", "--into", "dst", "-q"],
+        Some(manifest.as_bytes()),
+    );
+    assert!(
+        out.status.success(),
+        "cp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(read(&t.path("dst/berlin/2024/07/img.jpg")), b"img");
+    assert_eq!(read(&t.path("dst/notes.txt")), b"hello");
+    assert_eq!(read(&t.path("dst/unrelated.txt")), b"keep");
+    // Rerun converges cleanly.
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "-", "-C", "src", "--into", "dst", "-q"],
+        Some(manifest.as_bytes()),
+    );
+    assert!(out.status.success());
+}
+
+#[test]
+fn native_cp_mapping_file_manifest_and_base64_src() {
+    let t = Tmp::new();
+    let bad = t
+        .path("src")
+        .join(std::ffi::OsString::from_vec(b"caf\xe9.txt".to_vec()));
+    write(&bad, b"latin1 name");
+    let b64 = base64::engine::general_purpose::STANDARD.encode(b"caf\xe9.txt");
+    let manifest = format!(
+        "{{\"src\":{{\"encoding\":\"base64\",\"value\":\"{b64}\"}},\"dst\":{{\"encoding\":\"utf-8\",\"value\":\"cafe.txt\"}}}}\n"
+    );
+    write(&t.path("m.ndjson"), manifest.as_bytes());
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "m.ndjson", "-C", "src", "--into", "out", "-q"],
+        None,
+    );
+    assert!(
+        out.status.success(),
+        "cp failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(read(&t.path("out/cafe.txt")), b"latin1 name");
+}
+
+#[test]
+fn native_cp_mapping_entry_failures_are_partial_not_fatal() {
+    let t = Tmp::new();
+    write(&t.path("src/real.txt"), b"real");
+    fs::create_dir_all(t.path("src/adir")).unwrap();
+    let manifest = format!(
+        "{}{}{}",
+        entry_line("missing.txt", "a.txt", None),
+        entry_line("adir", "b.txt", Some("file")),
+        entry_line("real.txt", "c.txt", None),
+    );
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "-", "-C", "src", "--into", "dst", "-q"],
+        Some(manifest.as_bytes()),
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(23),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(stderr.contains("does not exist"), "{stderr}");
+    assert!(stderr.contains("not the declared file"), "{stderr}");
+    assert_eq!(read(&t.path("dst/c.txt")), b"real");
+    assert!(!t.path("dst/a.txt").exists());
+    assert!(!t.path("dst/b.txt").exists());
+}
+
+#[test]
+fn native_cp_mapping_hard_refusals() {
+    let t = Tmp::new();
+    write(&t.path("src/x.txt"), b"x");
+    let refuse = |manifest: &str, needle: &str| {
+        let out = syq_cp_in(
+            &t.path(""),
+            &["--mapping", "-", "-C", "src", "--into", "dst", "-q"],
+            Some(manifest.as_bytes()),
+        );
+        assert!(!out.status.success(), "expected refusal for {manifest:?}");
+        let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+        assert!(stderr.contains(needle), "wanted {needle:?} in: {stderr}");
+    };
+    let dup = format!(
+        "{}{}",
+        entry_line("x.txt", "same", None),
+        entry_line("x.txt", "same", None)
+    );
+    refuse(&dup, "duplicate destination");
+    refuse(
+        "{\"src\":{\"encoding\":\"utf-8\",\"value\":\"x.txt\"},\"dst\":{\"encoding\":\"utf-8\",\"value\":\"../out\"}}\n",
+        "component",
+    );
+    refuse(
+        "{\"src\":{\"encoding\":\"utf-8\",\"value\":\"/etc/passwd\"},\"dst\":{\"encoding\":\"utf-8\",\"value\":\"y\"}}\n",
+        "absolute",
+    );
+    refuse(
+        "{\"src\":{\"encoding\":\"utf-8\",\"value\":\"x.txt\"},\"dst\":{\"encoding\":\"utf-8\",\"value\":\"y\"},\"knd\":\"file\"}\n",
+        "unknown field",
+    );
+    // Parse-level grammar refusals.
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "-", "src/x.txt", "--into", "dst"],
+        Some(b""),
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("replaces source selectors"));
+    let out = syq_cp_in(&t.path(""), &["--mapping", "-", "--as", "exact"], Some(b""));
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("--as conflicts with --mapping"));
+}
+
+#[test]
+fn native_cp_mapping_end_to_end_map_pipeline() {
+    let t = Tmp::new();
+    write(&t.path("src/Berlin/IMG.JPG"), b"img");
+    write(&t.path("src/Notes.TXT"), b"hello");
+    // syq map | (lowercase transform) | syq cp --mapping -
+    let map_out = syq_map_in(&t.path(""), &["--src-src", "src"]);
+    assert!(map_out.status.success());
+    let transformed: String = String::from_utf8(map_out.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| {
+            let mut v: serde_json::Value = serde_json::from_str(line).unwrap();
+            let lower = v["dst"]["value"].as_str().unwrap().to_lowercase();
+            v["dst"]["value"] = serde_json::Value::String(lower);
+            format!("{v}\n")
+        })
+        .collect();
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "-", "-C", "src", "--into", "pub", "-q"],
+        Some(transformed.as_bytes()),
+    );
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(read(&t.path("pub/berlin/img.jpg")), b"img");
+    assert_eq!(read(&t.path("pub/notes.txt")), b"hello");
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -8366,7 +8366,7 @@ fn entry_line(src: &str, dst: &str, kind: Option<&str>) -> String {
 }
 
 #[test]
-fn native_cp_mapping_renames_creates_ancestors_and_streams_stdin() {
+fn native_cp_mapping_renames_creates_ancestors_and_reads_stdin() {
     let t = Tmp::new();
     write(&t.path("src/Berlin/IMG.JPG"), b"img");
     write(&t.path("src/Notes.TXT"), b"hello");
@@ -8836,14 +8836,53 @@ fn native_cp_mapping_specials_are_visible_skips_not_failures() {
         .lines()
         .map(|line| serde_json::from_str(line).unwrap())
         .collect();
-    let skipped = lines
-        .iter()
-        .find(|v| v["type"] == "operation_result" && v["dst"]["value"] == "pipe")
-        .expect("skipped record");
-    assert_eq!(skipped["disposition"], "skipped");
-    assert_eq!(skipped["kind"], "special");
-    assert!(skipped.get("retryable").is_none());
+    // Excluded entries are aggregate-only: no per-entry record, no failure.
+    assert!(
+        !lines
+            .iter()
+            .any(|v| v["type"] == "operation_result" && v["dst"]["value"] == "pipe"),
+        "policy exclusions appear only in terminal aggregates"
+    );
     let last = lines.last().unwrap();
     assert_eq!(last["status"], "success");
     assert_eq!(last["files_excluded"], 1);
+}
+
+#[test]
+fn native_cp_mapping_whole_manifest_preflight_writes_nothing() {
+    let t = Tmp::new();
+    write(&t.path("src/a.txt"), b"a");
+    write(&t.path("src/b.txt"), b"b");
+    // A duplicate destination far apart: refused with nothing written,
+    // even though the first entries were valid.
+    let mut manifest = String::new();
+    manifest.push_str(&entry_line("a.txt", "same.txt", None));
+    for i in 0..5000 {
+        manifest.push_str(&entry_line("b.txt", &format!("fill/{i}.txt"), None));
+    }
+    manifest.push_str(&entry_line("b.txt", "same.txt", None));
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "-", "-C", "src", "--into", "dst", "-q"],
+        Some(manifest.as_bytes()),
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("duplicate destination"));
+    // The --into container is created eagerly as with --files-from, but no
+    // entry may have been applied.
+    assert_eq!(fs::read_dir(t.path("dst")).unwrap().count(), 0);
+    // Declared-kind ancestor conflict is refused up front too.
+    let conflict = format!(
+        "{}{}",
+        entry_line("a.txt", "p", Some("file")),
+        entry_line("b.txt", "p/q.txt", None),
+    );
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "-", "-C", "src", "--into", "dst", "-q"],
+        Some(conflict.as_bytes()),
+    );
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("not dir"));
+    assert_eq!(fs::read_dir(t.path("dst")).unwrap().count(), 0);
 }


### PR DESCRIPTION
Implements the native mapping surface designed in `current-plans/mapping-input.md` plus the minimal machine-results slice from `current-plans/automation-interface.md`'s 2026-09-02 kickoff update, with user-facing docs in `MAPPINGS.md` and a README section.

- **`syq map`**: emits the resolved selection and placement of a copy as NDJSON (tagged UTF-8 paths, `kind`, `size`/`mtime` on files, byte-sorted parent-first). Local and read-only; selectors are normalized like `--files-from` (`.`/empty dropped, `..` refused) so emitted paths are always valid manifest paths; non-UTF-8 names abort emission; `--as` renames the single selected root.
- **`syq cp --mapping FILE|-`**: executes a manifest. The whole manifest is read and validated first — parse errors, duplicate destinations, and declared-kind ancestor conflicts refuse the run before any entry is applied (the `--into` container is created eagerly, as with `--files-from`); sources are then statted and planned in chunks, and transfers begin once planning completes. Entries flow through the existing claim/collision machinery keyed by destination, with a per-destination source override for the read side. Implicit destination ancestors are created with default metadata; missing sources and declared-kind mismatches fail that entry (exit 23) with the rest copied; policy exclusions (specials under the fixed `-rlt`) are aggregate-only, per the documented contract. `--as`, cp-prune, remote-to-remote, and the command-restricted receiver refuse it. Streaming consumption is not claimed; a `--stream` opt-in with a documented weaker preflight is a recorded follow-up for when a consumer exists.
- **`syq cp --results FILE|-`**: automation schema version 0 (explicitly unstable preview) — a `run` record, per-mutation `operation_result` records (sequence numbers allocated under the output lock), `error` records, and one flushed terminal `result`. Failed records carry `src`/`dst`/`kind` and round-trip as retry mapping entries; implicit-ancestor failures carry no fabricated source and are marked non-retryable so the documented retry filter selects only valid entries. `--dry-run` is refused pending the deferred trace design.
- MAPPINGS.md's pipeline examples are Bash blocks with `set -o pipefail`, note that a truncated producer yields a valid prefix a re-run completes, and show a materialized-manifest `&&` variant.

Sixteen new integration tests; `cargo fmt`, `clippy -D warnings`, and the full `--all-targets` suite (220+273+9) green at head. Not exercised: remote endpoints for `--mapping`/`--results` (same conn machinery as `--files-from`; remote-to-remote is refused at parse).

Whether this ships in the promoted launch stays a separate decision per the plan doc; merging only puts it on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZUmpPYue9iHrVTkmeDf8K
