### PR TITLE
Release syq 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Version bump for the syq 0.1.6 release. This release includes the work merged since v0.1.5 and exercises the newly published Python SDK against the candidate binary before the release tag can be accepted.

The first Python SDK release, syq 0.0.1, was published through the configured PyPI OIDC trusted publisher and verified from a clean install against pinned syq 0.1.5.

Local checks at fe5f225b386c:
- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets (220 unit, 257 local integration, 9 update)
- crate packaging and installer tests
- release signing/assembly and secret-tooling tests
- complete release-script shellcheck inventory
- 18 Python SDK tests against the syq 0.1.6 candidate on Python 3.10

After merge and a green exact-commit master CI run, the signed v0.1.6 tag will publish syq. The Python release-preparation workflow should then open the 0.0.2 mapping PR automatically.