### PR TITLE
Streamline release orchestration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,39 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rust:
+  scope:
     runs-on: ubuntu-latest
+    outputs:
+      native: ${{ steps.changes.outputs.native }}
+      sdks: ${{ steps.changes.outputs.sdks }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
-      - run: rustup component add rustfmt clippy
+      - name: Classify changed paths
+        id: changes
+        run: scripts/ci-scope.sh "$GITHUB_EVENT_PATH" >> "$GITHUB_OUTPUT"
+
+  rust:
+    needs: scope
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require successful path classification
+        if: needs.scope.result != 'success'
+        run: echo 'Path classification failed.' >&2; exit 1
+      - name: Complete the required check for documentation and SDK-only changes
+        if: needs.scope.outputs.native != 'true'
+        run: echo 'Full Rust validation is not needed for this change set.'
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.scope.outputs.native == 'true'
+        with:
+          persist-credentials: false
+      - if: needs.scope.outputs.native == 'true'
+        run: rustup component add rustfmt clippy
       - name: Check dependency policy
+        if: needs.scope.outputs.native == 'true'
         env:
           CARGO_DENY_VERSION: 0.20.2
           CARGO_DENY_SHA256: 9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5f
@@ -36,27 +61,51 @@ jobs:
           test "$("$RUNNER_TEMP/$directory/cargo-deny" --version)" = \
             "cargo-deny $CARGO_DENY_VERSION"
           "$RUNNER_TEMP/$directory/cargo-deny" --locked check
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --locked --all-targets --all-features -- -D warnings
-      - run: cargo test --locked --all-targets
-      - run: scripts/test-cargo-package.sh
-      - run: scripts/test-installer.sh
-      - run: scripts/test-release-tools.sh
-      - run: scripts/test-secret-tools.sh
-      - run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh
+      - if: needs.scope.outputs.native == 'true'
+        run: cargo fmt --all -- --check
+      - if: needs.scope.outputs.native == 'true'
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+      - if: needs.scope.outputs.native == 'true'
+        run: cargo test --locked --all-targets
+      - if: needs.scope.outputs.native == 'true'
+        run: scripts/test-cargo-package.sh
+      - if: needs.scope.outputs.native == 'true'
+        run: scripts/test-installer.sh
+      - if: needs.scope.outputs.native == 'true'
+        run: scripts/test-release-tools.sh
+      - if: needs.scope.outputs.native == 'true'
+        run: scripts/test-release-orchestration.sh
+      - if: needs.scope.outputs.native == 'true'
+        run: scripts/check-workflows.sh
+      - if: needs.scope.outputs.native == 'true'
+        run: scripts/test-secret-tools.sh
+      - if: needs.scope.outputs.native == 'true'
+        run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/ci-scope.sh scripts/approve-generated-pr-runs.sh scripts/release-preflight.sh scripts/release-status.sh scripts/check-workflows.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-release-orchestration.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh
 
   sdks:
+    needs: scope
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Require successful path classification
+        if: needs.scope.result != 'success'
+        run: echo 'Path classification failed.' >&2; exit 1
+      - name: Complete the required check for documentation-only changes
+        if: needs.scope.outputs.sdks != 'true'
+        run: echo 'Full SDK validation is not needed for this change set.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.scope.outputs.sdks == 'true'
         with:
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: needs.scope.outputs.sdks == 'true'
         with:
           python-version: "3.10"
       - name: Install pinned Python tooling
+        if: needs.scope.outputs.sdks == 'true'
         run: python -m pip install --disable-pip-version-check --no-deps uv==0.11.6
       - name: Require the SDK mapping for the latest syq release
+        if: needs.scope.outputs.sdks == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -67,8 +116,10 @@ jobs:
             exit 1
           }
       - name: Build the candidate syq executable
+        if: needs.scope.outputs.sdks == 'true'
         run: cargo build --locked --bin syq
       - name: Test and reproducibly package Python SDK
+        if: needs.scope.outputs.sdks == 'true'
         env:
           PYTHONPATH: sdk/python/src
           SYQ_CANDIDATE_EXECUTABLE: ${{ github.workspace }}/target/debug/syq
@@ -97,20 +148,24 @@ jobs:
             --with "$1" \
             python -c 'import syq; assert syq.version() == syq.PINNED_SYQ_VERSION'
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: needs.scope.outputs.sdks == 'true'
         with:
           node-version: "22.x"
           package-manager-cache: false
       - name: Test and package JavaScript SDK
+        if: needs.scope.outputs.sdks == 'true'
         working-directory: sdk/js
         run: |
           npm ci --ignore-scripts
           npm test
           npm pack --dry-run
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        if: needs.scope.outputs.sdks == 'true'
         with:
           go-version: "1.26.x"
           cache: false
       - name: Format, vet, and test Go SDK
+        if: needs.scope.outputs.sdks == 'true'
         working-directory: sdk/go
         run: |
           test -z "$(gofmt -l .)"
@@ -120,19 +175,41 @@ jobs:
   # The release workflow builds on this runner; libc field types differ from
   # x86-64 (st_nlink is u32 here), so check it before a tag can fail.
   linux-arm64:
+    needs: scope
+    if: always()
     runs-on: ubuntu-24.04-arm
     steps:
+      - name: Require successful path classification
+        if: needs.scope.result != 'success'
+        run: echo 'Path classification failed.' >&2; exit 1
+      - name: Complete the required check for documentation and SDK-only changes
+        if: needs.scope.outputs.native != 'true'
+        run: echo 'The ARM build is not affected by this change set.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.scope.outputs.native == 'true'
         with:
           persist-credentials: false
-      - run: cargo check --locked --all-targets
+      - if: needs.scope.outputs.native == 'true'
+        run: cargo check --locked --all-targets
 
   macos:
+    needs: scope
+    if: always()
     runs-on: macos-14
     steps:
+      - name: Require successful path classification
+        if: needs.scope.result != 'success'
+        run: echo 'Path classification failed.' >&2; exit 1
+      - name: Complete the required check for documentation and SDK-only changes
+        if: needs.scope.outputs.native != 'true'
+        run: echo 'The macOS build and installer are not affected by this change set.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.scope.outputs.native == 'true'
         with:
           persist-credentials: false
-      - run: cargo check --locked --all-targets
-      - run: scripts/test-installer.sh
-      - run: scripts/test-homebrew-formula.sh
+      - if: needs.scope.outputs.native == 'true'
+        run: cargo check --locked --all-targets
+      - if: needs.scope.outputs.native == 'true'
+        run: scripts/test-installer.sh
+      - if: needs.scope.outputs.native == 'true'
+        run: scripts/test-homebrew-formula.sh

--- a/.github/workflows/prepare-python-sdk.yml
+++ b/.github/workflows/prepare-python-sdk.yml
@@ -72,9 +72,11 @@ jobs:
           python_version=$(python3 -c \
             'import tomllib; print(tomllib.load(open("sdk/python/pyproject.toml", "rb"))["project"]["version"])')
           syq_version=$(jq -er .version "$RELEASE_MANIFEST")
-          echo 'changed=true' >> "$GITHUB_OUTPUT"
-          echo "python_version=$python_version" >> "$GITHUB_OUTPUT"
-          echo "syq_version=$syq_version" >> "$GITHUB_OUTPUT"
+          {
+            echo 'changed=true'
+            echo "python_version=$python_version"
+            echo "syq_version=$syq_version"
+          } >> "$GITHUB_OUTPUT"
       - name: Commit the prepared release and open a pull request
         if: steps.prepare.outputs.changed == 'true'
         env:
@@ -111,7 +113,7 @@ jobs:
             "- bumps the Python SDK to $PYTHON_VERSION" \
             "- embeds the exact signed v$SYQ_VERSION release manifest" \
             "- updates the documented SDK-to-syq mapping" \
-            "The native pull-request checks were approved explicitly because GitHub puts workflow runs caused by GITHUB_TOKEN into an approval-required state. Review and merge this pull request normally; publication still requires the maintainer-signed tag sdk-python-v$PYTHON_VERSION and approval of the protected pypi environment.")
+            "The native pull-request checks are approved explicitly because GitHub puts workflow runs caused by GITHUB_TOKEN into an approval-required state. Auto-merge is requested after those required checks are registered; publication still requires the maintainer-signed tag sdk-python-v$PYTHON_VERSION and approval of the protected pypi environment.")
           pr_url=$(gh pr create \
             --base master \
             --head "$branch" \
@@ -119,46 +121,7 @@ jobs:
             --body "$body")
           echo "Created $pr_url"
           head_sha=$(git rev-parse HEAD)
-          deadline=$((SECONDS + 60))
-          observed='[]'
-          while test "$SECONDS" -lt "$deadline"; do
-            observed=$(gh run list \
-              --branch "$branch" \
-              --event pull_request \
-              --limit 20 \
-              --json conclusion,databaseId,headSha,status,url,workflowName)
-            if jq -e --arg head_sha "$head_sha" '
-              any(.[]; .headSha == $head_sha and .workflowName == "ci") and
-              any(.[]; .headSha == $head_sha and .workflowName == "rsync compatibility")
-            ' <<<"$observed" >/dev/null; then
-              break
-            fi
-            echo "Waiting for GitHub to register the approval-required pull-request workflow runs for $head_sha"
-            sleep 5
-          done
-          if ! jq -e --arg head_sha "$head_sha" '
-            any(.[]; .headSha == $head_sha and .workflowName == "ci") and
-            any(.[]; .headSha == $head_sha and .workflowName == "rsync compatibility")
-          ' <<<"$observed" >/dev/null; then
-            echo "Timed out waiting for approval-required pull-request workflow runs for $head_sha; last observed state:" >&2
-            jq -c . <<<"$observed" >&2
-            exit 1
-          fi
-          for workflow_name in ci 'rsync compatibility'; do
-            run=$(jq -cer --arg head_sha "$head_sha" --arg workflow_name "$workflow_name" '
-              [.[] | select(
-                .headSha == $head_sha and .workflowName == $workflow_name
-              )] | max_by(.databaseId)
-            ' <<<"$observed")
-            run_id=$(jq -er .databaseId <<<"$run")
-            status=$(jq -er .status <<<"$run")
-            conclusion=$(jq -r '.conclusion // empty' <<<"$run")
-            if test "$conclusion" = action_required; then
-              gh api --method POST \
-                "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/approve" \
-                >/dev/null
-              echo "Approved $workflow_name pull-request workflow run $run_id for $head_sha"
-            else
-              echo "$workflow_name pull-request workflow run $run_id is already $status${conclusion:+/$conclusion}"
-            fi
-          done
+          scripts/approve-generated-pr-runs.sh \
+            "$GITHUB_REPOSITORY" "$branch" "$head_sha"
+          gh pr merge "$pr_url" --auto --merge --match-head-commit "$head_sha"
+          echo "Requested auto-merge for $pr_url at $head_sha"

--- a/.github/workflows/prepare-python-sdk.yml
+++ b/.github/workflows/prepare-python-sdk.yml
@@ -113,7 +113,7 @@ jobs:
             "- bumps the Python SDK to $PYTHON_VERSION" \
             "- embeds the exact signed v$SYQ_VERSION release manifest" \
             "- updates the documented SDK-to-syq mapping" \
-            "The native pull-request checks are approved explicitly because GitHub puts workflow runs caused by GITHUB_TOKEN into an approval-required state. Auto-merge is requested after those required checks are registered; publication still requires the maintainer-signed tag sdk-python-v$PYTHON_VERSION and approval of the protected pypi environment.")
+            "The native pull-request checks are approved explicitly because GitHub puts workflow runs caused by GITHUB_TOKEN into an approval-required state. Auto-merge is requested only after the substantive sdks check succeeds on this exact commit; publication still requires the maintainer-signed tag sdk-python-v$PYTHON_VERSION and approval of the protected pypi environment.")
           pr_url=$(gh pr create \
             --base master \
             --head "$branch" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,39 +230,18 @@ jobs:
           version=${GITHUB_REF_NAME#v}
           scripts/verify-crates-io-package.sh \
             "$version" "target/package/syq-$version.crate"
-      - name: Carry the verified published formula to the tap job
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: homebrew-formula
-          path: dist/syq.rb
-          if-no-files-found: error
-          retention-days: 1
-
-  homebrew:
-    name: update Homebrew tap
-    needs: release
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: read
-    steps:
       - name: Check out project-owned tap
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: greaber/homebrew-tap
           ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
           path: tap
-      - name: Download generated formula
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: homebrew-formula
-          path: formula
       - name: Commit formula update
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p tap/Formula
-          cp formula/syq.rb tap/Formula/syq.rb
+          cp dist/syq.rb tap/Formula/syq.rb
           cd tap
           git diff --check
           git add Formula/syq.rb

--- a/.github/workflows/rsync-compat.yml
+++ b/.github/workflows/rsync-compat.yml
@@ -10,16 +10,39 @@ permissions:
   contents: read
 
 jobs:
+  scope:
+    runs-on: ubuntu-latest
+    outputs:
+      conformance: ${{ steps.changes.outputs.conformance }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Classify changed paths
+        id: changes
+        run: scripts/ci-scope.sh "$GITHUB_EVENT_PATH" >> "$GITHUB_OUTPUT"
+
   conformance:
+    needs: scope
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       CARGO_TARGET_DIR: target/cargo
     steps:
+      - name: Require successful path classification
+        if: needs.scope.result != 'success'
+        run: echo 'Path classification failed.' >&2; exit 1
+      - name: Complete the required check for documentation and SDK-only changes
+        if: needs.scope.outputs.conformance != 'true'
+        run: echo 'Rsync conformance is not affected by this change set.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.scope.outputs.conformance == 'true'
         with:
           persist-credentials: false
       - name: Cache pinned rsync source and helpers
+        if: needs.scope.outputs.conformance == 'true'
         id: rsync-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -28,11 +51,12 @@ jobs:
             target/rsync-compat/suites
           key: rsync-compat-${{ runner.os }}-${{ hashFiles('scripts/rsync-compat.py', 'tests/rsync-compat/manifest.toml', 'tests/rsync-compat/inventory.tsv', 'tests/rsync-compat/adaptations/*.patch') }}
       - name: Install rsync test-build prerequisites
-        if: steps.rsync-cache.outputs.cache-hit != 'true'
+        if: needs.scope.outputs.conformance == 'true' && steps.rsync-cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y autoconf automake build-essential
       - name: Cache Cargo dependencies and build output
+        if: needs.scope.outputs.conformance == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
@@ -43,10 +67,13 @@ jobs:
           restore-keys: |
             cargo-rsync-compat-${{ runner.os }}-
       - name: Test compatibility harness
+        if: needs.scope.outputs.conformance == 'true'
         run: python3 tests/rsync-compat/harness_test.py
       - name: Run classified upstream tests
+        if: needs.scope.outputs.conformance == 'true'
         run: python3 scripts/rsync-compat.py --require-tests --test-timeout 120 -j 4
       - name: Run suite as root, including root-only circumstances
+        if: needs.scope.outputs.conformance == 'true'
         run: |
           sudo env \
             PATH="$PATH" \
@@ -56,10 +83,10 @@ jobs:
               --no-build-syq --syq-bin "$PWD/target/cargo/debug/syq" \
               --test-timeout 120 -j 4
       - name: Restore compatibility-cache ownership
-        if: always()
+        if: always() && needs.scope.outputs.conformance == 'true'
         run: sudo chown -R "$(id -u):$(id -g)" target/rsync-compat
       - name: Upload compatibility report
-        if: always()
+        if: always() && needs.scope.outputs.conformance == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rsync-compatibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,12 @@ outlive its premise and steer later work in the wrong direction.
 
 ## Release tag lifecycle
 
+- Before pushing a syq release tag, run
+  `scripts/release-preflight.sh v<version>` from the exact clean, synchronized
+  `master` commit. Treat any failure as a blocker rather than pushing the tag
+  to discover whether the release workflow starts. Use
+  `scripts/release-status.sh v<version>` after the push to correlate the exact
+  tag, workflow, approvals, and publication destinations.
 - Except for Go module tags, treat a release tag as provisional until its
   release workflow connects it to permanent published state. If an attempt is
   abandoned before that boundary, remove the failed tag locally and remotely

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -147,8 +147,20 @@ connection, so enable it only for a trusted release host rather than globally.
    gh run watch --exit-status "$(gh run list --workflow ci.yml --branch master --commit "$(git rev-parse master)" --json databaseId --jq '.[0].databaseId')"
    ```
 
-   Then create and push a signed annotated tag matching the package version.
-   Its signing key and email must be configured on your GitHub account so
+   Run the read-only preflight before creating the tag:
+
+   ```sh
+   scripts/release-preflight.sh v0.1.9
+   ```
+
+   It requires the exact clean, synchronized `master` tip; matching Cargo
+   metadata; successful required checks on that SHA; an SSH tag-signing key
+   registered with GitHub; the selected-Actions allowlist; the protected
+   `release` environment, tag policy, variables, and secret names; and absence
+   of the tag or version from GitHub, crates.io, and the Homebrew tap. It makes
+   no local or remote changes. Then create and push a signed annotated tag
+   matching the package version. Its signing key and email must be configured
+   on your GitHub account so
    GitHub reports the tag-object signature as verified:
 
    ```sh
@@ -156,8 +168,10 @@ connection, so enable it only for a trusted release host rather than globally.
    git push origin v0.1.0
    ```
 
-3. Approve the protected `release` environment for the publishing job, then
-   approve it again when the separate Homebrew tap job is ready. The workflow
+3. Approve the protected `release` environment once. The same protected job
+   publishes the release and updates Homebrew, so the deploy key is never
+   exposed to an unapproved job and a second approval adds no distinct trust
+   boundary. The workflow
    first verifies that the annotated tag's signature is valid and that it
    directly targets the workflow commit, that this commit is reachable
    from protected `master`, and that the `rust`, `sdks`, `macos`, and
@@ -172,6 +186,16 @@ connection, so enable it only for a trusted release host rather than globally.
    workflow opens a pull request for the next SDK patch release using this
    immutable syq manifest. PyPI publication remains a separate signed-tag and
    protected-environment action, so a registry outage cannot block syq.
+   Track the complete state at any time with:
+
+   ```sh
+   scripts/release-status.sh v0.1.9
+   scripts/release-status.sh --json v0.1.9
+   ```
+
+   The report correlates the exact tag commit, release runs and pending
+   environments, GitHub release state, crates.io, the mapped PyPI SDK version,
+   and the Homebrew formula without modifying any of them.
 4. Verify one or more downloaded artifacts and exercise all install paths:
 
    ```sh
@@ -217,6 +241,18 @@ managed remote-helper cache. The manifest's `helper_id: v<release>-p0` and the
 binary's `--remote-helper-id` output are deprecated compatibility shims for
 updaters through 0.1.1; `p0` is fixed and must not be treated or bumped as a
 protocol version.
+
+## CI scope
+
+The required `rust`, `sdks`, `linux-arm64`, `macos`, and `conformance` check
+names are stable. A checked-in path classifier lets those jobs finish with a
+small successful validation for documentation-only changes. SDK-only changes
+still run the full `sdks` job, including generated Python mappings, while the
+native and platform jobs finish quickly. Any Rust, test, script, build,
+installer, release-workflow, or otherwise unclassified path runs the complete
+native, SDK, platform, and conformance suites. Manual workflow runs also run
+everything. This keeps branch protection and release-tag verification attached
+to the same check names without repeatedly rebuilding unaffected code.
 
 ## macOS signing
 

--- a/scripts/approve-generated-pr-runs.sh
+++ b/scripts/approve-generated-pr-runs.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Approve only the native PR runs belonging to one exact trusted generated PR.
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 OWNER/REPOSITORY BRANCH HEAD_SHA" >&2
+  exit 2
+fi
+repository=$1
+branch=$2
+head_sha=$3
+trusted_repository=${SYQ_TRUSTED_REPOSITORY:-greaber/syq}
+timeout_seconds=${SYQ_APPROVAL_TIMEOUT_SECONDS:-60}
+interval_seconds=${SYQ_APPROVAL_INTERVAL_SECONDS:-5}
+
+[ "$repository" = "$trusted_repository" ] || {
+  echo "refusing generated-PR approval for $repository; expected $trusted_repository" >&2
+  exit 1
+}
+[[ "$branch" =~ ^automation/python-sdk-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "unsafe generated branch: $branch" >&2
+  exit 2
+}
+[[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "invalid generated head SHA: $head_sha" >&2
+  exit 2
+}
+[[ "$timeout_seconds" =~ ^[0-9]+$ ]] || {
+  echo "invalid approval timeout: $timeout_seconds" >&2
+  exit 2
+}
+if ! [[ "$interval_seconds" =~ ^[0-9]+$ ]] || [ "$interval_seconds" -le 0 ]; then
+  echo "invalid approval interval: $interval_seconds" >&2
+  exit 2
+fi
+command -v gh >/dev/null || { echo 'generated-PR approval needs gh' >&2; exit 1; }
+command -v jq >/dev/null || { echo 'generated-PR approval needs jq' >&2; exit 1; }
+
+owner=${repository%%/*}
+pulls=$(gh api --method GET "repos/$repository/pulls" \
+  -f state=open -f head="$owner:$branch" -f per_page=100)
+trusted_count=$(jq --arg repository "$repository" --arg branch "$branch" \
+  --arg head_sha "$head_sha" '[.[] | select(
+    .head.repo.full_name == $repository and .head.ref == $branch and
+    .head.sha == $head_sha and .base.ref == "master"
+  )] | length' <<<"$pulls")
+[ "$trusted_count" -eq 1 ] || {
+  echo "expected one trusted open pull request for $repository:$branch at $head_sha; found $trusted_count" >&2
+  exit 1
+}
+
+deadline=$((SECONDS + timeout_seconds))
+observed='[]'
+while :; do
+  observed=$(gh run list --repo "$repository" --branch "$branch" \
+    --event pull_request --limit 20 \
+    --json conclusion,databaseId,event,headSha,status,url,workflowName)
+  if jq -e --arg head_sha "$head_sha" '
+    . as $runs |
+    all(["ci", "rsync compatibility"][];
+      . as $workflow |
+      any($runs[]; .headSha == $head_sha and .event == "pull_request" and
+        .workflowName == $workflow))
+  ' <<<"$observed" >/dev/null; then
+    break
+  fi
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    echo "timed out waiting for native pull-request workflow runs for $head_sha; last observed state:" >&2
+    jq -c . <<<"$observed" >&2
+    exit 1
+  fi
+  echo "Waiting for GitHub to register native pull-request workflow runs for $head_sha"
+  sleep "$interval_seconds"
+done
+
+for workflow_name in ci 'rsync compatibility'; do
+  run=$(jq -cer --arg head_sha "$head_sha" --arg workflow_name "$workflow_name" '
+    [.[] | select(
+      .headSha == $head_sha and .event == "pull_request" and
+      .workflowName == $workflow_name
+    )] | max_by(.databaseId)
+  ' <<<"$observed")
+  run_id=$(jq -er .databaseId <<<"$run")
+  status=$(jq -er .status <<<"$run")
+  conclusion=$(jq -r '.conclusion // empty' <<<"$run")
+  case "$conclusion" in
+    action_required)
+      gh api --method POST "repos/$repository/actions/runs/$run_id/approve" >/dev/null
+      echo "Approved $workflow_name pull-request workflow run $run_id for $head_sha"
+      ;;
+    success)
+      echo "$workflow_name pull-request workflow run $run_id is already $status${conclusion:+/$conclusion}"
+      ;;
+    '')
+      case "$status" in
+        queued|in_progress|pending|requested|waiting)
+          echo "$workflow_name pull-request workflow run $run_id is already $status"
+          ;;
+        *)
+          echo "$workflow_name pull-request workflow run $run_id has no conclusion in unexpected status $status" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "$workflow_name pull-request workflow run $run_id is terminal: $status/$conclusion" >&2
+      exit 1
+      ;;
+  esac
+done

--- a/scripts/approve-generated-pr-runs.sh
+++ b/scripts/approve-generated-pr-runs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Approve only the native PR runs belonging to one exact trusted generated PR.
+# Approve only the native PR runs belonging to one exact trusted generated PR,
+# then require the substantive SDK check to pass on that same head.
 set -euo pipefail
 
 if [ "$#" -ne 3 ]; then
@@ -12,6 +13,7 @@ head_sha=$3
 trusted_repository=${SYQ_TRUSTED_REPOSITORY:-greaber/syq}
 timeout_seconds=${SYQ_APPROVAL_TIMEOUT_SECONDS:-60}
 interval_seconds=${SYQ_APPROVAL_INTERVAL_SECONDS:-5}
+check_timeout_seconds=${SYQ_REQUIRED_CHECK_TIMEOUT_SECONDS:-900}
 
 [ "$repository" = "$trusted_repository" ] || {
   echo "refusing generated-PR approval for $repository; expected $trusted_repository" >&2
@@ -27,6 +29,10 @@ interval_seconds=${SYQ_APPROVAL_INTERVAL_SECONDS:-5}
 }
 [[ "$timeout_seconds" =~ ^[0-9]+$ ]] || {
   echo "invalid approval timeout: $timeout_seconds" >&2
+  exit 2
+}
+[[ "$check_timeout_seconds" =~ ^[0-9]+$ ]] || {
+  echo "invalid required-check timeout: $check_timeout_seconds" >&2
   exit 2
 }
 if ! [[ "$interval_seconds" =~ ^[0-9]+$ ]] || [ "$interval_seconds" -le 0 ]; then
@@ -107,4 +113,38 @@ for workflow_name in ci 'rsync compatibility'; do
       exit 1
       ;;
   esac
+done
+
+check_deadline=$((SECONDS + check_timeout_seconds))
+check_state='{"count":0,"status":"missing","conclusion":null}'
+while :; do
+  check_runs=$(gh api \
+    "repos/$repository/commits/$head_sha/check-runs?filter=latest&per_page=100")
+  check_state=$(jq -c '
+    [.check_runs[] | select(.name == "sdks")] |
+    if length == 0 then {count:0,status:"missing",conclusion:null}
+    elif length > 1 then {count:length,status:"ambiguous",conclusion:null}
+    else {count:1,status:.[0].status,conclusion:(.[0].conclusion // null)} end
+  ' <<<"$check_runs")
+  check_status=$(jq -er .status <<<"$check_state")
+  check_conclusion=$(jq -r '.conclusion // empty' <<<"$check_state")
+  if [ "$check_status" = completed ] && [ "$check_conclusion" = success ]; then
+    echo "Required generated-PR check sdks passed for $head_sha"
+    break
+  fi
+  if [ "$check_status" = completed ] && [ "$check_conclusion" != action_required ]; then
+    echo "required generated-PR check sdks is $check_status/${check_conclusion:-missing} for $head_sha" >&2
+    exit 1
+  fi
+  if [ "$check_status" = ambiguous ]; then
+    echo "required generated-PR check sdks is ambiguous for $head_sha" >&2
+    exit 1
+  fi
+  if [ "$SECONDS" -ge "$check_deadline" ]; then
+    echo "timed out waiting for required generated-PR check sdks on $head_sha; last observed state:" >&2
+    jq -c . <<<"$check_state" >&2
+    exit 1
+  fi
+  echo "Waiting for required generated-PR check sdks on $head_sha; observed $check_status${check_conclusion:+/$check_conclusion}"
+  sleep "$interval_seconds"
 done

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Run a checksum-pinned actionlint without installing it globally.
+set -euo pipefail
+
+ACTIONLINT_VERSION=1.7.12
+os=$(uname -s)
+architecture=$(uname -m)
+case "$os:$architecture" in
+  Linux:x86_64)
+    platform=linux_amd64
+    sha256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+    ;;
+  Linux:aarch64|Linux:arm64)
+    platform=linux_arm64
+    sha256=325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6
+    ;;
+  Darwin:x86_64)
+    platform=darwin_amd64
+    sha256=5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644
+    ;;
+  Darwin:arm64)
+    platform=darwin_arm64
+    sha256=aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f
+    ;;
+  *)
+    echo "actionlint $ACTIONLINT_VERSION is not pinned for $os $architecture" >&2
+    exit 1
+    ;;
+esac
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-actionlint.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+archive="$work/actionlint.tar.gz"
+url="https://github.com/rhysd/actionlint/releases/download/v$ACTIONLINT_VERSION/actionlint_${ACTIONLINT_VERSION}_${platform}.tar.gz"
+curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+  --output "$archive" "$url"
+if command -v sha256sum >/dev/null; then
+  actual_sha256=$(sha256sum "$archive" | awk '{print $1}')
+else
+  actual_sha256=$(shasum -a 256 "$archive" | awk '{print $1}')
+fi
+[ "$actual_sha256" = "$sha256" ] || {
+  echo "actionlint archive checksum mismatch: $actual_sha256" >&2
+  exit 1
+}
+tar -xzf "$archive" -C "$work" actionlint
+"$work/actionlint" "$@"

--- a/scripts/ci-scope.sh
+++ b/scripts/ci-scope.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Classify a GitHub Actions change set without removing any required check.
+set -euo pipefail
+
+event_path=${1:-${GITHUB_EVENT_PATH:-}}
+changed_paths=
+
+if [ -n "${SYQ_TEST_CHANGED_PATHS_FILE:-}" ]; then
+  changed_paths=$(cat "$SYQ_TEST_CHANGED_PATHS_FILE")
+elif [ -n "$event_path" ] && [ -f "$event_path" ]; then
+  event_name=$(jq -r 'if has("pull_request") then "pull_request" elif has("before") then "push" else "workflow_dispatch" end' "$event_path")
+  case "$event_name" in
+    pull_request)
+      base=$(jq -er .pull_request.base.sha "$event_path")
+      head=$(jq -er .pull_request.head.sha "$event_path")
+      ;;
+    push)
+      base=$(jq -er .before "$event_path")
+      head=$(jq -er .after "$event_path")
+      if [[ "$base" =~ ^0+$ ]]; then
+        printf 'native=true\nsdks=true\nconformance=true\n'
+        echo 'CI scope: new branch or incomplete push history; running every check' >&2
+        exit 0
+      fi
+      ;;
+    workflow_dispatch)
+      printf 'native=true\nsdks=true\nconformance=true\n'
+      echo 'CI scope: manual run; running every check' >&2
+      exit 0
+      ;;
+    *)
+      echo "unsupported GitHub event in $event_path" >&2
+      exit 1
+      ;;
+  esac
+  git cat-file -e "$base^{commit}" 2>/dev/null \
+    || { echo "CI scope base commit is unavailable: $base" >&2; exit 1; }
+  git cat-file -e "$head^{commit}" 2>/dev/null \
+    || { echo "CI scope head commit is unavailable: $head" >&2; exit 1; }
+  changed_paths=$(git diff --name-only "$base" "$head")
+else
+  echo "usage: $0 GITHUB_EVENT_PATH" >&2
+  exit 2
+fi
+
+native=false
+sdks=false
+saw_path=false
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  saw_path=true
+  case "$path" in
+    sdk/*)
+      sdks=true
+      ;;
+    *.md|docs/*|.github/ISSUE_TEMPLATE/*|.github/dependabot.yml|LICENSE)
+      ;;
+    *)
+      native=true
+      sdks=true
+      ;;
+  esac
+done <<<"$changed_paths"
+
+if [ "$saw_path" = false ]; then
+  native=true
+  sdks=true
+fi
+
+printf 'native=%s\nsdks=%s\nconformance=%s\n' "$native" "$sdks" "$native"
+echo "CI scope: native=$native sdks=$sdks conformance=$native" >&2

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Read-only validation of every locally auditable prerequisite before a tag is pushed.
+set -euo pipefail
+
+CANONICAL_REPOSITORY=greaber/syq
+HOMEBREW_REPOSITORY=greaber/homebrew-tap
+RELEASE_ENVIRONMENT=release
+REQUIRED_CHECKS=rust,sdks,macos,linux-arm64
+CRATES_AUTH_ACTION=rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 vMAJOR.MINOR.PATCH" >&2
+  exit 2
+fi
+tag=$1
+[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "invalid syq release tag: $tag" >&2
+  exit 2
+}
+version=${tag#v}
+
+for command in git gh jq curl openssl ssh-keygen; do
+  command -v "$command" >/dev/null || die "release preflight needs $command"
+done
+
+root=$(git rev-parse --show-toplevel 2>/dev/null) || die 'run this from the syq repository'
+cd "$root"
+[ "$(git symbolic-ref --short HEAD 2>/dev/null)" = master ] \
+  || die 'release preflight must run on the master branch'
+[ -z "$(git status --porcelain)" ] || die 'working tree is not clean'
+
+origin_url=$(git config --get remote.origin.url 2>/dev/null || true)
+origin_url=${origin_url%.git}
+if [ "$origin_url" != "git@github.com:$CANONICAL_REPOSITORY" ] \
+  && [ "$origin_url" != "ssh://git@github.com/$CANONICAL_REPOSITORY" ] \
+  && [ "$origin_url" != "https://github.com/$CANONICAL_REPOSITORY" ]; then
+  die "origin is not the canonical $CANONICAL_REPOSITORY repository"
+fi
+[ "${GH_HOST:-github.com}" = github.com ] || die 'GH_HOST must be github.com'
+[ "$(gh repo view "$CANONICAL_REPOSITORY" --json nameWithOwner --jq .nameWithOwner)" = "$CANONICAL_REPOSITORY" ] \
+  || die "gh resolved an unexpected repository"
+
+head=$(git rev-parse HEAD)
+local_master=$(git rev-parse refs/heads/master)
+tracking_master=$(git rev-parse refs/remotes/origin/master 2>/dev/null) \
+  || die 'origin/master is unavailable; fetch it first'
+remote_master=$(git ls-remote origin refs/heads/master | awk 'NR == 1 {print $1}')
+[ "$head" = "$local_master" ] || die 'HEAD is not the local master tip'
+[ "$head" = "$tracking_master" ] || die "master is not synchronized with origin/master ($tracking_master)"
+[ "$head" = "$remote_master" ] || die "master is not synchronized with the remote master ($remote_master)"
+
+cargo_version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+[ "$cargo_version" = "$version" ] \
+  || die "tag $tag does not match Cargo.toml version $cargo_version"
+lock_version=$(awk '
+  $0 == "[[package]]" {name=""; version=""}
+  $0 == "name = \"syq\"" {name="syq"}
+  name == "syq" && /^version = / {gsub(/^version = "|"$/, ""); print; exit}
+' Cargo.lock)
+[ "$lock_version" = "$version" ] \
+  || die "Cargo.lock syq version $lock_version does not match $version"
+
+if git show-ref --verify --quiet "refs/tags/$tag"; then
+  die "local tag $tag already exists"
+fi
+remote_tags=$(git ls-remote --tags origin "refs/tags/$tag" "refs/tags/$tag^{}") \
+  || die "cannot inspect remote tag $tag"
+[ -z "$remote_tags" ] \
+  || die "remote tag $tag already exists"
+
+checks=$(gh api "repos/$CANONICAL_REPOSITORY/commits/$head/check-runs?filter=latest&per_page=100")
+IFS=, read -ra check_names <<<"$REQUIRED_CHECKS"
+for check_name in "${check_names[@]}"; do
+  conclusion=$(jq -r --arg name "$check_name" '
+    [.check_runs[] | select(.name == $name)] |
+    if length == 0 then "missing" elif length > 1 then "ambiguous"
+    else .[0].conclusion // "pending" end
+  ' <<<"$checks")
+  [ "$conclusion" = success ] \
+    || die "required check $check_name is $conclusion on $head"
+done
+
+signing_key=$(git config --get user.signingkey 2>/dev/null || true)
+signing_key=${signing_key#key::}
+signing_identity=$(awk '{print $1 " " $2}' <<<"$signing_key")
+[ "$(git config --get gpg.format 2>/dev/null || true)" = ssh ] \
+  || die 'gpg.format must be ssh for release tag signing'
+[ "$(git config --bool --get tag.gpgsign 2>/dev/null || true)" = true ] \
+  || die 'tag.gpgsign must be enabled'
+[[ "$signing_identity" == ssh-*' '* ]] || die 'user.signingkey is not an inline SSH public key'
+signing_fingerprint=$(ssh-keygen -lf /dev/stdin <<<"$signing_identity" | awk '{print $2}') \
+  || die 'cannot fingerprint user.signingkey'
+github_login=$(gh api user --jq .login)
+github_signing_keys=$(gh api "users/$github_login/ssh_signing_keys?per_page=100")
+jq -e --arg key "$signing_identity" '
+  any(.[]; ((.key | split(" "))[0:2] | join(" ")) == $key)
+' <<<"$github_signing_keys" >/dev/null \
+  || die "tag signing key $signing_fingerprint is not registered as a GitHub SSH signing key"
+
+permissions=$(gh api "repos/$CANONICAL_REPOSITORY/actions/permissions")
+jq -e '.enabled == true and .allowed_actions == "selected" and .sha_pinning_required == true' \
+  <<<"$permissions" >/dev/null \
+  || die 'GitHub Actions must be enabled with selected actions and SHA pinning required'
+selected_actions=$(gh api "repos/$CANONICAL_REPOSITORY/actions/permissions/selected-actions")
+jq -e '.github_owned_allowed == true and .verified_allowed == false' \
+  <<<"$selected_actions" >/dev/null \
+  || die 'unexpected GitHub selected-actions policy'
+mapfile -t workflow_actions < <(sed -n 's/^[[:space:]]*uses:[[:space:]]*\([^ #]*\).*/\1/p' .github/workflows/*.yml | sort -u)
+for action in "${workflow_actions[@]}"; do
+  case "$action" in
+    ./*) continue ;;
+  esac
+  ref=${action##*@}
+  [[ "$ref" =~ ^[0-9a-f]{40}$ ]] || die "workflow action is not pinned to a full SHA: $action"
+  case "$action" in
+    actions/*) ;;
+    *) jq -e --arg action "$action" '.patterns_allowed | index($action) != null' \
+         <<<"$selected_actions" >/dev/null \
+         || die "workflow action is not selected in repository policy: $action" ;;
+  esac
+done
+jq -e --arg action "$CRATES_AUTH_ACTION" '.patterns_allowed | index($action) != null' \
+  <<<"$selected_actions" >/dev/null \
+  || die "crates.io authentication action is not selected: $CRATES_AUTH_ACTION"
+
+environment=$(gh api "repos/$CANONICAL_REPOSITORY/environments/$RELEASE_ENVIRONMENT")
+jq -e '.name == "release" and any(.protection_rules[]?; .type == "required_reviewers")' \
+  <<<"$environment" >/dev/null \
+  || die 'release environment is missing its required-reviewer protection'
+deployment_policies=$(gh api "repos/$CANONICAL_REPOSITORY/environments/$RELEASE_ENVIRONMENT/deployment-branch-policies")
+jq -e 'any(.branch_policies[]?; .type == "tag" and .name == "v*")' \
+  <<<"$deployment_policies" >/dev/null \
+  || die 'release environment is not restricted to v* tags'
+secrets=$(gh secret list --repo "$CANONICAL_REPOSITORY" --env "$RELEASE_ENVIRONMENT" --json name)
+for secret in SYQ_RELEASE_SIGNING_KEY_PEM_B64 HOMEBREW_TAP_DEPLOY_KEY; do
+  jq -e --arg name "$secret" 'any(.[]; .name == $name)' <<<"$secrets" >/dev/null \
+    || die "release environment secret is missing: $secret"
+done
+variables=$(gh variable list --repo "$CANONICAL_REPOSITORY" --json name,value)
+public_key=$(jq -er '.[] | select(.name == "SYQ_RELEASE_PUBLIC_KEY") | .value' <<<"$variables") \
+  || die 'repository variable is missing: SYQ_RELEASE_PUBLIC_KEY'
+[ "$(printf '%s' "$public_key" | openssl base64 -d -A | wc -c | tr -d '[:space:]')" -eq 32 ] \
+  || die 'SYQ_RELEASE_PUBLIC_KEY is not a base64-encoded 32-byte key'
+
+releases=$(gh api --paginate --slurp "repos/$CANONICAL_REPOSITORY/releases?per_page=100")
+jq -e --arg tag "$tag" 'flatten | any(.[]; .tag_name == $tag) | not' <<<"$releases" >/dev/null \
+  || die "GitHub release $tag already exists"
+crates=$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+  --user-agent 'syq-release-preflight (https://github.com/greaber/syq)' \
+  https://crates.io/api/v1/crates/syq)
+jq -e --arg version "$version" 'any(.versions[]?; .num == $version) | not' <<<"$crates" >/dev/null \
+  || die "syq $version is already published on crates.io"
+formula_json=$(gh api "repos/$HOMEBREW_REPOSITORY/contents/Formula/syq.rb")
+formula=$(jq -er .content <<<"$formula_json" | tr -d '\n' | openssl base64 -d -A)
+if grep -F "/releases/download/$tag/" <<<"$formula" >/dev/null; then
+  die "Homebrew tap already references $tag"
+fi
+
+printf 'Release preflight passed for %s at %s.\n' "$tag" "$head"
+printf 'Tag signing key: %s\n' "$signing_fingerprint"
+printf 'Required checks: %s\n' "$REQUIRED_CHECKS"
+printf 'No existing GitHub release, crates.io version, or Homebrew formula was found.\n'

--- a/scripts/release-status.sh
+++ b/scripts/release-status.sh
@@ -32,12 +32,23 @@ if [ "$reference" != null ]; then
   object_sha=$(jq -er .object.sha <<<"$reference")
   if [ "$object_type" = tag ]; then
     tag_object=$(gh api "repos/$repository/git/tags/$object_sha")
-    tag_commit=$(jq -er .object.sha <<<"$tag_object")
+    actual_tag=$(jq -er .tag <<<"$tag_object")
+    target_type=$(jq -er .object.type <<<"$tag_object")
+    target_sha=$(jq -er .object.sha <<<"$tag_object")
     verified=$(jq -r '.verification.verified == true and .verification.reason == "valid"' <<<"$tag_object")
-    [ "$verified" = true ] && tag_state=verified || tag_state=unverified
-  else
+    if [ "$actual_tag" != "$tag" ]; then
+      tag_state=name-mismatch
+    elif [ "$target_type" != commit ]; then
+      tag_state=invalid-target
+    else
+      tag_commit=$target_sha
+      [ "$verified" = true ] && tag_state=verified || tag_state=unverified
+    fi
+  elif [ "$object_type" = commit ]; then
     tag_commit=$object_sha
     tag_state=lightweight
+  else
+    tag_state=invalid-target
   fi
 fi
 

--- a/scripts/release-status.sh
+++ b/scripts/release-status.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Report release progress without changing GitHub, registries, or local refs.
+set -euo pipefail
+
+repository=greaber/syq
+homebrew_repository=greaber/homebrew-tap
+json=false
+tag=
+for argument in "$@"; do
+  case "$argument" in
+    --json) json=true ;;
+    v[0-9]*.[0-9]*.[0-9]*) [ -z "$tag" ] || { echo 'only one tag may be supplied' >&2; exit 2; }; tag=$argument ;;
+    *) echo "usage: $0 [--json] [vMAJOR.MINOR.PATCH]" >&2; exit 2 ;;
+  esac
+done
+if [ -z "$tag" ]; then
+  version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+  tag="v$version"
+fi
+[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "invalid release tag: $tag" >&2; exit 2; }
+version=${tag#v}
+for command in gh jq curl openssl; do
+  command -v "$command" >/dev/null || { echo "release status needs $command" >&2; exit 1; }
+done
+
+tag_commit=
+tag_state=missing
+references=$(gh api "repos/$repository/git/matching-refs/tags/$tag")
+reference=$(jq -c --arg ref "refs/tags/$tag" 'map(select(.ref == $ref)) | first // null' <<<"$references")
+if [ "$reference" != null ]; then
+  object_type=$(jq -er .object.type <<<"$reference")
+  object_sha=$(jq -er .object.sha <<<"$reference")
+  if [ "$object_type" = tag ]; then
+    tag_object=$(gh api "repos/$repository/git/tags/$object_sha")
+    tag_commit=$(jq -er .object.sha <<<"$tag_object")
+    verified=$(jq -r '.verification.verified == true and .verification.reason == "valid"' <<<"$tag_object")
+    [ "$verified" = true ] && tag_state=verified || tag_state=unverified
+  else
+    tag_commit=$object_sha
+    tag_state=lightweight
+  fi
+fi
+
+releases=$(gh api --paginate --slurp "repos/$repository/releases?per_page=100")
+release=$(jq -c --arg tag "$tag" 'flatten | map(select(.tag_name == $tag)) | first // null' <<<"$releases")
+github_state=missing
+github_url=
+github_immutable=false
+if [ "$release" != null ]; then
+  github_url=$(jq -r .html_url <<<"$release")
+  github_immutable=$(jq -r '.immutable // false' <<<"$release")
+  if [ "$(jq -r .draft <<<"$release")" = true ]; then github_state=draft; else github_state=published; fi
+fi
+
+runs=$(gh run list --repo "$repository" --workflow release.yml --branch "$tag" --limit 20 \
+  --json conclusion,databaseId,event,headSha,status,url,workflowName)
+if [ -n "$tag_commit" ]; then
+  runs=$(jq -c --arg sha "$tag_commit" '[.[] | select(.headSha == $sha)]' <<<"$runs")
+fi
+runs_with_environments='[]'
+while IFS= read -r run; do
+  [ -n "$run" ] || continue
+  run_id=$(jq -er .databaseId <<<"$run")
+  if pending=$(gh api "repos/$repository/actions/runs/$run_id/pending_deployments" 2>/dev/null); then
+    environments=$(jq -c '[.[] | .environment.name]' <<<"$pending")
+  else
+    environments=null
+  fi
+  run=$(jq -c --argjson environments "$environments" '. + {pending_environments:$environments}' <<<"$run")
+  runs_with_environments=$(jq -c --argjson run "$run" '. + [$run]' <<<"$runs_with_environments")
+done < <(jq -c '.[]' <<<"$runs")
+
+crates_state=unknown
+if crates=$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+  --user-agent 'syq-release-status (https://github.com/greaber/syq)' \
+  https://crates.io/api/v1/crates/syq 2>/dev/null); then
+  if jq -e --arg version "$version" 'any(.versions[]?; .num == $version)' <<<"$crates" >/dev/null; then
+    crates_state=published
+  else
+    crates_state=missing
+  fi
+fi
+
+pypi_state=unknown
+pypi_version=
+mapped_tag=$(jq -r '.tag // empty' sdk/python/src/syq/syq-release-manifest.json 2>/dev/null || true)
+if [ "$mapped_tag" = "$tag" ]; then
+  pypi_version=$(sed -n 's/^version = "\(.*\)"/\1/p' sdk/python/pyproject.toml | head -1)
+fi
+if pypi=$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' \
+  https://pypi.org/pypi/syq/json 2>/dev/null); then
+  if [ -n "$pypi_version" ]; then
+    if jq -e --arg version "$pypi_version" '.releases[$version] | length > 0' <<<"$pypi" >/dev/null; then
+      pypi_state=published
+    else
+      pypi_state=missing
+    fi
+  else
+    pypi_state=unmapped
+    pypi_version=$(jq -r '.info.version // empty' <<<"$pypi")
+  fi
+fi
+
+homebrew_state=unknown
+if formula_json=$(gh api "repos/$homebrew_repository/contents/Formula/syq.rb" 2>/dev/null); then
+  formula=$(jq -er .content <<<"$formula_json" | tr -d '\n' | openssl base64 -d -A)
+  if grep -F "/releases/download/$tag/" <<<"$formula" >/dev/null; then
+    homebrew_state=published
+  else
+    homebrew_state=missing
+  fi
+fi
+
+result=$(jq -n \
+  --arg repository "$repository" --arg tag "$tag" --arg tag_commit "$tag_commit" \
+  --arg tag_state "$tag_state" --arg github_state "$github_state" \
+  --arg github_url "$github_url" --argjson github_immutable "$github_immutable" \
+  --argjson runs "$runs_with_environments" --arg crates "$crates_state" \
+  --arg pypi "$pypi_state" --arg pypi_version "$pypi_version" \
+  --arg homebrew "$homebrew_state" '
+  {repository:$repository, tag:$tag,
+   tag_commit:($tag_commit | if length > 0 then . else null end),
+   tag_state:$tag_state,
+   github_release:{state:$github_state, immutable:$github_immutable,
+     url:($github_url | if length > 0 then . else null end)},
+   release_runs:$runs,
+   publications:{crates_io:{version:($tag | ltrimstr("v")), state:$crates},
+     pypi:{version:($pypi_version | if length > 0 then . else null end), state:$pypi},
+     homebrew:{tag:$tag, state:$homebrew}}}
+  ')
+
+if [ "$json" = true ]; then
+  jq . <<<"$result"
+  exit 0
+fi
+jq -r '
+  "Release \(.tag)",
+  "  tag:       \(.tag_state)\(if .tag_commit then " at " + .tag_commit else "" end)",
+  "  GitHub:    \(.github_release.state)\(if .github_release.immutable then " (immutable)" else "" end)",
+  "  crates.io: \(.publications.crates_io.state)",
+  "  PyPI SDK:  \(.publications.pypi.state)\(if .publications.pypi.version then " (" + .publications.pypi.version + ")" else "" end)",
+  "  Homebrew:  \(.publications.homebrew.state)",
+  (if (.release_runs | length) == 0 then "  runs:       none"
+   else .release_runs[] | "  run \(.databaseId): \(.status)\(if .conclusion then "/" + .conclusion else "" end), pending environments: \(if .pending_environments == null then "unknown" else (.pending_environments | join(", ") | if length == 0 then "none" else . end) end)\n    \(.url)" end)
+' <<<"$result"

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Fixture-driven checks for path selection, generated-PR approval, preflight,
+# and release status reporting.
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-release-orchestration-test.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+
+expect_failure() {
+  local expected=$1
+  shift
+  if "$@" >"$work/failure.out" 2>&1; then
+    echo "command unexpectedly succeeded: $*" >&2
+    exit 1
+  fi
+  grep -F "$expected" "$work/failure.out" >/dev/null || {
+    echo "failure did not contain '$expected':" >&2
+    sed 's/^/  /' "$work/failure.out" >&2
+    exit 1
+  }
+}
+
+# Scope only the expensive jobs affected by a change while retaining all job
+# names as successful required checks.
+paths="$work/paths"
+printf 'README.md\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+grep -Fx 'native=false' <<<"$scope" >/dev/null
+grep -Fx 'sdks=false' <<<"$scope" >/dev/null
+grep -Fx 'conformance=false' <<<"$scope" >/dev/null
+printf 'sdk/python/src/syq/syq-release-manifest.json\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+grep -Fx 'native=false' <<<"$scope" >/dev/null
+grep -Fx 'sdks=true' <<<"$scope" >/dev/null
+printf 'src/main.rs\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+grep -Fx 'native=true' <<<"$scope" >/dev/null
+grep -Fx 'sdks=true' <<<"$scope" >/dev/null
+grep -Fx 'conformance=true' <<<"$scope" >/dev/null
+
+scope_repo="$work/scope-repo"
+mkdir "$scope_repo"
+git -C "$scope_repo" init -b master -q
+git -C "$scope_repo" config user.name Test
+git -C "$scope_repo" config user.email test@example.com
+printf 'documentation\n' >"$scope_repo/README.md"
+git -C "$scope_repo" add README.md
+git -C "$scope_repo" commit -qm base
+scope_base=$(git -C "$scope_repo" rev-parse HEAD)
+mkdir -p "$scope_repo/sdk/python"
+printf 'mapping\n' >"$scope_repo/sdk/python/mapping"
+git -C "$scope_repo" add sdk/python/mapping
+git -C "$scope_repo" commit -qm sdk
+scope_head=$(git -C "$scope_repo" rev-parse HEAD)
+scope_event="$work/pull-request-event.json"
+jq -n --arg base "$scope_base" --arg head "$scope_head" \
+  '{pull_request:{base:{sha:$base},head:{sha:$head}}}' >"$scope_event"
+scope=$(cd "$scope_repo" && "$script_dir/ci-scope.sh" "$scope_event")
+grep -Fx 'native=false' <<<"$scope" >/dev/null
+grep -Fx 'sdks=true' <<<"$scope" >/dev/null
+printf '{}\n' >"$work/workflow-dispatch-event.json"
+scope=$(cd "$scope_repo" && \
+  "$script_dir/ci-scope.sh" "$work/workflow-dispatch-event.json")
+grep -Fx 'native=true' <<<"$scope" >/dev/null
+grep -Fx 'sdks=true' <<<"$scope" >/dev/null
+
+# The approval helper binds the PR and both workflow runs to the same trusted
+# repository, native pull_request event, branch, and exact head SHA.
+approval_bin="$work/approval-bin"
+mkdir "$approval_bin"
+approval_log="$work/approvals"
+head_sha=0123456789abcdef0123456789abcdef01234567
+cat >"$approval_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = api ] && [[ " $* " == *" repos/greaber/syq/pulls "* ]]; then
+  jq -cn --arg repo "${SYQ_TEST_PR_REPOSITORY:-greaber/syq}" \
+    --arg branch automation/python-sdk-v0.1.9 --arg sha "$SYQ_TEST_HEAD_SHA" '
+    [{head:{repo:{full_name:$repo},ref:$branch,sha:$sha},base:{ref:"master"}}]'
+elif [ "$1:$2" = 'run:list' ]; then
+  jq -cn --arg sha "${SYQ_TEST_RUN_SHA:-$SYQ_TEST_HEAD_SHA}" \
+    --arg event "${SYQ_TEST_RUN_EVENT:-pull_request}" '[
+    {conclusion:"action_required",databaseId:101,event:$event,headSha:$sha,status:"completed",url:"https://example.test/101",workflowName:"ci"},
+    {conclusion:"action_required",databaseId:102,event:$event,headSha:$sha,status:"completed",url:"https://example.test/102",workflowName:"rsync compatibility"}]'
+elif [ "$1" = api ] && [[ " $* " == *'/approve '* ]]; then
+  printf '%s\n' "$*" >>"$SYQ_TEST_APPROVAL_LOG"
+else
+  echo "unexpected fake gh invocation: $*" >&2
+  exit 2
+fi
+EOF
+chmod 755 "$approval_bin/gh"
+SYQ_TEST_HEAD_SHA="$head_sha" SYQ_TEST_APPROVAL_LOG="$approval_log" \
+  PATH="$approval_bin:$PATH" \
+  "$script_dir/approve-generated-pr-runs.sh" \
+  greaber/syq automation/python-sdk-v0.1.9 "$head_sha" >/dev/null
+[ "$(wc -l <"$approval_log")" -eq 2 ]
+expect_failure 'expected one trusted open pull request' env \
+  SYQ_TEST_HEAD_SHA="$head_sha" SYQ_TEST_PR_REPOSITORY=attacker/syq \
+  SYQ_TEST_APPROVAL_LOG="$approval_log" PATH="$approval_bin:$PATH" \
+  "$script_dir/approve-generated-pr-runs.sh" \
+  greaber/syq automation/python-sdk-v0.1.9 "$head_sha"
+expect_failure 'timed out waiting for native pull-request workflow runs' env \
+  SYQ_TEST_HEAD_SHA="$head_sha" SYQ_TEST_RUN_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  SYQ_TEST_APPROVAL_LOG="$approval_log" SYQ_APPROVAL_TIMEOUT_SECONDS=0 \
+  PATH="$approval_bin:$PATH" \
+  "$script_dir/approve-generated-pr-runs.sh" \
+  greaber/syq automation/python-sdk-v0.1.9 "$head_sha"
+expect_failure 'timed out waiting for native pull-request workflow runs' env \
+  SYQ_TEST_HEAD_SHA="$head_sha" SYQ_TEST_RUN_EVENT=workflow_dispatch \
+  SYQ_TEST_APPROVAL_LOG="$approval_log" SYQ_APPROVAL_TIMEOUT_SECONDS=0 \
+  PATH="$approval_bin:$PATH" \
+  "$script_dir/approve-generated-pr-runs.sh" \
+  greaber/syq automation/python-sdk-v0.1.9 "$head_sha"
+
+# Build a clean disposable canonical checkout and serve every GitHub/registry
+# response from fixtures. The preflight must not create a tag or publication.
+preflight_repo="$work/preflight-repo"
+preflight_bin="$work/preflight-bin"
+mkdir -p "$preflight_repo/.github/workflows" "$preflight_bin"
+cat >"$preflight_repo/Cargo.toml" <<'EOF'
+[package]
+name = "syq"
+version = "9.9.9"
+EOF
+cat >"$preflight_repo/Cargo.lock" <<'EOF'
+version = 4
+
+[[package]]
+name = "syq"
+version = "9.9.9"
+EOF
+cat >"$preflight_repo/.github/workflows/release.yml" <<'EOF'
+steps:
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+  - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18
+EOF
+git -C "$preflight_repo" init -b master -q
+git -C "$preflight_repo" config user.name Test
+git -C "$preflight_repo" config user.email test@example.com
+git -C "$preflight_repo" add .
+git -C "$preflight_repo" commit -qm initial
+git -C "$preflight_repo" remote add origin git@github.com:greaber/syq.git
+preflight_head=$(git -C "$preflight_repo" rev-parse HEAD)
+git -C "$preflight_repo" update-ref refs/remotes/origin/master "$preflight_head"
+ssh-keygen -q -t ed25519 -N '' -f "$work/tag-signing-key"
+signing_key=$(awk '{print $1 " " $2}' "$work/tag-signing-key.pub")
+git -C "$preflight_repo" config gpg.format ssh
+git -C "$preflight_repo" config user.signingkey "key::$signing_key"
+git -C "$preflight_repo" config tag.gpgsign true
+real_git=$(command -v git)
+cat >"$preflight_bin/git" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = ls-remote ]; then
+  case " $* " in
+    *' refs/heads/master '*) printf '%s\trefs/heads/master\n' "$SYQ_TEST_PREFLIGHT_HEAD" ;;
+  esac
+  exit 0
+fi
+exec "$SYQ_TEST_REAL_GIT" "$@"
+EOF
+cat >"$preflight_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1:$2" in
+  repo:view) printf 'greaber/syq\n' ;;
+  secret:list) printf '[{"name":"SYQ_RELEASE_SIGNING_KEY_PEM_B64"},{"name":"HOMEBREW_TAP_DEPLOY_KEY"}]\n' ;;
+  variable:list) printf '[{"name":"SYQ_RELEASE_PUBLIC_KEY","value":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}]\n' ;;
+  api:user) printf 'greaber\n' ;;
+  api:*)
+    case " $* " in
+      *'/commits/'*'/check-runs'*) printf '%s\n' "$SYQ_TEST_CHECKS_JSON" ;;
+      *'/actions/permissions/selected-actions '*) printf '%s\n' "$SYQ_TEST_SELECTED_ACTIONS_JSON" ;;
+      *'/actions/permissions '*) printf '{"enabled":true,"allowed_actions":"selected","sha_pinning_required":true}\n' ;;
+      *'/deployment-branch-policies '*) printf '{"branch_policies":[{"name":"v*","type":"tag"}]}\n' ;;
+      *'/environments/release '*) printf '{"name":"release","protection_rules":[{"type":"required_reviewers"}]}\n' ;;
+      *'users/greaber/ssh_signing_keys'*) jq -cn --arg key "$SYQ_TEST_SIGNING_KEY" '[{key:$key}]' ;;
+      *'/releases?per_page=100 '*) printf '[[]]\n' ;;
+      *'homebrew-tap/contents/Formula/syq.rb '*) jq -cn --arg content "$SYQ_TEST_FORMULA_B64" '{content:$content}' ;;
+      *) echo "unexpected fake gh api invocation: $*" >&2; exit 2 ;;
+    esac
+    ;;
+  *) echo "unexpected fake gh invocation: $*" >&2; exit 2 ;;
+esac
+EOF
+cat >"$preflight_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+jq -cn --arg version "${SYQ_TEST_EXISTING_CRATE_VERSION:-}" '
+  {versions:(if $version == "" then [] else [{num:$version}] end)}'
+EOF
+chmod 755 "$preflight_bin/git" "$preflight_bin/gh" "$preflight_bin/curl"
+checks_json=$(jq -cn '{check_runs:["rust","sdks","macos","linux-arm64"] | map({name:.,conclusion:"success"})}')
+selected_json=$(jq -cn '{github_owned_allowed:true,verified_allowed:false,
+  patterns_allowed:["rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18"]}')
+formula_b64=$(printf 'url "https://github.com/greaber/syq/releases/download/v9.9.8/syq"\n' | openssl base64 -A)
+preflight_env=(
+  SYQ_TEST_PREFLIGHT_HEAD="$preflight_head"
+  SYQ_TEST_REAL_GIT="$real_git"
+  SYQ_TEST_CHECKS_JSON="$checks_json"
+  SYQ_TEST_SELECTED_ACTIONS_JSON="$selected_json"
+  SYQ_TEST_SIGNING_KEY="$signing_key"
+  SYQ_TEST_FORMULA_B64="$formula_b64"
+  PATH="$preflight_bin:$PATH"
+)
+(cd "$preflight_repo" && env "${preflight_env[@]}" \
+  "$script_dir/release-preflight.sh" v9.9.9) >"$work/preflight.out"
+grep -F "Release preflight passed for v9.9.9 at $preflight_head" "$work/preflight.out" >/dev/null
+if (cd "$preflight_repo" && env "${preflight_env[@]}" \
+  SYQ_TEST_EXISTING_CRATE_VERSION=9.9.9 \
+  "$script_dir/release-preflight.sh" v9.9.9) >"$work/failure.out" 2>&1; then
+  echo 'preflight unexpectedly accepted an existing crates.io version' >&2
+  exit 1
+fi
+grep -F 'already published on crates.io' "$work/failure.out" >/dev/null
+
+# Release status correlates the exact tag commit with runs, pending protected
+# environments, and every publication destination.
+status_bin="$work/status-bin"
+mkdir "$status_bin"
+status_commit=89abcdef0123456789abcdef0123456789abcdef
+status_tag_object=76543210abcdef9876543210abcdef9876543210
+status_formula_b64=$(printf 'url "https://github.com/greaber/syq/releases/download/v0.1.8/syq"\n' | openssl base64 -A)
+cat >"$status_bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1:$2" in
+  run:list) jq -cn --arg sha "$SYQ_TEST_STATUS_COMMIT" '[
+    {conclusion:null,databaseId:303,event:"push",headSha:$sha,status:"in_progress",url:"https://example.test/303",workflowName:"release"}]' ;;
+  api:*)
+    case " $* " in
+      *'/git/matching-refs/tags/v0.1.8 '*) jq -cn --arg sha "$SYQ_TEST_STATUS_TAG_OBJECT" '[{ref:"refs/tags/v0.1.8",object:{type:"tag",sha:$sha}}]' ;;
+      *'/git/tags/'*) jq -cn --arg sha "$SYQ_TEST_STATUS_COMMIT" '{object:{sha:$sha},verification:{verified:true,reason:"valid"}}' ;;
+      *'/releases?per_page=100 '*) printf '[[{"tag_name":"v0.1.8","draft":false,"immutable":true,"html_url":"https://example.test/v0.1.8"}]]\n' ;;
+      *'/actions/runs/303/pending_deployments '*) printf '[{"environment":{"name":"release"}}]\n' ;;
+      *'homebrew-tap/contents/Formula/syq.rb '*) jq -cn --arg content "$SYQ_TEST_STATUS_FORMULA_B64" '{content:$content}' ;;
+      *) echo "unexpected fake gh api invocation: $*" >&2; exit 2 ;;
+    esac
+    ;;
+  *) echo "unexpected fake gh invocation: $*" >&2; exit 2 ;;
+esac
+EOF
+cat >"$status_bin/curl" <<'EOF'
+#!/usr/bin/env bash
+case " $* " in
+  *'crates.io/'*) printf '{"versions":[{"num":"0.1.8"}]}\n' ;;
+  *'pypi.org/'*) printf '{"info":{"version":"0.0.3"},"releases":{"0.0.3":[{}]}}\n' ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod 755 "$status_bin/gh" "$status_bin/curl"
+PATH="$status_bin:$PATH" \
+SYQ_TEST_STATUS_COMMIT="$status_commit" \
+SYQ_TEST_STATUS_TAG_OBJECT="$status_tag_object" \
+SYQ_TEST_STATUS_FORMULA_B64="$status_formula_b64" \
+  "$script_dir/release-status.sh" --json v0.1.8 >"$work/status.json"
+jq -e --arg commit "$status_commit" '
+  .tag_state == "verified" and .tag_commit == $commit and
+  .github_release.state == "published" and .github_release.immutable == true and
+  .release_runs[0].databaseId == 303 and
+  .release_runs[0].pending_environments == ["release"] and
+  .publications.crates_io.state == "published" and
+  .publications.pypi.state == "published" and
+  .publications.homebrew.state == "published"
+' "$work/status.json" >/dev/null || {
+  echo 'release status fixture did not produce the expected state:' >&2
+  jq . "$work/status.json" >&2
+  exit 1
+}
+
+echo 'release orchestration tests passed'

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -86,6 +86,16 @@ elif [ "$1:$2" = 'run:list' ]; then
     {conclusion:"action_required",databaseId:102,event:$event,headSha:$sha,status:"completed",url:"https://example.test/102",workflowName:"rsync compatibility"}]'
 elif [ "$1" = api ] && [[ " $* " == *'/approve '* ]]; then
   printf '%s\n' "$*" >>"$SYQ_TEST_APPROVAL_LOG"
+elif [ "$1" = api ] && [[ "$2" == *'/check-runs?'* ]]; then
+  status=${SYQ_TEST_SDK_STATUS:-completed}
+  conclusion=${SYQ_TEST_SDK_CONCLUSION:-success}
+  if [ "$conclusion" = null ]; then
+    jq -cn --arg status "$status" \
+      '{check_runs:[{name:"sdks",status:$status,conclusion:null}]}'
+  else
+    jq -cn --arg status "$status" --arg conclusion "$conclusion" \
+      '{check_runs:[{name:"sdks",status:$status,conclusion:$conclusion}]}'
+  fi
 else
   echo "unexpected fake gh invocation: $*" >&2
   exit 2
@@ -106,6 +116,17 @@ expect_failure 'timed out waiting for native pull-request workflow runs' env \
   SYQ_TEST_HEAD_SHA="$head_sha" SYQ_TEST_RUN_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
   SYQ_TEST_APPROVAL_LOG="$approval_log" SYQ_APPROVAL_TIMEOUT_SECONDS=0 \
   PATH="$approval_bin:$PATH" \
+  "$script_dir/approve-generated-pr-runs.sh" \
+  greaber/syq automation/python-sdk-v0.1.9 "$head_sha"
+expect_failure 'required generated-PR check sdks is completed/failure' env \
+  SYQ_TEST_HEAD_SHA="$head_sha" SYQ_TEST_SDK_CONCLUSION=failure \
+  SYQ_TEST_APPROVAL_LOG="$approval_log" PATH="$approval_bin:$PATH" \
+  "$script_dir/approve-generated-pr-runs.sh" \
+  greaber/syq automation/python-sdk-v0.1.9 "$head_sha"
+expect_failure 'timed out waiting for required generated-PR check sdks' env \
+  SYQ_TEST_HEAD_SHA="$head_sha" SYQ_TEST_SDK_STATUS=in_progress \
+  SYQ_TEST_SDK_CONCLUSION=null SYQ_REQUIRED_CHECK_TIMEOUT_SECONDS=0 \
+  SYQ_TEST_APPROVAL_LOG="$approval_log" PATH="$approval_bin:$PATH" \
   "$script_dir/approve-generated-pr-runs.sh" \
   greaber/syq automation/python-sdk-v0.1.9 "$head_sha"
 expect_failure 'timed out waiting for native pull-request workflow runs' env \
@@ -231,7 +252,10 @@ case "$1:$2" in
   api:*)
     case " $* " in
       *'/git/matching-refs/tags/v0.1.8 '*) jq -cn --arg sha "$SYQ_TEST_STATUS_TAG_OBJECT" '[{ref:"refs/tags/v0.1.8",object:{type:"tag",sha:$sha}}]' ;;
-      *'/git/tags/'*) jq -cn --arg sha "$SYQ_TEST_STATUS_COMMIT" '{object:{sha:$sha},verification:{verified:true,reason:"valid"}}' ;;
+      *'/git/tags/'*) jq -cn --arg sha "$SYQ_TEST_STATUS_COMMIT" \
+        --arg tag "${SYQ_TEST_STATUS_OBJECT_TAG:-v0.1.8}" \
+        --arg type "${SYQ_TEST_STATUS_TARGET_TYPE:-commit}" \
+        '{tag:$tag,object:{type:$type,sha:$sha},verification:{verified:true,reason:"valid"}}' ;;
       *'/releases?per_page=100 '*) printf '[[{"tag_name":"v0.1.8","draft":false,"immutable":true,"html_url":"https://example.test/v0.1.8"}]]\n' ;;
       *'/actions/runs/303/pending_deployments '*) printf '[{"environment":{"name":"release"}}]\n' ;;
       *'homebrew-tap/contents/Formula/syq.rb '*) jq -cn --arg content "$SYQ_TEST_STATUS_FORMULA_B64" '{content:$content}' ;;
@@ -268,5 +292,23 @@ jq -e --arg commit "$status_commit" '
   jq . "$work/status.json" >&2
   exit 1
 }
+
+PATH="$status_bin:$PATH" \
+SYQ_TEST_STATUS_COMMIT="$status_commit" \
+SYQ_TEST_STATUS_TAG_OBJECT="$status_tag_object" \
+SYQ_TEST_STATUS_OBJECT_TAG=v0.1.7 \
+SYQ_TEST_STATUS_FORMULA_B64="$status_formula_b64" \
+  "$script_dir/release-status.sh" --json v0.1.8 >"$work/status-name-mismatch.json"
+jq -e '.tag_state == "name-mismatch" and .tag_commit == null' \
+  "$work/status-name-mismatch.json" >/dev/null
+
+PATH="$status_bin:$PATH" \
+SYQ_TEST_STATUS_COMMIT="$status_commit" \
+SYQ_TEST_STATUS_TAG_OBJECT="$status_tag_object" \
+SYQ_TEST_STATUS_TARGET_TYPE=tag \
+SYQ_TEST_STATUS_FORMULA_B64="$status_formula_b64" \
+  "$script_dir/release-status.sh" --json v0.1.8 >"$work/status-nested-tag.json"
+jq -e '.tag_state == "invalid-target" and .tag_commit == null' \
+  "$work/status-nested-tag.json" >/dev/null
 
 echo 'release orchestration tests passed'

--- a/sdk/RELEASING.md
+++ b/sdk/RELEASING.md
@@ -138,9 +138,11 @@ state. The preparation workflow waits until GitHub has registered both native
 runs for the exact generated commit, verifies that the pull request and native
 events belong to the trusted repository, then approves them through the
 Actions API so the required checks remain attached to the pull request. The
-fixture-tested helper has a bounded deadline and reports its last observed
-state on failure. Once the runs exist, the workflow requests auto-merge; GitHub
-still waits for every required check and branch-protection rule. The repository
+fixture-tested helper has bounded deadlines and reports its last observed state
+on failure. Because `sdks` is not currently a required branch-protection check,
+the helper also waits for that check to succeed on the exact generated commit
+before the workflow requests auto-merge. GitHub then still waits for every
+required check and branch-protection rule. The repository
 keeps the default workflow token read only, permits trusted Actions workflows
 to create pull requests, and grants write scopes only inside this preparation
 workflow.

--- a/sdk/RELEASING.md
+++ b/sdk/RELEASING.md
@@ -135,18 +135,25 @@ exact signed manifest and prepares the next Python patch version. It opens an
 cache-path documentation, lockfile, and mapping-table updates. GitHub places
 pull-request workflow runs caused by its own token into an approval-required
 state. The preparation workflow waits until GitHub has registered both native
-runs for the exact generated commit, then approves them through the Actions API
-so the required checks remain attached to the pull request. The repository
+runs for the exact generated commit, verifies that the pull request and native
+events belong to the trusted repository, then approves them through the
+Actions API so the required checks remain attached to the pull request. The
+fixture-tested helper has a bounded deadline and reports its last observed
+state on failure. Once the runs exist, the workflow requests auto-merge; GitHub
+still waits for every required check and branch-protection rule. The repository
 keeps the default workflow token read only, permits trusted Actions workflows
 to create pull requests, and grants write scopes only inside this preparation
 workflow.
 
-Review and merge that pull request normally. The final publication remains a
-deliberate release-authority action: create the signed annotated
+The generated pull request merges automatically after its required checks.
+Reviewers may still stop auto-merge while it is pending. The final publication
+remains a deliberate release-authority action: create the signed annotated
 `sdk-python-v<version>` tag and approve the protected `pypi` environment. The
 tag then publishes through OIDC without a local upload or long-lived PyPI
 credential. Keeping the tag signature manual avoids placing maintainer signing
-authority in CI; PyPI availability cannot block publication of syq itself.
+authority in CI. The additional PyPI environment approval is intentionally
+retained as defense in depth for a separate package registry; PyPI availability
+cannot block publication of syq itself.
 
 Python distributions use a pinned interpreter and the tagged commit timestamp
 as `SOURCE_DATE_EPOCH`, and the source archive is repacked with normalized


### PR DESCRIPTION
## Summary

- add read-only pre-tag preflight and cross-channel release status commands
- keep required checks stable while making native, platform, SDK, and conformance work path-aware
- extract generated-PR run approval into a fixture-tested trusted-head helper and request auto-merge
- update Homebrew inside the already-approved release job, reducing syq publication to one environment approval
- retain the separate PyPI environment approval as deliberate defense in depth
- pin a repository-local actionlint runner and document the resulting process

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`
- pinned `cargo-deny 0.20.2 --locked check`
- release package, installer, signing, secret, Python-release, and orchestration fixture scripts
- shellcheck, YAML parsing, and pinned actionlint 1.7.12
- Python SDK tests on Python 3.10, JavaScript tests/package dry run, and Go fmt/vet/tests
- live read-only `v0.1.8` status audit across GitHub, crates.io, PyPI, and Homebrew

The Homebrew formula test was not available locally because this Linux host has no `brew`; the required macOS CI job runs it.