### PR TITLE
Expose native file size selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,11 @@ compares existing regular-file contents with full BLAKE3 digests instead of
 trusting equal size and modification time; it does not add a second
 post-transfer verification pass. The bandwidth limit applies only to file
 data, not scanning, hashing, metadata, or pruning. A
+native copy may also use `--max-size SIZE` or `--min-size SIZE` to skip regular
+source files outside that inclusive range. Those files remain part of the
+source population, so `cp-prune` protects any corresponding destination paths.
+A command-restricted remote-to-remote copy currently refuses `--min-size` and
+refuses `--max-size` with `cp-prune`, as described below. A
 command-restricted remote-to-remote receiver independently enforces the signed
 aggregate limit, signed filters, and the selected staged or in-place publication
 policy. A receiver installed by an older syq rejects an extension or unsupported

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -755,6 +755,16 @@ struct NativeCopyFields {
     operational: NativeCopyOperationalArgs,
 }
 
+#[derive(clap::Args, Debug, Default)]
+struct NativeSizeSelectionArgs {
+    /// Skip regular source files larger than SIZE; cp-prune protects their destination paths
+    #[arg(long, value_name = "SIZE")]
+    max_size: Option<String>,
+    /// Skip regular source files smaller than SIZE; cp-prune protects their destination paths
+    #[arg(long, value_name = "SIZE")]
+    min_size: Option<String>,
+}
+
 #[derive(Parser, Debug)]
 #[command(
     name = "syq cp",
@@ -766,6 +776,8 @@ struct NativeCopyFields {
 struct NativeCopyCommand {
     #[command(flatten)]
     copy: NativeCopyFields,
+    #[command(flatten)]
+    size_selection: NativeSizeSelectionArgs,
 }
 
 #[derive(Parser, Debug)]
@@ -779,6 +791,8 @@ struct NativeCopyCommand {
 struct NativeCopyPruneCommand {
     #[command(flatten)]
     copy: NativeCopyFields,
+    #[command(flatten)]
+    size_selection: NativeSizeSelectionArgs,
     /// Refuse all removals if more than N are planned
     #[arg(long, value_name = "N")]
     max_delete: Option<u64>,
@@ -824,24 +838,35 @@ fn parse_native(argv: &[OsString], interface: Interface) -> Result<Args> {
 fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     let mut full_argv = vec![OsString::from(command_label(interface))];
     full_argv.extend_from_slice(argv);
-    let (mut parsed, matches, max_delete) = if interface == Interface::NativeCpPrune {
+    let (mut parsed, matches, max_delete, size_selection) = if interface == Interface::NativeCpPrune
+    {
         let matches = NativeCopyPruneCommand::command()
             .try_get_matches_from(full_argv)
             .unwrap_or_else(|error| error.exit());
         let parsed = NativeCopyPruneCommand::from_arg_matches(&matches)?;
-        (parsed.copy, matches, parsed.max_delete)
+        (
+            parsed.copy,
+            matches,
+            parsed.max_delete,
+            parsed.size_selection,
+        )
     } else if interface == Interface::NativeMap {
         let matches = NativeMapCommand::command()
             .try_get_matches_from(full_argv)
             .unwrap_or_else(|error| error.exit());
         let parsed = NativeMapCommand::from_arg_matches(&matches)?;
-        (parsed.copy, matches, None)
+        (
+            parsed.copy,
+            matches,
+            None,
+            NativeSizeSelectionArgs::default(),
+        )
     } else {
         let matches = NativeCopyCommand::command()
             .try_get_matches_from(full_argv)
             .unwrap_or_else(|error| error.exit());
         let parsed = NativeCopyCommand::from_arg_matches(&matches)?;
-        (parsed.copy, matches, None)
+        (parsed.copy, matches, None, parsed.size_selection)
     };
     // `syq map` keeps `-C` out of selector paths so emitted `src` values stay
     // relative to it; the walk joins it back.
@@ -1020,6 +1045,8 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     args.locations = locations;
     args.delete = interface == Interface::NativeCpPrune;
     args.max_delete = max_delete;
+    args.max_size = size_selection.max_size;
+    args.min_size = size_selection.min_size;
     args.native_map_cwd = map_cwd;
     args.native_map_target = native_map_target;
     args.native_mapping = mapping.map(OsStringExt::into_vec);
@@ -1660,6 +1687,8 @@ mod tests {
             "!keep.tmp",
             "--preserve=permissions,ownership,specials",
             "--inplace",
+            "--min-size=1K",
+            "--max-size=1M",
             "source",
             "--into",
             "destination",
@@ -1672,6 +1701,8 @@ mod tests {
         assert!(args.group);
         assert!(args.devices);
         assert!(args.inplace);
+        assert_eq!(args.min_size.as_deref(), Some("1K"));
+        assert_eq!(args.max_size.as_deref(), Some("1M"));
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -422,15 +422,15 @@ pub fn run(
         if args.existing {
             remote.push("--existing".into());
         }
-        if let Some(m) = &args.max_size {
-            remote.push(format!("--max-size={m}"));
-        }
-        if let Some(m) = &args.min_size {
-            remote.push(format!("--min-size={m}"));
-        }
         if let Some(path) = &args.checkpoint {
             remote.push(format!("--checkpoint={path}"));
         }
+    }
+    if let Some(maximum) = &args.max_size {
+        remote.push(format!("--max-size={maximum}"));
+    }
+    if let Some(minimum) = &args.min_size {
+        remote.push(format!("--min-size={minimum}"));
     }
     if let Some(rate) = &args.bwlimit {
         remote.push(format!("--bwlimit={rate}"));

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -582,6 +582,73 @@ fn native_filters_apply_to_copy_and_protect_pruned_paths() {
 }
 
 #[test]
+fn native_size_limits_select_regular_files_and_protect_pruned_paths() {
+    let t = Tmp::new();
+    write(&t.path("src/small"), b"s");
+    write(&t.path("src/in-range"), b"1234");
+    write(&t.path("src/large"), b"12345678");
+
+    run_native_ok(&[
+        "cp",
+        "--min-size",
+        "2",
+        "--max-size",
+        "4",
+        "--src-src",
+        &t.s("src"),
+        "--into",
+        &t.s("copied"),
+    ]);
+    assert_eq!(listing(&t.path("copied")), ["in-range"]);
+
+    write(&t.path("pruned/small"), b"old-small");
+    write(&t.path("pruned/in-range"), b"old-in-range");
+    write(&t.path("pruned/large"), b"old-large");
+    write(&t.path("pruned/extra"), b"remove");
+    run_native_ok(&[
+        "cp-prune",
+        "--min-size=2",
+        "--max-size=4",
+        "--src-src",
+        &t.s("src"),
+        "--into-existing",
+        &t.s("pruned"),
+    ]);
+    assert_eq!(read(&t.path("pruned/small")), b"old-small");
+    assert_eq!(read(&t.path("pruned/in-range")), b"1234");
+    assert_eq!(read(&t.path("pruned/large")), b"old-large");
+    assert!(!t.path("pruned/extra").exists());
+}
+
+#[test]
+fn native_size_limits_fail_before_destination_mutation() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+
+    for (option, value, destination) in [
+        ("--min-size", "tiny", "min-destination"),
+        ("--max-size", "18446744073709551616", "max-destination"),
+    ] {
+        let output = native_syq(&[
+            "cp",
+            option,
+            value,
+            "--src-src",
+            &t.s("src"),
+            "--into",
+            &t.s(destination),
+        ]);
+        assert!(!output.status.success(), "{option} accepted {value:?}");
+        assert!(
+            stderr_of(&output).contains("bad size"),
+            "{}",
+            stderr_of(&output)
+        );
+        assert!(!t.path(destination).exists());
+    }
+}
+
+#[test]
 fn native_preserve_policy_controls_permissions_and_special_files() {
     let t = Tmp::new();
     write(&t.path("src/file"), b"new");


### PR DESCRIPTION
## Summary

- add `--min-size` and `--max-size` to native `cp` and `cp-prune`
- preserve size-skipped destination paths during pruning and forward limits for direct remote copies
- document native and restricted-receiver behavior and cover validation and prune semantics

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`