### PR TITLE
Release syq 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Bump the syq crate and binary version to 0.1.8. This patch release exercises the repaired automatic Python SDK follow-up end to end.

Local verification:
- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets (222 unit, 258 integration, 9 updater tests)
- crate package, installer, release, secret, and shell tooling tests
- all 18 Python SDK candidate tests on Python 3.10