### PR TITLE
Release syq 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,6 +24,13 @@ Their registry setup and release procedure live in [`sdk/RELEASING.md`](sdk/RELE
    `v*` tags to release maintainers. GitHub's ruleset signature rule applies to
    commits, not annotated tag-object signatures; the release workflow checks
    the latter explicitly through GitHub's tag verification API.
+   The repository's selected-actions policy permits GitHub-owned actions and
+   the exact full-SHA
+   `rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18`
+   reference used by `release.yml`, while continuing to require full-SHA pins
+   and deny verified actions generally. This narrow exception lets the release
+   exchange GitHub OIDC identity for a crates.io credential without broadening
+   the Actions trust boundary beyond the one official Rust action it needs.
 4. Publish the first `syq` version to crates.io manually, then add a GitHub
    trusted publisher for repository `greaber/syq`, workflow `release.yml`, and
    environment `release`. Do not put a long-lived crates.io token in GitHub


### PR DESCRIPTION
Version bump for the syq 0.1.7 release.

The signed v0.1.6 tag did not publish anything: GitHub rejected release.yml at workflow startup because the repository selected-actions policy did not yet allow the pinned official crates.io OIDC authentication action. Startup produced zero jobs, no GitHub release or draft, no crates.io upload, and no Homebrew change. GitHub does not permit rerunning startup failures, and the immutable v0.1.6 tag was not deleted or moved.

The repository policy now narrowly allows only rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 in addition to GitHub-owned actions, with full-SHA enforcement retained. This PR documents that release prerequisite and advances to the next patch version.

Local checks at 9747407286a5:
- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets (220 unit, 257 local integration, 9 update)
- crate packaging and installer tests
- release signing/assembly and secret-tooling tests
- complete release-script shellcheck inventory
- 18 Python SDK tests against the syq 0.1.7 candidate on Python 3.10