### PR TITLE
Enforce existing-object and root-existence policies in the restricted receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,10 @@ ordinary pathname and publication behavior applies: these forms do not pin an
 inode or provide compare-and-swap behavior against a concurrent namespace
 writer. Changed regular files continue to use staged atomic publication.
 Mapping a non-directory source exactly onto an existing directory is rejected
-during the source's first scan batch, in both dry-run and execution.
+during the source's first scan batch, in both dry-run and execution. On the
+command-restricted remote-to-remote path the precondition is also signed: the
+receiver checks it against the enrolled root when it claims the grant, and a
+`new` root can only be created without replacing anything.
 
 `cp` copies or updates mapped source objects and keeps unrelated target
 objects. `cp-prune` uses the same mapping and transfer engine, then applies the
@@ -485,8 +488,8 @@ A compromised hostA can invent the source tree wholesale: names, object types,
 metadata, and file bytes need not correspond to anything on hostA's filesystem.
 It can also omit entries or stop the transfer. HostB can enforce only signed
 command properties visible in receiver requests, such as destination scopes,
-publication and preservation policy, resource limits, and whether a requested
-mutation could have survived the signed filter traversal. HostA still cannot
+publication, preservation, and existing-object policy, resource limits, and
+whether a requested mutation could have survived the signed filter traversal. HostA still cannot
 escape those checks or independently authenticate to hostB with the enrollment
 key.
 
@@ -500,10 +503,19 @@ root even when it overlaps an ignored path from another contents source.
 The signed publication policy distinguishes atomic staged writes from
 `--inplace`; in-place requests use descriptor-relative opens and writes beneath
 the enrolled root and cannot silently switch back to staged publication.
-`--no-tcp`, `--tcp-plain`, `--tcp-congestion`, `--update`, `--existing`,
-`--ignore-existing`, native `--*-new`/`--*-existing`, `--files-from`, `--mapping`,
-`--min-size`, `--syq-path`, and `--no-bootstrap` currently fail closed because
-the receiver cannot enforce those semantics independently of hostA.
+The existing-object policy is signed and enforced by the receiver. Under
+`--ignore-existing` every creation and publication is forced to no-replace
+creation, and metadata or content changes to any non-directory that existed
+before the transfer are refused; existing directories are reused, as in the
+ordinary engine. Under `--existing` the receiver refuses to create any object.
+Native `--into-new`/`--as-new` and `--into-existing`/`--as-existing` travel as
+a signed root precondition in a V4 grant, checked against the enrolled root
+when the grant is claimed; an older installed receiver rejects that grant
+safely until `syq enroll` refreshes it. `--update` still fails closed because
+it compares against source modification times that only hostA reports.
+`--no-tcp`, `--tcp-plain`, `--tcp-congestion`, `--files-from`, `--mapping`,
+`--min-size`, `--syq-path`, and `--no-bootstrap` also fail closed because the
+receiver cannot enforce those semantics independently of hostA.
 `--max-size` is enforced as a signed per-file limit, but is refused together
 with deletion because filtered source files could otherwise make hostA's
 deletion plan ambiguous. Explicit `-j` values above 64 are also refused; auto

--- a/README.md
+++ b/README.md
@@ -509,9 +509,10 @@ creation, and metadata or content changes to any non-directory that existed
 before the transfer are refused; existing directories are reused, as in the
 ordinary engine. Under `--existing` the receiver refuses to create any object
 and pins each update to the object it observed, so an existing object cannot
-change type. `--inplace` is refused together with `--ignore-existing` or
-`--as-new` on this path, because an in-place write opens the final pathname
-directly and cannot be made no-replace.
+change type. `--inplace` is refused together with `--ignore-existing`,
+`--existing`, or `--as-new` on this path, because an in-place write opens the
+final pathname directly and can neither be made no-replace nor be pinned to
+an observed object.
 Native `--into-new`/`--as-new` and `--into-existing`/`--as-existing` travel as
 a signed root precondition in a V4 grant, checked against the enrolled root
 when the grant is claimed; an older installed receiver rejects that grant

--- a/README.md
+++ b/README.md
@@ -507,7 +507,11 @@ The existing-object policy is signed and enforced by the receiver. Under
 `--ignore-existing` every creation and publication is forced to no-replace
 creation, and metadata or content changes to any non-directory that existed
 before the transfer are refused; existing directories are reused, as in the
-ordinary engine. Under `--existing` the receiver refuses to create any object.
+ordinary engine. Under `--existing` the receiver refuses to create any object
+and pins each update to the object it observed, so an existing object cannot
+change type. `--inplace` is refused together with `--ignore-existing` or
+`--as-new` on this path, because an in-place write opens the final pathname
+directly and cannot be made no-replace.
 Native `--into-new`/`--as-new` and `--into-existing`/`--as-existing` travel as
 a signed root precondition in a V4 grant, checked against the enrolled root
 when the grant is claimed; an older installed receiver rejects that grant

--- a/README.md
+++ b/README.md
@@ -491,7 +491,10 @@ command properties visible in receiver requests, such as destination scopes,
 publication, preservation, and existing-object policy, resource limits, and
 whether a requested mutation could have survived the signed filter traversal. HostA still cannot
 escape those checks or independently authenticate to hostB with the enrollment
-key.
+key. The boundary runs between the two hosts, not inside hostB: the receiver
+runs as the enrolled account and remembers what it created by pathname, so a
+local writer who can already modify the destination tree is outside its
+guarantee, exactly as for the ordinary engine.
 
 The command-restricted path requires encrypted TCP data connections. Ordered
 filter rules and `--delete-excluded` are included in a V3 signed grant: the

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -55,13 +55,15 @@ const WIRE_MAGIC: &[u8; 8] = b"SYQGRNT\0";
 // V1's typed GrantV1 body is frozen. V2 wraps that body with a signed
 // receiver-side file-data rate ceiling. V3 additionally binds source-selection
 // filters and their deletion policy so a remote source coordinator cannot
-// mutate a path the invoking machine excluded. Receivers retain V1/V2 decoding.
-// The SSHSIG namespace remains stable because the signed wire version already
-// separates the payloads and existing enrollment policies authorize this
-// protocol family by that namespace.
+// mutate a path the invoking machine excluded. V4 adds the placement root's
+// signed existence precondition (`--into-new`, `--as-existing`, and friends).
+// Receivers retain V1/V2/V3 decoding. The SSHSIG namespace remains stable
+// because the signed wire version already separates the payloads and existing
+// enrollment policies authorize this protocol family by that namespace.
 const WIRE_VERSION_V1: u16 = 1;
 const WIRE_VERSION_V2: u16 = 2;
-const WIRE_VERSION: u16 = 3;
+const WIRE_VERSION_V3: u16 = 3;
+const WIRE_VERSION: u16 = 4;
 const WIRE_HEADER_LEN: usize = WIRE_MAGIC.len() + 2 + 4 + 4;
 const MAX_GRANT_BYTES: usize = 32 * 1024;
 const MAX_SIGNATURE_BYTES: usize = 16 * 1024;
@@ -390,11 +392,35 @@ struct GrantBodyV3 {
     filters: FilterPolicyV3,
 }
 
+/// Signed precondition on the placement root itself. The receiver checks it
+/// once against the enrolled root when the grant is claimed, and `New`
+/// additionally forces no-replace creation of that root, so a remote source
+/// coordinator cannot turn `--into-new` into an update of an existing tree.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum RootExistenceV4 {
+    #[default]
+    Any,
+    /// The signed destination must not exist when the grant is claimed.
+    New,
+    /// The signed destination must already exist when the grant is claimed;
+    /// a directory placement additionally requires a directory.
+    Existing,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct GrantBodyV4 {
+    grant: GrantV1,
+    max_file_data_bytes_per_second: u64,
+    filters: FilterPolicyV3,
+    root_existence: RootExistenceV4,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct SignedGrantEnvelope {
     pub grant: GrantV1,
     pub max_file_data_bytes_per_second: u64,
     pub filters: FilterPolicyV3,
+    pub root_existence: RootExistenceV4,
     /// Canonical OpenSSH armored SSHSIG bytes.
     pub signature: Vec<u8>,
     wire_version: u16,
@@ -407,6 +433,7 @@ impl SignedGrantEnvelope {
             grant,
             max_file_data_bytes_per_second,
             filters: FilterPolicyV3::default(),
+            root_existence: RootExistenceV4::Any,
             signature,
             wire_version: WIRE_VERSION,
         }
@@ -420,6 +447,7 @@ impl SignedGrantEnvelope {
             &self.grant,
             self.max_file_data_bytes_per_second,
             &self.filters,
+            self.root_existence,
         )?;
         if body.len() > MAX_GRANT_BYTES {
             bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
@@ -445,7 +473,10 @@ impl SignedGrantEnvelope {
             bail!("not a SYQ signed grant envelope");
         }
         let version = u16::from_be_bytes(bytes[8..10].try_into().expect("fixed header"));
-        if !matches!(version, WIRE_VERSION_V1 | WIRE_VERSION_V2 | WIRE_VERSION) {
+        if !matches!(
+            version,
+            WIRE_VERSION_V1 | WIRE_VERSION_V2 | WIRE_VERSION_V3 | WIRE_VERSION
+        ) {
             bail!("unsupported signed grant envelope version {version}");
         }
         let grant_len =
@@ -466,11 +497,11 @@ impl SignedGrantEnvelope {
             bail!("signed grant envelope length is noncanonical");
         }
         let body_bytes = &bytes[WIRE_HEADER_LEN..WIRE_HEADER_LEN + grant_len];
-        let (grant, max_file_data_bytes_per_second, filters) = match version {
+        let (grant, max_file_data_bytes_per_second, filters, root_existence) = match version {
             WIRE_VERSION_V1 => {
                 let grant: GrantV1 =
                     postcard::from_bytes(body_bytes).context("decode signed grant")?;
-                (grant, 0, FilterPolicyV3::default())
+                (grant, 0, FilterPolicyV3::default(), RootExistenceV4::Any)
             }
             WIRE_VERSION_V2 => {
                 let body: GrantBodyV2 =
@@ -479,21 +510,38 @@ impl SignedGrantEnvelope {
                     body.grant,
                     body.max_file_data_bytes_per_second,
                     FilterPolicyV3::default(),
+                    RootExistenceV4::Any,
                 )
             }
-            WIRE_VERSION => {
+            WIRE_VERSION_V3 => {
                 let body: GrantBodyV3 =
                     postcard::from_bytes(body_bytes).context("decode signed grant")?;
                 (
                     body.grant,
                     body.max_file_data_bytes_per_second,
                     body.filters,
+                    RootExistenceV4::Any,
+                )
+            }
+            WIRE_VERSION => {
+                let body: GrantBodyV4 =
+                    postcard::from_bytes(body_bytes).context("decode signed grant")?;
+                (
+                    body.grant,
+                    body.max_file_data_bytes_per_second,
+                    body.filters,
+                    body.root_existence,
                 )
             }
             _ => unreachable!(),
         };
-        if canonical_body_bytes(version, &grant, max_file_data_bytes_per_second, &filters)?
-            != body_bytes
+        if canonical_body_bytes(
+            version,
+            &grant,
+            max_file_data_bytes_per_second,
+            &filters,
+            root_existence,
+        )? != body_bytes
         {
             bail!("signed grant uses a noncanonical encoding");
         }
@@ -505,6 +553,7 @@ impl SignedGrantEnvelope {
             grant,
             max_file_data_bytes_per_second,
             filters,
+            root_existence,
             signature,
             wire_version: version,
         })
@@ -516,6 +565,7 @@ impl SignedGrantEnvelope {
             &self.grant,
             self.max_file_data_bytes_per_second,
             &self.filters,
+            self.root_existence,
         )
     }
 }
@@ -524,6 +574,7 @@ pub(crate) fn sign_grant(
     grant: GrantV1,
     max_file_data_bytes_per_second: u64,
     mut filters: FilterPolicyV3,
+    root_existence: RootExistenceV4,
     private_key: &PrivateKey,
 ) -> Result<Vec<u8>> {
     if private_key.is_encrypted() {
@@ -541,8 +592,10 @@ pub(crate) fn sign_grant(
     filters.validate(&grant)?;
     // Keep emitting the oldest form capable of representing the request so
     // ordinary transfers remain usable with existing receiver enrollments.
-    let wire_version = if filters.is_active() {
+    let wire_version = if root_existence != RootExistenceV4::Any {
         WIRE_VERSION
+    } else if filters.is_active() {
+        WIRE_VERSION_V3
     } else if max_file_data_bytes_per_second == 0 {
         WIRE_VERSION_V1
     } else {
@@ -553,6 +606,7 @@ pub(crate) fn sign_grant(
         &grant,
         max_file_data_bytes_per_second,
         &filters,
+        root_existence,
     )?;
     let signature = private_key
         .sign(SSHSIG_NAMESPACE, HashAlg::Sha256, &payload)
@@ -564,6 +618,7 @@ pub(crate) fn sign_grant(
         grant,
         max_file_data_bytes_per_second,
         filters,
+        root_existence,
         signature,
         wire_version,
     }
@@ -577,6 +632,7 @@ fn signing_payload(grant: &GrantV1, max_file_data_bytes_per_second: u64) -> Resu
         grant,
         max_file_data_bytes_per_second,
         &FilterPolicyV3::default(),
+        RootExistenceV4::Any,
     )
 }
 
@@ -585,10 +641,17 @@ fn signing_payload_for_version(
     grant: &GrantV1,
     max_file_data_bytes_per_second: u64,
     filters: &FilterPolicyV3,
+    root_existence: RootExistenceV4,
 ) -> Result<Vec<u8>> {
     grant.validate_static()?;
     filters.validate(grant)?;
-    let body = canonical_body_bytes(wire_version, grant, max_file_data_bytes_per_second, filters)?;
+    let body = canonical_body_bytes(
+        wire_version,
+        grant,
+        max_file_data_bytes_per_second,
+        filters,
+        root_existence,
+    )?;
     if body.len() > MAX_GRANT_BYTES {
         bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
     }
@@ -605,17 +668,19 @@ fn canonical_body_bytes(
     grant: &GrantV1,
     max_file_data_bytes_per_second: u64,
     filters: &FilterPolicyV3,
+    root_existence: RootExistenceV4,
 ) -> Result<Vec<u8>> {
+    let root_constrained = root_existence != RootExistenceV4::Any;
     match wire_version {
         WIRE_VERSION_V1 => {
-            if max_file_data_bytes_per_second != 0 || filters.is_active() {
+            if max_file_data_bytes_per_second != 0 || filters.is_active() || root_constrained {
                 bail!("version-one grants cannot carry signed extensions");
             }
             canonical_grant_bytes(grant)
         }
         WIRE_VERSION_V2 => {
-            if filters.is_active() {
-                bail!("version-two grants cannot carry filter policy");
+            if filters.is_active() || root_constrained {
+                bail!("version-two grants cannot carry filter or root-existence policy");
             }
             postcard::to_stdvec(&GrantBodyV2 {
                 grant: grant.clone(),
@@ -623,10 +688,22 @@ fn canonical_body_bytes(
             })
             .context("encode canonical signed grant")
         }
-        WIRE_VERSION => postcard::to_stdvec(&GrantBodyV3 {
+        WIRE_VERSION_V3 => {
+            if root_constrained {
+                bail!("version-three grants cannot carry root-existence policy");
+            }
+            postcard::to_stdvec(&GrantBodyV3 {
+                grant: grant.clone(),
+                max_file_data_bytes_per_second,
+                filters: filters.clone(),
+            })
+            .context("encode canonical signed grant")
+        }
+        WIRE_VERSION => postcard::to_stdvec(&GrantBodyV4 {
             grant: grant.clone(),
             max_file_data_bytes_per_second,
             filters: filters.clone(),
+            root_existence,
         })
         .context("encode canonical signed grant"),
         _ => bail!("unsupported signed grant envelope version {wire_version}"),
@@ -1045,7 +1122,15 @@ pub(crate) struct VerifiedGrant {
     grant: GrantV1,
     max_file_data_bytes_per_second: u64,
     filters: FilterPolicyV3,
+    root_existence: RootExistenceV4,
     execution_deadline: Instant,
+}
+
+/// The signed extensions a verified grant carries beyond its frozen V1 body.
+pub(crate) struct GrantExtensions {
+    pub max_file_data_bytes_per_second: u64,
+    pub filters: FilterPolicyV3,
+    pub root_existence: RootExistenceV4,
 }
 
 impl VerifiedGrant {
@@ -1054,11 +1139,14 @@ impl VerifiedGrant {
         self.execution_deadline
     }
 
-    pub(crate) fn into_parts(self) -> (GrantV1, u64, FilterPolicyV3, Instant) {
+    pub(crate) fn into_parts(self) -> (GrantV1, GrantExtensions, Instant) {
         (
             self.grant,
-            self.max_file_data_bytes_per_second,
-            self.filters,
+            GrantExtensions {
+                max_file_data_bytes_per_second: self.max_file_data_bytes_per_second,
+                filters: self.filters,
+                root_existence: self.root_existence,
+            },
             self.execution_deadline,
         )
     }
@@ -1096,6 +1184,7 @@ pub(crate) fn verify_and_claim(
         grant: envelope.grant,
         max_file_data_bytes_per_second: envelope.max_file_data_bytes_per_second,
         filters: envelope.filters,
+        root_existence: envelope.root_existence,
         execution_deadline,
     })
 }
@@ -2157,6 +2246,7 @@ mod tests {
             grant,
             max_file_data_bytes_per_second,
             &FilterPolicyV3::default(),
+            RootExistenceV4::Any,
         )
         .expect("encode test grant");
         let mut out = Vec::new();
@@ -2183,6 +2273,7 @@ mod tests {
             &legacy_grant,
             0,
             &FilterPolicyV3::default(),
+            RootExistenceV4::Any,
         )
         .expect("make legacy signing payload");
         let legacy_signature = sign(&legacy_payload, &fixture.key, SSHSIG_NAMESPACE, None);
@@ -2190,6 +2281,7 @@ mod tests {
             grant: legacy_grant.clone(),
             max_file_data_bytes_per_second: 0,
             filters: FilterPolicyV3::default(),
+            root_existence: RootExistenceV4::Any,
             signature: legacy_signature,
             wire_version: WIRE_VERSION_V1,
         }
@@ -2206,7 +2298,7 @@ mod tests {
             &fixture.replay("version-one-compatibility-replay"),
         )
         .expect("verify version-one grant");
-        assert_eq!(verified.into_parts().1, 0);
+        assert_eq!(verified.into_parts().1.max_file_data_bytes_per_second, 0);
 
         let mut trailing = encoded.clone();
         trailing.push(0);
@@ -2240,8 +2332,14 @@ mod tests {
         let public = private.public_key().to_openssh().unwrap();
         fs::write(&fixture.allowed_signers, format!("{SIGNER} {public}\n")).unwrap();
         let replay = fixture.replay("in-process-signature-replay");
-        let encoded =
-            sign_grant(fixture_grant(44), 0, FilterPolicyV3::default(), &private).unwrap();
+        let encoded = sign_grant(
+            fixture_grant(44),
+            0,
+            FilterPolicyV3::default(),
+            RootExistenceV4::Any,
+            &private,
+        )
+        .unwrap();
         assert_eq!(
             SignedGrantEnvelope::decode(&encoded).unwrap().wire_version,
             WIRE_VERSION_V1
@@ -2254,8 +2352,14 @@ mod tests {
         )
         .expect("OpenSSH must accept the in-process SSHSIG");
 
-        let rate_limited =
-            sign_grant(fixture_grant(45), 4096, FilterPolicyV3::default(), &private).unwrap();
+        let rate_limited = sign_grant(
+            fixture_grant(45),
+            4096,
+            FilterPolicyV3::default(),
+            RootExistenceV4::Any,
+            &private,
+        )
+        .unwrap();
         let decoded = SignedGrantEnvelope::decode(&rate_limited).unwrap();
         assert_eq!(decoded.wire_version, WIRE_VERSION_V2);
         assert_eq!(decoded.max_file_data_bytes_per_second, 4096);
@@ -2272,10 +2376,18 @@ mod tests {
             destination_roots: vec![b"/srv/archive/project".to_vec()],
             delete_excluded: false,
         };
-        let filtered = sign_grant(fixture_grant(46), 0, filters.clone(), &private).unwrap();
+        let filtered = sign_grant(
+            fixture_grant(46),
+            0,
+            filters.clone(),
+            RootExistenceV4::Any,
+            &private,
+        )
+        .unwrap();
         let decoded = SignedGrantEnvelope::decode(&filtered).unwrap();
-        assert_eq!(decoded.wire_version, WIRE_VERSION);
+        assert_eq!(decoded.wire_version, WIRE_VERSION_V3);
         assert_eq!(decoded.filters, filters);
+        assert_eq!(decoded.root_existence, RootExistenceV4::Any);
         let verified = verify_and_claim(
             &filtered,
             &context(SIGNER, TARGET, NOW, 0),
@@ -2283,14 +2395,51 @@ mod tests {
             &fixture.replay("in-process-filter-signature-replay"),
         )
         .expect("OpenSSH must accept the signed filter extension");
-        assert_eq!(verified.into_parts().2, filters);
+        assert_eq!(verified.into_parts().1.filters, filters);
 
         let outside = FilterPolicyV3 {
             ignore: vec!["*.tmp".into()],
             destination_roots: vec![b"/srv/outside".to_vec()],
             delete_excluded: false,
         };
-        assert!(sign_grant(fixture_grant(47), 0, outside, &private).is_err());
+        assert!(sign_grant(
+            fixture_grant(47),
+            0,
+            outside,
+            RootExistenceV4::Any,
+            &private
+        )
+        .is_err());
+
+        // A root-existence precondition needs the V4 body, even without the
+        // other extensions, and survives verification unchanged.
+        let rooted = sign_grant(
+            fixture_grant(48),
+            0,
+            FilterPolicyV3::default(),
+            RootExistenceV4::New,
+            &private,
+        )
+        .unwrap();
+        let decoded = SignedGrantEnvelope::decode(&rooted).unwrap();
+        assert_eq!(decoded.wire_version, WIRE_VERSION);
+        assert_eq!(decoded.root_existence, RootExistenceV4::New);
+        let verified = verify_and_claim(
+            &rooted,
+            &context(SIGNER, TARGET, NOW, 0),
+            &fixture.policy(),
+            &fixture.replay("in-process-root-existence-signature-replay"),
+        )
+        .expect("OpenSSH must accept the signed root-existence extension");
+        assert_eq!(verified.into_parts().1.root_existence, RootExistenceV4::New);
+        assert!(canonical_body_bytes(
+            WIRE_VERSION_V3,
+            &fixture_grant(49),
+            0,
+            &FilterPolicyV3::default(),
+            RootExistenceV4::Existing,
+        )
+        .is_err());
     }
 
     #[test]
@@ -2331,9 +2480,14 @@ mod tests {
             transcript.extend_from_slice(&(label.len() as u32).to_be_bytes());
             transcript.extend_from_slice(label.as_bytes());
             transcript.push(operation_tag);
-            let payload =
-                signing_payload_for_version(WIRE_VERSION_V1, grant, 0, &FilterPolicyV3::default())
-                    .expect("encode version-one signing payload");
+            let payload = signing_payload_for_version(
+                WIRE_VERSION_V1,
+                grant,
+                0,
+                &FilterPolicyV3::default(),
+                RootExistenceV4::Any,
+            )
+            .expect("encode version-one signing payload");
             transcript.extend_from_slice(&(payload.len() as u32).to_be_bytes());
             transcript.extend_from_slice(&payload);
         }

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -263,13 +263,10 @@ pub fn run(
             destination_policy.port(),
             &destination_policy.host_key_algorithms(),
         ));
-        // Native new/existing forms are deliberately only ordinary initial
-        // pathname checks. The command-restricted receiver cannot currently
-        // represent that lightweight policy, so retain the live constrained
-        // broker without preparing a receiver grant for those forms.
-        let receiver_grant_allowed =
-            args.interface == Interface::Rsync || args.target_existence == Existence::Any;
-        let prepared = (!args.agent_broker_only && receiver_grant_allowed)
+        // Native new/existing placement forms travel in the signed grant as the
+        // root-existence precondition, so they use the receiver like any other
+        // form instead of silently keeping only the constrained broker.
+        let prepared = (!args.agent_broker_only)
             .then(|| {
                 crate::restricted::prepare_transfer(
                     args,

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1675,45 +1675,54 @@ fn apply_one_rooted(op: &Op, target: &GuardedTarget) -> Result<()> {
             target: link,
             condition,
             ..
-        } => {
-            if let Some(metadata) = observe_rooted_condition(target, *condition)? {
-                if *condition != TargetCondition::Any && !metadata.is_symlink() {
+        } => match observe_rooted_condition(target, *condition)? {
+            // A matched replacement swaps the new leaf in atomically, so a
+            // concurrent replacement of the observed object is refused
+            // rather than deleted.
+            Some(metadata) if *condition != TargetCondition::Any => {
+                if !metadata.is_symlink() {
                     bail!(
                         "target {} cannot change type under a matched condition",
                         target.label.display()
                     );
                 }
+                root.replace_symlink_if_same(path, link, metadata.dev, metadata.ino)
+            }
+            Some(metadata) => {
                 if metadata.is_dir() {
                     root.remove_directory(path)?;
                 } else {
                     root.unlink(path)?;
                 }
+                root.create_symlink(path, link)
             }
-            root.create_symlink(path, link)
-        }
+            None => root.create_symlink(path, link),
+        },
         Op::Mknod {
             mode,
             rdev,
             condition,
             ..
-        } => {
-            if let Some(metadata) = observe_rooted_condition(target, *condition)? {
-                if *condition != TargetCondition::Any
-                    && file_type_bits(metadata.mode) != file_type_bits(*mode)
-                {
+        } => match observe_rooted_condition(target, *condition)? {
+            Some(metadata) if *condition != TargetCondition::Any => {
+                if file_type_bits(metadata.mode) != file_type_bits(*mode) {
                     bail!(
                         "target {} cannot change type under a matched condition",
                         target.label.display()
                     );
                 }
+                root.replace_node_if_same(path, *mode, *rdev, metadata.dev, metadata.ino)
+            }
+            Some(metadata) => {
                 if metadata.is_dir() {
                     root.remove_directory(path)?;
                 } else {
                     root.unlink(path)?;
                 }
+                root.create_node(path, *mode, *rdev)
             }
-            root.create_node(path, *mode, *rdev)
-        }
+            None => root.create_node(path, *mode, *rdev),
+        },
         Op::SetMeta {
             meta,
             flags,

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1584,12 +1584,65 @@ fn relative_under(root: &Path, target: &Path) -> Result<RelativePath> {
     RelativePath::new(relative.as_os_str().as_bytes())
 }
 
+/// Observe the object at a guarded path and hold it to the planner's
+/// condition. `Absent` requires nothing there (the following `*at` creation
+/// then fails atomically if something appears); the matching conditions
+/// require the observed identity. `Any` accepts whatever is found.
+fn observe_rooted_condition(
+    target: &GuardedTarget,
+    condition: TargetCondition,
+) -> Result<Option<crate::rooted::RootMetadata>> {
+    let observed = target.root.metadata_optional(&target.relative)?;
+    let label = &target.label;
+    match (condition, observed) {
+        (TargetCondition::Any, observed) => Ok(observed),
+        (TargetCondition::Absent, None) => Ok(None),
+        (TargetCondition::Absent, Some(_)) => {
+            bail!(
+                "target {} appeared before no-replace creation",
+                label.display()
+            )
+        }
+        (TargetCondition::Matches { dev, ino }, Some(metadata))
+            if metadata.dev == dev && metadata.ino == ino =>
+        {
+            Ok(Some(metadata))
+        }
+        (
+            TargetCondition::MatchesFingerprint {
+                dev,
+                ino,
+                ctime,
+                ctime_nsec,
+            },
+            Some(metadata),
+        ) if metadata.dev == dev
+            && metadata.ino == ino
+            && metadata.ctime == ctime
+            && metadata.ctime_nsec == ctime_nsec =>
+        {
+            Ok(Some(metadata))
+        }
+        (TargetCondition::Matches { .. } | TargetCondition::MatchesFingerprint { .. }, _) => {
+            bail!(
+                "target {} changed before it could be replaced",
+                label.display()
+            )
+        }
+    }
+}
+
 fn apply_one_rooted(op: &Op, target: &GuardedTarget) -> Result<()> {
     let root = &target.root;
     let path = &target.relative;
     match op {
-        Op::Mkdir { mode, .. } => {
+        Op::Mkdir {
+            mode, condition, ..
+        } => {
             if path.is_empty() {
+                if *condition == TargetCondition::Absent {
+                    bail!("guarded root {} already exists", target.label.display());
+                }
                 let directory = root.open_directory(path)?;
                 let metadata = directory.metadata()?;
                 if metadata.mode() & 0o700 != 0o700 {
@@ -1598,7 +1651,7 @@ fn apply_one_rooted(op: &Op, target: &GuardedTarget) -> Result<()> {
                 }
                 return Ok(());
             }
-            match root.metadata_optional(path)? {
+            match observe_rooted_condition(target, *condition)? {
                 Some(metadata) if metadata.is_dir() => {
                     if metadata.mode & 0o700 != 0o700 {
                         let directory = root.open_metadata(path)?;
@@ -1607,6 +1660,10 @@ fn apply_one_rooted(op: &Op, target: &GuardedTarget) -> Result<()> {
                     }
                     Ok(())
                 }
+                Some(_) if *condition != TargetCondition::Any => bail!(
+                    "target {} cannot change type under a matched condition",
+                    target.label.display()
+                ),
                 Some(_) => {
                     root.unlink(path)?;
                     root.create_directory(path, (*mode & 0o7777) | 0o700)
@@ -1614,8 +1671,18 @@ fn apply_one_rooted(op: &Op, target: &GuardedTarget) -> Result<()> {
                 None => root.create_directory(path, (*mode & 0o7777) | 0o700),
             }
         }
-        Op::Symlink { target: link, .. } => {
-            if let Some(metadata) = root.metadata_optional(path)? {
+        Op::Symlink {
+            target: link,
+            condition,
+            ..
+        } => {
+            if let Some(metadata) = observe_rooted_condition(target, *condition)? {
+                if *condition != TargetCondition::Any && !metadata.is_symlink() {
+                    bail!(
+                        "target {} cannot change type under a matched condition",
+                        target.label.display()
+                    );
+                }
                 if metadata.is_dir() {
                     root.remove_directory(path)?;
                 } else {
@@ -1624,8 +1691,21 @@ fn apply_one_rooted(op: &Op, target: &GuardedTarget) -> Result<()> {
             }
             root.create_symlink(path, link)
         }
-        Op::Mknod { mode, rdev, .. } => {
-            if let Some(metadata) = root.metadata_optional(path)? {
+        Op::Mknod {
+            mode,
+            rdev,
+            condition,
+            ..
+        } => {
+            if let Some(metadata) = observe_rooted_condition(target, *condition)? {
+                if *condition != TargetCondition::Any
+                    && file_type_bits(metadata.mode) != file_type_bits(*mode)
+                {
+                    bail!(
+                        "target {} cannot change type under a matched condition",
+                        target.label.display()
+                    );
+                }
                 if metadata.is_dir() {
                     root.remove_directory(path)?;
                 } else {

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -114,10 +114,14 @@ pub(crate) struct PreparedTransfer {
 struct AuthorityState {
     paths: HashSet<Vec<u8>>,
     receiver_modes: HashMap<Vec<u8>, ReceiverModeState>,
-    /// Objects this grant created. The existing-object policy is about what
-    /// existed before the transfer, so later operations on these are the
-    /// transfer's own business.
+    /// Objects this grant created and the executor confirmed. The
+    /// existing-object policy is about what existed before the transfer, so
+    /// later operations on these are the transfer's own business.
     created: HashSet<Vec<u8>>,
+    /// Creations authorized but not yet confirmed or rolled back. They never
+    /// grant the shortcut above: a second creation of the same path races at
+    /// the kernel instead of trusting an outcome that has not happened yet.
+    provisional: HashSet<Vec<u8>>,
     transferred_bytes: u64,
     deletions: u64,
     live_connections: u16,
@@ -328,6 +332,7 @@ impl RestrictedAuthority {
                 paths: HashSet::new(),
                 receiver_modes: HashMap::new(),
                 created: HashSet::new(),
+                provisional: HashSet::new(),
                 transferred_bytes: 0,
                 deletions: 0,
                 live_connections: 0,
@@ -513,29 +518,32 @@ impl RestrictedAuthority {
         self.state.lock().unwrap().created.contains(path)
     }
 
-    /// Forget creations that the executor then reported as failed, so a path
-    /// this grant never actually created cannot later be replaced as its own.
+    /// Confirm or forget the provisional creations of an executed request.
+    /// Only a confirmed creation becomes this grant's own; a failed one is
+    /// dropped so the path cannot later be replaced as if it were.
     /// `response` is the executor's answer to the authorized request.
     pub(crate) fn settle(&self, settlement: Settlement, response: &proto::Response) {
         if settlement.0.is_empty() {
             return;
         }
-        let failed: Vec<&Vec<u8>> = match response {
-            proto::Response::Err(_) => settlement.0.iter().map(|(_, path)| path).collect(),
-            proto::Response::Applied(results) => settlement
-                .0
-                .iter()
-                .filter(|(index, _)| results.get(*index).is_some_and(Option::is_some))
-                .map(|(_, path)| path)
-                .collect(),
-            _ => Vec::new(),
+        let failed = |index: usize| match response {
+            proto::Response::Err(_) => true,
+            proto::Response::Applied(results) => results.get(index).is_some_and(Option::is_some),
+            _ => false,
         };
-        if failed.is_empty() {
-            return;
-        }
         let mut state = self.state.lock().unwrap();
-        for path in failed {
-            state.created.remove(path);
+        for (index, path) in settlement.0 {
+            state.provisional.remove(&path);
+            if !failed(index) {
+                state.created.insert(path);
+            }
+        }
+    }
+
+    fn forget_provisional(&self, pending: &[(usize, Vec<u8>)]) {
+        let mut state = self.state.lock().unwrap();
+        for (_, path) in pending {
+            state.provisional.remove(path);
         }
     }
 
@@ -589,6 +597,8 @@ impl RestrictedAuthority {
                 // Pin the mutation to what was observed: a signed deletion on
                 // another connection could otherwise empty the path between
                 // this check and execution, turning an update into a creation.
+                // A caller-supplied identity is accepted only when it names
+                // the observed object, never on its own authority.
                 match *condition {
                     Any => {
                         *condition = Matches {
@@ -599,7 +609,22 @@ impl RestrictedAuthority {
                     Absent => bail!(
                         "no-replace creation of {label} contradicts the signed existing-object policy"
                     ),
-                    Matches { .. } | MatchesFingerprint { .. } => {}
+                    Matches { dev, ino } if (dev, ino) == (metadata.dev, metadata.ino) => {}
+                    MatchesFingerprint {
+                        dev,
+                        ino,
+                        ctime,
+                        ctime_nsec,
+                    } if (dev, ino, ctime, ctime_nsec)
+                        == (
+                            metadata.dev,
+                            metadata.ino,
+                            metadata.ctime,
+                            metadata.ctime_nsec,
+                        ) => {}
+                    Matches { .. } | MatchesFingerprint { .. } => bail!(
+                        "requested identity for {label} does not match the object the receiver observed"
+                    ),
                 }
                 Ok(())
             }
@@ -623,9 +648,8 @@ impl RestrictedAuthority {
                         "replacement of {label} contradicts the signed existing-object policy"
                     ),
                 }
-                if self.state.lock().unwrap().created.insert(path.to_vec()) {
-                    pending.push((index, path.to_vec()));
-                }
+                self.state.lock().unwrap().provisional.insert(path.to_vec());
+                pending.push((index, path.to_vec()));
                 Ok(())
             }
             ExistingDestinationPolicyV1::UpdateIfOlder => {
@@ -639,10 +663,19 @@ impl RestrictedAuthority {
     /// existing-object policy. Only `Skip` forbids these, and only for objects
     /// that predate the transfer; directories are kept and may still receive
     /// metadata, as in the ordinary engine.
-    fn constrain_update(&self, path: &[u8], is_dir: bool) -> Result<()> {
+    fn constrain_update(
+        &self,
+        path: &[u8],
+        is_dir: bool,
+        pending: &[(usize, Vec<u8>)],
+    ) -> Result<()> {
+        // A creation earlier in this same request (a symlink followed by its
+        // metadata, say) counts: the batch executes in order, so the
+        // metadata only ever lands on this request's own creation.
         if self.copy.policy.existing != ExistingDestinationPolicyV1::Skip
             || is_dir
             || self.created_by_this_grant(path)
+            || pending.iter().any(|(_, created)| created == path)
         {
             return Ok(());
         }
@@ -1109,7 +1142,7 @@ impl RestrictedAuthority {
                 flags,
                 condition,
             } => {
-                self.constrain_update(path, is_dir)?;
+                self.constrain_update(path, is_dir, pending)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1124,7 +1157,7 @@ impl RestrictedAuthority {
                 flags,
                 condition,
             } => {
-                self.constrain_update(path, false)?;
+                self.constrain_update(path, false, pending)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1141,8 +1174,25 @@ impl RestrictedAuthority {
     /// settlement must be handed back to `settle` with the executor's
     /// response so provisional creations are forgotten when execution fails.
     pub(crate) fn authorize(&self, request: &mut Request, over_ssh: bool) -> Result<Settlement> {
-        self.check_deadline()?;
         let mut pending = Vec::new();
+        match self.authorize_inner(request, over_ssh, &mut pending) {
+            Ok(()) => Ok(Settlement(pending)),
+            Err(error) => {
+                // Nothing of a refused request executes, including the
+                // entries authorized before the refusing one.
+                self.forget_provisional(&pending);
+                Err(error)
+            }
+        }
+    }
+
+    fn authorize_inner(
+        &self,
+        request: &mut Request,
+        over_ssh: bool,
+        pending: &mut Vec<(usize, Vec<u8>)>,
+    ) -> Result<()> {
+        self.check_deadline()?;
         match request {
             Request::TcpListen {
                 key,
@@ -1235,7 +1285,7 @@ impl RestrictedAuthority {
             }
             Request::Apply { ops, guard } => {
                 for (index, operation) in ops.iter_mut().enumerate() {
-                    self.authorize_op(operation, index, &mut pending)?;
+                    self.authorize_op(operation, index, pending)?;
                 }
                 *guard = Some(self.guard.clone());
             }
@@ -1277,7 +1327,7 @@ impl RestrictedAuthority {
                     bail!("signed grant per-file byte limit exceeded");
                 }
                 self.check_mutation_path(path, false)?;
-                self.constrain_update(path, false)?;
+                self.constrain_update(path, false, pending)?;
                 *guard = Some(self.guard.clone());
             }
             Request::FinishBasis {
@@ -1289,7 +1339,7 @@ impl RestrictedAuthority {
                 ..
             } => {
                 self.check_mutation_path(path, false)?;
-                self.constrain_update(path, false)?;
+                self.constrain_update(path, false, pending)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1343,7 +1393,7 @@ impl RestrictedAuthority {
                     bail!("file finalization does not match the signed publication policy");
                 }
                 self.check_mutation_path(path, false)?;
-                self.constrain_creation(path, condition, false, 0, &mut pending)?;
+                self.constrain_creation(path, condition, false, 0, pending)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1369,13 +1419,7 @@ impl RestrictedAuthority {
                 }
                 for (index, put) in puts.iter_mut().enumerate() {
                     self.charge_bytes(&put.path, 0, put.data.len())?;
-                    self.constrain_creation(
-                        &put.path,
-                        &mut put.condition,
-                        false,
-                        index,
-                        &mut pending,
-                    )?;
+                    self.constrain_creation(&put.path, &mut put.condition, false, index, pending)?;
                     self.constrain_receiver_mode(
                         &put.path,
                         &mut put.meta,
@@ -1400,7 +1444,7 @@ impl RestrictedAuthority {
             Request::Hello { .. } => bail!("unexpected second receiver handshake"),
             Request::TransportStats | Request::Shutdown => {}
         }
-        Ok(Settlement(pending))
+        Ok(())
     }
 }
 
@@ -3422,11 +3466,13 @@ mod tests {
         let mut prepare_kept = prepare_request(&kept);
         assert!(authority.authorize(&mut prepare_kept, false).is_err());
         let mut publish_fresh = finalize_request(&fresh, Any);
-        authority.authorize(&mut publish_fresh, false).unwrap();
+        let settlement = authority.authorize(&mut publish_fresh, false).unwrap();
         assert_eq!(finalize_condition(&publish_fresh), Absent);
+        authority.settle(settlement, &proto::Response::Ok);
         let mut publish_kept = finalize_request(&kept, Any);
         assert!(authority.authorize(&mut publish_kept, false).is_err());
-        // What this grant created is its own to republish.
+        // What this grant created, and the executor confirmed, is its own to
+        // republish.
         let mut republish_fresh = finalize_request(&fresh, Matches { dev: 1, ino: 1 });
         authority.authorize(&mut republish_fresh, false).unwrap();
         assert_eq!(
@@ -3455,8 +3501,9 @@ mod tests {
         let mut link_over_file = apply(symlink_op(&kept));
         assert!(authority.authorize(&mut link_over_file, false).is_err());
         let mut create_link = apply(symlink_op(&link));
-        authority.authorize(&mut create_link, false).unwrap();
+        let settlement = authority.authorize(&mut create_link, false).unwrap();
         assert_eq!(op_condition(&create_link), Absent);
+        authority.settle(settlement, &proto::Response::Applied(vec![None]));
         let mut meta_link = apply(set_meta(&link));
         authority.authorize(&mut meta_link, false).unwrap();
         let mut meta_dir = apply(set_meta(&dir));
@@ -3622,6 +3669,93 @@ mod tests {
         let mut again_b = apply(mkdir(&dir_b));
         authority.authorize(&mut again_b, false).unwrap();
         assert_eq!(op_condition(&again_b), Absent);
+    }
+
+    #[test]
+    fn a_refused_request_leaves_no_provisional_creations_behind() {
+        use proto::TargetCondition::{Absent, Any};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let kept = target.join("kept");
+        let fresh = target.join("fresh");
+        let link = target.join("link");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(&kept, b"old").unwrap();
+        let authority = existence_authority(
+            &root,
+            ExistingDestinationPolicyV1::Skip,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .unwrap();
+
+        // The first entry is authorized before the second is refused; nothing
+        // of the batch runs, so the first must not count as created.
+        let mut batch = Request::Apply {
+            ops: vec![mkdir(&fresh), symlink_op(&kept)],
+            guard: None,
+        };
+        assert!(authority.authorize(&mut batch, false).is_err());
+        let mut again = apply(mkdir(&fresh));
+        authority.authorize(&mut again, false).unwrap();
+        assert_eq!(op_condition(&again), Absent);
+
+        // Until the executor confirms a creation, a second creation of the
+        // same path is not this grant's own either: it races at the kernel.
+        let mut concurrent = apply(mkdir(&fresh));
+        authority.authorize(&mut concurrent, false).unwrap();
+        assert_eq!(op_condition(&concurrent), Absent);
+
+        // Metadata may follow a creation within the same request.
+        let mut create_and_touch = Request::Apply {
+            ops: vec![symlink_op(&link), set_meta(&link)],
+            guard: None,
+        };
+        authority.authorize(&mut create_and_touch, false).unwrap();
+        let Request::Apply { ops, .. } = &create_and_touch else {
+            unreachable!()
+        };
+        assert!(matches!(ops[1], Op::SetMeta { condition: Any, .. }));
+    }
+
+    #[test]
+    fn must_exist_accepts_only_the_observed_identity() {
+        use proto::TargetCondition::{Matches, MatchesFingerprint};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let present = target.join("present");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(&present, b"old").unwrap();
+        let authority = existence_authority(
+            &root,
+            ExistingDestinationPolicyV1::MustExist,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .unwrap();
+        let identity = fs::symlink_metadata(&present).unwrap();
+        let mut bogus = finalize_request(&present, Matches { dev: 1, ino: 1 });
+        assert!(authority.authorize(&mut bogus, false).is_err());
+        let mut stale = finalize_request(
+            &present,
+            MatchesFingerprint {
+                dev: identity.dev(),
+                ino: identity.ino(),
+                ctime: identity.ctime() + 1,
+                ctime_nsec: identity.ctime_nsec() as u32,
+            },
+        );
+        assert!(authority.authorize(&mut stale, false).is_err());
+        let mut exact = finalize_request(
+            &present,
+            Matches {
+                dev: identity.dev(),
+                ino: identity.ino(),
+            },
+        );
+        authority.authorize(&mut exact, false).unwrap();
     }
 
     #[test]
@@ -3804,9 +3938,10 @@ mod tests {
         )
         .unwrap();
         let mut create_root = apply(mkdir(&target));
-        authority.authorize(&mut create_root, false).unwrap();
+        let settlement = authority.authorize(&mut create_root, false).unwrap();
         assert_eq!(op_condition(&create_root), Absent);
         fs::create_dir(&target).unwrap();
+        authority.settle(settlement, &proto::Response::Applied(vec![None]));
         let mut revisit_root = apply(mkdir(&target));
         authority.authorize(&mut revisit_root, false).unwrap();
         assert_eq!(op_condition(&revisit_root), Any);

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -626,6 +626,13 @@ impl RestrictedAuthority {
                         "requested identity for {label} does not match the object the receiver observed"
                     ),
                 }
+                if !directory {
+                    // The replacement this request makes is its own from here
+                    // on: metadata later in the same batch lands on the new
+                    // inode, not the one it replaces, so it must not be
+                    // pinned to the old identity.
+                    pending.push((index, path.to_vec()));
+                }
                 Ok(())
             }
             ExistingDestinationPolicyV1::Skip | ExistingDestinationPolicyV1::Replace => {
@@ -682,6 +689,7 @@ impl RestrictedAuthority {
             ExistingDestinationPolicyV1::Skip => {
                 bail!("signed grant retains existing objects: {label} may not be modified")
             }
+            ExistingDestinationPolicyV1::MustExist if own => Ok(()),
             ExistingDestinationPolicyV1::MustExist => {
                 // Updates are pinned to the observed object, like
                 // publications: nothing hostA supplies names an inode on its
@@ -3859,6 +3867,61 @@ mod tests {
         assert!(authority.authorize(&mut bogus, false).is_err());
         let mut absent = apply(set_meta(&missing));
         assert!(authority.authorize(&mut absent, false).is_err());
+    }
+
+    #[test]
+    fn must_exist_replacement_and_metadata_execute_as_one_batch() {
+        use proto::TargetCondition::{Any, Matches};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let link = target.join("link");
+        fs::create_dir_all(&target).unwrap();
+        std::os::unix::fs::symlink("old-target", &link).unwrap();
+        let authority = existence_authority(
+            &root,
+            ExistingDestinationPolicyV1::MustExist,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .unwrap();
+        let before = fs::symlink_metadata(&link).unwrap();
+
+        // A changed symlink is replaced and then given its metadata in one
+        // ordinary batch. The replacement is pinned to the old inode; the
+        // metadata must land on the new one.
+        let mut batch = Request::Apply {
+            ops: vec![symlink_op(&link), set_meta(&link)],
+            guard: None,
+        };
+        let settlement = authority.authorize(&mut batch, false).unwrap();
+        let Request::Apply {
+            ops,
+            guard: Some(guard),
+        } = &batch
+        else {
+            unreachable!()
+        };
+        assert!(matches!(
+            ops[0],
+            Op::Symlink { condition: Matches { dev, ino }, .. }
+                if (dev, ino) == (before.dev(), before.ino())
+        ));
+        assert!(matches!(ops[1], Op::SetMeta { condition: Any, .. }));
+        let results = crate::fsops::FsOps::new().apply(ops, Some(guard));
+        assert!(results.iter().all(Option::is_none), "{results:?}");
+        authority.settle(settlement, &proto::Response::Applied(results));
+        assert_eq!(
+            fs::read_link(&link).unwrap().as_os_str().as_bytes(),
+            b"elsewhere"
+        );
+        let after = fs::symlink_metadata(&link).unwrap();
+        assert_ne!(after.ino(), before.ino());
+
+        // Afterwards the replacement is this grant's own object.
+        let mut touch = apply(set_meta(&link));
+        authority.authorize(&mut touch, false).unwrap();
+        assert_eq!(op_condition(&touch), Any);
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -273,6 +273,16 @@ impl RestrictedAuthority {
             // coordinator reports, so the receiver cannot enforce it.
             bail!("update-if-older existing-object policy is not enforceable by the receiver");
         }
+        if copy.policy.publication == PublicationPolicyV1::InPlace
+            && (copy.policy.existing == ExistingDestinationPolicyV1::Skip
+                || (root_existence == RootExistenceV4::New
+                    && copy.policy.placement == DestinationPlacementV1::ExactPath))
+        {
+            // In-place preparation opens or creates the final pathname with
+            // no no-replace condition to attach, so it cannot be made to
+            // retain a pre-existing object.
+            bail!("in-place publication cannot honor a no-replace existing-object policy");
+        }
         let filter_matcher = crate::scan::build_ignore(&filters.ignore)?;
         let filter_roots = filters.destination_roots.clone();
         let root_path = Path::new(&config.root);
@@ -503,42 +513,93 @@ impl RestrictedAuthority {
         self.state.lock().unwrap().created.contains(path)
     }
 
+    /// Forget creations that the executor then reported as failed, so a path
+    /// this grant never actually created cannot later be replaced as its own.
+    /// `response` is the executor's answer to the authorized request.
+    pub(crate) fn settle(&self, settlement: Settlement, response: &proto::Response) {
+        if settlement.0.is_empty() {
+            return;
+        }
+        let failed: Vec<&Vec<u8>> = match response {
+            proto::Response::Err(_) => settlement.0.iter().map(|(_, path)| path).collect(),
+            proto::Response::Applied(results) => settlement
+                .0
+                .iter()
+                .filter(|(index, _)| results.get(*index).is_some_and(Option::is_some))
+                .map(|(_, path)| path)
+                .collect(),
+            _ => Vec::new(),
+        };
+        if failed.is_empty() {
+            return;
+        }
+        let mut state = self.state.lock().unwrap();
+        for path in failed {
+            state.created.remove(path);
+        }
+    }
+
     /// Bind an operation that creates or replaces the object at `path` to the
     /// signed existing-object policy. `Skip` retains whatever existed before
     /// the transfer, so creation is forced to be no-replace; `MustExist`
-    /// creates nothing, so something must already be there. `directory`
-    /// marks a directory creation, which may reuse an existing directory
-    /// under `Skip` exactly as the ordinary engine keeps recursing into it.
-    /// A root the grant requires to be new is forced to no-replace creation
-    /// under every policy.
+    /// creates nothing, so something must already be there and the mutation
+    /// is pinned to that object's identity. `directory` marks a directory
+    /// creation, which may reuse an existing directory under `Skip` exactly
+    /// as the ordinary engine keeps recursing into it. A root the grant
+    /// requires to be new is forced to no-replace creation under every
+    /// policy, as a directory whenever the placement puts names inside it.
+    /// A creation this call records is provisional until `settle` sees the
+    /// executor succeed; `index` and `pending` carry that bookkeeping.
     fn constrain_creation(
         &self,
         path: &[u8],
         condition: &mut proto::TargetCondition,
         directory: bool,
+        index: usize,
+        pending: &mut Vec<(usize, Vec<u8>)>,
     ) -> Result<()> {
         use proto::TargetCondition::{Absent, Any, Matches, MatchesFingerprint};
         let policy = self.copy.policy.existing;
         let root_must_be_new =
             self.root_existence == RootExistenceV4::New && path == self.destination;
+        let label = String::from_utf8_lossy(path);
+        if root_must_be_new
+            && !directory
+            && self.copy.policy.placement != DestinationPlacementV1::ExactPath
+        {
+            bail!(
+                "signed placement puts names inside {label}, so it must be created as a directory"
+            );
+        }
         if self.created_by_this_grant(path)
             || (policy == ExistingDestinationPolicyV1::Replace && !root_must_be_new)
         {
             return Ok(());
         }
         let observed = self.rooted_metadata(path)?;
-        let label = String::from_utf8_lossy(path);
         match policy {
             ExistingDestinationPolicyV1::MustExist => {
-                match observed {
-                    Some(metadata) if !directory || metadata.is_dir() => {}
+                let metadata = match observed {
+                    Some(metadata) if !directory || metadata.is_dir() => metadata,
                     Some(_) => {
                         bail!("signed grant creates nothing: {label} exists but is not a directory")
                     }
                     None => bail!("signed grant creates nothing: {label} does not exist"),
-                }
-                if *condition == Absent {
-                    bail!("no-replace creation of {label} contradicts the signed existing-object policy");
+                };
+                // Pin the mutation to what was observed: a signed deletion on
+                // another connection could otherwise empty the path between
+                // this check and execution, turning an update into a creation.
+                match *condition {
+                    Any => {
+                        *condition = Matches {
+                            dev: metadata.dev,
+                            ino: metadata.ino,
+                        }
+                    }
+                    Absent => bail!(
+                        "no-replace creation of {label} contradicts the signed existing-object policy"
+                    ),
+                    Matches { .. } | MatchesFingerprint { .. } => {}
                 }
                 Ok(())
             }
@@ -562,7 +623,9 @@ impl RestrictedAuthority {
                         "replacement of {label} contradicts the signed existing-object policy"
                     ),
                 }
-                self.state.lock().unwrap().created.insert(path.to_vec());
+                if self.state.lock().unwrap().created.insert(path.to_vec()) {
+                    pending.push((index, path.to_vec()));
+                }
                 Ok(())
             }
             ExistingDestinationPolicyV1::UpdateIfOlder => {
@@ -963,7 +1026,12 @@ impl RestrictedAuthority {
         Ok(())
     }
 
-    fn authorize_op(&self, operation: &mut Op) -> Result<()> {
+    fn authorize_op(
+        &self,
+        operation: &mut Op,
+        index: usize,
+        pending: &mut Vec<(usize, Vec<u8>)>,
+    ) -> Result<()> {
         let path = match &*operation {
             Op::Mkdir { path, .. }
             | Op::SetMeta { path, .. }
@@ -1008,7 +1076,7 @@ impl RestrictedAuthority {
                 mode,
                 condition,
             } => {
-                self.constrain_creation(path, condition, true)?;
+                self.constrain_creation(path, condition, true, index, pending)?;
                 if !self.copy.options.preserve_permissions {
                     self.remember_receiver_creation(path, true)?;
                     *mode = 0o700;
@@ -1017,14 +1085,14 @@ impl RestrictedAuthority {
             }
             Op::Symlink {
                 path, condition, ..
-            } => self.constrain_creation(path, condition, false),
+            } => self.constrain_creation(path, condition, false, index, pending),
             Op::Mknod {
                 path,
                 mode,
                 condition,
                 ..
             } => {
-                self.constrain_creation(path, condition, false)?;
+                self.constrain_creation(path, condition, false, index, pending)?;
                 if !self.copy.options.preserve_permissions {
                     self.remember_receiver_creation(path, false)?;
                     #[cfg(target_os = "linux")]
@@ -1069,8 +1137,12 @@ impl RestrictedAuthority {
         }
     }
 
-    pub(crate) fn authorize(&self, request: &mut Request, over_ssh: bool) -> Result<()> {
+    /// Check and rewrite one request against the signed grant. The returned
+    /// settlement must be handed back to `settle` with the executor's
+    /// response so provisional creations are forgotten when execution fails.
+    pub(crate) fn authorize(&self, request: &mut Request, over_ssh: bool) -> Result<Settlement> {
         self.check_deadline()?;
+        let mut pending = Vec::new();
         match request {
             Request::TcpListen {
                 key,
@@ -1162,8 +1234,8 @@ impl RestrictedAuthority {
                 *guard = Some(self.guard.clone());
             }
             Request::Apply { ops, guard } => {
-                for operation in ops {
-                    self.authorize_op(operation)?;
+                for (index, operation) in ops.iter_mut().enumerate() {
+                    self.authorize_op(operation, index, &mut pending)?;
                 }
                 *guard = Some(self.guard.clone());
             }
@@ -1271,7 +1343,7 @@ impl RestrictedAuthority {
                     bail!("file finalization does not match the signed publication policy");
                 }
                 self.check_mutation_path(path, false)?;
-                self.constrain_creation(path, condition, false)?;
+                self.constrain_creation(path, condition, false, 0, &mut pending)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1295,9 +1367,15 @@ impl RestrictedAuthority {
                         bail!("small-file batch exceeds the signed file-data rate-limit burst");
                     }
                 }
-                for put in puts {
+                for (index, put) in puts.iter_mut().enumerate() {
                     self.charge_bytes(&put.path, 0, put.data.len())?;
-                    self.constrain_creation(&put.path, &mut put.condition, false)?;
+                    self.constrain_creation(
+                        &put.path,
+                        &mut put.condition,
+                        false,
+                        index,
+                        &mut pending,
+                    )?;
                     self.constrain_receiver_mode(
                         &put.path,
                         &mut put.meta,
@@ -1322,9 +1400,14 @@ impl RestrictedAuthority {
             Request::Hello { .. } => bail!("unexpected second receiver handshake"),
             Request::TransportStats | Request::Shutdown => {}
         }
-        Ok(())
+        Ok(Settlement(pending))
     }
 }
+
+/// Creations an authorized request recorded provisionally, keyed by the
+/// operation or small-put index the executor reports on.
+#[derive(Debug, Default)]
+pub(crate) struct Settlement(Vec<(usize, Vec<u8>)>);
 
 fn current_account() -> Result<(String, PathBuf)> {
     let uid = unsafe { libc::geteuid() };
@@ -2193,6 +2276,14 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
     if args.update {
         bail!(
             "--update compares against source modification times that only hostA reports, so the command-restricted receiver cannot enforce it"
+        );
+    }
+    if args.inplace
+        && (args.ignore_existing
+            || (args.target_existence == Existence::New && args.placement == Placement::As))
+    {
+        bail!(
+            "--inplace cannot be combined with --ignore-existing or --as-new on the command-restricted path: in-place writes open the final pathname directly, so the receiver cannot make them no-replace"
         );
     }
     if !args.files_from_lines.is_empty()
@@ -3406,7 +3497,7 @@ mod tests {
 
     #[test]
     fn signed_must_exist_policy_creates_nothing() {
-        use proto::TargetCondition::{Absent, Any};
+        use proto::TargetCondition::{Absent, Any, Matches};
         let temporary = tempfile::tempdir().unwrap();
         let root = temporary.path().join("root");
         let target = root.join("target");
@@ -3431,7 +3522,14 @@ mod tests {
         assert!(authority.authorize(&mut prepare_missing, false).is_err());
         let mut update_present = finalize_request(&present, Any);
         authority.authorize(&mut update_present, false).unwrap();
-        assert_eq!(finalize_condition(&update_present), Any);
+        let present_identity = fs::symlink_metadata(&present).unwrap();
+        assert_eq!(
+            finalize_condition(&update_present),
+            Matches {
+                dev: present_identity.dev(),
+                ino: present_identity.ino(),
+            }
+        );
         let mut create_present = finalize_request(&present, Absent);
         assert!(authority.authorize(&mut create_present, false).is_err());
         let mut publish_missing = finalize_request(&missing, Any);
@@ -3449,7 +3547,14 @@ mod tests {
         assert!(authority.authorize(&mut dir_over_file, false).is_err());
         let mut replace_link = apply(symlink_op(&link));
         authority.authorize(&mut replace_link, false).unwrap();
-        assert_eq!(op_condition(&replace_link), Any);
+        let link_identity = fs::symlink_metadata(&link).unwrap();
+        assert_eq!(
+            op_condition(&replace_link),
+            Matches {
+                dev: link_identity.dev(),
+                ino: link_identity.ino(),
+            }
+        );
         let mut create_link = apply(symlink_op(&missing));
         assert!(authority.authorize(&mut create_link, false).is_err());
 
@@ -3464,6 +3569,211 @@ mod tests {
         authority.authorize(&mut finish, false).unwrap();
         let mut meta_present = apply(set_meta(&present));
         authority.authorize(&mut meta_present, false).unwrap();
+    }
+
+    #[test]
+    fn provisional_creations_are_forgotten_when_execution_fails() {
+        use proto::TargetCondition::{Absent, Any, Matches};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        fs::create_dir_all(&target).unwrap();
+        let authority = existence_authority(
+            &root,
+            ExistingDestinationPolicyV1::Skip,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .unwrap();
+        let fresh = target.join("fresh");
+        let kept = target.join("kept");
+        let dir_a = target.join("dir-a");
+        let dir_b = target.join("dir-b");
+
+        // A failed no-replace publication leaves nothing behind, so a foreign
+        // object that appears afterwards is retained like any other.
+        let mut publish = finalize_request(&fresh, Any);
+        let settlement = authority.authorize(&mut publish, false).unwrap();
+        authority.settle(settlement, &proto::Response::Err("raced".into()));
+        fs::write(&fresh, b"foreign").unwrap();
+        let mut republish = finalize_request(&fresh, Any);
+        assert!(authority.authorize(&mut republish, false).is_err());
+
+        // A successful one stays this grant's own.
+        let mut publish = small_put(&kept);
+        let settlement = authority.authorize(&mut publish, false).unwrap();
+        authority.settle(settlement, &proto::Response::Applied(vec![None]));
+        let mut republish = finalize_request(&kept, Matches { dev: 1, ino: 1 });
+        authority.authorize(&mut republish, false).unwrap();
+
+        // Per-operation results settle a batch operation by operation.
+        let mut batch = Request::Apply {
+            ops: vec![mkdir(&dir_a), mkdir(&dir_b)],
+            guard: None,
+        };
+        let settlement = authority.authorize(&mut batch, false).unwrap();
+        authority.settle(
+            settlement,
+            &proto::Response::Applied(vec![None, Some("raced".into())]),
+        );
+        let mut again_a = apply(mkdir(&dir_a));
+        authority.authorize(&mut again_a, false).unwrap();
+        assert_eq!(op_condition(&again_a), Any);
+        let mut again_b = apply(mkdir(&dir_b));
+        authority.authorize(&mut again_b, false).unwrap();
+        assert_eq!(op_condition(&again_b), Absent);
+    }
+
+    #[test]
+    fn guarded_executor_honors_creation_conditions() {
+        use proto::TargetCondition::{Absent, Any, Matches};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let file = target.join("file");
+        let dir = target.join("dir");
+        let link = target.join("link");
+        let fresh = target.join("fresh");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(&file, b"keep").unwrap();
+        std::os::unix::fs::symlink("file", &link).unwrap();
+        let root_identity = fs::metadata(&root).unwrap();
+        let guard = ContainerGuard {
+            root: path_bytes(&root),
+            dev: root_identity.dev(),
+            ino: root_identity.ino(),
+        };
+        let identity = |path: &Path| {
+            let metadata = fs::symlink_metadata(path).unwrap();
+            Matches {
+                dev: metadata.dev(),
+                ino: metadata.ino(),
+            }
+        };
+        let run = |op: Op| crate::fsops::FsOps::new().apply(&[op], Some(&guard))[0].clone();
+        let with = |op: Op, condition| match op {
+            Op::Mkdir { path, mode, .. } => Op::Mkdir {
+                path,
+                mode,
+                condition,
+            },
+            Op::Symlink { path, target, .. } => Op::Symlink {
+                path,
+                target,
+                condition,
+            },
+            other => other,
+        };
+
+        // No-replace creation never removes what is there.
+        assert!(run(with(mkdir(&file), Absent)).is_some());
+        assert!(run(with(symlink_op(&file), Absent)).is_some());
+        assert!(run(with(mkdir(&dir), Absent)).is_some());
+        assert_eq!(fs::read(&file).unwrap(), b"keep");
+        assert!(run(with(mkdir(&fresh), Absent)).is_none());
+        assert!(fresh.is_dir());
+
+        // Matched replacement requires the observed object and its type.
+        assert!(run(with(symlink_op(&link), Matches { dev: 1, ino: 1 })).is_some());
+        assert!(run(with(symlink_op(&file), identity(&file))).is_some());
+        assert_eq!(fs::read(&file).unwrap(), b"keep");
+        assert!(run(with(symlink_op(&link), identity(&link))).is_none());
+        assert!(run(with(mkdir(&file), identity(&file))).is_some());
+        assert!(run(with(mkdir(&dir), identity(&dir))).is_none());
+
+        // The unconditioned form keeps the ordinary replace behavior.
+        assert!(run(with(symlink_op(&file), Any)).is_none());
+        assert!(file.is_symlink());
+    }
+
+    #[test]
+    fn new_directory_placement_root_must_be_created_as_a_directory() {
+        use proto::TargetCondition::{Absent, Any};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let target = root.join("target");
+        let authority = existence_authority(
+            &root,
+            ExistingDestinationPolicyV1::Replace,
+            DestinationPlacementV1::DirectoryAsChild,
+            RootExistenceV4::New,
+        )
+        .unwrap();
+        let mut as_file = finalize_request(&target, Any);
+        assert!(authority.authorize(&mut as_file, false).is_err());
+        let mut as_small_file = small_put(&target);
+        assert!(authority.authorize(&mut as_small_file, false).is_err());
+        let mut as_link = apply(symlink_op(&target));
+        assert!(authority.authorize(&mut as_link, false).is_err());
+        let mut as_directory = apply(mkdir(&target));
+        authority.authorize(&mut as_directory, false).unwrap();
+        assert_eq!(op_condition(&as_directory), Absent);
+    }
+
+    #[test]
+    fn inplace_publication_cannot_honor_no_replace_policies() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let inplace = |existing, placement, root_existence| {
+            test_authority_with_existence(
+                &root,
+                DeletionPolicyV1::Forbid,
+                1024,
+                0,
+                FilterPolicyV3::default(),
+                PublicationPolicyV1::InPlace,
+                existing,
+                placement,
+                root_existence,
+            )
+        };
+        assert!(inplace(
+            ExistingDestinationPolicyV1::Skip,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .is_err());
+        assert!(inplace(
+            ExistingDestinationPolicyV1::Replace,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::New,
+        )
+        .is_err());
+        // A new directory root is created by mkdir, so in-place files
+        // beneath it are fine, as are in-place updates of existing files.
+        inplace(
+            ExistingDestinationPolicyV1::Replace,
+            DestinationPlacementV1::DirectoryContents,
+            RootExistenceV4::New,
+        )
+        .unwrap();
+        inplace(
+            ExistingDestinationPolicyV1::MustExist,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .unwrap();
+
+        // The orchestrator refuses the same combination before signing. The
+        // rsync-shaped parser already makes --inplace and --ignore-existing
+        // conflict, so the reachable case is the native --as-new placement.
+        let mut args = Args::try_parse_from([
+            "syq rsync",
+            "-r",
+            "--inplace",
+            "host-a:source",
+            "host-b:/backup",
+        ])
+        .unwrap();
+        args.normalize();
+        validate_restricted_args(&args).unwrap();
+        args.placement = Placement::As;
+        args.target_existence = Existence::New;
+        assert!(validate_restricted_args(&args).is_err());
+        args.placement = Placement::Into;
+        validate_restricted_args(&args).unwrap();
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -3,8 +3,8 @@
 use crate::cli::{Args, Existence, Interface, Location, Placement};
 use crate::delegation::{
     self, CopyLimitsV1, CopyOperationV1, CopyOptionsV1, CopyPolicyV1, DeletionPolicyV1,
-    DestinationPlacementV1, ExistingDestinationPolicyV1, FilterPolicyV3, GrantOperationV1, GrantV1,
-    MutationScopeV1, PublicationPolicyV1, RequestId,
+    DestinationPlacementV1, ExistingDestinationPolicyV1, FilterPolicyV3, GrantExtensions,
+    GrantOperationV1, GrantV1, MutationScopeV1, PublicationPolicyV1, RequestId, RootExistenceV4,
 };
 use crate::enrollment::{
     self, AuthorizedKeyEntry, AuthorizedKeysChange, EnrollmentId, EnrollmentRoute, SshEndpoint,
@@ -114,6 +114,10 @@ pub(crate) struct PreparedTransfer {
 struct AuthorityState {
     paths: HashSet<Vec<u8>>,
     receiver_modes: HashMap<Vec<u8>, ReceiverModeState>,
+    /// Objects this grant created. The existing-object policy is about what
+    /// existed before the transfer, so later operations on these are the
+    /// transfer's own business.
+    created: HashSet<Vec<u8>>,
     transferred_bytes: u64,
     deletions: u64,
     live_connections: u16,
@@ -243,6 +247,7 @@ pub(crate) struct RestrictedAuthority {
     filters: FilterPolicyV3,
     filter_matcher: Option<ignore::gitignore::Gitignore>,
     filter_roots: Vec<Vec<u8>>,
+    root_existence: RootExistenceV4,
     file_data_limit: Option<crate::bwlimit::BandwidthLimit>,
     receiver_umask: u32,
     deadline: Instant,
@@ -254,11 +259,20 @@ impl RestrictedAuthority {
     fn new(
         config: &ReceiverEnrollment,
         grant: GrantV1,
-        max_file_data_bytes_per_second: u64,
-        filters: FilterPolicyV3,
+        extensions: GrantExtensions,
         deadline: Instant,
     ) -> Result<Self> {
+        let GrantExtensions {
+            max_file_data_bytes_per_second,
+            filters,
+            root_existence,
+        } = extensions;
         let GrantOperationV1::Copy(copy) = grant.operation;
+        if copy.policy.existing == ExistingDestinationPolicyV1::UpdateIfOlder {
+            // The comparison depends on a source mtime only the remote
+            // coordinator reports, so the receiver cannot enforce it.
+            bail!("update-if-older existing-object policy is not enforceable by the receiver");
+        }
         let filter_matcher = crate::scan::build_ignore(&filters.ignore)?;
         let filter_roots = filters.destination_roots.clone();
         let root_path = Path::new(&config.root);
@@ -284,7 +298,7 @@ impl RestrictedAuthority {
         let receiver_umask = read_process_umask();
         let file_data_limit = (max_file_data_bytes_per_second > 0)
             .then(|| crate::bwlimit::BandwidthLimit::new(max_file_data_bytes_per_second));
-        Ok(Self {
+        let authority = Self {
             guard: ContainerGuard {
                 root: config.root.as_bytes().to_vec(),
                 dev: config.root_dev,
@@ -295,6 +309,7 @@ impl RestrictedAuthority {
             filters,
             filter_matcher,
             filter_roots,
+            root_existence,
             file_data_limit,
             receiver_umask,
             deadline,
@@ -302,12 +317,42 @@ impl RestrictedAuthority {
             state: Mutex::new(AuthorityState {
                 paths: HashSet::new(),
                 receiver_modes: HashMap::new(),
+                created: HashSet::new(),
                 transferred_bytes: 0,
                 deletions: 0,
                 live_connections: 0,
                 tcp_listener_started: false,
             }),
-        })
+        };
+        authority.check_root_existence()?;
+        Ok(authority)
+    }
+
+    /// Check the signed placement-root precondition once, against the
+    /// enrolled root, before any request is served. `New` is then kept true
+    /// by `constrain_creation`, which forces no-replace creation of the root.
+    fn check_root_existence(&self) -> Result<()> {
+        let observed = self.rooted_metadata(&self.destination)?;
+        let destination = String::from_utf8_lossy(&self.destination);
+        match (self.root_existence, observed) {
+            (RootExistenceV4::Any, _) => Ok(()),
+            (RootExistenceV4::New, Some(_)) => bail!(
+                "signed destination {destination} already exists, but the grant requires a new path"
+            ),
+            (RootExistenceV4::New, None) => Ok(()),
+            (RootExistenceV4::Existing, None) => bail!(
+                "signed destination {destination} does not exist, but the grant requires an existing path"
+            ),
+            (RootExistenceV4::Existing, Some(metadata))
+                if self.copy.policy.placement != DestinationPlacementV1::ExactPath
+                    && !metadata.is_dir() =>
+            {
+                bail!(
+                    "signed destination {destination} is not a directory, but the grant places names inside it"
+                )
+            }
+            (RootExistenceV4::Existing, Some(_)) => Ok(()),
+        }
     }
 
     pub(crate) fn validate_hello(&self, compressed: bool) -> Result<()> {
@@ -452,6 +497,114 @@ impl RestrictedAuthority {
             bail!("receiver mutation targets a path excluded by the signed filter policy");
         }
         self.record_path(path)
+    }
+
+    fn created_by_this_grant(&self, path: &[u8]) -> bool {
+        self.state.lock().unwrap().created.contains(path)
+    }
+
+    /// Bind an operation that creates or replaces the object at `path` to the
+    /// signed existing-object policy. `Skip` retains whatever existed before
+    /// the transfer, so creation is forced to be no-replace; `MustExist`
+    /// creates nothing, so something must already be there. `directory`
+    /// marks a directory creation, which may reuse an existing directory
+    /// under `Skip` exactly as the ordinary engine keeps recursing into it.
+    /// A root the grant requires to be new is forced to no-replace creation
+    /// under every policy.
+    fn constrain_creation(
+        &self,
+        path: &[u8],
+        condition: &mut proto::TargetCondition,
+        directory: bool,
+    ) -> Result<()> {
+        use proto::TargetCondition::{Absent, Any, Matches, MatchesFingerprint};
+        let policy = self.copy.policy.existing;
+        let root_must_be_new =
+            self.root_existence == RootExistenceV4::New && path == self.destination;
+        if self.created_by_this_grant(path)
+            || (policy == ExistingDestinationPolicyV1::Replace && !root_must_be_new)
+        {
+            return Ok(());
+        }
+        let observed = self.rooted_metadata(path)?;
+        let label = String::from_utf8_lossy(path);
+        match policy {
+            ExistingDestinationPolicyV1::MustExist => {
+                match observed {
+                    Some(metadata) if !directory || metadata.is_dir() => {}
+                    Some(_) => {
+                        bail!("signed grant creates nothing: {label} exists but is not a directory")
+                    }
+                    None => bail!("signed grant creates nothing: {label} does not exist"),
+                }
+                if *condition == Absent {
+                    bail!("no-replace creation of {label} contradicts the signed existing-object policy");
+                }
+                Ok(())
+            }
+            ExistingDestinationPolicyV1::Skip | ExistingDestinationPolicyV1::Replace => {
+                match observed {
+                    Some(metadata)
+                        if directory
+                            && metadata.is_dir()
+                            && policy == ExistingDestinationPolicyV1::Skip =>
+                    {
+                        return Ok(());
+                    }
+                    Some(_) => {
+                        bail!("signed grant retains existing objects: {label} already exists")
+                    }
+                    None => {}
+                }
+                match *condition {
+                    Any | Absent => *condition = Absent,
+                    Matches { .. } | MatchesFingerprint { .. } => bail!(
+                        "replacement of {label} contradicts the signed existing-object policy"
+                    ),
+                }
+                self.state.lock().unwrap().created.insert(path.to_vec());
+                Ok(())
+            }
+            ExistingDestinationPolicyV1::UpdateIfOlder => {
+                bail!("update-if-older existing-object policy is not enforceable by the receiver")
+            }
+        }
+    }
+
+    /// Bind an operation that modifies an existing non-directory object at
+    /// `path` (metadata, replacement bases, in-place content) to the signed
+    /// existing-object policy. Only `Skip` forbids these, and only for objects
+    /// that predate the transfer; directories are kept and may still receive
+    /// metadata, as in the ordinary engine.
+    fn constrain_update(&self, path: &[u8], is_dir: bool) -> Result<()> {
+        if self.copy.policy.existing != ExistingDestinationPolicyV1::Skip
+            || is_dir
+            || self.created_by_this_grant(path)
+        {
+            return Ok(());
+        }
+        bail!(
+            "signed grant retains existing objects: {} may not be modified",
+            String::from_utf8_lossy(path)
+        )
+    }
+
+    /// Refuse staging work whose eventual publication the existing-object
+    /// policy would reject, so the transfer fails before moving bytes.
+    fn constrain_prepare(&self, path: &[u8]) -> Result<()> {
+        if self.created_by_this_grant(path) {
+            return Ok(());
+        }
+        let label = String::from_utf8_lossy(path);
+        match self.copy.policy.existing {
+            ExistingDestinationPolicyV1::Skip if self.rooted_metadata(path)?.is_some() => {
+                bail!("signed grant retains existing objects: {label} already exists")
+            }
+            ExistingDestinationPolicyV1::MustExist if self.rooted_metadata(path)?.is_none() => {
+                bail!("signed grant creates nothing: {label} does not exist")
+            }
+            _ => Ok(()),
+        }
     }
 
     fn check_flags(&self, flags: u8) -> Result<()> {
@@ -850,14 +1003,28 @@ impl RestrictedAuthority {
         };
         self.check_mutation_path(path, is_dir)?;
         match operation {
-            Op::Mkdir { path, mode, .. } => {
+            Op::Mkdir {
+                path,
+                mode,
+                condition,
+            } => {
+                self.constrain_creation(path, condition, true)?;
                 if !self.copy.options.preserve_permissions {
                     self.remember_receiver_creation(path, true)?;
                     *mode = 0o700;
                 }
                 Ok(())
             }
-            Op::Mknod { path, mode, .. } => {
+            Op::Symlink {
+                path, condition, ..
+            } => self.constrain_creation(path, condition, false),
+            Op::Mknod {
+                path,
+                mode,
+                condition,
+                ..
+            } => {
+                self.constrain_creation(path, condition, false)?;
                 if !self.copy.options.preserve_permissions {
                     self.remember_receiver_creation(path, false)?;
                     #[cfg(target_os = "linux")]
@@ -873,26 +1040,32 @@ impl RestrictedAuthority {
                 meta,
                 flags,
                 condition,
-            } => self.constrain_receiver_mode(
-                path,
-                meta,
-                flags,
-                condition,
-                ReceiverModeTarget::AnyExisting,
-            ),
+            } => {
+                self.constrain_update(path, is_dir)?;
+                self.constrain_receiver_mode(
+                    path,
+                    meta,
+                    flags,
+                    condition,
+                    ReceiverModeTarget::AnyExisting,
+                )
+            }
             Op::SetFileMetaIfSame {
                 path,
                 meta,
                 flags,
                 condition,
-            } => self.constrain_receiver_mode(
-                path,
-                meta,
-                flags,
-                condition,
-                ReceiverModeTarget::RegularFile,
-            ),
-            _ => Ok(()),
+            } => {
+                self.constrain_update(path, false)?;
+                self.constrain_receiver_mode(
+                    path,
+                    meta,
+                    flags,
+                    condition,
+                    ReceiverModeTarget::RegularFile,
+                )
+            }
+            Op::Remove { .. } | Op::Rmdir { .. } | Op::Unlink { .. } => Ok(()),
         }
     }
 
@@ -1032,6 +1205,7 @@ impl RestrictedAuthority {
                     bail!("signed grant per-file byte limit exceeded");
                 }
                 self.check_mutation_path(path, false)?;
+                self.constrain_update(path, false)?;
                 *guard = Some(self.guard.clone());
             }
             Request::FinishBasis {
@@ -1043,6 +1217,7 @@ impl RestrictedAuthority {
                 ..
             } => {
                 self.check_mutation_path(path, false)?;
+                self.constrain_update(path, false)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1066,6 +1241,7 @@ impl RestrictedAuthority {
                     bail!("signed grant per-file byte limit exceeded");
                 }
                 self.check_mutation_path(path, false)?;
+                self.constrain_prepare(path)?;
                 *guard = Some(self.guard.clone());
             }
             Request::WriteRange {
@@ -1095,6 +1271,7 @@ impl RestrictedAuthority {
                     bail!("file finalization does not match the signed publication policy");
                 }
                 self.check_mutation_path(path, false)?;
+                self.constrain_creation(path, condition, false)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1120,6 +1297,7 @@ impl RestrictedAuthority {
                 }
                 for put in puts {
                     self.charge_bytes(&put.path, 0, put.data.len())?;
+                    self.constrain_creation(&put.path, &mut put.condition, false)?;
                     self.constrain_receiver_mode(
                         &put.path,
                         &mut put.meta,
@@ -1997,6 +2175,14 @@ fn now() -> Result<i64> {
         .context("current time exceeds signed grant range")
 }
 
+fn root_existence_for(existence: Existence) -> RootExistenceV4 {
+    match existence {
+        Existence::Any => RootExistenceV4::Any,
+        Existence::New => RootExistenceV4::New,
+        Existence::Existing => RootExistenceV4::Existing,
+    }
+}
+
 fn validate_restricted_args(args: &Args) -> Result<()> {
     if args.no_tcp || args.tcp_plain {
         bail!("command-restricted transfers require encrypted TCP data connections");
@@ -2004,13 +2190,9 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
     if args.tcp_congestion.is_some() {
         bail!("--tcp-congestion is not yet represented in the signed receiver grant");
     }
-    if args.update
-        || args.ignore_existing
-        || args.existing
-        || args.target_existence != Existence::Any
-    {
+    if args.update {
         bail!(
-            "--update, --ignore-existing, --existing, and destination-existence constraints are not yet enforceable by the command-restricted receiver"
+            "--update compares against source modification times that only hostA reports, so the command-restricted receiver cannot enforce it"
         );
     }
     if !args.files_from_lines.is_empty()
@@ -2104,11 +2286,15 @@ fn grant_for(
     };
     mutation_scopes.sort_by(|left, right| left.path.cmp(&right.path));
     mutation_scopes.dedup_by(|left, right| left.path == right.path);
+    // Per-object policy only. The placement root's own precondition
+    // (`--into-existing` and friends) is the separate signed root-existence
+    // field; folding it in here would forbid creating files inside an
+    // existing directory.
     let existing = if args.ignore_existing {
         ExistingDestinationPolicyV1::Skip
     } else if args.update {
         ExistingDestinationPolicyV1::UpdateIfOlder
-    } else if args.existing || args.target_existence == Existence::Existing {
+    } else if args.existing {
         ExistingDestinationPolicyV1::MustExist
     } else {
         ExistingDestinationPolicyV1::Replace
@@ -2259,6 +2445,7 @@ pub(crate) fn prepare_transfer(
             )?,
             delete_excluded: args.delete_excluded,
         },
+        root_existence_for(args.target_existence),
         &private_key,
     )?;
     Ok(PreparedTransfer {
@@ -2310,13 +2497,9 @@ pub(crate) fn run_receiver(enrollment: &str) -> Result<()> {
         revocation_file: None,
     };
     let verified = delegation::verify_and_claim(&envelope, &context, &policy, &replay)?;
-    let (grant, max_file_data_bytes_per_second, filters, deadline) = verified.into_parts();
+    let (grant, extensions, deadline) = verified.into_parts();
     let authority = std::sync::Arc::new(RestrictedAuthority::new(
-        &config,
-        grant,
-        max_file_data_bytes_per_second,
-        filters,
-        deadline,
+        &config, grant, extensions, deadline,
     )?);
     crate::server::run_restricted(authority)
 }
@@ -2531,9 +2714,35 @@ mod tests {
         deletion: DeletionPolicyV1,
         maximum_bytes: u64,
         max_file_data_bytes_per_second: u64,
-        mut filters: FilterPolicyV3,
+        filters: FilterPolicyV3,
         publication: PublicationPolicyV1,
     ) -> RestrictedAuthority {
+        test_authority_with_existence(
+            root,
+            deletion,
+            maximum_bytes,
+            max_file_data_bytes_per_second,
+            filters,
+            publication,
+            ExistingDestinationPolicyV1::Replace,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .unwrap()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn test_authority_with_existence(
+        root: &Path,
+        deletion: DeletionPolicyV1,
+        maximum_bytes: u64,
+        max_file_data_bytes_per_second: u64,
+        mut filters: FilterPolicyV3,
+        publication: PublicationPolicyV1,
+        existing: ExistingDestinationPolicyV1,
+        placement: DestinationPlacementV1,
+        root_existence: RootExistenceV4,
+    ) -> Result<RestrictedAuthority> {
         let opened = Root::open(root).unwrap();
         let identity = opened.identity();
         let id = EnrollmentId::random();
@@ -2567,8 +2776,8 @@ mod tests {
                     descendants: true,
                 }],
                 policy: CopyPolicyV1 {
-                    placement: DestinationPlacementV1::ExactPath,
-                    existing: ExistingDestinationPolicyV1::Replace,
+                    placement,
+                    existing,
                     deletion,
                     publication,
                 },
@@ -2602,11 +2811,13 @@ mod tests {
         RestrictedAuthority::new(
             &config,
             grant,
-            max_file_data_bytes_per_second,
-            filters,
+            GrantExtensions {
+                max_file_data_bytes_per_second,
+                filters,
+                root_existence,
+            },
             Instant::now() + std::time::Duration::from_secs(60),
         )
-        .unwrap()
     }
 
     #[test]
@@ -2960,6 +3171,383 @@ mod tests {
         authority.authorize(&mut inplace, false).unwrap();
         let mut staged = prepare(false);
         assert!(authority.authorize(&mut staged, false).is_err());
+    }
+
+    fn existence_authority(
+        root: &Path,
+        existing: ExistingDestinationPolicyV1,
+        placement: DestinationPlacementV1,
+        root_existence: RootExistenceV4,
+    ) -> Result<RestrictedAuthority> {
+        test_authority_with_existence(
+            root,
+            DeletionPolicyV1::DeleteDestinationOnly,
+            1024,
+            0,
+            FilterPolicyV3::default(),
+            PublicationPolicyV1::AtomicStaged,
+            existing,
+            placement,
+            root_existence,
+        )
+    }
+
+    fn path_bytes(path: &Path) -> Vec<u8> {
+        path.as_os_str().as_bytes().to_vec()
+    }
+
+    fn plain_meta() -> proto::Meta {
+        proto::Meta {
+            mode: 0o644,
+            uid: 0,
+            gid: 0,
+            mtime: 0,
+            mtime_nsec: 0,
+        }
+    }
+
+    fn prepare_request(path: &Path) -> Request {
+        Request::Prepare {
+            path: path_bytes(path),
+            size: 4,
+            inplace: false,
+            partial_id: [1; 16],
+            mode: 0o600,
+            guard: None,
+        }
+    }
+
+    fn finalize_request(path: &Path, condition: proto::TargetCondition) -> Request {
+        Request::Finalize {
+            path: path_bytes(path),
+            inplace: false,
+            partial_id: [1; 16],
+            meta: plain_meta(),
+            flags: 0,
+            condition,
+            guard: None,
+        }
+    }
+
+    fn finalize_condition(request: &Request) -> proto::TargetCondition {
+        let Request::Finalize { condition, .. } = request else {
+            unreachable!()
+        };
+        *condition
+    }
+
+    fn small_put(path: &Path) -> Request {
+        Request::PutSmallBatch(vec![proto::SmallPut {
+            path: path_bytes(path),
+            partial_id: [1; 16],
+            data: b"new".to_vec(),
+            hash: crate::fsops::content_digest(b"new"),
+            meta: plain_meta(),
+            flags: 0,
+            condition: proto::TargetCondition::Any,
+            guard: None,
+        }])
+    }
+
+    fn small_put_condition(request: &Request) -> proto::TargetCondition {
+        let Request::PutSmallBatch(puts) = request else {
+            unreachable!()
+        };
+        puts[0].condition
+    }
+
+    fn apply(op: Op) -> Request {
+        Request::Apply {
+            ops: vec![op],
+            guard: None,
+        }
+    }
+
+    fn op_condition(request: &Request) -> proto::TargetCondition {
+        let Request::Apply { ops, .. } = request else {
+            unreachable!()
+        };
+        match &ops[0] {
+            Op::Mkdir { condition, .. }
+            | Op::Symlink { condition, .. }
+            | Op::Mknod { condition, .. }
+            | Op::SetMeta { condition, .. }
+            | Op::SetFileMetaIfSame { condition, .. } => *condition,
+            Op::Remove { .. } | Op::Rmdir { .. } | Op::Unlink { .. } => unreachable!(),
+        }
+    }
+
+    fn mkdir(path: &Path) -> Op {
+        Op::Mkdir {
+            path: path_bytes(path),
+            mode: 0o755,
+            condition: proto::TargetCondition::Any,
+        }
+    }
+
+    fn symlink_op(path: &Path) -> Op {
+        Op::Symlink {
+            path: path_bytes(path),
+            target: b"elsewhere".to_vec(),
+            condition: proto::TargetCondition::Any,
+        }
+    }
+
+    fn set_meta(path: &Path) -> Op {
+        Op::SetMeta {
+            path: path_bytes(path),
+            meta: plain_meta(),
+            flags: 0,
+            condition: proto::TargetCondition::Any,
+        }
+    }
+
+    #[test]
+    fn signed_skip_policy_retains_preexisting_objects() {
+        use proto::TargetCondition::{Absent, Any, Matches};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let dir = target.join("dir");
+        let kept = target.join("kept");
+        let fresh = target.join("fresh");
+        let small = target.join("small");
+        let new_dir = target.join("new-dir");
+        let link = target.join("link");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(&kept, b"old").unwrap();
+        let authority = existence_authority(
+            &root,
+            ExistingDestinationPolicyV1::Skip,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .unwrap();
+
+        // New files are staged and published without replacing anything;
+        // staging for a pre-existing object fails before bytes move.
+        let mut prepare_fresh = prepare_request(&fresh);
+        authority.authorize(&mut prepare_fresh, false).unwrap();
+        let mut prepare_kept = prepare_request(&kept);
+        assert!(authority.authorize(&mut prepare_kept, false).is_err());
+        let mut publish_fresh = finalize_request(&fresh, Any);
+        authority.authorize(&mut publish_fresh, false).unwrap();
+        assert_eq!(finalize_condition(&publish_fresh), Absent);
+        let mut publish_kept = finalize_request(&kept, Any);
+        assert!(authority.authorize(&mut publish_kept, false).is_err());
+        // What this grant created is its own to republish.
+        let mut republish_fresh = finalize_request(&fresh, Matches { dev: 1, ino: 1 });
+        authority.authorize(&mut republish_fresh, false).unwrap();
+        assert_eq!(
+            finalize_condition(&republish_fresh),
+            Matches { dev: 1, ino: 1 }
+        );
+        let mut small_kept = small_put(&kept);
+        assert!(authority.authorize(&mut small_kept, false).is_err());
+        let mut small_new = small_put(&small);
+        authority.authorize(&mut small_new, false).unwrap();
+        assert_eq!(small_put_condition(&small_new), Absent);
+
+        // Existing directories are kept and reused; nothing existing becomes
+        // a directory, and new directories are created without replacement.
+        let mut reuse_dir = apply(mkdir(&dir));
+        authority.authorize(&mut reuse_dir, false).unwrap();
+        assert_eq!(op_condition(&reuse_dir), Any);
+        let mut dir_over_file = apply(mkdir(&kept));
+        assert!(authority.authorize(&mut dir_over_file, false).is_err());
+        let mut create_dir = apply(mkdir(&new_dir));
+        authority.authorize(&mut create_dir, false).unwrap();
+        assert_eq!(op_condition(&create_dir), Absent);
+
+        // Symlinks follow the same rule, and metadata may follow only this
+        // grant's own creations or directories.
+        let mut link_over_file = apply(symlink_op(&kept));
+        assert!(authority.authorize(&mut link_over_file, false).is_err());
+        let mut create_link = apply(symlink_op(&link));
+        authority.authorize(&mut create_link, false).unwrap();
+        assert_eq!(op_condition(&create_link), Absent);
+        let mut meta_link = apply(set_meta(&link));
+        authority.authorize(&mut meta_link, false).unwrap();
+        let mut meta_dir = apply(set_meta(&dir));
+        authority.authorize(&mut meta_dir, false).unwrap();
+        let mut meta_kept = apply(set_meta(&kept));
+        assert!(authority.authorize(&mut meta_kept, false).is_err());
+        let mut same_kept = apply(Op::SetFileMetaIfSame {
+            path: path_bytes(&kept),
+            condition: Any,
+            meta: plain_meta(),
+            flags: 0,
+        });
+        assert!(authority.authorize(&mut same_kept, false).is_err());
+
+        // Content repair of a pre-existing file is refused; deletion remains
+        // governed by the separately signed deletion policy.
+        let mut finish = Request::FinishBasis {
+            path: path_bytes(&kept),
+            partial_id: [1; 16],
+            meta: plain_meta(),
+            flags: 0,
+            condition: Any,
+            guard: None,
+        };
+        assert!(authority.authorize(&mut finish, false).is_err());
+        let mut seed = Request::SeedBasis {
+            path: path_bytes(&kept),
+            partial_id: [1; 16],
+            len: 3,
+            guard: None,
+        };
+        assert!(authority.authorize(&mut seed, false).is_err());
+        let mut delete = apply(Op::Unlink {
+            path: path_bytes(&kept),
+        });
+        authority.authorize(&mut delete, false).unwrap();
+    }
+
+    #[test]
+    fn signed_must_exist_policy_creates_nothing() {
+        use proto::TargetCondition::{Absent, Any};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let dir = target.join("dir");
+        let present = target.join("present");
+        let link = target.join("link");
+        let missing = target.join("missing");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(&present, b"old").unwrap();
+        std::os::unix::fs::symlink("present", &link).unwrap();
+        let authority = existence_authority(
+            &root,
+            ExistingDestinationPolicyV1::MustExist,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .unwrap();
+
+        let mut prepare_present = prepare_request(&present);
+        authority.authorize(&mut prepare_present, false).unwrap();
+        let mut prepare_missing = prepare_request(&missing);
+        assert!(authority.authorize(&mut prepare_missing, false).is_err());
+        let mut update_present = finalize_request(&present, Any);
+        authority.authorize(&mut update_present, false).unwrap();
+        assert_eq!(finalize_condition(&update_present), Any);
+        let mut create_present = finalize_request(&present, Absent);
+        assert!(authority.authorize(&mut create_present, false).is_err());
+        let mut publish_missing = finalize_request(&missing, Any);
+        assert!(authority.authorize(&mut publish_missing, false).is_err());
+        let mut small_missing = small_put(&missing);
+        assert!(authority.authorize(&mut small_missing, false).is_err());
+        let mut small_present = small_put(&present);
+        authority.authorize(&mut small_present, false).unwrap();
+
+        let mut reuse_dir = apply(mkdir(&dir));
+        authority.authorize(&mut reuse_dir, false).unwrap();
+        let mut create_dir = apply(mkdir(&missing));
+        assert!(authority.authorize(&mut create_dir, false).is_err());
+        let mut dir_over_file = apply(mkdir(&present));
+        assert!(authority.authorize(&mut dir_over_file, false).is_err());
+        let mut replace_link = apply(symlink_op(&link));
+        authority.authorize(&mut replace_link, false).unwrap();
+        assert_eq!(op_condition(&replace_link), Any);
+        let mut create_link = apply(symlink_op(&missing));
+        assert!(authority.authorize(&mut create_link, false).is_err());
+
+        let mut finish = Request::FinishBasis {
+            path: path_bytes(&present),
+            partial_id: [1; 16],
+            meta: plain_meta(),
+            flags: 0,
+            condition: Any,
+            guard: None,
+        };
+        authority.authorize(&mut finish, false).unwrap();
+        let mut meta_present = apply(set_meta(&present));
+        authority.authorize(&mut meta_present, false).unwrap();
+    }
+
+    #[test]
+    fn signed_root_existence_is_checked_at_claim_and_forced_on_creation() {
+        use proto::TargetCondition::{Absent, Any};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let target = root.join("target");
+        let replace = ExistingDestinationPolicyV1::Replace;
+
+        // A root that must be new is refused when present, and otherwise may
+        // only be created without replacement; afterwards it is this grant's.
+        fs::create_dir(&target).unwrap();
+        assert!(existence_authority(
+            &root,
+            replace,
+            DestinationPlacementV1::DirectoryContents,
+            RootExistenceV4::New,
+        )
+        .is_err());
+        fs::remove_dir(&target).unwrap();
+        let authority = existence_authority(
+            &root,
+            replace,
+            DestinationPlacementV1::DirectoryContents,
+            RootExistenceV4::New,
+        )
+        .unwrap();
+        let mut create_root = apply(mkdir(&target));
+        authority.authorize(&mut create_root, false).unwrap();
+        assert_eq!(op_condition(&create_root), Absent);
+        fs::create_dir(&target).unwrap();
+        let mut revisit_root = apply(mkdir(&target));
+        authority.authorize(&mut revisit_root, false).unwrap();
+        assert_eq!(op_condition(&revisit_root), Any);
+        let mut child = finalize_request(&target.join("child"), Any);
+        authority.authorize(&mut child, false).unwrap();
+        assert_eq!(finalize_condition(&child), Any);
+
+        // A root that must exist needs the object, and a directory whenever
+        // the placement puts names inside it.
+        fs::remove_dir(&target).unwrap();
+        assert!(existence_authority(
+            &root,
+            replace,
+            DestinationPlacementV1::DirectoryContents,
+            RootExistenceV4::Existing,
+        )
+        .is_err());
+        fs::write(&target, b"file").unwrap();
+        assert!(existence_authority(
+            &root,
+            replace,
+            DestinationPlacementV1::DirectoryContents,
+            RootExistenceV4::Existing,
+        )
+        .is_err());
+        existence_authority(
+            &root,
+            replace,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Existing,
+        )
+        .unwrap();
+        fs::remove_file(&target).unwrap();
+        fs::create_dir(&target).unwrap();
+        existence_authority(
+            &root,
+            replace,
+            DestinationPlacementV1::DirectoryAsChild,
+            RootExistenceV4::Existing,
+        )
+        .unwrap();
+
+        // The one existing-object policy the receiver cannot enforce is
+        // refused when the grant is claimed rather than trusted.
+        assert!(existence_authority(
+            &root,
+            ExistingDestinationPolicyV1::UpdateIfOlder,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -532,18 +532,18 @@ impl RestrictedAuthority {
             _ => false,
         };
         let mut state = self.state.lock().unwrap();
-        for (index, path) in settlement.0 {
-            state.provisional.remove(&path);
-            if !failed(index) {
-                state.created.insert(path);
+        for creation in settlement.0 {
+            state.provisional.remove(&creation.path);
+            if creation.persist && !failed(creation.index) {
+                state.created.insert(creation.path);
             }
         }
     }
 
-    fn forget_provisional(&self, pending: &[(usize, Vec<u8>)]) {
+    fn forget_provisional(&self, pending: &[PendingCreation]) {
         let mut state = self.state.lock().unwrap();
-        for (_, path) in pending {
-            state.provisional.remove(path);
+        for creation in pending {
+            state.provisional.remove(&creation.path);
         }
     }
 
@@ -564,7 +564,7 @@ impl RestrictedAuthority {
         condition: &mut proto::TargetCondition,
         directory: bool,
         index: usize,
-        pending: &mut Vec<(usize, Vec<u8>)>,
+        pending: &mut Vec<PendingCreation>,
     ) -> Result<()> {
         use proto::TargetCondition::{Absent, Any, Matches, MatchesFingerprint};
         let policy = self.copy.policy.existing;
@@ -627,11 +627,17 @@ impl RestrictedAuthority {
                     ),
                 }
                 if !directory {
-                    // The replacement this request makes is its own from here
-                    // on: metadata later in the same batch lands on the new
+                    // Metadata later in this same batch lands on the new
                     // inode, not the one it replaces, so it must not be
-                    // pinned to the old identity.
-                    pending.push((index, path.to_vec()));
+                    // pinned to the old identity. The replacement is never
+                    // remembered beyond this request: a later request must
+                    // again observe and pin whatever is there, or a chain of
+                    // replacements could change the object's type.
+                    pending.push(PendingCreation {
+                        index,
+                        path: path.to_vec(),
+                        persist: false,
+                    });
                 }
                 Ok(())
             }
@@ -656,7 +662,11 @@ impl RestrictedAuthority {
                     ),
                 }
                 self.state.lock().unwrap().provisional.insert(path.to_vec());
-                pending.push((index, path.to_vec()));
+                pending.push(PendingCreation {
+                    index,
+                    path: path.to_vec(),
+                    persist: true,
+                });
                 Ok(())
             }
             ExistingDestinationPolicyV1::UpdateIfOlder => {
@@ -675,15 +685,15 @@ impl RestrictedAuthority {
         path: &[u8],
         is_dir: bool,
         condition: Option<&mut proto::TargetCondition>,
-        pending: &[(usize, Vec<u8>)],
+        pending: &[PendingCreation],
     ) -> Result<()> {
         use proto::TargetCondition::{Absent, Any, Matches, MatchesFingerprint};
         let label = String::from_utf8_lossy(path);
         // A creation earlier in this same request (a symlink followed by its
         // metadata, say) counts: the batch executes in order, so the
         // metadata only ever lands on this request's own creation.
-        let own =
-            self.created_by_this_grant(path) || pending.iter().any(|(_, created)| created == path);
+        let own = self.created_by_this_grant(path)
+            || pending.iter().any(|creation| creation.path == path);
         match self.copy.policy.existing {
             ExistingDestinationPolicyV1::Skip if is_dir || own => Ok(()),
             ExistingDestinationPolicyV1::Skip => {
@@ -1114,7 +1124,7 @@ impl RestrictedAuthority {
         &self,
         operation: &mut Op,
         index: usize,
-        pending: &mut Vec<(usize, Vec<u8>)>,
+        pending: &mut Vec<PendingCreation>,
     ) -> Result<()> {
         let path = match &*operation {
             Op::Mkdir { path, .. }
@@ -1241,7 +1251,7 @@ impl RestrictedAuthority {
         &self,
         request: &mut Request,
         over_ssh: bool,
-        pending: &mut Vec<(usize, Vec<u8>)>,
+        pending: &mut Vec<PendingCreation>,
     ) -> Result<()> {
         self.check_deadline()?;
         match request {
@@ -1502,7 +1512,17 @@ impl RestrictedAuthority {
 /// Creations an authorized request recorded provisionally, keyed by the
 /// operation or small-put index the executor reports on.
 #[derive(Debug, Default)]
-pub(crate) struct Settlement(Vec<(usize, Vec<u8>)>);
+pub(crate) struct Settlement(Vec<PendingCreation>);
+
+/// One object a request creates or replaces. Only creations that `persist`
+/// become the grant's own once confirmed; a `MustExist` replacement counts
+/// only for the rest of its own request.
+#[derive(Debug)]
+pub(crate) struct PendingCreation {
+    index: usize,
+    path: Vec<u8>,
+    persist: bool,
+}
 
 fn current_account() -> Result<(String, PathBuf)> {
     let uid = unsafe { libc::geteuid() };
@@ -3918,10 +3938,29 @@ mod tests {
         let after = fs::symlink_metadata(&link).unwrap();
         assert_ne!(after.ino(), before.ino());
 
-        // Afterwards the replacement is this grant's own object.
+        // A later request must observe and pin the replacement afresh; it
+        // is not a creation the grant may now treat as its own, so neither a
+        // type change nor an unpinned publication is possible.
         let mut touch = apply(set_meta(&link));
         authority.authorize(&mut touch, false).unwrap();
-        assert_eq!(op_condition(&touch), Any);
+        assert_eq!(
+            op_condition(&touch),
+            Matches {
+                dev: after.dev(),
+                ino: after.ino(),
+            }
+        );
+        let mut as_directory = apply(mkdir(&link));
+        assert!(authority.authorize(&mut as_directory, false).is_err());
+        let mut publish = finalize_request(&link, Any);
+        authority.authorize(&mut publish, false).unwrap();
+        assert_eq!(
+            finalize_condition(&publish),
+            Matches {
+                dev: after.dev(),
+                ino: after.ino(),
+            }
+        );
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -278,14 +278,14 @@ impl RestrictedAuthority {
             bail!("update-if-older existing-object policy is not enforceable by the receiver");
         }
         if copy.policy.publication == PublicationPolicyV1::InPlace
-            && (copy.policy.existing == ExistingDestinationPolicyV1::Skip
+            && (copy.policy.existing != ExistingDestinationPolicyV1::Replace
                 || (root_existence == RootExistenceV4::New
                     && copy.policy.placement == DestinationPlacementV1::ExactPath))
         {
-            // In-place preparation opens or creates the final pathname with
-            // no no-replace condition to attach, so it cannot be made to
-            // retain a pre-existing object.
-            bail!("in-place publication cannot honor a no-replace existing-object policy");
+            // In-place preparation opens, creates, or replaces the final
+            // pathname with no condition to attach, so it can neither retain
+            // a pre-existing object nor be pinned to one.
+            bail!("in-place publication cannot honor a signed existing-object policy");
         }
         let filter_matcher = crate::scan::build_ignore(&filters.ignore)?;
         let filter_roots = filters.destination_roots.clone();
@@ -667,22 +667,65 @@ impl RestrictedAuthority {
         &self,
         path: &[u8],
         is_dir: bool,
+        condition: Option<&mut proto::TargetCondition>,
         pending: &[(usize, Vec<u8>)],
     ) -> Result<()> {
+        use proto::TargetCondition::{Absent, Any, Matches, MatchesFingerprint};
+        let label = String::from_utf8_lossy(path);
         // A creation earlier in this same request (a symlink followed by its
         // metadata, say) counts: the batch executes in order, so the
         // metadata only ever lands on this request's own creation.
-        if self.copy.policy.existing != ExistingDestinationPolicyV1::Skip
-            || is_dir
-            || self.created_by_this_grant(path)
-            || pending.iter().any(|(_, created)| created == path)
-        {
-            return Ok(());
+        let own =
+            self.created_by_this_grant(path) || pending.iter().any(|(_, created)| created == path);
+        match self.copy.policy.existing {
+            ExistingDestinationPolicyV1::Skip if is_dir || own => Ok(()),
+            ExistingDestinationPolicyV1::Skip => {
+                bail!("signed grant retains existing objects: {label} may not be modified")
+            }
+            ExistingDestinationPolicyV1::MustExist => {
+                // Updates are pinned to the observed object, like
+                // publications: nothing hostA supplies names an inode on its
+                // own authority.
+                let Some(metadata) = self.rooted_metadata(path)? else {
+                    bail!("signed grant creates nothing: {label} does not exist")
+                };
+                let Some(condition) = condition else {
+                    return Ok(());
+                };
+                match *condition {
+                    Any => {
+                        *condition = Matches {
+                            dev: metadata.dev,
+                            ino: metadata.ino,
+                        }
+                    }
+                    Absent => bail!(
+                        "no-replace update of {label} contradicts the signed existing-object policy"
+                    ),
+                    Matches { dev, ino } if (dev, ino) == (metadata.dev, metadata.ino) => {}
+                    MatchesFingerprint {
+                        dev,
+                        ino,
+                        ctime,
+                        ctime_nsec,
+                    } if (dev, ino, ctime, ctime_nsec)
+                        == (
+                            metadata.dev,
+                            metadata.ino,
+                            metadata.ctime,
+                            metadata.ctime_nsec,
+                        ) => {}
+                    Matches { .. } | MatchesFingerprint { .. } => bail!(
+                        "requested identity for {label} does not match the object the receiver observed"
+                    ),
+                }
+                Ok(())
+            }
+            ExistingDestinationPolicyV1::Replace => Ok(()),
+            ExistingDestinationPolicyV1::UpdateIfOlder => {
+                bail!("update-if-older existing-object policy is not enforceable by the receiver")
+            }
         }
-        bail!(
-            "signed grant retains existing objects: {} may not be modified",
-            String::from_utf8_lossy(path)
-        )
     }
 
     /// Refuse staging work whose eventual publication the existing-object
@@ -1142,7 +1185,7 @@ impl RestrictedAuthority {
                 flags,
                 condition,
             } => {
-                self.constrain_update(path, is_dir, pending)?;
+                self.constrain_update(path, is_dir, Some(&mut *condition), pending)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1157,7 +1200,7 @@ impl RestrictedAuthority {
                 flags,
                 condition,
             } => {
-                self.constrain_update(path, false, pending)?;
+                self.constrain_update(path, false, Some(&mut *condition), pending)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1327,7 +1370,7 @@ impl RestrictedAuthority {
                     bail!("signed grant per-file byte limit exceeded");
                 }
                 self.check_mutation_path(path, false)?;
-                self.constrain_update(path, false, pending)?;
+                self.constrain_update(path, false, None, pending)?;
                 *guard = Some(self.guard.clone());
             }
             Request::FinishBasis {
@@ -1339,7 +1382,7 @@ impl RestrictedAuthority {
                 ..
             } => {
                 self.check_mutation_path(path, false)?;
-                self.constrain_update(path, false, pending)?;
+                self.constrain_update(path, false, Some(&mut *condition), pending)?;
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -2324,10 +2367,11 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
     }
     if args.inplace
         && (args.ignore_existing
+            || args.existing
             || (args.target_existence == Existence::New && args.placement == Placement::As))
     {
         bail!(
-            "--inplace cannot be combined with --ignore-existing or --as-new on the command-restricted path: in-place writes open the final pathname directly, so the receiver cannot make them no-replace"
+            "--inplace cannot be combined with --ignore-existing, --existing, or --as-new on the command-restricted path: in-place writes open the final pathname directly, so the receiver can neither make them no-replace nor pin them to an observed object"
         );
     }
     if !args.files_from_lines.is_empty()
@@ -3759,6 +3803,65 @@ mod tests {
     }
 
     #[test]
+    fn must_exist_pins_update_only_operations() {
+        use proto::TargetCondition::{Any, Matches};
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let present = target.join("present");
+        let missing = target.join("missing");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(&present, b"old").unwrap();
+        let authority = existence_authority(
+            &root,
+            ExistingDestinationPolicyV1::MustExist,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .unwrap();
+        let identity = fs::symlink_metadata(&present).unwrap();
+        let expected = Matches {
+            dev: identity.dev(),
+            ino: identity.ino(),
+        };
+
+        let mut meta = apply(set_meta(&present));
+        authority.authorize(&mut meta, false).unwrap();
+        assert_eq!(op_condition(&meta), expected);
+        let mut same = apply(Op::SetFileMetaIfSame {
+            path: path_bytes(&present),
+            condition: Any,
+            meta: plain_meta(),
+            flags: 0,
+        });
+        authority.authorize(&mut same, false).unwrap();
+        assert_eq!(op_condition(&same), expected);
+        let mut finish = Request::FinishBasis {
+            path: path_bytes(&present),
+            partial_id: [1; 16],
+            meta: plain_meta(),
+            flags: 0,
+            condition: Any,
+            guard: None,
+        };
+        authority.authorize(&mut finish, false).unwrap();
+        let Request::FinishBasis { condition, .. } = &finish else {
+            unreachable!()
+        };
+        assert_eq!(*condition, expected);
+
+        let mut bogus = apply(Op::SetMeta {
+            path: path_bytes(&present),
+            meta: plain_meta(),
+            flags: 0,
+            condition: Matches { dev: 1, ino: 1 },
+        });
+        assert!(authority.authorize(&mut bogus, false).is_err());
+        let mut absent = apply(set_meta(&missing));
+        assert!(authority.authorize(&mut absent, false).is_err());
+    }
+
+    #[test]
     fn guarded_executor_honors_creation_conditions() {
         use proto::TargetCondition::{Absent, Any, Matches};
         let temporary = tempfile::tempdir().unwrap();
@@ -3875,18 +3978,19 @@ mod tests {
             RootExistenceV4::New,
         )
         .is_err());
-        // A new directory root is created by mkdir, so in-place files
-        // beneath it are fine, as are in-place updates of existing files.
+        // In-place preparation cannot be pinned to an observed object either,
+        // so MustExist is refused as well; only Replace remains, and a new
+        // directory root is fine because mkdir creates it.
+        assert!(inplace(
+            ExistingDestinationPolicyV1::MustExist,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+        )
+        .is_err());
         inplace(
             ExistingDestinationPolicyV1::Replace,
             DestinationPlacementV1::DirectoryContents,
             RootExistenceV4::New,
-        )
-        .unwrap();
-        inplace(
-            ExistingDestinationPolicyV1::MustExist,
-            DestinationPlacementV1::ExactPath,
-            RootExistenceV4::Any,
         )
         .unwrap();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -163,12 +163,16 @@ fn serve<R: Read + Send + 'static, W: Write>(
             Err(_) => break,
         };
         t[0] += t0.elapsed().as_secs_f64();
-        if let Some(authority) = &authority {
-            if let Err(error) = authority.authorize(&mut req, over_ssh) {
-                w.write_msg(&Response::Err(format!("{error:#}")))?;
-                continue;
-            }
-        }
+        let settlement = match &authority {
+            Some(authority) => match authority.authorize(&mut req, over_ssh) {
+                Ok(settlement) => Some(settlement),
+                Err(error) => {
+                    w.write_msg(&Response::Err(format!("{error:#}")))?;
+                    continue;
+                }
+            },
+            None => None,
+        };
         match &req {
             Request::WriteRange { data, .. } => {
                 blocks += 1;
@@ -321,6 +325,9 @@ fn serve<R: Read + Send + 'static, W: Write>(
             other => {
                 let t0 = std::time::Instant::now();
                 let resp = ops.handle(&other);
+                if let (Some(authority), Some(settlement)) = (&authority, settlement) {
+                    authority.settle(settlement, &resp);
+                }
                 t[1] += t0.elapsed().as_secs_f64();
                 if drop_after_handling_for_test(&other) {
                     return Ok(());


### PR DESCRIPTION
## Summary

- The signed `ExistingDestinationPolicyV1` was constructed but never consulted by the receiver. `Skip` (`--ignore-existing`) and `MustExist` (`--existing`) are now enforced on hostB: `Skip` forces no-replace creation and refuses changes to any pre-existing non-directory (existing directories are reused, this grant's own creations stay its own); `MustExist` refuses to create anything. `UpdateIfOlder` (`--update`) remains refused, now at grant-claim time as well, because it depends on source mtimes only hostA reports.
- Native `--into-new`/`--into-existing`/`--as-new`/`--as-existing` previously kept the constrained broker but prepared **no receiver grant**, so hostA silently received the destination account's full authority. They now travel as a signed root-existence precondition in a V4 grant body, checked against the enrolled root when the grant is claimed; a `new` root is forced to no-replace creation.
- `grant_for` no longer conflates `--into-existing` (root must exist) with per-object `MustExist` (create nothing).
- V1–V3 grant decoding is retained; the orchestrator still emits the oldest body that can represent the request, so V4 is used only when a root precondition is present.
- README: fail-closed list and native placement paragraph updated.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (230 unit, 285 local integration, 9 update tests)
- New unit tests: `signed_skip_policy_retains_preexisting_objects`, `signed_must_exist_policy_creates_nothing`, `signed_root_existence_is_checked_at_claim_and_forced_on_creation`, plus V4 round-trip and downgrade-refusal coverage in `delegation.rs`.
- Not verified: a live two-host remote-to-remote transfer through an enrolled receiver with these options. Coverage is at the `authorize` and grant-encoding level, as for the existing filter and in-place policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqM3Msd5sJYmuYjguVBB5E
