### PR TITLE
Add native copy filters, preservation, and in-place writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,15 +481,22 @@ local→hostA login and ordinary enrollment SSH sessions, but hostA never gets
 access to it.
 
 The restriction protects hostB; it does not make hostA a trustworthy source.
-A compromised hostA can omit source files, alter their contents, lie about
-source metadata, or stop the transfer. It still cannot escape the signed
-destination scopes or independently authenticate to hostB with the enrollment
+A compromised hostA can invent the source tree wholesale: names, object types,
+metadata, and file bytes need not correspond to anything on hostA's filesystem.
+It can also omit entries or stop the transfer. HostB can enforce only signed
+command properties visible in receiver requests, such as destination scopes,
+publication and preservation policy, resource limits, and whether a requested
+mutation could have survived the signed filter traversal. HostA still cannot
+escape those checks or independently authenticate to hostB with the enrollment
 key.
 
 The command-restricted path requires encrypted TCP data connections. Ordered
 filter rules and `--delete-excluded` are included in a V3 signed grant: the
 receiver requires destination scans to use the exact policy and rejects
-mutations of excluded paths unless their deletion was explicitly authorized.
+mutations that could only descend through a pruned source directory unless
+their deletion was explicitly authorized. Each source's actual mapped
+destination root is signed, so an explicitly selected named source remains a
+root even when it overlaps an ignored path from another contents source.
 The signed publication policy distinguishes atomic staged writes from
 `--inplace`; in-place requests use descriptor-relative opens and writes beneath
 the enrolled root and cannot silently switch back to staged publication.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ syq cp --src-file report --src-dir assets --into /backup
 syq cp --src-files a.txt b.txt --src-dirs images fonts --into /archive
 syq cp report --to server --as-new /reports/final
 syq cp --hash report --to server --as-existing /reports/final
+syq cp --ignore '*.tmp' --src-src project --to server --into /app
+syq cp --preserve=permissions,ownership project --to server --into /backup
+syq cp --inplace disk.img --to server --as-existing /images/disk.img
 syq cp-prune --src-src build --to server --into-existing /srv/app
 syq rm cache old-output
 syq rm --from server --cwd /srv --src old-output
@@ -248,35 +251,40 @@ detected write failure cancels queued work and stops directory scans from
 scheduling more removals; operations already completed or inside a filesystem
 call are not rolled back. Native `rm` has no detached mode.
 
-The first native fidelity default is exactly `-rlt`: it recurses through
-directories, copies symlinks as symlinks, and retains mtimes. Owner, group,
-modes, special files,
-hard links, ACLs, xattrs, filtering, other copy policies, and the automation API
-are intentionally not frozen by this first grammar. Use `syq rsync` when the
-current compatibility options for those capabilities are needed.
+Native copy fidelity defaults to `-rlt`: recurse through directories, copy
+symlinks as symlinks, and retain mtimes. `--preserve=permissions` additionally
+copies modes, `--preserve=ownership` requests numeric owner and group, and
+`--preserve=specials` copies device, FIFO, and socket nodes. The option is
+repeatable and accepts comma-separated values. Ownership follows the same
+receiver-side rules as archive mode: owner is set only when the receiver runs
+as root, while group changes that fail with `EPERM` are skipped. Hard links,
+ACLs, and xattrs are not preserved.
 
 All native commands accept `-n`/`--dry-run`, `-v`/`--verbose`, `-q`/`--quiet`,
 `-j`/`--connections`, `--progress`/`--no-progress`, and `--progress-json` in
 addition to their endpoint and selector options. `cp` and `cp-prune` also
-accept `--hash`, `--no-compress`, `--bwlimit RATE`, and `--stats`. `--hash`
+accept `--hash`, `--no-compress`, `--bwlimit RATE`, `--stats`, repeatable
+`--ignore PATTERN`/`--ignore-from FILE`, `--preserve`, and `--inplace`. Filters
+use the gitignore semantics described below and apply at every source root;
+`cp-prune` protects excluded destination paths from pruning. `--hash`
 compares existing regular-file contents with full BLAKE3 digests instead of
 trusting equal size and modification time; it does not add a second
 post-transfer verification pass. The bandwidth limit applies only to file
 data, not scanning, hashing, metadata, or pruning. A
 command-restricted remote-to-remote receiver independently enforces the signed
-aggregate limit. A receiver installed by an older syq rejects that V2 grant
-safely; rerun `syq enroll HOST:DEST` to refresh an existing enrollment to the
-current binary. `cp` additionally accepts `--mapping` and `--results` (see
-[MAPPINGS.md](MAPPINGS.md)). `cp-prune` additionally
+aggregate limit, signed filters, and the selected staged or in-place publication
+policy. A receiver installed by an older syq rejects an extension or unsupported
+policy safely; rerun `syq enroll HOST:DEST` to refresh an existing enrollment
+to the current binary. `cp` additionally accepts `--mapping` and `--results`
+(see [MAPPINGS.md](MAPPINGS.md)). `cp-prune` additionally
 accepts `--max-delete`; `rm` additionally accepts `--root` and `--follow` plus
 its endpoint-side removal semantics.
 
-Preservation policies, filters, other comparison and write controls, block and
-split sizing, and SSH/transport configuration remain available only through `syq rsync`;
-sharing the transfer engine does not expose those options in native mode.
-Remote-to-remote copies still use the ordinary automatic transport. Native raw
-path bytes are relayed through syq's protocol when they cannot be represented
-in a direct remote shell command.
+Other comparison and selection controls, block and split sizing, and
+SSH/transport configuration remain available only through `syq rsync`.
+Remote-to-remote native copies always use the automatic topology and do not
+expose `--relay`; raw path bytes are relayed internally through syq's protocol
+when they cannot be represented in a direct remote shell command.
 
 ## Mappings
 
@@ -457,8 +465,8 @@ cannot supply special bits or turn this path into chmod authority over existing
 objects. A new directory does retain a setgid bit inherited from its destination
 parent by hostB's kernel; that bit is read from the newly created inode and is
 not accepted from HostA's mode proposal. Preserved modes are bound to the
-receiver-observed inode fingerprint; atomic publication fails if that object
-changes instead of carrying its mode onto a replacement. Hash requests must use
+receiver-observed inode fingerprint; publication fails if that object changes
+instead of carrying its mode onto a replacement. Hash requests must use
 the signed block size, and the receiver rejects any request whose hash vector
 could exceed the protocol frame
 limit.
@@ -478,13 +486,16 @@ source metadata, or stop the transfer. It still cannot escape the signed
 destination scopes or independently authenticate to hostB with the enrollment
 key.
 
-The command-restricted path requires atomic staged publication and encrypted
-TCP data connections. `--inplace`, `--no-tcp`, `--tcp-plain`,
-`--tcp-congestion`, `--update`, `--existing`, `--ignore-existing`, native
-`--*-new`/`--*-existing`,
-`--ignore`/`--ignore-from`, `--files-from`, `--mapping`, `--min-size`,
-`--syq-path`, and
-`--no-bootstrap` currently fail closed because
+The command-restricted path requires encrypted TCP data connections. Ordered
+filter rules and `--delete-excluded` are included in a V3 signed grant: the
+receiver requires destination scans to use the exact policy and rejects
+mutations of excluded paths unless their deletion was explicitly authorized.
+The signed publication policy distinguishes atomic staged writes from
+`--inplace`; in-place requests use descriptor-relative opens and writes beneath
+the enrolled root and cannot silently switch back to staged publication.
+`--no-tcp`, `--tcp-plain`, `--tcp-congestion`, `--update`, `--existing`,
+`--ignore-existing`, native `--*-new`/`--*-existing`, `--files-from`, `--mapping`,
+`--min-size`, `--syq-path`, and `--no-bootstrap` currently fail closed because
 the receiver cannot enforce those semantics independently of hostA.
 `--max-size` is enforced as a signed per-file limit, but is refused together
 with deletion because filtered source files could otherwise make hostA's
@@ -1181,6 +1192,8 @@ syq rsync -a --ignore '*.o' --ignore /build src/ host:dst/      # glob; leading 
 syq rsync -a --ignore 'logs/*' --ignore '!logs/keep/' src/ dst/ # everything in logs/ except keep/
 syq rsync -a --ignore-from .gitignore --ignore '!dist/' repo/ host:repo/
 syq rsync -a --ignore '*' --ignore '!*/' --ignore '!*.jpg' photos/ bak/ # copy only *.jpg
+syq cp --ignore-from .gitignore --src-src repo --to host --into repo
+syq cp-prune --ignore cache/ --src-src build --into-existing deploy
 ```
 
 Rules of thumb (they're git's): `foo` matches a file or directory named `foo`
@@ -1190,8 +1203,9 @@ it is transferred or even scanned — which is why "only `*.jpg`" needs the
 `!*/` line to keep descending. Empty directories are copied like any other
 (this is a filter on the walk, not git's notion of what's tracked). The source
 root itself is never ignored; with several sources each is filtered from its
-own root. `-n` previews the selected scope and intended changes. `--rm` does not
-take filters (it always removes the whole tree), so `--ignore` conflicts with it.
+own root. `-n` previews the selected scope and intended changes. The same rules
+are available on native `cp` and `cp-prune`. Neither native `rm` nor compatibility
+`--rm` takes filters: removal always selects the whole explicit tree.
 
 As in git, a `!` rule cannot re-include something whose parent directory is
 ignored: `logs/**` prunes `logs/keep` itself, so `!logs/keep/**` after it has

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use clap::{CommandFactory, FromArgMatches, Parser};
+use clap::{CommandFactory, FromArgMatches, Parser, ValueEnum};
 use std::ffi::OsString;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 
@@ -470,29 +470,7 @@ fn finish_parse(mut args: Args, matches: &clap::ArgMatches) -> Result<Args> {
         .map(crate::bwlimit::parse_rate)
         .transpose()?
         .unwrap_or(0);
-    let mut items: Vec<(usize, bool, String)> = Vec::new();
-    if let Some(idx) = matches.indices_of("ignore") {
-        for (i, v) in idx.zip(&args.ignore) {
-            items.push((i, false, v.clone()));
-        }
-    }
-    if let Some(idx) = matches.indices_of("ignore_from") {
-        for (i, v) in idx.zip(&args.ignore_from) {
-            items.push((i, true, v.clone()));
-        }
-    }
-    items.sort_by_key(|(i, _, _)| *i);
-    for (_, from_file, v) in items {
-        if from_file {
-            let text = std::fs::read_to_string(&v)
-                .map_err(|e| anyhow::anyhow!("--ignore-from {v}: {e}"))?;
-            let text = text.strip_prefix('\u{feff}').unwrap_or(&text);
-            args.ignore_lines
-                .extend(text.lines().map(|l| l.trim_end_matches('\r').to_string()));
-        } else {
-            args.ignore_lines.push(v);
-        }
-    }
+    args.ignore_lines = ordered_ignore_lines(&args.ignore, &args.ignore_from, matches)?;
     if let Some(f) = &args.files_from {
         // Check this before reading the list (it may be stdin) and before
         // anything connects: the list lives on this machine, but a direct
@@ -513,6 +491,45 @@ fn finish_parse(mut args: Args, matches: &clap::ArgMatches) -> Result<Args> {
         args.files_from_lines = read_files_from(f, args.from0)?;
     }
     Ok(args)
+}
+
+fn ordered_ignore_lines(
+    ignore: &[String],
+    ignore_from: &[String],
+    matches: &clap::ArgMatches,
+) -> Result<Vec<String>> {
+    let mut items: Vec<(usize, bool, String)> = Vec::new();
+    if let Some(indices) = matches.indices_of("ignore") {
+        items.extend(
+            indices
+                .zip(ignore)
+                .map(|(index, value)| (index, false, value.clone())),
+        );
+    }
+    if let Some(indices) = matches.indices_of("ignore_from") {
+        items.extend(
+            indices
+                .zip(ignore_from)
+                .map(|(index, value)| (index, true, value.clone())),
+        );
+    }
+    items.sort_by_key(|(index, _, _)| *index);
+
+    let mut lines = Vec::new();
+    for (_, from_file, value) in items {
+        if from_file {
+            let text = std::fs::read_to_string(&value)
+                .map_err(|error| anyhow::anyhow!("--ignore-from {value}: {error}"))?;
+            let text = text.strip_prefix('\u{feff}').unwrap_or(&text);
+            lines.extend(
+                text.lines()
+                    .map(|line| line.trim_end_matches('\r').to_string()),
+            );
+        } else {
+            lines.push(value);
+        }
+    }
+    Ok(lines)
 }
 
 fn print_root_help() {
@@ -648,6 +665,25 @@ struct NativeCopyOperationalArgs {
     /// Print transfer statistics at the end
     #[arg(long)]
     stats: bool,
+    /// Skip paths matching a gitignore-style pattern (repeatable)
+    #[arg(long = "ignore", value_name = "PATTERN", allow_hyphen_values = true)]
+    ignore: Vec<String>,
+    /// Read gitignore-style patterns from FILE (repeatable; stacks in command-line order)
+    #[arg(long, value_name = "FILE")]
+    ignore_from: Vec<String>,
+    /// Preserve additional metadata (permissions, ownership, or specials; repeatable/comma-separated)
+    #[arg(long, value_name = "ATTRIBUTE", value_delimiter = ',')]
+    preserve: Vec<NativePreserve>,
+    /// Update destination files directly, using no full-sized staging file; interruption can leave them incomplete
+    #[arg(long)]
+    inplace: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum NativePreserve {
+    Permissions,
+    Ownership,
+    Specials,
 }
 
 #[derive(clap::Args, Debug)]
@@ -724,7 +760,7 @@ struct NativeCopyFields {
     name = "syq cp",
     version,
     about = "Copy selected objects with explicit endpoint and placement syntax",
-    long_about = "Copy selected objects with explicit endpoint and placement syntax.\n\nNative copies use fixed rsync -rlt behavior: recursive traversal, symlinks copied as symlinks, and modification times preserved. Permissions, owner, group, devices, and special files are not preserved.",
+    long_about = "Copy selected objects with explicit endpoint and placement syntax.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files.",
     override_usage = "syq cp [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]... PLACEMENT"
 )]
 struct NativeCopyCommand {
@@ -737,7 +773,7 @@ struct NativeCopyCommand {
     name = "syq cp-prune",
     version,
     about = "Copy selected objects, then remove target-only objects in mapped scopes",
-    long_about = "Copy selected objects, then remove target-only objects in mapped scopes.\n\nCopying uses fixed rsync -rlt behavior: recursive traversal, symlinks copied as symlinks, and modification times preserved. Permissions, owner, group, devices, and special files are not preserved. Removal uses the current post-transfer deletion scopes and guards.",
+    long_about = "Copy selected objects, then remove target-only objects in mapped scopes.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files. Removal uses the current post-transfer deletion scopes and guards; ignored paths remain protected.",
     override_usage = "syq cp-prune [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]... PLACEMENT"
 )]
 struct NativeCopyPruneCommand {
@@ -998,7 +1034,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
             bail!("--mapping with a remote-to-remote copy is not supported; one end must be local");
         }
     }
-    apply_native_copy_operational(&mut args, parsed.operational)?;
+    apply_native_copy_operational(&mut args, parsed.operational, &matches)?;
     apply_internal_native_direct(&mut args)?;
     Ok(args)
 }
@@ -1153,6 +1189,7 @@ fn apply_native_operational(args: &mut Args, operational: NativeOperationalArgs)
 fn apply_native_copy_operational(
     args: &mut Args,
     operational: NativeCopyOperationalArgs,
+    matches: &clap::ArgMatches,
 ) -> Result<()> {
     let NativeCopyOperationalArgs {
         common,
@@ -1160,6 +1197,10 @@ fn apply_native_copy_operational(
         no_compress,
         bwlimit,
         stats,
+        ignore,
+        ignore_from,
+        preserve,
+        inplace,
     } = operational;
     args.checksum = hash;
     args.no_compress = no_compress;
@@ -1173,6 +1214,20 @@ fn apply_native_copy_operational(
         .unwrap_or(0);
     args.bwlimit = bwlimit;
     args.stats = stats;
+    args.ignore_lines = ordered_ignore_lines(&ignore, &ignore_from, matches)?;
+    args.ignore = ignore;
+    args.ignore_from = ignore_from;
+    args.inplace = inplace;
+    for attribute in preserve {
+        match attribute {
+            NativePreserve::Permissions => args.perms = true,
+            NativePreserve::Ownership => {
+                args.owner = true;
+                args.group = true;
+            }
+            NativePreserve::Specials => args.devices = true,
+        }
+    }
     apply_native_operational(args, common);
     Ok(())
 }
@@ -1594,6 +1649,29 @@ mod tests {
         let argv = ["--hash", "source", "--into", "destination"].map(std::ffi::OsString::from);
         let args = parse_native_copy(&argv, Interface::NativeCp).unwrap();
         assert!(args.checksum);
+    }
+
+    #[test]
+    fn native_copy_policies_lower_to_the_shared_engine() {
+        let argv = [
+            "--ignore",
+            "*.tmp",
+            "--ignore",
+            "!keep.tmp",
+            "--preserve=permissions,ownership,specials",
+            "--inplace",
+            "source",
+            "--into",
+            "destination",
+        ]
+        .map(std::ffi::OsString::from);
+        let args = parse_native_copy(&argv, Interface::NativeCp).unwrap();
+        assert_eq!(args.ignore_lines, ["*.tmp", "!keep.tmp"]);
+        assert!(args.perms);
+        assert!(args.owner);
+        assert!(args.group);
+        assert!(args.devices);
+        assert!(args.inplace);
     }
 
     #[test]

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -53,12 +53,15 @@ use std::time::{Duration, Instant};
 pub(crate) const SSHSIG_NAMESPACE: &str = "syq-grant-v1@greaber.github";
 const WIRE_MAGIC: &[u8; 8] = b"SYQGRNT\0";
 // V1's typed GrantV1 body is frozen. V2 wraps that body with a signed
-// receiver-side file-data rate ceiling; receivers still accept V1 as
-// unlimited. The SSHSIG namespace remains stable because the signed wire
-// version already separates the payloads and existing enrollment policies
-// authorize this protocol family by that namespace.
+// receiver-side file-data rate ceiling. V3 additionally binds source-selection
+// filters and their deletion policy so a remote source coordinator cannot
+// mutate a path the invoking machine excluded. Receivers retain V1/V2 decoding.
+// The SSHSIG namespace remains stable because the signed wire version already
+// separates the payloads and existing enrollment policies authorize this
+// protocol family by that namespace.
 const WIRE_VERSION_V1: u16 = 1;
-const WIRE_VERSION: u16 = 2;
+const WIRE_VERSION_V2: u16 = 2;
+const WIRE_VERSION: u16 = 3;
 const WIRE_HEADER_LEN: usize = WIRE_MAGIC.len() + 2 + 4 + 4;
 const MAX_GRANT_BYTES: usize = 32 * 1024;
 const MAX_SIGNATURE_BYTES: usize = 16 * 1024;
@@ -77,6 +80,8 @@ const MAX_ENTRIES: u64 = 1_000_000_000_000;
 // Keep later accounting representable in both signed and unsigned counters.
 const MAX_COPY_BYTES: u64 = i64::MAX as u64;
 const MAX_CONNECTIONS: u16 = 64;
+const MAX_FILTER_RULES: usize = 4096;
+const MAX_FILTER_RULE_BYTES: usize = 4096;
 const CLAIM_MAGIC: &[u8; 8] = b"SYQCLM\0\0";
 const CLAIM_VERSION: u16 = 1;
 const CLAIM_RECORD_LEN: usize = CLAIM_MAGIC.len() + 2 + 8 + 32 + 32;
@@ -310,10 +315,54 @@ struct GrantBodyV2 {
     max_file_data_bytes_per_second: u64,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct FilterPolicyV3 {
+    /// Ordered gitignore-style rules, anchored independently at every source
+    /// root mapped into the signed destination scopes.
+    pub ignore: Vec<String>,
+    /// Permit ignored destination paths to be removed by a prune operation.
+    pub delete_excluded: bool,
+}
+
+impl FilterPolicyV3 {
+    fn is_active(&self) -> bool {
+        !self.ignore.is_empty() || self.delete_excluded
+    }
+
+    fn validate(&self, grant: &GrantV1) -> Result<()> {
+        if self.ignore.len() > MAX_FILTER_RULES {
+            bail!("signed filter-rule count exceeds the supported range");
+        }
+        for rule in &self.ignore {
+            if rule.len() > MAX_FILTER_RULE_BYTES || rule.contains('\0') {
+                bail!("signed filter rule is outside the supported range");
+            }
+        }
+        crate::scan::build_ignore(&self.ignore).context("validate signed filter policy")?;
+        if self.delete_excluded {
+            let GrantOperationV1::Copy(copy) = &grant.operation;
+            if copy.policy.deletion == DeletionPolicyV1::Forbid {
+                bail!(
+                    "signed filter policy cannot delete excluded paths when deletion is forbidden"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct GrantBodyV3 {
+    grant: GrantV1,
+    max_file_data_bytes_per_second: u64,
+    filters: FilterPolicyV3,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct SignedGrantEnvelope {
     pub grant: GrantV1,
     pub max_file_data_bytes_per_second: u64,
+    pub filters: FilterPolicyV3,
     /// Canonical OpenSSH armored SSHSIG bytes.
     pub signature: Vec<u8>,
     wire_version: u16,
@@ -325,6 +374,7 @@ impl SignedGrantEnvelope {
         Self {
             grant,
             max_file_data_bytes_per_second,
+            filters: FilterPolicyV3::default(),
             signature,
             wire_version: WIRE_VERSION,
         }
@@ -337,6 +387,7 @@ impl SignedGrantEnvelope {
             self.wire_version,
             &self.grant,
             self.max_file_data_bytes_per_second,
+            &self.filters,
         )?;
         if body.len() > MAX_GRANT_BYTES {
             bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
@@ -362,7 +413,7 @@ impl SignedGrantEnvelope {
             bail!("not a SYQ signed grant envelope");
         }
         let version = u16::from_be_bytes(bytes[8..10].try_into().expect("fixed header"));
-        if !matches!(version, WIRE_VERSION_V1 | WIRE_VERSION) {
+        if !matches!(version, WIRE_VERSION_V1 | WIRE_VERSION_V2 | WIRE_VERSION) {
             bail!("unsupported signed grant envelope version {version}");
         }
         let grant_len =
@@ -383,28 +434,45 @@ impl SignedGrantEnvelope {
             bail!("signed grant envelope length is noncanonical");
         }
         let body_bytes = &bytes[WIRE_HEADER_LEN..WIRE_HEADER_LEN + grant_len];
-        let (grant, max_file_data_bytes_per_second) = match version {
+        let (grant, max_file_data_bytes_per_second, filters) = match version {
             WIRE_VERSION_V1 => {
                 let grant: GrantV1 =
                     postcard::from_bytes(body_bytes).context("decode signed grant")?;
-                (grant, 0)
+                (grant, 0, FilterPolicyV3::default())
             }
-            WIRE_VERSION => {
+            WIRE_VERSION_V2 => {
                 let body: GrantBodyV2 =
                     postcard::from_bytes(body_bytes).context("decode signed grant")?;
-                (body.grant, body.max_file_data_bytes_per_second)
+                (
+                    body.grant,
+                    body.max_file_data_bytes_per_second,
+                    FilterPolicyV3::default(),
+                )
+            }
+            WIRE_VERSION => {
+                let body: GrantBodyV3 =
+                    postcard::from_bytes(body_bytes).context("decode signed grant")?;
+                (
+                    body.grant,
+                    body.max_file_data_bytes_per_second,
+                    body.filters,
+                )
             }
             _ => unreachable!(),
         };
-        if canonical_body_bytes(version, &grant, max_file_data_bytes_per_second)? != body_bytes {
+        if canonical_body_bytes(version, &grant, max_file_data_bytes_per_second, &filters)?
+            != body_bytes
+        {
             bail!("signed grant uses a noncanonical encoding");
         }
         grant.validate_static()?;
+        filters.validate(&grant)?;
         let signature = bytes[WIRE_HEADER_LEN + grant_len..].to_vec();
         validate_canonical_sshsig(&signature)?;
         Ok(Self {
             grant,
             max_file_data_bytes_per_second,
+            filters,
             signature,
             wire_version: version,
         })
@@ -415,6 +483,7 @@ impl SignedGrantEnvelope {
             self.wire_version,
             &self.grant,
             self.max_file_data_bytes_per_second,
+            &self.filters,
         )
     }
 }
@@ -422,21 +491,33 @@ impl SignedGrantEnvelope {
 pub(crate) fn sign_grant(
     grant: GrantV1,
     max_file_data_bytes_per_second: u64,
+    mut filters: FilterPolicyV3,
     private_key: &PrivateKey,
 ) -> Result<Vec<u8>> {
     if private_key.is_encrypted() {
         bail!("cannot sign a grant with an encrypted transport key");
     }
-    // Keep emitting the frozen V1 form for unlimited transfers so an existing
-    // enrolled receiver remains usable. Only the new signed rate extension
-    // requires V2.
-    let wire_version = if max_file_data_bytes_per_second == 0 {
+    // With no filters, --delete-excluded has no observable effect. Erase that
+    // no-op so such commands retain the oldest compatible grant encoding.
+    if filters.ignore.is_empty() {
+        filters.delete_excluded = false;
+    }
+    filters.validate(&grant)?;
+    // Keep emitting the oldest form capable of representing the request so
+    // ordinary transfers remain usable with existing receiver enrollments.
+    let wire_version = if filters.is_active() {
+        WIRE_VERSION
+    } else if max_file_data_bytes_per_second == 0 {
         WIRE_VERSION_V1
     } else {
-        WIRE_VERSION
+        WIRE_VERSION_V2
     };
-    let payload =
-        signing_payload_for_version(wire_version, &grant, max_file_data_bytes_per_second)?;
+    let payload = signing_payload_for_version(
+        wire_version,
+        &grant,
+        max_file_data_bytes_per_second,
+        &filters,
+    )?;
     let signature = private_key
         .sign(SSHSIG_NAMESPACE, HashAlg::Sha256, &payload)
         .context("sign restricted transfer grant")?
@@ -446,6 +527,7 @@ pub(crate) fn sign_grant(
     SignedGrantEnvelope {
         grant,
         max_file_data_bytes_per_second,
+        filters,
         signature,
         wire_version,
     }
@@ -454,16 +536,23 @@ pub(crate) fn sign_grant(
 
 #[cfg(test)]
 fn signing_payload(grant: &GrantV1, max_file_data_bytes_per_second: u64) -> Result<Vec<u8>> {
-    signing_payload_for_version(WIRE_VERSION, grant, max_file_data_bytes_per_second)
+    signing_payload_for_version(
+        WIRE_VERSION,
+        grant,
+        max_file_data_bytes_per_second,
+        &FilterPolicyV3::default(),
+    )
 }
 
 fn signing_payload_for_version(
     wire_version: u16,
     grant: &GrantV1,
     max_file_data_bytes_per_second: u64,
+    filters: &FilterPolicyV3,
 ) -> Result<Vec<u8>> {
     grant.validate_static()?;
-    let body = canonical_body_bytes(wire_version, grant, max_file_data_bytes_per_second)?;
+    filters.validate(grant)?;
+    let body = canonical_body_bytes(wire_version, grant, max_file_data_bytes_per_second, filters)?;
     if body.len() > MAX_GRANT_BYTES {
         bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
     }
@@ -479,17 +568,29 @@ fn canonical_body_bytes(
     wire_version: u16,
     grant: &GrantV1,
     max_file_data_bytes_per_second: u64,
+    filters: &FilterPolicyV3,
 ) -> Result<Vec<u8>> {
     match wire_version {
         WIRE_VERSION_V1 => {
-            if max_file_data_bytes_per_second != 0 {
-                bail!("version-one grants cannot carry a file-data rate limit");
+            if max_file_data_bytes_per_second != 0 || filters.is_active() {
+                bail!("version-one grants cannot carry signed extensions");
             }
             canonical_grant_bytes(grant)
         }
-        WIRE_VERSION => postcard::to_stdvec(&GrantBodyV2 {
+        WIRE_VERSION_V2 => {
+            if filters.is_active() {
+                bail!("version-two grants cannot carry filter policy");
+            }
+            postcard::to_stdvec(&GrantBodyV2 {
+                grant: grant.clone(),
+                max_file_data_bytes_per_second,
+            })
+            .context("encode canonical signed grant")
+        }
+        WIRE_VERSION => postcard::to_stdvec(&GrantBodyV3 {
             grant: grant.clone(),
             max_file_data_bytes_per_second,
+            filters: filters.clone(),
         })
         .context("encode canonical signed grant"),
         _ => bail!("unsupported signed grant envelope version {wire_version}"),
@@ -907,6 +1008,7 @@ pub(crate) struct VerifiedGrant {
     #[allow(dead_code)]
     grant: GrantV1,
     max_file_data_bytes_per_second: u64,
+    filters: FilterPolicyV3,
     execution_deadline: Instant,
 }
 
@@ -916,10 +1018,11 @@ impl VerifiedGrant {
         self.execution_deadline
     }
 
-    pub(crate) fn into_parts(self) -> (GrantV1, u64, Instant) {
+    pub(crate) fn into_parts(self) -> (GrantV1, u64, FilterPolicyV3, Instant) {
         (
             self.grant,
             self.max_file_data_bytes_per_second,
+            self.filters,
             self.execution_deadline,
         )
     }
@@ -956,6 +1059,7 @@ pub(crate) fn verify_and_claim(
     Ok(VerifiedGrant {
         grant: envelope.grant,
         max_file_data_bytes_per_second: envelope.max_file_data_bytes_per_second,
+        filters: envelope.filters,
         execution_deadline,
     })
 }
@@ -2012,8 +2116,13 @@ mod tests {
         max_file_data_bytes_per_second: u64,
         signature: &[u8],
     ) -> Vec<u8> {
-        let grant = canonical_body_bytes(WIRE_VERSION, grant, max_file_data_bytes_per_second)
-            .expect("encode test grant");
+        let grant = canonical_body_bytes(
+            WIRE_VERSION,
+            grant,
+            max_file_data_bytes_per_second,
+            &FilterPolicyV3::default(),
+        )
+        .expect("encode test grant");
         let mut out = Vec::new();
         out.extend_from_slice(WIRE_MAGIC);
         out.extend_from_slice(&WIRE_VERSION.to_be_bytes());
@@ -2033,12 +2142,18 @@ mod tests {
         assert_eq!(decoded.max_file_data_bytes_per_second, 0);
 
         let legacy_grant = fixture_grant(28);
-        let legacy_payload = signing_payload_for_version(WIRE_VERSION_V1, &legacy_grant, 0)
-            .expect("make legacy signing payload");
+        let legacy_payload = signing_payload_for_version(
+            WIRE_VERSION_V1,
+            &legacy_grant,
+            0,
+            &FilterPolicyV3::default(),
+        )
+        .expect("make legacy signing payload");
         let legacy_signature = sign(&legacy_payload, &fixture.key, SSHSIG_NAMESPACE, None);
         let legacy_encoded = SignedGrantEnvelope {
             grant: legacy_grant.clone(),
             max_file_data_bytes_per_second: 0,
+            filters: FilterPolicyV3::default(),
             signature: legacy_signature,
             wire_version: WIRE_VERSION_V1,
         }
@@ -2089,7 +2204,8 @@ mod tests {
         let public = private.public_key().to_openssh().unwrap();
         fs::write(&fixture.allowed_signers, format!("{SIGNER} {public}\n")).unwrap();
         let replay = fixture.replay("in-process-signature-replay");
-        let encoded = sign_grant(fixture_grant(44), 0, &private).unwrap();
+        let encoded =
+            sign_grant(fixture_grant(44), 0, FilterPolicyV3::default(), &private).unwrap();
         assert_eq!(
             SignedGrantEnvelope::decode(&encoded).unwrap().wire_version,
             WIRE_VERSION_V1
@@ -2102,9 +2218,10 @@ mod tests {
         )
         .expect("OpenSSH must accept the in-process SSHSIG");
 
-        let rate_limited = sign_grant(fixture_grant(45), 4096, &private).unwrap();
+        let rate_limited =
+            sign_grant(fixture_grant(45), 4096, FilterPolicyV3::default(), &private).unwrap();
         let decoded = SignedGrantEnvelope::decode(&rate_limited).unwrap();
-        assert_eq!(decoded.wire_version, WIRE_VERSION);
+        assert_eq!(decoded.wire_version, WIRE_VERSION_V2);
         assert_eq!(decoded.max_file_data_bytes_per_second, 4096);
         verify_and_claim(
             &rate_limited,
@@ -2113,6 +2230,23 @@ mod tests {
             &fixture.replay("in-process-rate-signature-replay"),
         )
         .expect("OpenSSH must accept the signed rate extension");
+
+        let filters = FilterPolicyV3 {
+            ignore: vec!["*.tmp".into(), "!keep.tmp".into()],
+            delete_excluded: false,
+        };
+        let filtered = sign_grant(fixture_grant(46), 0, filters.clone(), &private).unwrap();
+        let decoded = SignedGrantEnvelope::decode(&filtered).unwrap();
+        assert_eq!(decoded.wire_version, WIRE_VERSION);
+        assert_eq!(decoded.filters, filters);
+        let verified = verify_and_claim(
+            &filtered,
+            &context(SIGNER, TARGET, NOW, 0),
+            &fixture.policy(),
+            &fixture.replay("in-process-filter-signature-replay"),
+        )
+        .expect("OpenSSH must accept the signed filter extension");
+        assert_eq!(verified.into_parts().2, filters);
     }
 
     #[test]
@@ -2153,8 +2287,9 @@ mod tests {
             transcript.extend_from_slice(&(label.len() as u32).to_be_bytes());
             transcript.extend_from_slice(label.as_bytes());
             transcript.push(operation_tag);
-            let payload = signing_payload_for_version(WIRE_VERSION_V1, grant, 0)
-                .expect("encode version-one signing payload");
+            let payload =
+                signing_payload_for_version(WIRE_VERSION_V1, grant, 0, &FilterPolicyV3::default())
+                    .expect("encode version-one signing payload");
             transcript.extend_from_slice(&(payload.len() as u32).to_be_bytes());
             transcript.extend_from_slice(&payload);
         }

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -82,6 +82,7 @@ const MAX_COPY_BYTES: u64 = i64::MAX as u64;
 const MAX_CONNECTIONS: u16 = 64;
 const MAX_FILTER_RULES: usize = 4096;
 const MAX_FILTER_RULE_BYTES: usize = 4096;
+const MAX_FILTER_ROOTS: usize = 1024;
 const CLAIM_MAGIC: &[u8; 8] = b"SYQCLM\0\0";
 const CLAIM_VERSION: u16 = 1;
 const CLAIM_RECORD_LEN: usize = CLAIM_MAGIC.len() + 2 + 8 + 32 + 32;
@@ -320,13 +321,15 @@ pub(crate) struct FilterPolicyV3 {
     /// Ordered gitignore-style rules, anchored independently at every source
     /// root mapped into the signed destination scopes.
     pub ignore: Vec<String>,
+    /// Canonical receiver-side roots produced by those source mappings.
+    pub destination_roots: Vec<Vec<u8>>,
     /// Permit ignored destination paths to be removed by a prune operation.
     pub delete_excluded: bool,
 }
 
 impl FilterPolicyV3 {
     fn is_active(&self) -> bool {
-        !self.ignore.is_empty() || self.delete_excluded
+        !self.ignore.is_empty() || !self.destination_roots.is_empty() || self.delete_excluded
     }
 
     fn validate(&self, grant: &GrantV1) -> Result<()> {
@@ -339,6 +342,35 @@ impl FilterPolicyV3 {
             }
         }
         crate::scan::build_ignore(&self.ignore).context("validate signed filter policy")?;
+        if self.ignore.is_empty() {
+            if !self.destination_roots.is_empty() {
+                bail!("signed filter roots require filter rules");
+            }
+        } else {
+            if self.destination_roots.is_empty() || self.destination_roots.len() > MAX_FILTER_ROOTS
+            {
+                bail!("signed filter-root count is outside the supported range");
+            }
+            let GrantOperationV1::Copy(copy) = &grant.operation;
+            for root in &self.destination_roots {
+                validate_absolute_path(root)?;
+                if !copy.mutation_scopes.iter().any(|scope| {
+                    root == &scope.path
+                        || (scope.descendants
+                            && root.starts_with(&scope.path)
+                            && root.get(scope.path.len()) == Some(&b'/'))
+                }) {
+                    bail!("signed filter root is outside the destination mutation scopes");
+                }
+            }
+            if self
+                .destination_roots
+                .windows(2)
+                .any(|roots| roots[0] >= roots[1])
+            {
+                bail!("signed filter roots must be sorted and unique");
+            }
+        }
         if self.delete_excluded {
             let GrantOperationV1::Copy(copy) = &grant.operation;
             if copy.policy.deletion == DeletionPolicyV1::Forbid {
@@ -501,6 +533,10 @@ pub(crate) fn sign_grant(
     // no-op so such commands retain the oldest compatible grant encoding.
     if filters.ignore.is_empty() {
         filters.delete_excluded = false;
+        filters.destination_roots.clear();
+    } else {
+        filters.destination_roots.sort();
+        filters.destination_roots.dedup();
     }
     filters.validate(&grant)?;
     // Keep emitting the oldest form capable of representing the request so
@@ -2233,6 +2269,7 @@ mod tests {
 
         let filters = FilterPolicyV3 {
             ignore: vec!["*.tmp".into(), "!keep.tmp".into()],
+            destination_roots: vec![b"/srv/archive/project".to_vec()],
             delete_excluded: false,
         };
         let filtered = sign_grant(fixture_grant(46), 0, filters.clone(), &private).unwrap();
@@ -2247,6 +2284,13 @@ mod tests {
         )
         .expect("OpenSSH must accept the signed filter extension");
         assert_eq!(verified.into_parts().2, filters);
+
+        let outside = FilterPolicyV3 {
+            ignore: vec!["*.tmp".into()],
+            destination_roots: vec![b"/srv/outside".to_vec()],
+            delete_excluded: false,
+        };
+        assert!(sign_grant(fixture_grant(47), 0, outside, &private).is_err());
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -175,11 +175,15 @@ fn automatic_enrollment_allowed(dry_run: bool, verify_only: bool) -> bool {
     !(dry_run || verify_only)
 }
 
-fn utf8_path(path: &[u8], role: &str) -> Result<String> {
+fn utf8_path(path: &[u8], role: &str, interface: Interface) -> Result<String> {
     String::from_utf8(path.to_vec()).map_err(|_| {
-        anyhow::anyhow!(
-            "direct remote-to-remote {role} is not valid UTF-8; use --relay so raw path bytes travel in the protocol"
-        )
+        if interface == Interface::Rsync {
+            anyhow::anyhow!(
+                "direct remote-to-remote {role} is not valid UTF-8; use --relay so raw path bytes travel in the protocol"
+            )
+        } else {
+            anyhow::anyhow!("native direct remote-to-remote {role} must be valid UTF-8")
+        }
     })
 }
 
@@ -373,6 +377,23 @@ pub fn run(
     if args.interface != Interface::Rsync && args.checksum {
         remote.push("--hash".into());
     }
+    if args.inplace {
+        remote.push("--inplace".into());
+    }
+    for line in &args.ignore_lines {
+        remote.push(format!("--ignore={line}"));
+    }
+    if args.interface != Interface::Rsync {
+        if args.perms {
+            remote.push("--preserve=permissions".into());
+        }
+        if args.owner || args.group {
+            remote.push("--preserve=ownership".into());
+        }
+        if args.devices {
+            remote.push("--preserve=specials".into());
+        }
+    }
     if let Some(j) = args.connections_opt {
         remote.push("-j".into());
         remote.push(j.to_string());
@@ -382,9 +403,6 @@ pub fn run(
         remote.push(format!("--min-split={}", args.min_split));
         if args.verify_only {
             remote.push("--verify-only".into());
-        }
-        if args.inplace {
-            remote.push("--inplace".into());
         }
         if args.insecure_links {
             remote.push("--insecure-links".into());
@@ -412,9 +430,6 @@ pub fn run(
         }
         if let Some(path) = &args.checkpoint {
             remote.push(format!("--checkpoint={path}"));
-        }
-        for line in &args.ignore_lines {
-            remote.push(format!("--ignore={line}"));
         }
     }
     if let Some(rate) = &args.bwlimit {
@@ -478,11 +493,13 @@ pub fn run(
     if args.interface == Interface::Rsync {
         remote.push("--".into());
         for source in srcs {
-            remote.push(utf8_path(&source.path, "source path")?);
+            remote.push(utf8_path(&source.path, "source path", args.interface)?);
         }
-        let dst_path = restricted_destination_path
-            .clone()
-            .unwrap_or(utf8_path(&dst.path, "target path")?);
+        let dst_path = restricted_destination_path.clone().unwrap_or(utf8_path(
+            &dst.path,
+            "target path",
+            args.interface,
+        )?);
         let dst_arg = if srcs[0].same_host(dst) {
             if dst.path.starts_with(b"/")
                 || dst.path == b"~"
@@ -522,7 +539,7 @@ pub fn run(
                 }
                 .into(),
             );
-            remote.push(utf8_path(&source.path, "source path")?);
+            remote.push(utf8_path(&source.path, "source path", args.interface)?);
         }
         if !srcs[0].same_host(dst) {
             remote.push("--to".into());
@@ -533,11 +550,11 @@ pub fn run(
             ));
         }
         remote.push(native_placement_arg(args)?.into());
-        remote.push(
-            restricted_destination_path
-                .clone()
-                .unwrap_or(utf8_path(&dst.path, "target path")?),
-        );
+        remote.push(restricted_destination_path.clone().unwrap_or(utf8_path(
+            &dst.path,
+            "target path",
+            args.interface,
+        )?));
     }
 
     if args.detach {
@@ -671,7 +688,11 @@ pub fn run(
         return Ok(0);
     }
     if !args.quiet {
-        eprintln!("syq: remote-to-remote: running on {src_host} (use --relay to route data through this machine)");
+        if args.interface == Interface::Rsync {
+            eprintln!("syq: remote-to-remote: running on {src_host} (use --relay to route data through this machine)");
+        } else {
+            eprintln!("syq: remote-to-remote: running on {src_host}");
+        }
     }
     let run = || {
         let mut cmd = make_command();
@@ -706,9 +727,15 @@ pub fn run(
                 && !args.unrestricted_agent_forwarding
                 && !same_host
             {
-                bail!("remote-to-remote transfer on {src_host} failed (exit {c}); constrained authentication permits only {}@{} and requires OpenSSH session-bind/host-bound authentication. Retry with --relay, use --no-forward-agent with source-host credentials, or explicitly accept full agent exposure with --unrestricted-agent-forwarding", destination_login_user.as_deref().unwrap_or("the destination user"), dst.host.as_deref().unwrap_or("the destination"))
+                if args.interface == Interface::Rsync {
+                    bail!("remote-to-remote transfer on {src_host} failed (exit {c}); constrained authentication permits only {}@{} and requires OpenSSH session-bind/host-bound authentication. Retry with --relay, use --no-forward-agent with source-host credentials, or explicitly accept full agent exposure with --unrestricted-agent-forwarding", destination_login_user.as_deref().unwrap_or("the destination user"), dst.host.as_deref().unwrap_or("the destination"))
+                }
+                bail!("remote-to-remote transfer on {src_host} failed (exit {c}); constrained authentication permits only {}@{} and requires OpenSSH session-bind/host-bound authentication. Use --no-forward-agent with source-host credentials, or explicitly accept full agent exposure with --unrestricted-agent-forwarding", destination_login_user.as_deref().unwrap_or("the destination user"), dst.host.as_deref().unwrap_or("the destination"))
             }
-            bail!("remote-to-remote transfer on {src_host} failed (exit {c}); if {src_host} cannot reach the destination, retry with --relay")
+            if args.interface == Interface::Rsync {
+                bail!("remote-to-remote transfer on {src_host} failed (exit {c}); if {src_host} cannot reach the destination, retry with --relay")
+            }
+            bail!("remote-to-remote transfer on {src_host} failed (exit {c}); {src_host} may not be able to reach the destination")
         }
         None => bail!("remote syq on {src_host} killed by signal"),
     }
@@ -734,7 +761,7 @@ pub fn follow(args: &Args) -> Result<i32> {
     let (Some(host), log) = (&loc.host, &loc.path) else {
         bail!("usage: syq rsync --follow HOST:LOGFILE")
     };
-    let log = utf8_path(log, "log path")?;
+    let log = utf8_path(log, "log path", Interface::Rsync)?;
     let rsh = parse_rsh(&args.rsh)?;
     let mut cmd = Command::new(&rsh[0]);
     cmd.args(&rsh[1..]);

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -2674,12 +2674,15 @@ impl FsOps {
             && !destination_fs.synchronous;
         let mut userspace_fallback = false;
         #[cfg(debug_assertions)]
-        if !inplace && std::env::var_os("SYQ_TEST_COPY_LOCAL_EXDEV").is_some() {
+        if std::env::var_os("SYQ_TEST_COPY_LOCAL_EXDEV").is_some() {
             if use_sequential_nfs_fallback {
                 userspace_fallback = true;
             } else {
                 drop(d);
-                fs::remove_file(&target).with_context(|| format!("remove {}", target.display()))?;
+                if !inplace {
+                    fs::remove_file(&target)
+                        .with_context(|| format!("remove {}", target.display()))?;
+                }
                 bail!("EXDEV");
             }
         }
@@ -2710,14 +2713,11 @@ impl FsOps {
                         userspace_fallback = true;
                         continue;
                     }
-                    if inplace {
-                        drop(d);
-                        let _ = fs::remove_file(&target);
-                    } else {
+                    drop(d);
+                    if !inplace {
                         // The planner probed before this empty sidecar existed.
                         // A content-identical fallback completes through its
                         // retained basis fd and would otherwise orphan it.
-                        drop(d);
                         fs::remove_file(&target)
                             .with_context(|| format!("remove {}", target.display()))?;
                     }

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -2391,7 +2391,44 @@ impl FsOps {
         let p = resolve(path);
         if let Some(guard) = guard {
             if inplace {
-                bail!("guarded destination cannot be prepared in place");
+                self.uncache(&p);
+                let target = guarded_target(path, guard)?;
+                for _ in 0..8 {
+                    match target.root.metadata_optional(&target.relative)? {
+                        Some(metadata) if metadata.is_file() => {
+                            let file = target.root.open_regular_write(&target.relative, false)?;
+                            require_rooted_metadata(&file, metadata, &target.label)?;
+                            file.set_len(size).with_context(|| {
+                                format!("resize confined file {}", target.label.display())
+                            })?;
+                            return Ok(());
+                        }
+                        Some(metadata) if metadata.is_dir() => {
+                            bail!("destination {} is a directory", target.label.display())
+                        }
+                        Some(_) => target.root.unlink(&target.relative)?,
+                        None => match target.root.create_file(&target.relative, mode) {
+                            Ok(file) => {
+                                file.set_len(size).with_context(|| {
+                                    format!("resize confined file {}", target.label.display())
+                                })?;
+                                return Ok(());
+                            }
+                            Err(error)
+                                if error.downcast_ref::<io::Error>().is_some_and(|error| {
+                                    error.kind() == io::ErrorKind::AlreadyExists
+                                }) =>
+                            {
+                                continue
+                            }
+                            Err(error) => return Err(error),
+                        },
+                    }
+                }
+                bail!(
+                    "destination {} changed repeatedly while opening it",
+                    target.label.display()
+                );
             }
             let target = guarded_target(path, guard)?;
             let pp = partial_path(&p, partial_id)?;
@@ -2884,11 +2921,19 @@ impl FsOps {
         };
         let f = if let Some(guard) = target.guard {
             if inplace {
-                bail!("guarded destination cannot be written in place");
+                let final_target = guarded_target(target.path, guard)?;
+                self.cached_rooted(
+                    &p,
+                    &final_target.root,
+                    &final_target.relative,
+                    attempt,
+                    false,
+                )?
+            } else {
+                let final_target = guarded_target(target.path, guard)?;
+                let relative = relative_under(&final_target.root_path, &p)?;
+                self.cached_rooted(&p, &final_target.root, &relative, attempt, true)?
             }
-            let final_target = guarded_target(target.path, guard)?;
-            let relative = relative_under(&final_target.root_path, &p)?;
-            self.cached_rooted(&p, &final_target.root, &relative, attempt, true)?
         } else {
             self.cached(&p, true, attempt, !inplace)?
         };
@@ -2991,10 +3036,17 @@ impl FsOps {
         else {
             unreachable!("rooted finalization requires a container guard")
         };
-        if inplace {
-            bail!("guarded destination cannot be finalized in place");
-        }
         let target = guarded_target(path, guard)?;
+        if inplace {
+            let file = self
+                .uncache(&target.label)
+                .map(Ok)
+                .unwrap_or_else(|| target.root.open_regular_write(&target.relative, false))?;
+            set_meta_file(&file, meta, flags)
+                .with_context(|| format!("set metadata {}", target.label.display()))?;
+            require_rooted_named_identity(&target, &file, condition)?;
+            return Ok(());
+        }
         let src = partial_path(&target.label, partial_id)?;
         let src_relative = relative_under(&target.root_path, &src)?;
         let file = self
@@ -3665,6 +3717,84 @@ mod tests {
 
         assert!(regular_opened);
         assert!(link_rejected);
+    }
+
+    #[test]
+    fn guarded_inplace_updates_are_confined_and_keep_the_target_inode() {
+        let dir = test_dir();
+        let root_path = dir.join("root");
+        let outside = dir.join("outside");
+        fs::create_dir_all(&root_path).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        let target = root_path.join("file");
+        let sentinel = outside.join("sentinel");
+        fs::write(&target, b"old").unwrap();
+        fs::write(&sentinel, b"outside").unwrap();
+        symlink(&outside, root_path.join("escape")).unwrap();
+
+        let root = Root::open(&root_path).unwrap();
+        let identity = root.identity();
+        let guard = ContainerGuard {
+            root: root_path.as_os_str().as_bytes().to_vec(),
+            dev: identity.dev,
+            ino: identity.ino,
+        };
+        let target_bytes = target.as_os_str().as_bytes();
+        let partial_id = [7; 16];
+        let inode = fs::metadata(&target).unwrap().ino();
+        let mut operations = FsOps::new();
+        operations
+            .prepare(target_bytes, 3, true, &partial_id, 0o600, Some(&guard))
+            .unwrap();
+        operations
+            .write_range(
+                PartialTarget {
+                    path: target_bytes,
+                    id: &partial_id,
+                    guard: Some(&guard),
+                },
+                true,
+                0,
+                0,
+                content_digest(b"new"),
+                b"new",
+            )
+            .unwrap();
+        operations
+            .finalize(
+                target_bytes,
+                true,
+                &partial_id,
+                &Meta {
+                    mode: 0o600,
+                    uid: 0,
+                    gid: 0,
+                    mtime: 0,
+                    mtime_nsec: 0,
+                },
+                0,
+                TargetMutation {
+                    condition: TargetCondition::Any,
+                    guard: Some(&guard),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"new");
+        assert_eq!(fs::metadata(&target).unwrap().ino(), inode);
+        let escaped = root_path.join("escape/sentinel");
+        assert!(operations
+            .prepare(
+                escaped.as_os_str().as_bytes(),
+                1,
+                true,
+                &partial_id,
+                0o600,
+                Some(&guard),
+            )
+            .is_err());
+        assert_eq!(fs::read(&sentinel).unwrap(), b"outside");
+        fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -3,7 +3,7 @@
 use crate::cli::{Args, Existence, Interface, Location, Placement};
 use crate::delegation::{
     self, CopyLimitsV1, CopyOperationV1, CopyOptionsV1, CopyPolicyV1, DeletionPolicyV1,
-    DestinationPlacementV1, ExistingDestinationPolicyV1, GrantOperationV1, GrantV1,
+    DestinationPlacementV1, ExistingDestinationPolicyV1, FilterPolicyV3, GrantOperationV1, GrantV1,
     MutationScopeV1, PublicationPolicyV1, RequestId,
 };
 use crate::enrollment::{
@@ -240,6 +240,9 @@ pub(crate) struct RestrictedAuthority {
     guard: ContainerGuard,
     destination: Vec<u8>,
     copy: CopyOperationV1,
+    filters: FilterPolicyV3,
+    filter_matcher: Option<ignore::gitignore::Gitignore>,
+    filter_roots: Vec<Vec<u8>>,
     file_data_limit: Option<crate::bwlimit::BandwidthLimit>,
     receiver_umask: u32,
     deadline: Instant,
@@ -252,9 +255,22 @@ impl RestrictedAuthority {
         config: &ReceiverEnrollment,
         grant: GrantV1,
         max_file_data_bytes_per_second: u64,
+        filters: FilterPolicyV3,
         deadline: Instant,
     ) -> Result<Self> {
         let GrantOperationV1::Copy(copy) = grant.operation;
+        let filter_matcher = crate::scan::build_ignore(&filters.ignore)?;
+        let filter_roots = match copy.policy.placement {
+            DestinationPlacementV1::ExactPath | DestinationPlacementV1::DirectoryContents => {
+                vec![copy.destination.clone()]
+            }
+            DestinationPlacementV1::DirectoryAsChild => copy
+                .mutation_scopes
+                .iter()
+                .filter(|scope| scope.path != copy.destination)
+                .map(|scope| scope.path.clone())
+                .collect(),
+        };
         let root_path = Path::new(&config.root);
         let destination = Path::new(std::ffi::OsStr::from_bytes(&copy.destination));
         let relative = destination.strip_prefix(root_path).with_context(|| {
@@ -286,6 +302,9 @@ impl RestrictedAuthority {
             },
             destination: copy.destination.clone(),
             copy,
+            filters,
+            filter_matcher,
+            filter_roots,
             file_data_limit,
             receiver_umask,
             deadline,
@@ -363,6 +382,40 @@ impl RestrictedAuthority {
                 && path.get(scope.path.len()) == Some(&b'/'))
     }
 
+    fn filter_applies(&self, path: &[u8]) -> bool {
+        self.filter_roots.iter().any(|root| {
+            path == root || (path.starts_with(root) && path.get(root.len()) == Some(&b'/'))
+        })
+    }
+
+    /// A mapped source root itself is never ignored. A destination path that
+    /// can be supplied by several overlapping roots remains allowed when any
+    /// one of those source-relative spellings is included.
+    fn path_is_ignored(&self, path: &[u8], is_dir: bool) -> bool {
+        let Some(matcher) = &self.filter_matcher else {
+            return false;
+        };
+        let mut under_root = false;
+        for root in &self.filter_roots {
+            if path == root {
+                return false;
+            }
+            if !path.starts_with(root) || path.get(root.len()) != Some(&b'/') {
+                continue;
+            }
+            under_root = true;
+            let relative = &path[root.len() + 1..];
+            let relative = Path::new(OsStr::from_bytes(relative));
+            if !matcher
+                .matched_path_or_any_parents(relative, is_dir)
+                .is_ignore()
+            {
+                return false;
+            }
+        }
+        under_root
+    }
+
     fn record_path(&self, path: &[u8]) -> Result<()> {
         let mut state = self.state.lock().unwrap();
         if state.paths.insert(path.to_vec())
@@ -387,7 +440,7 @@ impl RestrictedAuthority {
         self.record_path(path)
     }
 
-    fn check_mutation_path(&self, path: &[u8]) -> Result<()> {
+    fn check_mutation_authority(&self, path: &[u8]) -> Result<()> {
         if self.copy.options.dry_run || self.copy.options.verify_only {
             bail!("signed read-only transfer forbids destination mutations");
         }
@@ -399,6 +452,14 @@ impl RestrictedAuthority {
             .any(|scope| Self::scope_allows(scope, path))
         {
             bail!("receiver mutation is outside the signed destination scopes");
+        }
+        Ok(())
+    }
+
+    fn check_mutation_path(&self, path: &[u8], is_dir: bool) -> Result<()> {
+        self.check_mutation_authority(path)?;
+        if self.path_is_ignored(path, is_dir) {
+            bail!("receiver mutation targets a path excluded by the signed filter policy");
         }
         self.record_path(path)
     }
@@ -709,7 +770,7 @@ impl RestrictedAuthority {
     }
 
     fn charge_bytes(&self, path: &[u8], offset: u64, bytes: usize) -> Result<()> {
-        self.check_mutation_path(path)?;
+        self.check_mutation_path(path, false)?;
         let bytes = u64::try_from(bytes).context("request byte count overflow")?;
         if self
             .file_data_limit
@@ -738,11 +799,16 @@ impl RestrictedAuthority {
         Ok(())
     }
 
-    fn charge_deletion(&self, path: &[u8]) -> Result<()> {
+    fn charge_deletion(&self, path: &[u8], is_dir: bool) -> Result<()> {
         if path == self.destination {
             bail!("the signed destination root itself may not be deleted");
         }
-        self.check_mutation_path(path)?;
+        if self.filters.delete_excluded {
+            self.check_mutation_authority(path)?;
+            self.record_path(path)?;
+        } else {
+            self.check_mutation_path(path, is_dir)?;
+        }
         if self.copy.policy.deletion == DeletionPolicyV1::Forbid {
             bail!("deletion is not authorized by the signed grant");
         }
@@ -774,13 +840,25 @@ impl RestrictedAuthority {
             Op::Remove { .. } => {
                 bail!("recursive remove is not supported by the root-confined receiver")
             }
-            Op::Rmdir { path } | Op::Unlink { path } => {
-                self.charge_deletion(path)?;
+            Op::Rmdir { path } => {
+                self.charge_deletion(path, true)?;
+                self.state.lock().unwrap().receiver_modes.remove(path);
+                return Ok(());
+            }
+            Op::Unlink { path } => {
+                self.charge_deletion(path, false)?;
                 self.state.lock().unwrap().receiver_modes.remove(path);
                 return Ok(());
             }
         };
-        self.check_mutation_path(path)?;
+        let is_dir = match operation {
+            Op::Mkdir { .. } => true,
+            Op::SetMeta { .. } => self
+                .rooted_metadata(path)?
+                .is_some_and(|metadata| metadata.is_dir()),
+            _ => false,
+        };
+        self.check_mutation_path(path, is_dir)?;
         match operation {
             Op::Mkdir { path, mode, .. } => {
                 if !self.copy.options.preserve_permissions {
@@ -865,6 +943,7 @@ impl RestrictedAuthority {
             Request::Scan {
                 root,
                 follow_root,
+                ignore,
                 guard,
                 ..
             } => {
@@ -872,6 +951,16 @@ impl RestrictedAuthority {
                     bail!("signed destination scans cannot follow a root symlink");
                 }
                 self.check_observation_path(root)?;
+                if self.filter_applies(root) {
+                    let expected = if self.filters.delete_excluded {
+                        &[][..]
+                    } else {
+                        self.filters.ignore.as_slice()
+                    };
+                    if ignore.as_slice() != expected {
+                        bail!("destination scan filters do not match the signed filter policy");
+                    }
+                }
                 *guard = Some(self.guard.clone());
             }
             Request::StatMany {
@@ -946,10 +1035,13 @@ impl RestrictedAuthority {
             Request::SeedBasis {
                 path, len, guard, ..
             } => {
+                if self.copy.policy.publication != PublicationPolicyV1::AtomicStaged {
+                    bail!("in-place signed receiver forbids staged basis creation");
+                }
                 if *len > self.copy.limits.max_file_bytes {
                     bail!("signed grant per-file byte limit exceeded");
                 }
-                self.check_mutation_path(path)?;
+                self.check_mutation_path(path, false)?;
                 *guard = Some(self.guard.clone());
             }
             Request::FinishBasis {
@@ -960,7 +1052,7 @@ impl RestrictedAuthority {
                 guard,
                 ..
             } => {
-                self.check_mutation_path(path)?;
+                self.check_mutation_path(path, false)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -977,13 +1069,13 @@ impl RestrictedAuthority {
                 guard,
                 ..
             } => {
-                if *inplace || self.copy.policy.publication != PublicationPolicyV1::AtomicStaged {
-                    bail!("signed receiver requires atomic staged publication");
+                if *inplace != (self.copy.policy.publication == PublicationPolicyV1::InPlace) {
+                    bail!("file preparation does not match the signed publication policy");
                 }
                 if *size > self.copy.limits.max_file_bytes {
                     bail!("signed grant per-file byte limit exceeded");
                 }
-                self.check_mutation_path(path)?;
+                self.check_mutation_path(path, false)?;
                 *guard = Some(self.guard.clone());
             }
             Request::WriteRange {
@@ -994,8 +1086,8 @@ impl RestrictedAuthority {
                 guard,
                 ..
             } => {
-                if *inplace {
-                    bail!("signed receiver requires atomic staged publication");
+                if *inplace != (self.copy.policy.publication == PublicationPolicyV1::InPlace) {
+                    bail!("file write does not match the signed publication policy");
                 }
                 self.charge_bytes(path, *off, data.len())?;
                 *guard = Some(self.guard.clone());
@@ -1009,10 +1101,10 @@ impl RestrictedAuthority {
                 guard,
                 ..
             } => {
-                if *inplace {
-                    bail!("signed receiver requires atomic staged publication");
+                if *inplace != (self.copy.policy.publication == PublicationPolicyV1::InPlace) {
+                    bail!("file finalization does not match the signed publication policy");
                 }
-                self.check_mutation_path(path)?;
+                self.check_mutation_path(path, false)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1023,6 +1115,9 @@ impl RestrictedAuthority {
                 *guard = Some(self.guard.clone());
             }
             Request::PutSmallBatch(puts) => {
+                if self.copy.policy.publication != PublicationPolicyV1::AtomicStaged {
+                    bail!("in-place signed receiver forbids staged small-file publication");
+                }
                 if let Some(limit) = &self.file_data_limit {
                     let bytes = puts.iter().try_fold(0u64, |total, put| {
                         total
@@ -1916,9 +2011,6 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
     if args.no_tcp || args.tcp_plain {
         bail!("command-restricted transfers require encrypted TCP data connections");
     }
-    if args.inplace {
-        bail!("command-restricted transfers currently require atomic staged publication");
-    }
     if args.tcp_congestion.is_some() {
         bail!("--tcp-congestion is not yet represented in the signed receiver grant");
     }
@@ -1931,14 +2023,13 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
             "--update, --ignore-existing, --existing, and destination-existence constraints are not yet enforceable by the command-restricted receiver"
         );
     }
-    if !args.ignore_lines.is_empty()
-        || !args.files_from_lines.is_empty()
+    if !args.files_from_lines.is_empty()
         || args.files_from.is_some()
         || args.native_mapping.is_some()
         || args.min_size.is_some()
     {
         bail!(
-            "--ignore/--ignore-from, --files-from, --mapping, and --min-size are not yet independently enforceable by the command-restricted receiver"
+            "--files-from, --mapping, and --min-size are not yet independently enforceable by the command-restricted receiver"
         );
     }
     if args.syq_path.is_some() || args.no_bootstrap {
@@ -2147,6 +2238,10 @@ pub(crate) fn prepare_transfer(
             &canonical_destination,
         )?,
         args.bwlimit_bytes,
+        FilterPolicyV3 {
+            ignore: args.ignore_lines.clone(),
+            delete_excluded: args.delete_excluded,
+        },
         &private_key,
     )?;
     Ok(PreparedTransfer {
@@ -2198,11 +2293,12 @@ pub(crate) fn run_receiver(enrollment: &str) -> Result<()> {
         revocation_file: None,
     };
     let verified = delegation::verify_and_claim(&envelope, &context, &policy, &replay)?;
-    let (grant, max_file_data_bytes_per_second, deadline) = verified.into_parts();
+    let (grant, max_file_data_bytes_per_second, filters, deadline) = verified.into_parts();
     let authority = std::sync::Arc::new(RestrictedAuthority::new(
         &config,
         grant,
         max_file_data_bytes_per_second,
+        filters,
         deadline,
     )?);
     crate::server::run_restricted(authority)
@@ -2403,6 +2499,24 @@ mod tests {
         maximum_bytes: u64,
         max_file_data_bytes_per_second: u64,
     ) -> RestrictedAuthority {
+        test_authority_with_policy(
+            root,
+            deletion,
+            maximum_bytes,
+            max_file_data_bytes_per_second,
+            FilterPolicyV3::default(),
+            PublicationPolicyV1::AtomicStaged,
+        )
+    }
+
+    fn test_authority_with_policy(
+        root: &Path,
+        deletion: DeletionPolicyV1,
+        maximum_bytes: u64,
+        max_file_data_bytes_per_second: u64,
+        filters: FilterPolicyV3,
+        publication: PublicationPolicyV1,
+    ) -> RestrictedAuthority {
         let opened = Root::open(root).unwrap();
         let identity = opened.identity();
         let id = EnrollmentId::random();
@@ -2436,7 +2550,7 @@ mod tests {
                     placement: DestinationPlacementV1::ExactPath,
                     existing: ExistingDestinationPolicyV1::Replace,
                     deletion,
-                    publication: PublicationPolicyV1::AtomicStaged,
+                    publication,
                 },
                 options: CopyOptionsV1 {
                     recursive: true,
@@ -2469,6 +2583,7 @@ mod tests {
             &config,
             grant,
             max_file_data_bytes_per_second,
+            filters,
             Instant::now() + std::time::Duration::from_secs(60),
         )
         .unwrap()
@@ -2668,6 +2783,111 @@ mod tests {
             guard: None,
         };
         assert!(authority.authorize(&mut write, false).is_err());
+    }
+
+    #[test]
+    fn signed_filters_bind_scans_mutations_and_prune_protection() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let policy = FilterPolicyV3 {
+            ignore: vec!["ignored/".into()],
+            delete_excluded: false,
+        };
+        let authority = test_authority_with_policy(
+            &root,
+            DeletionPolicyV1::DeleteDestinationOnly,
+            16,
+            0,
+            policy.clone(),
+            PublicationPolicyV1::AtomicStaged,
+        );
+        let target = root.join("target").as_os_str().as_bytes().to_vec();
+        let ignored = root
+            .join("target/ignored/file")
+            .as_os_str()
+            .as_bytes()
+            .to_vec();
+        let included = root.join("target/included").as_os_str().as_bytes().to_vec();
+
+        let scan = |ignore: Vec<String>| Request::Scan {
+            root: target.clone(),
+            follow_root: false,
+            ignore,
+            report_ignored: true,
+            guard: None,
+        };
+        let mut matching_scan = scan(policy.ignore.clone());
+        authority.authorize(&mut matching_scan, false).unwrap();
+        let mut altered_scan = scan(Vec::new());
+        assert!(authority.authorize(&mut altered_scan, false).is_err());
+
+        let prepare = |path| Request::Prepare {
+            path,
+            size: 4,
+            inplace: false,
+            partial_id: [1; 16],
+            mode: 0o600,
+            guard: None,
+        };
+        let mut included_prepare = prepare(included);
+        authority.authorize(&mut included_prepare, false).unwrap();
+        let mut ignored_prepare = prepare(ignored.clone());
+        assert!(authority.authorize(&mut ignored_prepare, false).is_err());
+        let mut protected_delete = Request::Apply {
+            ops: vec![Op::Unlink {
+                path: ignored.clone(),
+            }],
+            guard: None,
+        };
+        assert!(authority.authorize(&mut protected_delete, false).is_err());
+
+        let delete_excluded = test_authority_with_policy(
+            &root,
+            DeletionPolicyV1::DeleteDestinationOnly,
+            16,
+            0,
+            FilterPolicyV3 {
+                ignore: policy.ignore,
+                delete_excluded: true,
+            },
+            PublicationPolicyV1::AtomicStaged,
+        );
+        let mut permitted_delete = Request::Apply {
+            ops: vec![Op::Unlink { path: ignored }],
+            guard: None,
+        };
+        delete_excluded
+            .authorize(&mut permitted_delete, false)
+            .unwrap();
+    }
+
+    #[test]
+    fn signed_inplace_policy_requires_inplace_file_mutations() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let authority = test_authority_with_policy(
+            &root,
+            DeletionPolicyV1::Forbid,
+            16,
+            0,
+            FilterPolicyV3::default(),
+            PublicationPolicyV1::InPlace,
+        );
+        let target = root.join("target/file").as_os_str().as_bytes().to_vec();
+        let prepare = |inplace| Request::Prepare {
+            path: target.clone(),
+            size: 4,
+            inplace,
+            partial_id: [1; 16],
+            mode: 0o600,
+            guard: None,
+        };
+        let mut inplace = prepare(true);
+        authority.authorize(&mut inplace, false).unwrap();
+        let mut staged = prepare(false);
+        assert!(authority.authorize(&mut staged, false).is_err());
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -260,17 +260,7 @@ impl RestrictedAuthority {
     ) -> Result<Self> {
         let GrantOperationV1::Copy(copy) = grant.operation;
         let filter_matcher = crate::scan::build_ignore(&filters.ignore)?;
-        let filter_roots = match copy.policy.placement {
-            DestinationPlacementV1::ExactPath | DestinationPlacementV1::DirectoryContents => {
-                vec![copy.destination.clone()]
-            }
-            DestinationPlacementV1::DirectoryAsChild => copy
-                .mutation_scopes
-                .iter()
-                .filter(|scope| scope.path != copy.destination)
-                .map(|scope| scope.path.clone())
-                .collect(),
-        };
+        let filter_roots = filters.destination_roots.clone();
         let root_path = Path::new(&config.root);
         let destination = Path::new(std::ffi::OsStr::from_bytes(&copy.destination));
         let relative = destination.strip_prefix(root_path).with_context(|| {
@@ -406,10 +396,10 @@ impl RestrictedAuthority {
             under_root = true;
             let relative = &path[root.len() + 1..];
             let relative = Path::new(OsStr::from_bytes(relative));
-            if !matcher
-                .matched_path_or_any_parents(relative, is_dir)
-                .is_ignore()
-            {
+            let pruned_by_ancestor = relative.ancestors().skip(1).any(|ancestor| {
+                !ancestor.as_os_str().is_empty() && matcher.matched(ancestor, true).is_ignore()
+            });
+            if !pruned_by_ancestor && !matcher.matched(relative, is_dir).is_ignore() {
                 return false;
             }
         }
@@ -2189,6 +2179,28 @@ fn grant_for(
     Ok(grant)
 }
 
+fn filter_destination_roots(
+    args: &Args,
+    sources: &[Location],
+    destination: &[u8],
+) -> Result<Vec<Vec<u8>>> {
+    let mut roots = Vec::with_capacity(sources.len());
+    for source in sources {
+        if args.placement == Placement::As || source.copies_contents() {
+            roots.push(destination.to_vec());
+        } else {
+            let basename = source.basename();
+            if basename.is_empty() {
+                bail!("named source has no destination basename for signed filters");
+            }
+            roots.push(crate::fsops::join(destination, &basename));
+        }
+    }
+    roots.sort();
+    roots.dedup();
+    Ok(roots)
+}
+
 pub(crate) fn prepare_transfer(
     args: &Args,
     sources: &[Location],
@@ -2240,6 +2252,11 @@ pub(crate) fn prepare_transfer(
         args.bwlimit_bytes,
         FilterPolicyV3 {
             ignore: args.ignore_lines.clone(),
+            destination_roots: filter_destination_roots(
+                args,
+                sources,
+                canonical_destination.as_bytes(),
+            )?,
             delete_excluded: args.delete_excluded,
         },
         &private_key,
@@ -2514,7 +2531,7 @@ mod tests {
         deletion: DeletionPolicyV1,
         maximum_bytes: u64,
         max_file_data_bytes_per_second: u64,
-        filters: FilterPolicyV3,
+        mut filters: FilterPolicyV3,
         publication: PublicationPolicyV1,
     ) -> RestrictedAuthority {
         let opened = Root::open(root).unwrap();
@@ -2532,6 +2549,9 @@ mod tests {
             receiver_path: "/usr/bin/syq".into(),
         };
         let destination = root.join("target");
+        if !filters.ignore.is_empty() && filters.destination_roots.is_empty() {
+            filters.destination_roots = vec![destination.as_os_str().as_bytes().to_vec()];
+        }
         let grant = GrantV1 {
             enrollment_id: id,
             target_login: "receiver".into(),
@@ -2791,7 +2811,8 @@ mod tests {
         let root = temporary.path().join("root");
         fs::create_dir(&root).unwrap();
         let policy = FilterPolicyV3 {
-            ignore: vec!["ignored/".into()],
+            ignore: vec!["ignored/".into(), "!ignored/file".into()],
+            destination_roots: Vec::new(),
             delete_excluded: false,
         };
         let authority = test_authority_with_policy(
@@ -2849,6 +2870,7 @@ mod tests {
             0,
             FilterPolicyV3 {
                 ignore: policy.ignore,
+                destination_roots: Vec::new(),
                 delete_excluded: true,
             },
             PublicationPolicyV1::AtomicStaged,
@@ -2860,6 +2882,56 @@ mod tests {
         delete_excluded
             .authorize(&mut permitted_delete, false)
             .unwrap();
+    }
+
+    #[test]
+    fn mixed_filter_mappings_keep_an_explicit_named_source_root() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let destination = root.join("target").as_os_str().as_bytes().to_vec();
+        let mut args = Args::try_parse_from([
+            "syq rsync",
+            "-r",
+            "host-a:tree/",
+            "host-a:cache",
+            "host-b:/target",
+        ])
+        .unwrap();
+        args.normalize();
+        args.placement = Placement::Into;
+        let sources = [
+            Location::parse("host-a:tree/").unwrap(),
+            Location::parse("host-a:cache").unwrap(),
+        ];
+        let destination_roots = filter_destination_roots(&args, &sources, &destination).unwrap();
+        let cache = root.join("target/cache").as_os_str().as_bytes().to_vec();
+        assert_eq!(destination_roots, vec![destination, cache.clone()]);
+
+        let authority = test_authority_with_policy(
+            &root,
+            DeletionPolicyV1::Forbid,
+            16,
+            0,
+            FilterPolicyV3 {
+                ignore: vec!["cache/".into()],
+                destination_roots,
+                delete_excluded: false,
+            },
+            PublicationPolicyV1::AtomicStaged,
+        );
+        let prepare = |path| Request::Prepare {
+            path,
+            size: 4,
+            inplace: false,
+            partial_id: [2; 16],
+            mode: 0o600,
+            guard: None,
+        };
+        let mut cache_root = prepare(cache.clone());
+        authority.authorize(&mut cache_root, false).unwrap();
+        let mut cache_child = prepare(crate::fsops::join(&cache, b"file"));
+        authority.authorize(&mut cache_child, false).unwrap();
     }
 
     #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::ffi::OsStringExt;
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -541,6 +541,99 @@ fn native_hash_repairs_equal_metadata_content_mismatches() {
             assert!(!t.path(&format!("{destination}/extra")).exists());
         }
     }
+}
+
+#[test]
+fn native_filters_apply_to_copy_and_protect_pruned_paths() {
+    let t = Tmp::new();
+    write(&t.path("src/keep"), b"keep");
+    write(&t.path("src/discard.tmp"), b"new-discard");
+    write(&t.path("src/important.tmp"), b"important");
+
+    run_native_ok(&[
+        "cp",
+        "--ignore",
+        "*.tmp",
+        "--src-src",
+        &t.s("src"),
+        "--into",
+        &t.s("copied"),
+    ]);
+    assert_eq!(listing(&t.path("copied")), ["keep"]);
+
+    write(&t.path("patterns"), b"*.tmp\n");
+    write(&t.path("pruned/discard.tmp"), b"protected-old-copy");
+    write(&t.path("pruned/extra"), b"remove");
+    run_native_ok(&[
+        "cp-prune",
+        "--ignore-from",
+        &t.s("patterns"),
+        "--ignore",
+        "!important.tmp",
+        "--src-src",
+        &t.s("src"),
+        "--into-existing",
+        &t.s("pruned"),
+    ]);
+    assert_eq!(read(&t.path("pruned/keep")), b"keep");
+    assert_eq!(read(&t.path("pruned/important.tmp")), b"important");
+    assert_eq!(read(&t.path("pruned/discard.tmp")), b"protected-old-copy");
+    assert!(!t.path("pruned/extra").exists());
+}
+
+#[test]
+fn native_preserve_policy_controls_permissions_and_special_files() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"new");
+    fs::set_permissions(t.path("src/file"), fs::Permissions::from_mode(0o751)).unwrap();
+    mkfifo(&t.path("src/fifo"));
+    write(&t.path("dst/file"), b"old");
+    fs::set_permissions(t.path("dst/file"), fs::Permissions::from_mode(0o600)).unwrap();
+    set_mtime(&t.path("src/file"), 1_700_000_000);
+    set_mtime(&t.path("dst/file"), 1_600_000_000);
+
+    run_native_ok(&[
+        "cp",
+        "--preserve=permissions,specials",
+        "--src-src",
+        &t.s("src"),
+        "--into-existing",
+        &t.s("dst"),
+    ]);
+
+    assert_eq!(read(&t.path("dst/file")), b"new");
+    assert_eq!(
+        fs::metadata(t.path("dst/file")).unwrap().mode() & 0o777,
+        0o751
+    );
+    assert!(fs::symlink_metadata(t.path("dst/fifo"))
+        .unwrap()
+        .file_type()
+        .is_fifo());
+}
+
+#[test]
+fn native_inplace_updates_the_existing_inode_without_a_sidecar() {
+    let t = Tmp::new();
+    let expected = vec![b'n'; 5 * 1024 * 1024];
+    write(&t.path("src/file"), &expected);
+    write(&t.path("dst/file"), &vec![b'o'; expected.len()]);
+    set_mtime(&t.path("src/file"), 1_700_000_000);
+    set_mtime(&t.path("dst/file"), 1_600_000_000);
+    let inode = fs::metadata(t.path("dst/file")).unwrap().ino();
+
+    run_native_ok(&[
+        "cp",
+        "--inplace",
+        "--src-src",
+        &t.s("src"),
+        "--into-existing",
+        &t.s("dst"),
+    ]);
+
+    assert_eq!(read(&t.path("dst/file")), expected);
+    assert_eq!(fs::metadata(t.path("dst/file")).unwrap().ino(), inode);
+    assert!(partial_files(&t.path("dst")).is_empty());
 }
 
 #[test]
@@ -8199,6 +8292,63 @@ fn direct_remote_to_remote_forwards_receiver_policy_opt_outs() {
         log.contains("--insecure-links"),
         "the source-side orchestrator silently changed destination-link policy"
     );
+}
+
+#[test]
+fn native_direct_remote_to_remote_forwards_copy_policies() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    let helper = cached_remote_helper(&t);
+    fs::create_dir_all(helper.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), &helper).unwrap();
+
+    let contents = vec![7u8; 5 << 20];
+    write(&t.path("src/keep"), &contents);
+    write(&t.path("src/skip.tmp"), b"excluded");
+    fs::set_permissions(t.path("src/keep"), fs::Permissions::from_mode(0o640)).unwrap();
+    write(&t.path("dst/keep"), b"old");
+    let original_inode = fs::metadata(t.path("dst/keep")).unwrap().ino();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--from",
+            "fake",
+            "--src-src",
+            &t.s("src"),
+            "--to",
+            "fake",
+            "--ignore=*.tmp",
+            "--preserve=permissions",
+            "--inplace",
+            "--into-existing",
+            &t.s("dst"),
+            "-q",
+        ])
+        .env("SYQ_INTERNAL_NATIVE_RSH", rsh)
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .run()
+        .expect("run native direct transfer through fake remote shell");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst/keep")), contents);
+    let metadata = fs::metadata(t.path("dst/keep")).unwrap();
+    assert_eq!(
+        metadata.ino(),
+        original_inode,
+        "--inplace was not forwarded"
+    );
+    assert_eq!(metadata.mode() & 0o777, 0o640);
+    assert!(!t.path("dst/skip.tmp").exists());
+    let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    for option in ["--ignore=*.tmp", "--preserve=permissions", "--inplace"] {
+        assert!(
+            log.contains(option),
+            "source command omitted {option}: {log}"
+        );
+    }
 }
 
 // ----------------------------------------------------------- review round 13

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -6754,6 +6754,40 @@ fn copy_local_exdev_fallback_leaves_no_partial() {
 
 #[cfg(all(debug_assertions, target_os = "linux"))]
 #[test]
+fn native_inplace_exdev_fallback_preserves_hardlink_aliases() {
+    let t = Tmp::new();
+    let contents = vec![b'n'; 8 * 1024 * 1024];
+    write(&t.path("src"), &contents);
+    write(&t.path("dst"), &vec![b'o'; contents.len()]);
+    fs::hard_link(t.path("dst"), t.path("alias")).unwrap();
+    set_mtime(&t.path("src"), 1_700_000_000);
+    set_mtime(&t.path("dst"), 1_600_000_000);
+    let original_inode = fs::metadata(t.path("dst")).unwrap().ino();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--inplace",
+            "--src",
+            &t.s("src"),
+            "--as",
+            &t.s("dst"),
+            "-q",
+        ])
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .output()
+        .unwrap();
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), contents);
+    assert_eq!(read(&t.path("alias")), contents);
+    assert_eq!(fs::metadata(t.path("dst")).unwrap().ino(), original_inode);
+    assert_eq!(fs::metadata(t.path("alias")).unwrap().ino(), original_inode);
+    assert!(partial_files(&t.0).is_empty());
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
 fn copy_local_nfs_exdev_uses_sequential_receiver_fallback() {
     let t = Tmp::new();
     let contents = vec![b'x'; 8 * 1024 * 1024];


### PR DESCRIPTION
## Summary

- add ordered gitignore filters, explicit preservation values, and `--inplace` to native `cp` and `cp-prune`
- forward those policies through direct remote-to-remote copies and bind filters/publication policy in the command-restricted receiver
- add descriptor-confined guarded in-place writes and keep `--relay` absent from native syntax and diagnostics
- document the native contract and interruption/security tradeoffs

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (226 unit, 262 filesystem/CLI integration, 9 update tests)