### PR TITLE
Add native BLAKE3 content hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +152,19 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.1",
+]
 
 [[package]]
 name = "block-buffer"
@@ -299,6 +318,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cpubits"
@@ -1630,6 +1655,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "base64",
+ "blake3",
  "clap",
  "ed25519-dalek 3.0.0",
  "flate2",
@@ -1652,7 +1678,6 @@ dependencies = [
  "ssh-key",
  "tempfile",
  "ureq",
- "xxhash-rust",
  "zstd",
 ]
 
@@ -1894,12 +1919,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "xxhash-rust"
-version = "0.8.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1", features = ["derive"] }
 postcard = { version = "1", features = ["alloc", "use-std"] }
 jwalk = "0.9"
 ignore = "0.4"
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
+blake3 = "1"
 zstd = "0.13"
 libc = "0.2"
 shell-words = "1"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ syq cp --from server --cwd /data --src a --src b --into ./data
 syq cp --src-file report --src-dir assets --into /backup
 syq cp --src-files a.txt b.txt --src-dirs images fonts --into /archive
 syq cp report --to server --as-new /reports/final
+syq cp --hash report --to server --as-existing /reports/final
 syq cp-prune --src-src build --to server --into-existing /srv/app
 syq rm cache old-output
 syq rm --from server --cwd /srv --src old-output
@@ -250,15 +251,18 @@ call are not rolled back. Native `rm` has no detached mode.
 The first native fidelity default is exactly `-rlt`: it recurses through
 directories, copies symlinks as symlinks, and retains mtimes. Owner, group,
 modes, special files,
-hard links, ACLs, xattrs, filtering, comparison policy, and the automation API
+hard links, ACLs, xattrs, filtering, other copy policies, and the automation API
 are intentionally not frozen by this first grammar. Use `syq rsync` when the
 current compatibility options for those capabilities are needed.
 
 All native commands accept `-n`/`--dry-run`, `-v`/`--verbose`, `-q`/`--quiet`,
 `-j`/`--connections`, `--progress`/`--no-progress`, and `--progress-json` in
 addition to their endpoint and selector options. `cp` and `cp-prune` also
-accept `--no-compress`, `--bwlimit RATE`, and `--stats`; the bandwidth limit
-applies only to file data, not scanning, hashing, metadata, or pruning. A
+accept `--hash`, `--no-compress`, `--bwlimit RATE`, and `--stats`. `--hash`
+compares existing regular-file contents with full BLAKE3 digests instead of
+trusting equal size and modification time; it does not add a second
+post-transfer verification pass. The bandwidth limit applies only to file
+data, not scanning, hashing, metadata, or pruning. A
 command-restricted remote-to-remote receiver independently enforces the signed
 aggregate limit. A receiver installed by an older syq rejects that V2 grant
 safely; rerun `syq enroll HOST:DEST` to refresh an existing enrollment to the
@@ -266,8 +270,8 @@ current binary. `cp-prune` additionally
 accepts `--max-delete`; `rm` additionally accepts `--root` and `--follow` plus
 its endpoint-side removal semantics.
 
-Preservation policies, filters, comparison controls, block and split sizing,
-and SSH/transport configuration remain available only through `syq rsync`;
+Preservation policies, filters, other comparison and write controls, block and
+split sizing, and SSH/transport configuration remain available only through `syq rsync`;
 sharing the transfer engine does not expose those options in native mode.
 Remote-to-remote copies still use the ordinary automatic transport. Native raw
 path bytes are relayed through syq's protocol when they cannot be represented
@@ -318,7 +322,7 @@ explicitly say otherwise.
 | `--insecure-links` | Allow a receiving process to follow destination-path symlinks owned by other users (unsafe legacy opt-out) |
 | `--progress-json` | One JSON line per second on stderr |
 | `--stats` | Summary counts at the end |
-| `-c`, `--checksum` | Compare every file block by block instead of size+mtime; repair mismatches |
+| `-c`, `--checksum` | Compare every file with BLAKE3 instead of size+mtime; repair mismatches (native spelling: `--hash`) |
 | `--verify-only` | Hash every file in the run's scope on both sides and report differences; write nothing |
 | `--inplace` | Write directly into destination files (no partial + rename) |
 | `--checkpoint FILE` | Avoid completed-file destination lookups on later runs; normal resume does not need it |
@@ -785,9 +789,9 @@ needed for this normal resumption. Resume works at two levels.
 
 - Files whose size and mtime already match are skipped (the rsync quick check).
 - If this job's range-transfer `.name.syq-part.<job-id>` exists, both sides
-  hash it and the source in `--block-size` blocks and only the mismatching
-  blocks are sent. A leftover is reused only when it can be safely opened as a
-  singly-linked regular file without following a symlink; numeric ownership is
+  hash it and the source with full BLAKE3 digests in `--block-size` blocks and
+  only the mismatching blocks are sent. A leftover is reused only when it can
+  be safely opened as a singly-linked regular file without following a symlink; numeric ownership is
   deliberately not required because NFS root squashing and some FUSE/CIFS
   mounts remap it. A safe leftover that cannot be made mode `0600` is discarded
   and recreated instead of permanently blocking that file. Anything else is
@@ -895,9 +899,10 @@ modify destination files during a transfer.
 
 Always:
 
-- Every block carries an xxh3 hash checked on receipt (read side and write
-  side); a mismatch aborts that file with an error (exit 23) rather than
-  silently continuing — it indicates transport corruption, which is rare.
+- Every transferred block carries a full BLAKE3 digest computed by the reader
+  and checked by the receiver; a mismatch aborts that file with an error (exit
+  23) rather than silently continuing — it indicates transport corruption,
+  which is rare.
 - After a file completes, the source is re-stat'ed. If its size or mtime
   changed during the transfer the file is redone (up to three attempts), then
   reported as an error.
@@ -907,10 +912,19 @@ Always:
 
 On request:
 
-- `--verify-only` hashes every file on both sides in parallel and reports
-  `DIFFERS` / `MISSING`.
-- `-c` does the block comparison for every file, not just ones that fail the
-  quick check, and repairs what differs.
+- `--verify-only` hashes every file on both sides with BLAKE3 in parallel and
+  reports `DIFFERS` / `MISSING`.
+- `-c`/`--checksum` (`--hash` in the native interface) does the BLAKE3 block
+  comparison for every file, not just ones that fail the quick check, and
+  repairs what differs.
+
+Full BLAKE3 digests replaced XXH3 for content decisions in September 2026 so a
+digest match is collision-resistant rather than merely a fast corruption
+check. In one release-mode, single-thread CPU microbenchmark with 4 MiB inputs
+on an AMD EPYC 9454P, BLAKE3 processed 6.69 GB/s, compared with 31.25 GB/s for
+XXH3 and 1.86 GB/s for SHA-256. This is design-rationale data, not an end-to-end
+copy-speed claim; filesystem and transport work usually dominate, and syq
+hashes concurrently across workers.
 
 Not verified: directory and symlink metadata are set but not read back; a
 source that changes *between* the final re-stat and the next block of another

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -619,6 +619,9 @@ struct NativeOperationalArgs {
 struct NativeCopyOperationalArgs {
     #[command(flatten)]
     common: NativeOperationalArgs,
+    /// Hash existing source and destination files instead of trusting size and modification time
+    #[arg(long)]
+    hash: bool,
     /// Disable transport compression
     #[arg(long)]
     no_compress: bool,
@@ -964,10 +967,12 @@ fn apply_native_copy_operational(
 ) -> Result<()> {
     let NativeCopyOperationalArgs {
         common,
+        hash,
         no_compress,
         bwlimit,
         stats,
     } = operational;
+    args.checksum = hash;
     args.no_compress = no_compress;
     if no_compress {
         args.compress = false;
@@ -1392,6 +1397,13 @@ mod tests {
         assert!(!args.owner);
         assert!(!args.group);
         assert!(!args.devices);
+    }
+
+    #[test]
+    fn native_hash_selects_content_comparison() {
+        let argv = ["--hash", "source", "--into", "destination"].map(std::ffi::OsString::from);
+        let args = parse_native_copy(&argv, Interface::NativeCp).unwrap();
+        assert!(args.checksum);
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -369,6 +369,9 @@ pub fn run(
     if !args.compress {
         remote.push("--no-compress".into());
     }
+    if args.interface != Interface::Rsync && args.checksum {
+        remote.push("--hash".into());
+    }
     if let Some(j) = args.connections_opt {
         remote.push("-j".into());
         remote.push(j.to_string());

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -16,13 +16,16 @@ use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
-use xxhash_rust::xxh3::{xxh3_128, xxh3_64, Xxh3};
 
 pub const PARTIAL_MARKER: &str = ".syq-part.";
 const FD_CACHE_MAX: usize = 16;
 const COMMON_NAME_MAX: usize = 255;
 const COMPACT_HASH_BYTES: usize = 10;
 const NAME_MAX_CACHE_CAP: usize = 1024;
+
+pub(crate) fn content_digest(data: &[u8]) -> ContentDigest {
+    *blake3::hash(data).as_bytes()
+}
 
 #[cfg(target_os = "linux")]
 #[derive(Clone, Copy, Default)]
@@ -2119,7 +2122,7 @@ fn parallel_map<T: Sync, R: Send>(items: &[T], f: impl Fn(&T) -> R + Sync) -> Ve
 /// Hash exactly `len` bytes in fixed blocks. A short reader contributes the
 /// bytes it has and empty hashes for the missing blocks, matching both source
 /// and destination behavior through one implementation.
-fn hash_reader(reader: &mut impl Read, block: u64, len: u64) -> Result<Vec<u64>> {
+fn hash_reader(reader: &mut impl Read, block: u64, len: u64) -> Result<Vec<ContentDigest>> {
     if !hash_response_fits(block, len) {
         bail!("hash block size or response count is outside protocol limits");
     }
@@ -2137,10 +2140,10 @@ fn hash_reader(reader: &mut impl Read, block: u64, len: u64) -> Result<Vec<u64>>
             }
             got += read;
         }
-        hashes.push(xxh3_64(&buf[..got]));
+        hashes.push(content_digest(&buf[..got]));
         if got < want {
             while hashes.len() < n {
-                hashes.push(xxh3_64(&[]));
+                hashes.push(content_digest(&[]));
             }
             break;
         }
@@ -2436,7 +2439,7 @@ impl FsOps {
         len: u64,
         condition: TargetCondition,
         guard: Option<&ContainerGuard>,
-    ) -> Result<(Vec<u64>, u64)> {
+    ) -> Result<(Vec<ContentDigest>, u64)> {
         let p = resolve(path);
         #[cfg(debug_assertions)]
         if std::env::var_os("SYQ_TEST_FAIL_HASH_BASIS").is_some() {
@@ -2740,12 +2743,12 @@ impl FsOps {
         &mut self,
         target: PartialTarget<'_>,
         data: &[u8],
-        hash: u64,
+        hash: ContentDigest,
         meta: &Meta,
         flags: u8,
         condition: TargetCondition,
     ) -> Result<()> {
-        if xxh3_64(data) != hash {
+        if content_digest(data) != hash {
             bail!("block hash mismatch on receive");
         }
         let p = resolve(target.path);
@@ -2808,7 +2811,7 @@ impl FsOps {
         block: u64,
         len: u64,
         guard: Option<&ContainerGuard>,
-    ) -> Result<Vec<u64>> {
+    ) -> Result<Vec<ContentDigest>> {
         let p = resolve(path);
         let p = if which == Which::Partial {
             if guard.is_some() {
@@ -2855,7 +2858,7 @@ impl FsOps {
         let mut data = vec![0u8; len as usize];
         f.read_exact_at(&mut data, off)
             .with_context(|| format!("read {} @{off}+{len}", p.display()))?;
-        let hash = xxh3_64(&data);
+        let hash = content_digest(&data);
         Ok(Response::Block { off, hash, data })
     }
 
@@ -2865,10 +2868,10 @@ impl FsOps {
         inplace: bool,
         attempt: u32,
         off: u64,
-        hash: u64,
+        hash: ContentDigest,
         data: &[u8],
     ) -> Result<()> {
-        if xxh3_64(data) != hash {
+        if content_digest(data) != hash {
             bail!("block hash mismatch on receive @{off}");
         }
         let p = resolve(target.path);
@@ -3028,7 +3031,7 @@ impl FsOps {
         } else {
             open_existing_regular(&p, false)?
         };
-        let mut h = Xxh3::new();
+        let mut h = blake3::Hasher::new();
         let mut buf = vec![0u8; 1 << 20];
         let mut size = 0u64;
         loop {
@@ -3039,10 +3042,9 @@ impl FsOps {
             h.update(&buf[..n]);
             size += n as u64;
         }
-        let _ = xxh3_128; // keep the symbol in case of future use
         Ok(Response::FileHash {
             size,
-            hash: h.digest128(),
+            hash: *h.finalize().as_bytes(),
         })
     }
 
@@ -4014,13 +4016,25 @@ mod tests {
         assert_eq!(
             hashes,
             vec![
-                xxh3_64(&vec![b'a'; block]),
-                xxh3_64(&vec![b'b'; block]),
-                xxh3_64(b"tail"),
-                xxh3_64(b""),
+                content_digest(&vec![b'a'; block]),
+                content_digest(&vec![b'b'; block]),
+                content_digest(b"tail"),
+                content_digest(b""),
             ]
         );
         assert!(hash_reader(&mut &b"x"[..], 0, 1).is_err());
         assert!(hash_reader(&mut &b"x"[..], 1, 1).is_err());
+    }
+
+    #[test]
+    fn content_digest_is_full_blake3() {
+        assert_eq!(
+            content_digest(b""),
+            [
+                0xaf, 0x13, 0x49, 0xb9, 0xf5, 0xf9, 0xa1, 0xa6, 0xa0, 0x40, 0x4d, 0xea, 0x36, 0xdc,
+                0xc9, 0x49, 0x9b, 0xcb, 0x25, 0xc9, 0xad, 0xc1, 0x12, 0xb7, 0xcc, 0x9a, 0x93, 0xca,
+                0xe4, 0x1f, 0x32, 0x62,
+            ]
+        );
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -11,8 +11,7 @@ use std::io::{self, BufReader, BufWriter, Read, Write};
 pub const MAX_FRAME: usize = 256 * 1024 * 1024;
 pub const MIN_HASH_BLOCK_BYTES: u64 = 64 * 1024;
 pub const MAX_HASH_BLOCK_BYTES: u64 = 64 * 1024 * 1024;
-// Postcard encodes a u64 as a base-128 varint of at most ten bytes.
-const HASH_RESPONSE_BYTES_PER_ENTRY: u64 = 10;
+const HASH_RESPONSE_BYTES_PER_ENTRY: u64 = 32;
 const HASH_RESPONSE_OVERHEAD: u64 = 24;
 const COMPRESS_MIN: usize = 512;
 const COMPRESS_LEVEL: i32 = 1;
@@ -30,6 +29,8 @@ pub fn hash_response_fits(block: u64, len: u64) -> bool {
 
 /// Path bytes, as given by the user (absolute, or relative to the server's cwd).
 pub type PathBytes = Vec<u8>;
+/// Full BLAKE3 digest used whenever content equality affects copy behavior.
+pub type ContentDigest = [u8; 32];
 
 /// Stable identifier for one logical copy command. Destination partial names
 /// include this value so unrelated commands never write the same staged inode.
@@ -147,7 +148,7 @@ pub struct SmallPut {
     pub partial_id: PartialId,
     #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
-    pub hash: u64,
+    pub hash: ContentDigest,
     pub meta: Meta,
     pub flags: u8,
     pub condition: TargetCondition,
@@ -159,7 +160,7 @@ pub struct SmallPut {
 pub struct SmallBlock {
     #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
-    pub hash: u64,
+    pub hash: ContentDigest,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
@@ -425,7 +426,7 @@ pub enum Request {
         partial_id: PartialId,
         attempt: u32,
         off: u64,
-        hash: u64,
+        hash: ContentDigest,
         #[serde(with = "serde_bytes")]
         data: Vec<u8>,
         guard: Option<ContainerGuard>,
@@ -498,21 +499,21 @@ pub enum Response {
     },
     Applied(Vec<Option<String>>),
     PartialSize(Option<u64>),
-    Hashes(Vec<u64>),
+    Hashes(Vec<ContentDigest>),
     HeldHashes {
-        hashes: Vec<u64>,
+        hashes: Vec<ContentDigest>,
         len: u64,
     },
     Block {
         off: u64,
-        hash: u64,
+        hash: ContentDigest,
         #[serde(with = "serde_bytes")]
         data: Vec<u8>,
     },
     SmallBlocks(Vec<std::result::Result<SmallBlock, String>>),
     FileHash {
         size: u64,
-        hash: u128,
+        hash: ContentDigest,
     },
     Path(PathBytes),
     TransportStats(Option<TcpSocketStats>),
@@ -586,7 +587,7 @@ impl SizeHint for Response {
                 blocks
                     .iter()
                     .map(|block| match block {
-                        Ok(block) => block.data.len() + 16,
+                        Ok(block) => block.data.len() + 40,
                         Err(error) => error.len() + 8,
                     })
                     .sum::<usize>()
@@ -612,7 +613,7 @@ impl SizeHint for Response {
                     + others.as_ref().map_or(0, |items| items.len() * 96)
                     + 32
             }
-            Response::Hashes(v) | Response::HeldHashes { hashes: v, .. } => v.len() * 9 + 24,
+            Response::Hashes(v) | Response::HeldHashes { hashes: v, .. } => v.len() * 32 + 24,
             _ => 256,
         }
     }
@@ -716,7 +717,7 @@ mod tests {
         FrameWriter::new(&mut frame, compress)
             .write_msg(&Response::Block {
                 off: 7,
-                hash: 11,
+                hash: [11; 32],
                 data,
             })
             .unwrap();
@@ -738,7 +739,7 @@ mod tests {
                 hash,
                 data: decoded,
             } => {
-                assert_eq!((off, hash), (7, 11));
+                assert_eq!((off, hash), (7, [11; 32]));
                 assert_eq!(decoded, data);
             }
             other => panic!("unexpected response {other:?}"),

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -2631,7 +2631,7 @@ mod tests {
             path: target.clone(),
             partial_id: [1; 16],
             data: vec![0; 4],
-            hash: 0,
+            hash: [0; 32],
             meta: proto::Meta {
                 mode: 0o644,
                 uid: 0,
@@ -2662,7 +2662,7 @@ mod tests {
             partial_id: [0; 16],
             attempt: 0,
             off: 0,
-            hash: 0,
+            hash: [0; 32],
             data: vec![0; 5],
             guard: None,
         };
@@ -2867,7 +2867,7 @@ mod tests {
             path: path.as_os_str().as_bytes().to_vec(),
             partial_id: [1; 16],
             data: b"new".to_vec(),
-            hash: xxhash_rust::xxh3::xxh3_64(b"new"),
+            hash: crate::fsops::content_digest(b"new"),
             meta: proto::Meta {
                 mode,
                 uid: 0,
@@ -3043,7 +3043,7 @@ mod tests {
         }
 
         authority.copy.limits.hash_block_bytes = proto::MIN_HASH_BLOCK_BYTES;
-        let excessive_entries = proto::MAX_FRAME as u64 / 10 + 1;
+        let excessive_entries = proto::MAX_FRAME as u64 / 32 + 1;
         let mut excessive = request(
             proto::MIN_HASH_BLOCK_BYTES,
             excessive_entries * proto::MIN_HASH_BLOCK_BYTES,
@@ -3070,7 +3070,7 @@ mod tests {
             partial_id: [0; 16],
             attempt: 0,
             off,
-            hash: 0,
+            hash: [0; 32],
             data: vec![0; 256],
             guard: None,
         };
@@ -3184,7 +3184,7 @@ mod tests {
             path: target.clone(),
             partial_id: [1; 16],
             data: vec![0],
-            hash: 0,
+            hash: [0; 32],
             meta: proto::Meta {
                 mode: 0o600,
                 uid: 0,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -8,7 +8,7 @@ use crate::conn::{
     ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, SshMultiplexer, TcpCandidate,
     TcpPairStats,
 };
-use crate::fsops::{is_partial_name, join};
+use crate::fsops::{content_digest, is_partial_name, join};
 use crate::progress::{commas, human, Progress, WorkerStatus};
 use crate::proto::*;
 use crate::sched::{FileJob, Item, RangeHandle, Sched};
@@ -19,7 +19,6 @@ use std::os::unix::ffi::OsStrExt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
 use std::sync::Arc;
 use std::sync::Mutex;
-use xxhash_rust::xxh3::xxh3_64;
 
 const WINDOW: usize = 4;
 const MAX_ATTEMPTS: u32 = 3;
@@ -5100,19 +5099,18 @@ impl Worker {
             }
         };
         let mut blocks = blocks.into_iter();
-        let mut data: Vec<Result<Vec<u8>>> = jobs
+        let mut data: Vec<Result<SmallBlock>> = jobs
             .iter()
             .map(|job| {
                 if job.entry.size == 0 {
-                    return Ok(Vec::new());
+                    return Ok(SmallBlock {
+                        data: Vec::new(),
+                        hash: content_digest(&[]),
+                    });
                 }
                 match blocks.next() {
-                    Some(Ok(SmallBlock { data, hash }))
-                        if data.len() as u64 == job.entry.size && xxh3_64(&data) == hash =>
-                    {
-                        Ok(data)
-                    }
-                    Some(Ok(_)) => Err(anyhow::anyhow!("block size or hash mismatch on read")),
+                    Some(Ok(block)) if block.data.len() as u64 == job.entry.size => Ok(block),
+                    Some(Ok(_)) => Err(anyhow::anyhow!("block size mismatch on read")),
                     Some(Err(error)) => Err(anyhow::anyhow!("read: {error}")),
                     None => Err(anyhow::anyhow!("missing block in read small batch")),
                 }
@@ -5125,19 +5123,26 @@ impl Worker {
         let flags = publication_metadata_flags(self.opts.flags);
         let mut sent: Vec<bool> = Vec::with_capacity(jobs.len());
         let mut puts = Vec::with_capacity(jobs.len());
-        for (j, d) in jobs.iter().zip(data.iter_mut()) {
-            let Ok(bytes) = d else {
-                sent.push(false);
-                continue;
+        for (j, block) in jobs.iter().zip(data.iter_mut()) {
+            let SmallBlock { data, hash } = match block {
+                Ok(block) => std::mem::replace(
+                    block,
+                    SmallBlock {
+                        data: Vec::new(),
+                        hash: content_digest(&[]),
+                    },
+                ),
+                Err(_) => {
+                    sent.push(false);
+                    continue;
+                }
             };
-            let bytes = std::mem::take(bytes);
-            let hash = xxh3_64(&bytes);
             let mut meta = j.entry.meta();
             meta.mode = self.create_mode(j);
             puts.push(SmallPut {
                 path: j.dst.clone(),
                 partial_id: self.partial_id(),
-                data: bytes,
+                data,
                 hash,
                 meta,
                 flags,
@@ -5654,14 +5659,14 @@ impl Worker {
         })
     }
 
-    fn hashes(response: Response) -> Result<Vec<u64>> {
+    fn hashes(response: Response) -> Result<Vec<ContentDigest>> {
         match response {
             Response::Hashes(hashes) => Ok(hashes),
             other => bail!("unexpected response {other:?}"),
         }
     }
 
-    fn destination_hashes(response: Response) -> Result<(Vec<u64>, Option<u64>)> {
+    fn destination_hashes(response: Response) -> Result<(Vec<ContentDigest>, Option<u64>)> {
         match response {
             Response::Hashes(hashes) => Ok((hashes, None)),
             Response::HeldHashes { hashes, len } => Ok((hashes, Some(len))),
@@ -5670,8 +5675,8 @@ impl Worker {
     }
 
     fn different_ranges(
-        source: &[u64],
-        destination: &[u64],
+        source: &[ContentDigest],
+        destination: &[ContentDigest],
         block: u64,
         size: u64,
     ) -> Vec<(u64, u64)> {
@@ -5749,9 +5754,6 @@ impl Worker {
             };
             self.t[0] += t0.elapsed().as_secs_f64();
             reads_out -= 1;
-            if xxh3_64(&data) != hash {
-                bail!("block hash mismatch on read @{off}");
-            }
             let n = data.len() as u64;
             let t0 = std::time::Instant::now();
             self.dst.send(Request::WriteRange {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -501,6 +501,49 @@ fn native_copy_accepts_copy_only_operational_controls() {
 }
 
 #[test]
+fn native_hash_repairs_equal_metadata_content_mismatches() {
+    let t = Tmp::new();
+    let expected = vec![b'a'; 5 * 1024 * 1024];
+    let mut corrupted = expected.clone();
+    corrupted[2_500_000] = b'b';
+    write(&t.path("src/file"), &expected);
+    set_mtime(&t.path("src/file"), 1_600_000_000);
+
+    for (command, destination) in [("cp", "copied"), ("cp-prune", "pruned")] {
+        write(&t.path(&format!("{destination}/file")), &corrupted);
+        set_mtime(&t.path(&format!("{destination}/file")), 1_600_000_000);
+        if command == "cp-prune" {
+            write(&t.path(&format!("{destination}/extra")), b"remove");
+        }
+
+        run_native_ok(&[
+            command,
+            "--src-src",
+            &t.s("src"),
+            "--into-existing",
+            &t.s(destination),
+        ]);
+        assert_eq!(read(&t.path(&format!("{destination}/file"))), corrupted);
+        if command == "cp-prune" {
+            write(&t.path(&format!("{destination}/extra")), b"remove");
+        }
+
+        run_native_ok(&[
+            command,
+            "--hash",
+            "--src-src",
+            &t.s("src"),
+            "--into-existing",
+            &t.s(destination),
+        ]);
+        assert_eq!(read(&t.path(&format!("{destination}/file"))), expected);
+        if command == "cp-prune" {
+            assert!(!t.path(&format!("{destination}/extra")).exists());
+        }
+    }
+}
+
+#[test]
 fn native_copy_named_selector_preserves_a_root_symlink() {
     use std::os::unix::fs::symlink;
 
@@ -4149,6 +4192,7 @@ fn native_rejects_positional_destinations_implicit_verbs_and_compat_flags() {
         ["rm", "--no-tcp", "source", "", ""].as_slice(),
         ["rm", "--bwlimit", "1M", "source", ""].as_slice(),
         ["rm", "--no-compress", "source", "", ""].as_slice(),
+        ["rm", "--hash", "source", "", ""].as_slice(),
         ["rm", "--stats", "source", "", ""].as_slice(),
     ] {
         let args: Vec<_> = args.iter().copied().filter(|arg| !arg.is_empty()).collect();


### PR DESCRIPTION
Summary:
- add --hash to native cp and cp-prune while retaining rsync -c/--checksum
- replace XXH3 content equality and transfer digests with full 256-bit BLAKE3
- forward native hashing through direct remote orchestration and keep the signed comparison policy
- document semantics, integrity rationale, and measured CPU throughput

Verification:
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets (222 unit, 258 filesystem integration, 9 update)