### PR TITLE
Approve checks for automated Python SDK PRs

### DIFF
--- a/.github/workflows/prepare-python-sdk.yml
+++ b/.github/workflows/prepare-python-sdk.yml
@@ -111,12 +111,54 @@ jobs:
             "- bumps the Python SDK to $PYTHON_VERSION" \
             "- embeds the exact signed v$SYQ_VERSION release manifest" \
             "- updates the documented SDK-to-syq mapping" \
-            "The SDK checks were dispatched explicitly because GitHub suppresses ordinary workflow events for branches and pull requests created by GITHUB_TOKEN. Review and merge this pull request normally; publication still requires the maintainer-signed tag sdk-python-v$PYTHON_VERSION and approval of the protected pypi environment.")
+            "The native pull-request checks were approved explicitly because GitHub puts workflow runs caused by GITHUB_TOKEN into an approval-required state. Review and merge this pull request normally; publication still requires the maintainer-signed tag sdk-python-v$PYTHON_VERSION and approval of the protected pypi environment.")
           pr_url=$(gh pr create \
             --base master \
             --head "$branch" \
             --title "Pin Python SDK $PYTHON_VERSION to syq $SYQ_VERSION" \
             --body "$body")
           echo "Created $pr_url"
-          gh workflow run ci.yml --ref "$branch"
-          gh workflow run rsync-compat.yml --ref "$branch"
+          head_sha=$(git rev-parse HEAD)
+          deadline=$((SECONDS + 60))
+          observed='[]'
+          while test "$SECONDS" -lt "$deadline"; do
+            observed=$(gh run list \
+              --branch "$branch" \
+              --event pull_request \
+              --limit 20 \
+              --json conclusion,databaseId,headSha,status,url,workflowName)
+            if jq -e --arg head_sha "$head_sha" '
+              any(.[]; .headSha == $head_sha and .workflowName == "ci") and
+              any(.[]; .headSha == $head_sha and .workflowName == "rsync compatibility")
+            ' <<<"$observed" >/dev/null; then
+              break
+            fi
+            echo "Waiting for GitHub to register the approval-required pull-request workflow runs for $head_sha"
+            sleep 5
+          done
+          if ! jq -e --arg head_sha "$head_sha" '
+            any(.[]; .headSha == $head_sha and .workflowName == "ci") and
+            any(.[]; .headSha == $head_sha and .workflowName == "rsync compatibility")
+          ' <<<"$observed" >/dev/null; then
+            echo "Timed out waiting for approval-required pull-request workflow runs for $head_sha; last observed state:" >&2
+            jq -c . <<<"$observed" >&2
+            exit 1
+          fi
+          for workflow_name in ci 'rsync compatibility'; do
+            run=$(jq -cer --arg head_sha "$head_sha" --arg workflow_name "$workflow_name" '
+              [.[] | select(
+                .headSha == $head_sha and .workflowName == $workflow_name
+              )] | max_by(.databaseId)
+            ' <<<"$observed")
+            run_id=$(jq -er .databaseId <<<"$run")
+            status=$(jq -er .status <<<"$run")
+            conclusion=$(jq -r '.conclusion // empty' <<<"$run")
+            if test "$conclusion" = action_required; then
+              gh api --method POST \
+                "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/approve" \
+                >/dev/null
+              echo "Approved $workflow_name pull-request workflow run $run_id for $head_sha"
+            else
+              echo "$workflow_name pull-request workflow run $run_id is already $status${conclusion:+/$conclusion}"
+            fi
+          done

--- a/sdk/RELEASING.md
+++ b/sdk/RELEASING.md
@@ -121,12 +121,14 @@ After `.github/workflows/release.yml` completes successfully and the GitHub
 release is immutable, `.github/workflows/prepare-python-sdk.yml` downloads its
 exact signed manifest and prepares the next Python patch version. It opens an
 `automation/python-sdk-vX.Y.Z` pull request containing the version, manifest,
-cache-path documentation, lockfile, and mapping-table updates, then explicitly
-dispatches the normal CI and compatibility workflows. GitHub intentionally
-suppresses ordinary workflow events caused by its own token, which is why the
-dispatch is explicit. The repository keeps the default workflow token read
-only, permits trusted Actions workflows to create pull requests, and grants
-write scopes only inside this preparation workflow.
+cache-path documentation, lockfile, and mapping-table updates. GitHub places
+pull-request workflow runs caused by its own token into an approval-required
+state. The preparation workflow waits until GitHub has registered both native
+runs for the exact generated commit, then approves them through the Actions API
+so the required checks remain attached to the pull request. The repository
+keeps the default workflow token read only, permits trusted Actions workflows
+to create pull requests, and grants write scopes only inside this preparation
+workflow.
 
 Review and merge that pull request normally. The final publication remains a
 deliberate release-authority action: create the signed annotated


### PR DESCRIPTION
GitHub puts native pull-request workflows caused by GITHUB_TOKEN into an approval-required state. Wait for both exact-head runs and approve them through the Actions API, rather than dispatching detached checks that cannot satisfy branch protection.\n\nAlso records the behavior and rationale in sdk/RELEASING.md.