### PR TITLE
Add explicit receiver ceilings and require a stated deletion budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,8 @@ tuning may use up to that signed ceiling.
 Deletion through the receiver (`cp-prune`, or `--delete` on the rsync-shaped
 command) requires an explicit `--max-delete`, so the deletion authority a
 compromised hostA could exercise inside the scope is always stated on the
-command line rather than defaulting to a hundred million. The other signed
+command line rather than defaulting to a hundred million; `--max-delete 0`
+signs a grant that forbids deletion outright. The other signed
 ceilings default to 100 million entries, 8 TiB of file data, and a 23-hour
 grant; native `--max-entries`, `--max-total-bytes`, and `--max-runtime` lower
 them for one transfer, which bounds what a claimed grant is worth to hostA.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,12 @@ command-restricted remote-to-remote receiver independently enforces the signed
 aggregate limit, signed filters, and the selected staged or in-place publication
 policy. A receiver installed by an older syq rejects an extension or unsupported
 policy safely; rerun `syq enroll HOST:DEST` to refresh an existing enrollment
-to the current binary. `cp` additionally accepts `--mapping` and `--results`
+to the current binary. On a direct remote-to-remote copy through that
+receiver, `cp` and `cp-prune` also accept the receiver ceilings
+`--max-entries N`, `--max-total-bytes SIZE`, and `--max-runtime DURATION`
+(`s`, `m`, or `h`; at most 23h). They are signed into the grant and enforced
+by hostB, and are refused anywhere else because nothing would enforce them.
+`cp` additionally accepts `--mapping` and `--results`
 (see [MAPPINGS.md](MAPPINGS.md)). `cp-prune` additionally
 accepts `--max-delete`; `rm` additionally accepts `--root` and `--follow` plus
 its endpoint-side removal semantics.
@@ -528,6 +533,14 @@ receiver cannot enforce those semantics independently of hostA.
 with deletion because filtered source files could otherwise make hostA's
 deletion plan ambiguous. Explicit `-j` values above 64 are also refused; auto
 tuning may use up to that signed ceiling.
+
+Deletion through the receiver (`cp-prune`, or `--delete` on the rsync-shaped
+command) requires an explicit `--max-delete`, so the deletion authority a
+compromised hostA could exercise inside the scope is always stated on the
+command line rather than defaulting to a hundred million. The other signed
+ceilings default to 100 million entries, 8 TiB of file data, and a 23-hour
+grant; native `--max-entries`, `--max-total-bytes`, and `--max-runtime` lower
+them for one transfer, which bounds what a claimed grant is worth to hostA.
 
 `--dry-run` and `--verify-only` are cryptographically read-only: the signed
 grant marks them as such and the receiver rejects every mutation even if hostA

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -320,6 +320,13 @@ pub struct Args {
     /// With --delete, refuse to delete anything if more than N deletions are planned (exit 25)
     #[arg(long, value_name = "N", requires = "delete")]
     pub max_delete: Option<u64>,
+    /// Native-only command-restricted receiver ceilings, signed into the grant.
+    #[arg(skip)]
+    pub max_entries: Option<u64>,
+    #[arg(skip)]
+    pub max_total_bytes: Option<u64>,
+    #[arg(skip)]
+    pub max_runtime_secs: Option<u32>,
     /// Skip regular files that are newer on the destination (directories,
     /// symlinks and specials are unaffected)
     #[arg(short = 'u', long)]
@@ -677,6 +684,15 @@ struct NativeCopyOperationalArgs {
     /// Update destination files directly, using no full-sized staging file; interruption can leave them incomplete
     #[arg(long)]
     inplace: bool,
+    /// Command-restricted receiver ceiling: refuse to touch more than N destination entries (direct remote-to-remote only)
+    #[arg(long, value_name = "N")]
+    max_entries: Option<u64>,
+    /// Command-restricted receiver ceiling: refuse to write more than SIZE bytes of file data in total (direct remote-to-remote only)
+    #[arg(long, value_name = "SIZE")]
+    max_total_bytes: Option<String>,
+    /// Command-restricted receiver ceiling: the signed grant expires DURATION after it is issued, e.g. 30m or 2h (direct remote-to-remote only; at most 23h)
+    #[arg(long, value_name = "DURATION")]
+    max_runtime: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -1035,6 +1051,21 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
         }
     }
     apply_native_copy_operational(&mut args, parsed.operational, &matches)?;
+    if args.max_entries.is_some()
+        || args.max_total_bytes.is_some()
+        || args.max_runtime_secs.is_some()
+    {
+        // These are assertions for hostB's enrolled receiver to enforce; with
+        // no such receiver in the topology, nothing would enforce them, so
+        // refuse rather than let them read as local limits.
+        let src_remote = args.locations.first().is_some_and(|l| l.host.is_some());
+        let dst_remote = args.locations.last().is_some_and(|l| l.host.is_some());
+        if !(src_remote && dst_remote) {
+            bail!(
+                "--max-entries, --max-total-bytes, and --max-runtime are command-restricted receiver ceilings; they apply only to direct remote-to-remote copies"
+            );
+        }
+    }
     apply_internal_native_direct(&mut args)?;
     Ok(args)
 }
@@ -1201,7 +1232,16 @@ fn apply_native_copy_operational(
         ignore_from,
         preserve,
         inplace,
+        max_entries,
+        max_total_bytes,
+        max_runtime,
     } = operational;
+    args.max_entries = max_entries;
+    args.max_total_bytes = max_total_bytes.as_deref().map(parse_size).transpose()?;
+    args.max_runtime_secs = max_runtime
+        .as_deref()
+        .map(parse_duration_secs)
+        .transpose()?;
     args.checksum = hash;
     args.no_compress = no_compress;
     if no_compress {
@@ -1530,6 +1570,34 @@ fn message_for_short(c: char) -> Option<&'static str> {
     })
 }
 
+/// Parse a whole-number duration with an optional `s`, `m`, or `h` suffix
+/// (seconds when unsuffixed) into seconds. Zero is rejected.
+pub fn parse_duration_secs(s: &str) -> Result<u32> {
+    let s = s.trim();
+    let (num, mult) = match s.chars().last() {
+        Some(c) if c.is_ascii_alphabetic() => {
+            let m: u32 = match c.to_ascii_lowercase() {
+                's' => 1,
+                'm' => 60,
+                'h' => 60 * 60,
+                _ => bail!("bad duration suffix in {s:?}; use s, m, or h"),
+            };
+            (&s[..s.len() - 1], m)
+        }
+        _ => (s, 1),
+    };
+    let n: u32 = num
+        .parse()
+        .map_err(|_| anyhow::anyhow!("bad duration {s:?}"))?;
+    let seconds = n
+        .checked_mul(mult)
+        .ok_or_else(|| anyhow::anyhow!("bad duration {s:?}: value is too large"))?;
+    if seconds == 0 {
+        bail!("duration {s:?} must be at least one second");
+    }
+    Ok(seconds)
+}
+
 pub fn parse_size(s: &str) -> Result<u64> {
     let s = s.trim();
     let (num, mult) = match s.chars().last() {
@@ -1570,10 +1638,21 @@ pub fn parse_size(s: &str) -> Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::{
-        native_engine_defaults, parse_native_copy, parse_native_endpoint, parse_size, Args,
-        Interface, Placement, SourceSelection,
+        native_engine_defaults, parse_duration_secs, parse_native_copy, parse_native_endpoint,
+        parse_size, Args, Interface, Placement, SourceSelection,
     };
     use clap::Parser;
+
+    #[test]
+    fn durations_take_seconds_minutes_or_hours_and_reject_zero() {
+        assert_eq!(parse_duration_secs("45").unwrap(), 45);
+        assert_eq!(parse_duration_secs("90s").unwrap(), 90);
+        assert_eq!(parse_duration_secs("30m").unwrap(), 1800);
+        assert_eq!(parse_duration_secs("2H").unwrap(), 7200);
+        for bad in ["0", "0m", "", "5d", "1.5h", "-3", "4294967295h"] {
+            assert!(parse_duration_secs(bad).is_err(), "{bad:?}");
+        }
+    }
 
     fn args(options: &[&str]) -> Args {
         let mut argv = vec!["syq"];

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -373,14 +373,12 @@ impl FilterPolicyV3 {
                 bail!("signed filter roots must be sorted and unique");
             }
         }
-        if self.delete_excluded {
-            let GrantOperationV1::Copy(copy) = &grant.operation;
-            if copy.policy.deletion == DeletionPolicyV1::Forbid {
-                bail!(
-                    "signed filter policy cannot delete excluded paths when deletion is forbidden"
-                );
-            }
-        }
+        // `delete_excluded` is also a scan policy: with it, the orchestrator
+        // inspects the destination unfiltered, and the receiver requires
+        // exactly that. It therefore stays meaningful when deletion is
+        // forbidden (a dry run, or a zero deletion budget); the receiver's
+        // deletion policy still refuses every actual removal.
+        let _ = grant;
         Ok(())
     }
 }
@@ -2440,6 +2438,21 @@ mod tests {
             RootExistenceV4::Existing,
         )
         .is_err());
+    }
+
+    #[test]
+    fn delete_excluded_filters_remain_valid_when_deletion_is_forbidden() {
+        let grant = fixture_grant(50);
+        let GrantOperationV1::Copy(copy) = &grant.operation;
+        assert_eq!(copy.policy.deletion, DeletionPolicyV1::Forbid);
+        let filters = FilterPolicyV3 {
+            ignore: vec!["*.tmp".into()],
+            destination_roots: vec![b"/srv/archive/project".to_vec()],
+            delete_excluded: true,
+        };
+        // The unfiltered-scan policy still matters for a dry run or a zero
+        // deletion budget; the receiver's deletion policy refuses removals.
+        filters.validate(&grant).unwrap();
     }
 
     #[test]

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -78,9 +78,9 @@ const MAX_SIGNER_BYTES: usize = 512;
 const MAX_GRANT_VALIDITY_SECS: i64 = 24 * 60 * 60;
 const MAX_CLOCK_SKEW_SECS: i64 = 5 * 60;
 const MAX_UNIX_TIMESTAMP: i64 = 253_402_300_799; // 9999-12-31T23:59:59Z
-const MAX_ENTRIES: u64 = 1_000_000_000_000;
+pub(crate) const MAX_ENTRIES: u64 = 1_000_000_000_000;
 // Keep later accounting representable in both signed and unsigned counters.
-const MAX_COPY_BYTES: u64 = i64::MAX as u64;
+pub(crate) const MAX_COPY_BYTES: u64 = i64::MAX as u64;
 const MAX_CONNECTIONS: u16 = 64;
 const MAX_FILTER_RULES: usize = 4096;
 const MAX_FILTER_RULE_BYTES: usize = 4096;

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -308,6 +308,15 @@ pub fn run(
             broker: socket,
         })
     };
+    if (args.max_entries.is_some()
+        || args.max_total_bytes.is_some()
+        || args.max_runtime_secs.is_some())
+        && restricted_grant.is_none()
+    {
+        bail!(
+            "--max-entries, --max-total-bytes, and --max-runtime are command-restricted receiver ceilings, but this transfer does not use the enrolled receiver"
+        );
+    }
     // The follow target must reconnect the way we did: keep an explicit user.
     let src_target = match &srcs[0].user {
         Some(user) => format!("{user}@{src_host}"),

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -4883,6 +4883,44 @@ mod tests {
     }
 
     #[test]
+    fn forbidden_deletion_keeps_the_unfiltered_scan_but_refuses_removals() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let authority = test_authority_with_policy(
+            &root,
+            DeletionPolicyV1::Forbid,
+            16,
+            0,
+            FilterPolicyV3 {
+                ignore: vec!["ignored/".into()],
+                destination_roots: Vec::new(),
+                delete_excluded: true,
+            },
+            PublicationPolicyV1::AtomicStaged,
+        );
+        let target = root.join("target").as_os_str().as_bytes().to_vec();
+        let mut unfiltered_scan = Request::Scan {
+            root: target,
+            follow_root: false,
+            ignore: Vec::new(),
+            report_ignored: true,
+            guard: None,
+        };
+        authority.authorize(&mut unfiltered_scan, false).unwrap();
+        let ignored = root
+            .join("target/ignored/file")
+            .as_os_str()
+            .as_bytes()
+            .to_vec();
+        let mut delete = Request::Apply {
+            ops: vec![Op::Unlink { path: ignored }],
+            guard: None,
+        };
+        assert!(authority.authorize(&mut delete, false).is_err());
+    }
+
+    #[test]
     fn ceiling_ranges_are_checked_before_any_enrollment_side_effect() {
         let parse = |options: &[&str]| {
             let mut argv = vec!["syq rsync", "-r"];

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -122,10 +122,12 @@ struct AuthorityState {
     /// grant the shortcut above: a second creation of the same path races at
     /// the kernel instead of trusting an outcome that has not happened yet.
     provisional: HashSet<Vec<u8>>,
-    /// Bytes each prepared file may occupy on disk before any payload is
-    /// written: preallocation and basis seeding are charged against the
-    /// aggregate ceiling here, once per path at its largest declared size.
-    reserved: HashMap<Vec<u8>, u64>,
+    /// Bytes each staged or in-place file may occupy on disk, keyed by the
+    /// destination path and the partial this grant declared for it:
+    /// preallocation and basis seeding are charged against the aggregate
+    /// ceiling here, once per file at its largest declared size, and every
+    /// write or publication must name a declared partial.
+    reserved: HashMap<(Vec<u8>, proto::PartialId), u64>,
     reserved_bytes: u64,
     transferred_bytes: u64,
     deletions: u64,
@@ -477,9 +479,10 @@ impl RestrictedAuthority {
     /// the signed aggregate byte ceiling. A path is charged once, at the
     /// largest size declared for it, so retries and resumes do not double
     /// count while many distinct preparations cannot exceed the ceiling.
-    fn reserve_bytes(&self, path: &[u8], size: u64) -> Result<()> {
+    fn reserve_bytes(&self, path: &[u8], partial_id: proto::PartialId, size: u64) -> Result<()> {
         let mut state = self.state.lock().unwrap();
-        let previous = state.reserved.get(path).copied().unwrap_or(0);
+        let key = (path.to_vec(), partial_id);
+        let previous = state.reserved.get(&key).copied().unwrap_or(0);
         if size <= previous {
             return Ok(());
         }
@@ -491,7 +494,52 @@ impl RestrictedAuthority {
             bail!("signed grant total-byte limit exceeded by file preparation");
         }
         state.reserved_bytes = total;
-        state.reserved.insert(path.to_vec(), size);
+        state.reserved.insert(key, size);
+        Ok(())
+    }
+
+    /// The size this grant declared for a partial, which bounds what may be
+    /// written into it and what may be published from it. A partial left by
+    /// an earlier grant has no declaration here and cannot be used.
+    fn declared_size(&self, path: &[u8], partial_id: proto::PartialId) -> Result<u64> {
+        self.state
+            .lock()
+            .unwrap()
+            .reserved
+            .get(&(path.to_vec(), partial_id))
+            .copied()
+            .with_context(|| {
+                format!(
+                    "staged file {} was not declared under this grant",
+                    String::from_utf8_lossy(path)
+                )
+            })
+    }
+
+    /// Refuse to publish a staged or in-place file that is larger than the
+    /// size this grant declared for it.
+    fn check_published_length(
+        &self,
+        path: &[u8],
+        partial_id: proto::PartialId,
+        inplace: bool,
+    ) -> Result<()> {
+        let declared = self.declared_size(path, partial_id)?;
+        let staged = if inplace {
+            path.to_vec()
+        } else {
+            crate::fsops::partial_path(Path::new(OsStr::from_bytes(path)), &partial_id)?
+                .into_os_string()
+                .into_vec()
+        };
+        if let Some(metadata) = self.rooted_metadata(&staged)? {
+            if metadata.len > declared {
+                bail!(
+                    "staged file {} exceeds its declared size",
+                    String::from_utf8_lossy(path)
+                );
+            }
+        }
         Ok(())
     }
 
@@ -1428,7 +1476,11 @@ impl RestrictedAuthority {
                 *guard = Some(self.guard.clone());
             }
             Request::SeedBasis {
-                path, len, guard, ..
+                path,
+                partial_id,
+                len,
+                guard,
+                ..
             } => {
                 if self.copy.policy.publication != PublicationPolicyV1::AtomicStaged {
                     bail!("in-place signed receiver forbids staged basis creation");
@@ -1438,7 +1490,7 @@ impl RestrictedAuthority {
                 }
                 self.check_mutation_path(path, false)?;
                 self.constrain_update(path, false, None, pending)?;
-                self.reserve_bytes(path, *len)?;
+                self.reserve_bytes(path, *partial_id, *len)?;
                 *guard = Some(self.guard.clone());
             }
             Request::FinishBasis {
@@ -1464,6 +1516,7 @@ impl RestrictedAuthority {
                 path,
                 size,
                 inplace,
+                partial_id,
                 guard,
                 ..
             } => {
@@ -1475,12 +1528,13 @@ impl RestrictedAuthority {
                 }
                 self.check_mutation_path(path, false)?;
                 self.constrain_prepare(path)?;
-                self.reserve_bytes(path, *size)?;
+                self.reserve_bytes(path, *partial_id, *size)?;
                 *guard = Some(self.guard.clone());
             }
             Request::WriteRange {
                 path,
                 inplace,
+                partial_id,
                 off,
                 data,
                 guard,
@@ -1489,12 +1543,20 @@ impl RestrictedAuthority {
                 if *inplace != (self.copy.policy.publication == PublicationPolicyV1::InPlace) {
                     bail!("file write does not match the signed publication policy");
                 }
+                let declared = self.declared_size(path, *partial_id)?;
+                if off
+                    .checked_add(data.len() as u64)
+                    .is_none_or(|end| end > declared)
+                {
+                    bail!("file write extends past the size declared for it");
+                }
                 self.charge_bytes(path, *off, data.len())?;
                 *guard = Some(self.guard.clone());
             }
             Request::Finalize {
                 path,
                 inplace,
+                partial_id,
                 meta,
                 flags,
                 condition,
@@ -1505,6 +1567,7 @@ impl RestrictedAuthority {
                     bail!("file finalization does not match the signed publication policy");
                 }
                 self.check_mutation_path(path, false)?;
+                self.check_published_length(path, *partial_id, *inplace)?;
                 self.constrain_creation(path, condition, false, 0, pending)?;
                 self.constrain_receiver_mode(
                     path,
@@ -3827,6 +3890,9 @@ mod tests {
 
         // A failed no-replace publication leaves nothing behind, so a foreign
         // object that appears afterwards is retained like any other.
+        authority
+            .authorize(&mut prepare_request(&fresh), false)
+            .unwrap();
         let mut publish = finalize_request(&fresh, Any);
         let settlement = authority.authorize(&mut publish, false).unwrap();
         authority.settle(settlement, &proto::Response::Err("raced".into()));
@@ -3838,6 +3904,9 @@ mod tests {
         let mut publish = small_put(&kept);
         let settlement = authority.authorize(&mut publish, false).unwrap();
         authority.settle(settlement, &proto::Response::Applied(vec![None]));
+        authority
+            .authorize(&mut prepare_request(&kept), false)
+            .unwrap();
         let mut republish = finalize_request(&kept, Matches { dev: 1, ino: 1 });
         authority.authorize(&mut republish, false).unwrap();
 
@@ -3936,6 +4005,9 @@ mod tests {
             },
         );
         assert!(authority.authorize(&mut stale, false).is_err());
+        authority
+            .authorize(&mut prepare_request(&present), false)
+            .unwrap();
         let mut exact = finalize_request(
             &present,
             Matches {
@@ -4267,6 +4339,9 @@ mod tests {
         let mut revisit_root = apply(mkdir(&target));
         authority.authorize(&mut revisit_root, false).unwrap();
         assert_eq!(op_condition(&revisit_root), Any);
+        authority
+            .authorize(&mut prepare_request(&target.join("child")), false)
+            .unwrap();
         let mut child = finalize_request(&target.join("child"), Any);
         authority.authorize(&mut child, false).unwrap();
         assert_eq!(finalize_condition(&child), Any);
@@ -4723,6 +4798,18 @@ mod tests {
             guard: None,
         };
 
+        // Writes must land in a partial this grant declared.
+        assert!(authority.authorize(&mut request(0), false).is_err());
+        let mut prepare = Request::Prepare {
+            path: target.clone(),
+            size: 1024,
+            inplace: false,
+            partial_id: [0; 16],
+            mode: 0o600,
+            guard: None,
+        };
+        authority.authorize(&mut prepare, false).unwrap();
+
         let started = Instant::now();
         authority.authorize(&mut request(0), false).unwrap();
         authority.authorize(&mut request(256), false).unwrap();
@@ -4731,7 +4818,7 @@ mod tests {
             "signed aggregate rate limit did not pace consecutive writes"
         );
 
-        let mut oversized = request(512);
+        let mut oversized = request(0);
         if let Request::WriteRange { data, .. } = &mut oversized {
             data.resize(513, 0);
         }

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -122,6 +122,11 @@ struct AuthorityState {
     /// grant the shortcut above: a second creation of the same path races at
     /// the kernel instead of trusting an outcome that has not happened yet.
     provisional: HashSet<Vec<u8>>,
+    /// Bytes each prepared file may occupy on disk before any payload is
+    /// written: preallocation and basis seeding are charged against the
+    /// aggregate ceiling here, once per path at its largest declared size.
+    reserved: HashMap<Vec<u8>, u64>,
+    reserved_bytes: u64,
     transferred_bytes: u64,
     deletions: u64,
     live_connections: u16,
@@ -333,6 +338,8 @@ impl RestrictedAuthority {
                 receiver_modes: HashMap::new(),
                 created: HashSet::new(),
                 provisional: HashSet::new(),
+                reserved: HashMap::new(),
+                reserved_bytes: 0,
                 transferred_bytes: 0,
                 deletions: 0,
                 live_connections: 0,
@@ -464,6 +471,44 @@ impl RestrictedAuthority {
             }
         }
         under_root
+    }
+
+    /// Charge the on-disk size a prepared or seeded file will occupy against
+    /// the signed aggregate byte ceiling. A path is charged once, at the
+    /// largest size declared for it, so retries and resumes do not double
+    /// count while many distinct preparations cannot exceed the ceiling.
+    fn reserve_bytes(&self, path: &[u8], size: u64) -> Result<()> {
+        let mut state = self.state.lock().unwrap();
+        let previous = state.reserved.get(path).copied().unwrap_or(0);
+        if size <= previous {
+            return Ok(());
+        }
+        let total = state
+            .reserved_bytes
+            .checked_add(size - previous)
+            .context("signed reservation byte counter overflow")?;
+        if total > self.copy.limits.max_total_bytes {
+            bail!("signed grant total-byte limit exceeded by file preparation");
+        }
+        state.reserved_bytes = total;
+        state.reserved.insert(path.to_vec(), size);
+        Ok(())
+    }
+
+    /// Charge every entry a destination scan returns against the signed entry
+    /// ceiling, so enumeration is bounded like every other observation.
+    pub(crate) fn record_scanned<'a>(
+        &self,
+        root: &[u8],
+        entries: impl IntoIterator<Item = &'a [u8]>,
+    ) -> Result<()> {
+        for relative in entries {
+            if relative.is_empty() {
+                continue;
+            }
+            self.record_path(&crate::fsops::join(root, relative))?;
+        }
+        Ok(())
     }
 
     fn record_path(&self, path: &[u8]) -> Result<()> {
@@ -1393,6 +1438,7 @@ impl RestrictedAuthority {
                 }
                 self.check_mutation_path(path, false)?;
                 self.constrain_update(path, false, None, pending)?;
+                self.reserve_bytes(path, *len)?;
                 *guard = Some(self.guard.clone());
             }
             Request::FinishBasis {
@@ -1429,6 +1475,7 @@ impl RestrictedAuthority {
                 }
                 self.check_mutation_path(path, false)?;
                 self.constrain_prepare(path)?;
+                self.reserve_bytes(path, *size)?;
                 *guard = Some(self.guard.clone());
             }
             Request::WriteRange {
@@ -4918,6 +4965,76 @@ mod tests {
             guard: None,
         };
         assert!(authority.authorize(&mut delete, false).is_err());
+    }
+
+    #[test]
+    fn preparation_and_seeding_are_charged_against_the_byte_ceiling() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        // The helper grant allows 16 bytes in total and per file.
+        let authority = test_authority(&root, DeletionPolicyV1::Forbid, 16);
+        let prepare = |name: &str, size| Request::Prepare {
+            path: root
+                .join("target")
+                .join(name)
+                .as_os_str()
+                .as_bytes()
+                .to_vec(),
+            size,
+            inplace: false,
+            partial_id: [1; 16],
+            mode: 0o600,
+            guard: None,
+        };
+        authority.authorize(&mut prepare("a", 10), false).unwrap();
+        // A second file would take the aggregate past the ceiling.
+        assert!(authority.authorize(&mut prepare("b", 10), false).is_err());
+        // Re-preparing the same file at the same or a larger size charges only
+        // the difference; a retry never double counts.
+        authority.authorize(&mut prepare("a", 10), false).unwrap();
+        authority.authorize(&mut prepare("a", 14), false).unwrap();
+        assert!(authority.authorize(&mut prepare("b", 3), false).is_err());
+        authority.authorize(&mut prepare("b", 2), false).unwrap();
+        let mut seed = Request::SeedBasis {
+            path: root.join("target/b").as_os_str().as_bytes().to_vec(),
+            partial_id: [1; 16],
+            len: 3,
+            guard: None,
+        };
+        assert!(authority.authorize(&mut seed, false).is_err());
+    }
+
+    #[test]
+    fn scanned_entries_count_against_the_entry_ceiling() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        // The helper grant allows eight entries.
+        let authority = test_authority(&root, DeletionPolicyV1::Forbid, 1024);
+        let target = root.join("target").as_os_str().as_bytes().to_vec();
+        let mut scan = Request::Scan {
+            root: target.clone(),
+            follow_root: false,
+            ignore: Vec::new(),
+            report_ignored: false,
+            guard: None,
+        };
+        authority.authorize(&mut scan, false).unwrap();
+        let names: Vec<Vec<u8>> = (0..7)
+            .map(|index| format!("entry-{index}").into_bytes())
+            .collect();
+        let mut batch: Vec<&[u8]> = vec![b""];
+        batch.extend(names.iter().map(Vec::as_slice));
+        // Root plus seven descendants fills the ceiling exactly.
+        authority.record_scanned(&target, batch).unwrap();
+        assert!(authority
+            .record_scanned(&target, [b"entry-7".as_slice()])
+            .is_err());
+        // Already counted entries may be listed again.
+        authority
+            .record_scanned(&target, [b"entry-0".as_slice()])
+            .unwrap();
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -482,13 +482,15 @@ impl RestrictedAuthority {
     fn reserve_bytes(&self, path: &[u8], partial_id: proto::PartialId, size: u64) -> Result<()> {
         let mut state = self.state.lock().unwrap();
         let key = (path.to_vec(), partial_id);
-        let previous = state.reserved.get(&key).copied().unwrap_or(0);
-        if size <= previous {
+        // An existing declaration only grows; a new one is registered even
+        // at zero length, so an empty file can still be published.
+        let previous = state.reserved.get(&key).copied();
+        if previous.is_some_and(|previous| size <= previous) {
             return Ok(());
         }
         let total = state
             .reserved_bytes
-            .checked_add(size - previous)
+            .checked_add(size - previous.unwrap_or(0))
             .context("signed reservation byte counter overflow")?;
         if total > self.copy.limits.max_total_bytes {
             bail!("signed grant total-byte limit exceeded by file preparation");
@@ -4140,6 +4142,9 @@ mod tests {
         );
         let mut as_directory = apply(mkdir(&link));
         assert!(authority.authorize(&mut as_directory, false).is_err());
+        authority
+            .authorize(&mut prepare_request(&link), false)
+            .unwrap();
         let mut publish = finalize_request(&link, Any);
         authority.authorize(&mut publish, false).unwrap();
         assert_eq!(
@@ -5058,7 +5063,7 @@ mod tests {
     fn preparation_and_seeding_are_charged_against_the_byte_ceiling() {
         let temporary = tempfile::tempdir().unwrap();
         let root = temporary.path().join("root");
-        fs::create_dir(&root).unwrap();
+        fs::create_dir_all(root.join("target")).unwrap();
         // The helper grant allows 16 bytes in total and per file.
         let authority = test_authority(&root, DeletionPolicyV1::Forbid, 16);
         let prepare = |name: &str, size| Request::Prepare {
@@ -5090,6 +5095,44 @@ mod tests {
             guard: None,
         };
         assert!(authority.authorize(&mut seed, false).is_err());
+
+        // An empty file is declared at zero length and can be published.
+        authority
+            .authorize(&mut prepare("empty", 0), false)
+            .unwrap();
+        let mut publish_empty = Request::Finalize {
+            path: root.join("target/empty").as_os_str().as_bytes().to_vec(),
+            inplace: false,
+            partial_id: [1; 16],
+            meta: proto::Meta {
+                mode: 0o644,
+                uid: 0,
+                gid: 0,
+                mtime: 0,
+                mtime_nsec: 0,
+            },
+            flags: 0,
+            condition: proto::TargetCondition::Any,
+            guard: None,
+        };
+        authority.authorize(&mut publish_empty, false).unwrap();
+        // A file never declared under this grant cannot be published.
+        let mut publish_foreign = Request::Finalize {
+            path: root.join("target/foreign").as_os_str().as_bytes().to_vec(),
+            inplace: false,
+            partial_id: [9; 16],
+            meta: proto::Meta {
+                mode: 0o644,
+                uid: 0,
+                gid: 0,
+                mtime: 0,
+                mtime_nsec: 0,
+            },
+            flags: 0,
+            condition: proto::TargetCondition::Any,
+            guard: None,
+        };
+        assert!(authority.authorize(&mut publish_foreign, false).is_err());
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -468,11 +468,15 @@ impl RestrictedAuthority {
 
     fn record_path(&self, path: &[u8]) -> Result<()> {
         let mut state = self.state.lock().unwrap();
-        if state.paths.insert(path.to_vec())
-            && state.paths.len() as u64 > self.copy.limits.max_entries
-        {
+        if state.paths.contains(path) {
+            return Ok(());
+        }
+        // Check before inserting: a path rejected at the ceiling must not be
+        // remembered, or resubmitting it would pass as already counted.
+        if state.paths.len() as u64 >= self.copy.limits.max_entries {
             bail!("signed grant entry limit exceeded");
         }
+        state.paths.insert(path.to_vec());
         Ok(())
     }
 
@@ -2414,6 +2418,36 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
             "deletion through the command-restricted receiver needs an explicit --max-delete ceiling"
         );
     }
+    // Range-check every ceiling here, before automatic enrollment can touch
+    // hostB, rather than leaving it to grant validation after the fact.
+    if let Some(runtime) = args.max_runtime_secs {
+        if runtime > DEFAULT_RUNTIME_SECONDS {
+            bail!(
+                "--max-runtime exceeds the {}-hour signed grant ceiling",
+                DEFAULT_RUNTIME_SECONDS / 3600
+            );
+        }
+    }
+    if args
+        .max_entries
+        .is_some_and(|entries| entries == 0 || entries > delegation::MAX_ENTRIES)
+    {
+        bail!(
+            "--max-entries must be between 1 and {}",
+            delegation::MAX_ENTRIES
+        );
+    }
+    if args
+        .max_total_bytes
+        .is_some_and(|bytes| bytes == 0 || bytes > delegation::MAX_COPY_BYTES)
+    {
+        bail!("--max-total-bytes must be at least 1 byte");
+    }
+    if let Some(maximum) = args.max_size.as_deref() {
+        if crate::cli::parse_size(maximum)? == 0 {
+            bail!("--max-size must be at least 1 byte on the command-restricted path");
+        }
+    }
     if !args.files_from_lines.is_empty()
         || args.files_from.is_some()
         || args.native_mapping.is_some()
@@ -2460,7 +2494,12 @@ fn grant_for(
     validate_restricted_args(args)?;
     let issued_at = now()?;
     let read_only = args.dry_run || args.verify_only;
-    let deletion = if !read_only && (args.delete || args.interface == Interface::NativeCpPrune) {
+    // `--max-delete 0` means nothing may be deleted, which the grant states
+    // directly as a forbidding policy rather than a zero budget.
+    let deletion = if !read_only
+        && (args.delete || args.interface == Interface::NativeCpPrune)
+        && args.max_delete != Some(0)
+    {
         DeletionPolicyV1::DeleteDestinationOnly
     } else {
         DeletionPolicyV1::Forbid
@@ -2488,20 +2527,12 @@ fn grant_for(
                 .context("signed grant expiration overflow")?,
             DEFAULT_RUNTIME_SECONDS,
         ),
-        Some(runtime) => {
-            if runtime > DEFAULT_RUNTIME_SECONDS {
-                bail!(
-                    "--max-runtime exceeds the {}-hour signed grant ceiling",
-                    DEFAULT_RUNTIME_SECONDS / 3600
-                );
-            }
-            (
-                issued_at
-                    .checked_add(i64::from(runtime))
-                    .context("signed grant expiration overflow")?,
-                runtime,
-            )
-        }
+        Some(runtime) => (
+            issued_at
+                .checked_add(i64::from(runtime))
+                .context("signed grant expiration overflow")?,
+            runtime,
+        ),
     };
     let copies_contents = sources.iter().any(Location::copies_contents);
     let placement = match args.placement {
@@ -4814,6 +4845,85 @@ mod tests {
             guard: None,
         };
         authority.authorize(&mut observe_container, false).unwrap();
+    }
+
+    #[test]
+    fn entry_ceiling_survives_resubmission_of_a_rejected_path() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        // The helper grant allows eight entries.
+        let authority = test_authority(&root, DeletionPolicyV1::Forbid, 1024);
+        let stat = |name: String| Request::StatMany {
+            paths: vec![root
+                .join("target")
+                .join(name)
+                .as_os_str()
+                .as_bytes()
+                .to_vec()],
+            follow: false,
+            guard: None,
+        };
+        for index in 0..8 {
+            authority
+                .authorize(&mut stat(format!("entry-{index}")), false)
+                .unwrap();
+        }
+        assert!(authority
+            .authorize(&mut stat("entry-8".into()), false)
+            .is_err());
+        // Resubmitting the rejected path must not slip through as counted.
+        assert!(authority
+            .authorize(&mut stat("entry-8".into()), false)
+            .is_err());
+        // Paths already inside the ceiling remain usable.
+        authority
+            .authorize(&mut stat("entry-0".into()), false)
+            .unwrap();
+    }
+
+    #[test]
+    fn ceiling_ranges_are_checked_before_any_enrollment_side_effect() {
+        let parse = |options: &[&str]| {
+            let mut argv = vec!["syq rsync", "-r"];
+            argv.extend_from_slice(options);
+            argv.extend_from_slice(&["host-a:source", "host-b:/backup"]);
+            let mut args = Args::try_parse_from(argv).unwrap();
+            args.normalize();
+            args
+        };
+        // validate_restricted_args runs first in prepare_transfer, before
+        // the enrollment lookup or installation.
+        let mut args = parse(&[]);
+        validate_restricted_args(&args).unwrap();
+        args.max_runtime_secs = Some(DEFAULT_RUNTIME_SECONDS + 1);
+        assert!(validate_restricted_args(&args).is_err());
+        let mut args = parse(&[]);
+        args.max_entries = Some(0);
+        assert!(validate_restricted_args(&args).is_err());
+        args.max_entries = Some(delegation::MAX_ENTRIES + 1);
+        assert!(validate_restricted_args(&args).is_err());
+        let mut args = parse(&[]);
+        args.max_total_bytes = Some(0);
+        assert!(validate_restricted_args(&args).is_err());
+        assert!(validate_restricted_args(&parse(&["--max-size", "0"])).is_err());
+        assert!(validate_restricted_args(&parse(&["--delete"])).is_err());
+        validate_restricted_args(&parse(&["--delete", "--max-delete", "0"])).unwrap();
+
+        // A zero deletion budget signs a grant that forbids deletion outright.
+        let id = EnrollmentId::random();
+        let source = Location::parse("host-a:source").unwrap();
+        let grant = grant_for(
+            &parse(&["--delete", "--max-delete", "0"]),
+            std::slice::from_ref(&source),
+            id,
+            "backup",
+            "/backup",
+        )
+        .unwrap();
+        let GrantOperationV1::Copy(copy) = &grant.operation;
+        assert_eq!(copy.policy.deletion, DeletionPolicyV1::Forbid);
+        assert_eq!(copy.limits.max_deletions, 0);
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -2402,6 +2402,18 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
             "--inplace cannot be combined with --ignore-existing, --existing, or --as-new on the command-restricted path: in-place writes open the final pathname directly, so the receiver can neither make them no-replace nor pin them to an observed object"
         );
     }
+    if !args.dry_run
+        && !args.verify_only
+        && (args.delete || args.interface == Interface::NativeCpPrune)
+        && args.max_delete.is_none()
+    {
+        // The signed deletion count is the only bound on what a compromised
+        // hostA can remove inside the scope, so make it an explicit choice
+        // instead of a silent hundred-million default.
+        bail!(
+            "deletion through the command-restricted receiver needs an explicit --max-delete ceiling"
+        );
+    }
     if !args.files_from_lines.is_empty()
         || args.files_from.is_some()
         || args.native_mapping.is_some()
@@ -2453,9 +2465,43 @@ fn grant_for(
     } else {
         DeletionPolicyV1::Forbid
     };
+    let max_entries = args.max_entries.unwrap_or(DEFAULT_MAX_ENTRIES);
+    let max_total_bytes = args.max_total_bytes.unwrap_or(DEFAULT_MAX_BYTES);
+    let max_file_bytes = args
+        .max_size
+        .as_deref()
+        .map(crate::cli::parse_size)
+        .transpose()?
+        .unwrap_or(DEFAULT_MAX_BYTES)
+        .min(max_total_bytes);
     let max_deletions = match deletion {
         DeletionPolicyV1::Forbid => 0,
-        DeletionPolicyV1::DeleteDestinationOnly => args.max_delete.unwrap_or(DEFAULT_MAX_ENTRIES),
+        DeletionPolicyV1::DeleteDestinationOnly => args
+            .max_delete
+            .context("deletion through the command-restricted receiver needs --max-delete")?
+            .min(max_entries),
+    };
+    let (not_after, max_runtime_seconds) = match args.max_runtime_secs {
+        None => (
+            issued_at
+                .checked_add(GRANT_VALIDITY_SECONDS - CLOCK_SKEW_SECONDS)
+                .context("signed grant expiration overflow")?,
+            DEFAULT_RUNTIME_SECONDS,
+        ),
+        Some(runtime) => {
+            if runtime > DEFAULT_RUNTIME_SECONDS {
+                bail!(
+                    "--max-runtime exceeds the {}-hour signed grant ceiling",
+                    DEFAULT_RUNTIME_SECONDS / 3600
+                );
+            }
+            (
+                issued_at
+                    .checked_add(i64::from(runtime))
+                    .context("signed grant expiration overflow")?,
+                runtime,
+            )
+        }
     };
     let copies_contents = sources.iter().any(Location::copies_contents);
     let placement = match args.placement {
@@ -2514,9 +2560,7 @@ fn grant_for(
         request_id: RequestId::random()?,
         issued_at,
         not_before: issued_at.saturating_sub(CLOCK_SKEW_SECONDS),
-        not_after: issued_at
-            .checked_add(GRANT_VALIDITY_SECONDS - CLOCK_SKEW_SECONDS)
-            .context("signed grant expiration overflow")?,
+        not_after,
         operation: GrantOperationV1::Copy(CopyOperationV1 {
             destination: destination_bytes,
             mutation_scopes,
@@ -2547,15 +2591,9 @@ fn grant_for(
                 tcp_port_hi,
             },
             limits: CopyLimitsV1 {
-                max_entries: DEFAULT_MAX_ENTRIES,
-                max_total_bytes: DEFAULT_MAX_BYTES,
-                max_file_bytes: args
-                    .max_size
-                    .as_deref()
-                    .map(crate::cli::parse_size)
-                    .transpose()?
-                    .unwrap_or(DEFAULT_MAX_BYTES)
-                    .min(DEFAULT_MAX_BYTES),
+                max_entries,
+                max_total_bytes,
+                max_file_bytes,
                 hash_block_bytes: crate::cli::parse_size(&args.block_size)?
                     .clamp(proto::MIN_HASH_BLOCK_BYTES, proto::MAX_HASH_BLOCK_BYTES),
                 max_connections: u16::try_from(if args.connections_opt.is_some() {
@@ -2565,7 +2603,7 @@ fn grant_for(
                 })
                 .context("connection maximum exceeds grant representation")?,
                 max_deletions,
-                max_runtime_seconds: DEFAULT_RUNTIME_SECONDS,
+                max_runtime_seconds,
             },
         }),
     };
@@ -4776,6 +4814,109 @@ mod tests {
             guard: None,
         };
         authority.authorize(&mut observe_container, false).unwrap();
+    }
+
+    #[test]
+    fn explicit_ceilings_are_signed_and_deletion_needs_a_stated_budget() {
+        let id = EnrollmentId::random();
+        let source = Location::parse("host-a:source").unwrap();
+        let parse = |options: &[&str]| {
+            let mut argv = vec!["syq rsync", "-r"];
+            argv.extend_from_slice(options);
+            argv.extend_from_slice(&["host-a:source", "host-b:/backup"]);
+            let mut args = Args::try_parse_from(argv).unwrap();
+            args.normalize();
+            args
+        };
+
+        // Defaults are the wide built-in ceilings and the 24-hour validity.
+        let default_args = parse(&[]);
+        let default_grant = grant_for(
+            &default_args,
+            std::slice::from_ref(&source),
+            id,
+            "backup",
+            "/backup",
+        )
+        .unwrap();
+        let GrantOperationV1::Copy(default_copy) = &default_grant.operation;
+        assert_eq!(default_copy.limits.max_entries, DEFAULT_MAX_ENTRIES);
+        assert_eq!(default_copy.limits.max_total_bytes, DEFAULT_MAX_BYTES);
+        assert_eq!(default_copy.limits.max_file_bytes, DEFAULT_MAX_BYTES);
+        assert_eq!(
+            default_copy.limits.max_runtime_seconds,
+            DEFAULT_RUNTIME_SECONDS
+        );
+        assert_eq!(
+            default_grant.not_after - default_grant.not_before,
+            GRANT_VALIDITY_SECONDS
+        );
+
+        // Explicit ceilings land in the signed limits; the per-file bound
+        // never exceeds the total, and the validity shrinks to the runtime.
+        let mut ceilings = parse(&["--max-size", "3M"]);
+        ceilings.max_entries = Some(12);
+        ceilings.max_total_bytes = Some(2 << 20);
+        ceilings.max_runtime_secs = Some(1800);
+        let grant = grant_for(
+            &ceilings,
+            std::slice::from_ref(&source),
+            id,
+            "backup",
+            "/backup",
+        )
+        .unwrap();
+        let GrantOperationV1::Copy(copy) = &grant.operation;
+        assert_eq!(copy.limits.max_entries, 12);
+        assert_eq!(copy.limits.max_total_bytes, 2 << 20);
+        assert_eq!(copy.limits.max_file_bytes, 2 << 20);
+        assert_eq!(copy.limits.max_runtime_seconds, 1800);
+        assert_eq!(grant.not_after - grant.issued_at, 1800);
+        assert_eq!(grant.issued_at - grant.not_before, CLOCK_SKEW_SECONDS);
+
+        let mut too_long = parse(&[]);
+        too_long.max_runtime_secs = Some(DEFAULT_RUNTIME_SECONDS + 1);
+        assert!(grant_for(
+            &too_long,
+            std::slice::from_ref(&source),
+            id,
+            "backup",
+            "/backup"
+        )
+        .is_err());
+
+        // Deletion authority must be stated; it is then capped by the entry
+        // ceiling so the grant stays self-consistent.
+        let unbounded = parse(&["--delete"]);
+        assert!(grant_for(
+            &unbounded,
+            std::slice::from_ref(&source),
+            id,
+            "backup",
+            "/backup"
+        )
+        .is_err());
+        let mut bounded = parse(&["--delete", "--max-delete", "40"]);
+        bounded.max_entries = Some(30);
+        let grant = grant_for(
+            &bounded,
+            std::slice::from_ref(&source),
+            id,
+            "backup",
+            "/backup",
+        )
+        .unwrap();
+        let GrantOperationV1::Copy(copy) = &grant.operation;
+        assert_eq!(
+            copy.policy.deletion,
+            DeletionPolicyV1::DeleteDestinationOnly
+        );
+        assert_eq!(copy.limits.max_deletions, 30);
+        // A read-only run plans no deletion, so it needs no budget.
+        let preview = parse(&["--delete", "--dry-run"]);
+        let grant = grant_for(&preview, &[source], id, "backup", "/backup").unwrap();
+        let GrantOperationV1::Copy(copy) = &grant.operation;
+        assert_eq!(copy.policy.deletion, DeletionPolicyV1::Forbid);
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -294,8 +294,13 @@ fn serve<R: Read + Send + 'static, W: Write>(
                     }
                     Ok(w.write_msg(&Response::ScanBatch(batch))?)
                 };
-                let mut ignored =
-                    |paths| Ok(wref.borrow_mut().write_msg(&Response::ScanIgnored(paths))?);
+                let mut ignored = |paths: Vec<crate::proto::PathBytes>| {
+                    if let Some(authority) = &authority {
+                        authority
+                            .record_scanned(&requested_root, paths.iter().map(Vec::as_slice))?;
+                    }
+                    Ok(wref.borrow_mut().write_msg(&Response::ScanIgnored(paths))?)
+                };
                 let res = if let Some(guard) = guard {
                     crate::scan::scan_rooted(
                         &root,

--- a/src/server.rs
+++ b/src/server.rs
@@ -269,6 +269,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 report_ignored,
                 guard,
             } => {
+                let requested_root = root.clone();
                 let root = match ops.scan_root(&root) {
                     Ok(root) => root,
                     Err(error) => {
@@ -280,7 +281,13 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 // writer borrow suffices.
                 let warns = std::cell::RefCell::new(Vec::new());
                 let wref = std::cell::RefCell::new(&mut w);
-                let mut sink = |batch| {
+                let mut sink = |batch: Vec<crate::proto::Entry>| {
+                    if let Some(authority) = &authority {
+                        authority.record_scanned(
+                            &requested_root,
+                            batch.iter().map(|entry| entry.path.as_slice()),
+                        )?;
+                    }
                     let mut w = wref.borrow_mut();
                     for m in warns.borrow_mut().drain(..) {
                         w.write_msg(&Response::ScanWarn(m))?;

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -717,6 +717,56 @@ fn native_cp_prune_removes_only_target_extras_after_copy() {
 }
 
 #[test]
+fn native_receiver_ceilings_apply_only_to_direct_remote_copies() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"data");
+    for option in [
+        "--max-entries=5",
+        "--max-total-bytes=1M",
+        "--max-runtime=30m",
+    ] {
+        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "cp",
+                option,
+                "--src-src",
+                &t.s("src"),
+                "--into",
+                &t.s("dst"),
+            ])
+            .run()
+            .unwrap();
+        assert!(!out.status.success(), "{option}");
+        assert!(
+            String::from_utf8_lossy(&out.stderr)
+                .contains("apply only to direct remote-to-remote copies"),
+            "{option}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(!t.path("dst").exists(), "{option} copied anyway");
+    }
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--max-runtime=0m",
+            "--src-src",
+            &t.s("src"),
+            "--to",
+            "hostb",
+            "--into",
+            "/dst",
+        ])
+        .run()
+        .unwrap();
+    assert!(!out.status.success());
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("at least one second"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
 fn native_rejects_transport_configuration() {
     for option in ["--rsh", "--syq-path", "--no-tcp", "--relay"] {
         let out = Command::new(env!("CARGO_BIN_EXE_syq"))


### PR DESCRIPTION
Stacked on #97 (`receiver-existence-policies`); merge that first, then retarget or merge this into `master`.

## Summary

- Native `cp`/`cp-prune` gain `--max-entries N`, `--max-total-bytes SIZE`, and `--max-runtime DURATION` (`s`/`m`/`h`, at most 23h). They fill the grant's existing `max_entries`, `max_total_bytes`, and `max_runtime_seconds` fields (no wire change), the per-file limit is capped by the total, and the grant validity shrinks to the runtime.
- The options are refused for any transfer that does not use the enrolled receiver (local, single-remote, `--agent-broker-only`, explicit rsh): nothing would enforce them, so they must not read as local limits. They are deliberately not added to `syq rsync`.
- Deletion through the receiver (`cp-prune`, or rsync-shaped `--delete`) now requires an explicit `--max-delete`; previously the signed deletion ceiling silently defaulted to 100 million. The budget is capped by the entry ceiling so the grant validates. Read-only runs are unaffected.
- README: native option paragraph and the remote-to-remote guarantee section updated.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (232 unit, 286 local integration, 9 update tests)
- New tests: `explicit_ceilings_are_signed_and_deletion_needs_a_stated_budget` (grant construction), `durations_take_seconds_minutes_or_hours_and_reject_zero` (parser), `native_receiver_ceilings_apply_only_to_direct_remote_copies` (CLI refusal).
- Not verified: a live two-host transfer through an enrolled receiver; the receiver-side enforcement of these limits already existed and is covered by the existing `authorize` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqM3Msd5sJYmuYjguVBB5E
