### PR TITLE
Clarify failed release tag cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,25 @@ outlive its premise and steer later work in the wrong direction.
   task-related stash, and no commits that still need integration. An ancestry
   result such as `git branch --merged` says nothing about uncommitted files.
 
+## Release tag lifecycle
+
+- Treat a release tag as provisional until its release workflow connects it to
+  permanent published state. If an attempt is abandoned before that boundary,
+  remove the failed tag locally and remotely instead of reserving a version
+  that was never released. Never force-update or silently move the tag.
+- A release tag becomes permanent as soon as any associated version or artifact
+  reaches an immutable or append-only destination, including an immutable
+  GitHub release, a package registry, a module proxy, the Homebrew tap, or a
+  durable artifact attestation. Never move or delete a permanent tag. Repair or
+  rerun the remaining publication steps from that exact tag when safe, or cut a
+  new version when they cannot be completed consistently.
+- Before deleting a provisional tag, stop or wait for its active workflows and
+  audit every release destination with read-only checks. Resolve the exact tag
+  object and target commit; verify that no permanent publication exists; and
+  inspect and clean any recoverable draft state. Delete only the explicitly
+  audited local and remote refs, then verify their absence and report what was
+  removed and whether it can be recovered.
+
 ## Always report the commit you are talking about
 
 - Any status report about branch or PR work states the short SHA it refers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,22 +110,27 @@ outlive its premise and steer later work in the wrong direction.
 
 ## Release tag lifecycle
 
-- Treat a release tag as provisional until its release workflow connects it to
-  permanent published state. If an attempt is abandoned before that boundary,
-  remove the failed tag locally and remotely instead of reserving a version
-  that was never released. Never force-update or silently move the tag.
+- Except for Go module tags, treat a release tag as provisional until its
+  release workflow connects it to permanent published state. If an attempt is
+  abandoned before that boundary, remove the failed tag locally and remotely
+  instead of reserving a version that was never released. Never force-update or
+  silently move the tag.
+- A Go module tag such as `sdk/go/v*` is permanent as soon as it is pushed.
+  Pushing the tag publishes the module: clients or arbitrary proxies may fetch
+  and cache it without an observable central publication step. Never delete,
+  recreate, or move a Go module tag.
 - A release tag becomes permanent as soon as any associated version or artifact
   reaches an immutable or append-only destination, including an immutable
   GitHub release, a package registry, a module proxy, the Homebrew tap, or a
   durable artifact attestation. Never move or delete a permanent tag. Repair or
   rerun the remaining publication steps from that exact tag when safe, or cut a
   new version when they cannot be completed consistently.
-- Before deleting a provisional tag, stop or wait for its active workflows and
-  audit every release destination with read-only checks. Resolve the exact tag
-  object and target commit; verify that no permanent publication exists; and
-  inspect and clean any recoverable draft state. Delete only the explicitly
-  audited local and remote refs, then verify their absence and report what was
-  removed and whether it can be recovered.
+- Before deleting a provisional non-Go tag, stop or wait for its active
+  workflows and audit every release destination with read-only checks. Resolve
+  the exact tag object and target commit; verify that no permanent publication
+  exists; and inspect and clean any recoverable draft state. Delete only the
+  explicitly audited local and remote refs, then verify their absence and
+  report what was removed and whether it can be recovered.
 
 ## Always report the commit you are talking about
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -191,6 +191,25 @@ formula to the tap job. The same rerun packages the source crate again and
 requires its SHA-256 to match the immutable crates.io version; a missing
 version is published, while a divergent version fails closed.
 
+### Failed tag cleanup and the permanence boundary
+
+A pushed tag is provisional until the release reaches permanent published
+state. If an attempt is abandoned before then, do not burn the version merely
+because the tag existed: verify that no GitHub release, package-registry
+version, Homebrew update, module-proxy entry, or durable attestation exists,
+clean any recoverable draft, and delete the exact local and remote tag refs.
+Never force-update the tag. Once the cause is fixed, a maintainer may create a
+new signed tag for the still-unpublished version from a fully checked `master`
+commit.
+
+Once any permanent destination accepts the version, the tag is immutable even
+if later publication steps fail. Do not delete or move it. Rerun the idempotent
+steps from the same tag when their checks permit it; otherwise repair the
+remaining channel without changing published bytes or advance to a new
+version. Record the exact tag object, target commit, failed workflow, and every
+destination checked whenever deciding which side of this boundary an attempt
+is on.
+
 The release workflow sets `SYQ_RELEASE_BUILD=1`, which makes each platform
 binary report the tag (for example `v0.2.0`) as its build identity. Ordinary
 source builds instead include their Git revision and cannot populate the

--- a/sdk/RELEASING.md
+++ b/sdk/RELEASING.md
@@ -1,7 +1,11 @@
 # Releasing the language SDKs
 
 SDK releases use independent versions and tags. Published versions are
-immutable: never move a release tag or attempt to replace an uploaded package.
+immutable: never move or delete their release tags or attempt to replace an
+uploaded package. A tag whose publication is abandoned before any permanent
+release or registry state exists remains provisional; audit all destinations,
+clean any recoverable draft, and delete that tag rather than burning an
+unpublished SDK version.
 
 ## One-time setup
 

--- a/sdk/RELEASING.md
+++ b/sdk/RELEASING.md
@@ -2,10 +2,17 @@
 
 SDK releases use independent versions and tags. Published versions are
 immutable: never move or delete their release tags or attempt to replace an
-uploaded package. A tag whose publication is abandoned before any permanent
-release or registry state exists remains provisional; audit all destinations,
-clean any recoverable draft, and delete that tag rather than burning an
-unpublished SDK version.
+uploaded package. A Python or JavaScript tag whose publication is abandoned
+before any permanent release or registry state exists remains provisional;
+audit all destinations, clean any recoverable draft, and delete that tag rather
+than burning an unpublished SDK version.
+
+A Go module tag such as `sdk/go/v*` is permanent as soon as it is pushed. The
+tag itself publishes the version: a client or arbitrary module proxy may fetch
+and cache it before the documented `proxy.golang.org` request. That publication
+cannot be fully audited, and deleting or recreating the tag can leave clients
+with conflicting authenticated content. Never delete, recreate, or move a Go
+module tag.
 
 ## One-time setup
 


### PR DESCRIPTION
Treat release tags as provisional until publication crosses a permanent external boundary. Abandoned pre-publication tags should be audited and deleted; tags connected to immutable or append-only release state must never be moved or removed.\n\nDocuments the same boundary for syq and SDK releases.