### PR TITLE
Allow Python SDK lock resolution in release prep

### DIFF
--- a/.github/workflows/prepare-python-sdk.yml
+++ b/.github/workflows/prepare-python-sdk.yml
@@ -60,7 +60,7 @@ jobs:
           set -euo pipefail
           python3 scripts/prepare-python-sdk-release.py \
             --manifest "$RELEASE_MANIFEST"
-          uv lock --project sdk/python --offline
+          uv lock --project sdk/python
           if git diff --quiet; then
             echo 'changed=false' >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
The automated Python SDK follow-up for syq v0.1.7 failed at `uv lock --offline` because a fresh runner does not have the SDK build requirements cached.

This lets the lock command use the registry, while the subsequent SDK test remains frozen against the resulting lockfile.

Verified locally with the pinned uv 0.11.6, the release-tool tests, and all 18 Python SDK tests (2 platform skips).