### PR TITLE
Expose native remote topology and transport controls

### DIFF
--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -284,6 +284,14 @@ the terminal aggregates, and metadata-only updates are not yet
 reported per operation. A missing terminal record means the run did
 not finish.
 
+The results writer lives with the transfer coordinator. For a direct
+remote-to-remote copy, use `--results -` to stream its NDJSON back over the
+coordinator connection. A named results file is accepted only when the
+coordinator is local, including `--run-at local`; this avoids interpreting a
+local-looking pathname on a remote host. `--results` cannot be combined with
+`--detach`, because the caller would no longer be attached for the complete
+stream and its terminal record.
+
 Failed operation records carry `src`, `dst`, and `kind`, so a retry
 manifest is one filter away:
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ target placement in separate arguments:
 syq cp project --to server --into /backup       # named object → /backup/project
 syq cp --src-src project --to server --into /app # project contents → /app
 syq cp --from server --cwd /data --src a --src b --into ./data
+syq cp --from server:2222 data --to backup:2200 --into /archive
+syq cp --from server data --to backup --run-at target --into /archive
 syq cp --src-file report --src-dir assets --into /backup
 syq cp --src-files a.txt b.txt --src-dirs images fonts --into /archive
 syq cp report --to server --as-new /reports/final
@@ -164,9 +166,13 @@ syq rm --root /srv --src-dir cache
 syq rm --cwd /srv --follow --src-dir current-release
 ```
 
-`--from [USER@]HOST` selects one source endpoint and `--to [USER@]HOST`
-selects one target endpoint; omission means local. A local path containing `:`
-stays local because native mode never guesses endpoints from path text.
+`--from [USER@]HOST[:PORT]` selects one source endpoint and `--to
+[USER@]HOST[:PORT]` selects one target endpoint; omission means local. Enclose
+an IPv6 address in brackets, for example `alice@[2001:db8::1]:2222`. The port
+override is used consistently for the SSH connection, `ssh -G` policy
+resolution, known-host lookup, automatic enrollment, and later enrollment
+reuse. A local path containing `:` stays local because native mode never
+guesses endpoints from path text.
 `--cwd DIR`/`-C DIR` changes where relative source selectors are resolved at
 the source endpoint. Copy selectors may be absolute and then ignore `--cwd`.
 Removal selectors are always relative; native `rm` rejects a leading slash and
@@ -352,11 +358,42 @@ mapping manifests define no deletion region, and the preview results schema
 does not yet represent deletions. `--max-delete` requires `--prune`; `rm`
 additionally accepts `--root` plus its endpoint-side removal semantics.
 
-Other comparison and selection controls, block and split sizing, and
-SSH/transport configuration remain available only through `syq rsync`.
-Remote-to-remote native copies always use the automatic topology and do not
-expose `--relay`; raw path bytes are relayed internally through syq's protocol
-when they cannot be represented in a direct remote shell command.
+Native `cp` and `cp-prune` expose the remote runtime and transport controls
+directly: `--rsh COMMAND`, `--syq-path PATH`, `--no-bootstrap`, `--no-tcp`,
+`--tcp-plain`, `--tcp-ports LO-HI`, and Linux `--tcp-congestion ALGO`. An
+explicit `--rsh` is the complete SSH and agent policy and bypasses automatic
+broker/receiver setup. A port in native endpoint syntax can be combined with
+the default SSH command or an explicit command whose executable is `ssh`; an
+arbitrary remote-shell wrapper must carry its own port option.
+
+For two remote endpoints, `--run-at auto` (the default) places the coordinator
+at the source when the paths can be represented in a remote command and
+otherwise relays raw path bytes locally. `--run-at source` explicitly selects
+a direct push, `--run-at target` selects a direct pull with the SSH edge
+reversed, and `--run-at local` selects a relay without exposing the rsync-only
+`--relay` spelling. Explicit source or target placement therefore requires
+UTF-8 paths. `--run-at` is rejected for copies that do not have two remote
+endpoints.
+
+The default push uses destination-bound agent authentication plus the
+command-restricted write receiver. Default pull fails closed until the
+corresponding read-restricted receiver is implemented; it never silently
+downgrades to authentication-only confinement. Pull is currently available
+with an explicit `--rsh`, `--no-forward-agent` when the target owns source
+credentials, `--agent-broker-only`, or
+`--unrestricted-agent-forwarding`. The authentication options and `--detach`
+apply only to a direct copy between distinct remote endpoints. A detached
+launch requires coordinator-owned credentials (`--no-forward-agent`) or an
+explicit remote-shell policy; the launcher reports a follow target only after
+the detached coordinator has established the transfer route and completed
+destination preflight.
+
+The one-shot command-restricted write receiver currently requires encrypted
+TCP data connections. Consequently `--no-tcp`, TCP fallback, `--tcp-plain`,
+and `--tcp-congestion` work with ordinary and explicitly managed SSH modes but
+remain fail-closed on that receiver until its authenticated worker-session
+join protocol represents them. Other comparison and selection controls, and
+block and split sizing, remain available only through `syq rsync`.
 
 ## Mappings
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,9 @@ apply only to a direct copy between distinct remote endpoints. A detached
 launch requires coordinator-owned credentials (`--no-forward-agent`) or an
 explicit remote-shell policy; the launcher reports a follow target only after
 the detached coordinator has established the transfer route and completed
-destination preflight.
+destination preflight. If that readiness deadline expires, the launcher
+terminates and verifies the complete detached process group before reporting
+failure.
 
 The one-shot command-restricted write receiver currently requires encrypted
 TCP data connections. Consequently `--no-tcp`, TCP fallback, `--tcp-plain`,
@@ -520,10 +522,10 @@ credential caching, and notably a hardware-token approval is not required for
 reuse; do not enable it where that window is unacceptable. Data connections
 are unaffected: they remain separate TCP streams (or independent ssh
 processes under `--no-tcp`), so throughput does not change. Not available
-with an explicit `-e`/`--rsh`. Direct remote-to-remote transfers refuse it —
-the orchestrator runs on the source host, where no reusable local master
-exists — so add `--relay` to keep the orchestrator and its reusable
-connections on this machine; the command-restricted path additionally
+with an explicit `-e`/`--rsh`. Explicit endpoint ports are part of the reuse
+identity. Direct remote-to-remote transfers refuse it because a remote
+coordinator has no reusable local master, so use `--relay` with `syq rsync` or
+`--run-at local` with native syntax; the command-restricted path additionally
 refuses it because its host-bound authentication is verified on each fresh
 connection.
 

--- a/README.md
+++ b/README.md
@@ -353,12 +353,18 @@ receiver, `cp` also accepts the receiver ceilings
 (`s`, `m`, or `h`; at most 23h). They are signed into the grant and enforced
 by hostB, and are refused anywhere else because nothing would enforce them.
 `cp` additionally accepts `--mapping` and `--results`
-(see [MAPPINGS.md](MAPPINGS.md)), but neither can be combined with `--prune`:
-mapping manifests define no deletion region, and the preview results schema
-does not yet represent deletions. `--max-delete` requires `--prune`; `rm`
-additionally accepts `--root` plus its endpoint-side removal semantics.
+(see [MAPPINGS.md](MAPPINGS.md)). For a direct remote-to-remote copy,
+`--results -` streams the remote coordinator's NDJSON back to the invoking
+terminal. A named results file requires `--run-at local`; direct remote
+coordinators reject it rather than creating a surprising remote file.
+`--results` is also rejected with `--detach`, because its stream would no
+longer remain attached. Neither `--mapping` nor `--results` can be combined
+with `--prune`: mapping manifests define no deletion region, and the preview
+results schema does not yet represent deletions. `--max-delete` requires
+`--prune`; `rm` additionally accepts `--root` plus its endpoint-side removal
+semantics.
 
-Native `cp` and `cp-prune` expose the remote runtime and transport controls
+Native `cp` exposes the remote runtime and transport controls
 directly: `--rsh COMMAND`, `--syq-path PATH`, `--no-bootstrap`, `--no-tcp`,
 `--tcp-plain`, `--tcp-ports LO-HI`, and Linux `--tcp-congestion ALGO`. An
 explicit `--rsh` is the complete SSH and agent policy and bypasses automatic

--- a/src/agent_broker.rs
+++ b/src/agent_broker.rs
@@ -150,8 +150,29 @@ pub fn resolve_host_policy(
     host: &str,
     load_user_certificates: bool,
 ) -> Result<HostPolicy> {
-    let inspection = inspect_ssh_configuration(ssh_program, explicit_user, host, false)?;
-    let defaults = inspect_ssh_configuration(ssh_program, explicit_user, host, true)?;
+    resolve_host_policy_at(
+        ssh_program,
+        explicit_user,
+        host,
+        None,
+        load_user_certificates,
+    )
+}
+
+/// Resolve host policy after applying an explicit endpoint port. Keeping the
+/// port in the OpenSSH query makes the actual connection, known-host lookup,
+/// broker binding, and enrollment route describe the same endpoint.
+pub fn resolve_host_policy_at(
+    ssh_program: &str,
+    explicit_user: Option<&str>,
+    host: &str,
+    explicit_port: Option<u16>,
+    load_user_certificates: bool,
+) -> Result<HostPolicy> {
+    let inspection =
+        inspect_ssh_configuration_at(ssh_program, explicit_user, host, explicit_port, false)?;
+    let defaults =
+        inspect_ssh_configuration_at(ssh_program, explicit_user, host, explicit_port, true)?;
     let defaults = KnownHostsDefaults::from_openssh(&defaults.output)?;
     let config = parse_ssh_config_with_defaults(
         &inspection.output,
@@ -196,10 +217,27 @@ struct SshConfigurationInspection {
     known_hosts_configured: KnownHostsConfigured,
 }
 
+#[cfg(test)]
 fn inspect_ssh_configuration(
     ssh_program: &str,
     explicit_user: Option<&str>,
     host: &str,
+    compiled_defaults_only: bool,
+) -> Result<SshConfigurationInspection> {
+    inspect_ssh_configuration_at(
+        ssh_program,
+        explicit_user,
+        host,
+        None,
+        compiled_defaults_only,
+    )
+}
+
+fn inspect_ssh_configuration_at(
+    ssh_program: &str,
+    explicit_user: Option<&str>,
+    host: &str,
+    explicit_port: Option<u16>,
     compiled_defaults_only: bool,
 ) -> Result<SshConfigurationInspection> {
     let mut command = Command::new(ssh_program);
@@ -209,6 +247,9 @@ fn inspect_ssh_configuration(
     }
     if let Some(user) = explicit_user {
         command.args(["-l", user]);
+    }
+    if let Some(port) = explicit_port {
+        command.args(["-p", &port.to_string()]);
     }
     command.args(["--", host]).env("LC_ALL", "C");
     let output = command
@@ -2839,6 +2880,12 @@ mod tests {
         assert_eq!(resolved.known_hosts_name, "stable-vault");
         assert_eq!(resolved.host_keys, [host_key]);
         assert!(resolved.user_certificates.is_empty());
+
+        let overridden =
+            resolve_host_policy_at(ssh.to_str().unwrap(), None, "vault", Some(2200), false)
+                .unwrap();
+        assert_eq!(overridden.port(), 2200);
+        assert_eq!(overridden.known_hosts_name, "stable-vault");
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -834,8 +834,8 @@ struct NativeCopyFields {
     #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
     mapping: Option<OsString>,
     /// Write machine-readable NDJSON operation results to FILE (`-` writes
-    /// to stdout; combine with -q). Automation schema version 0, an
-    /// unstable preview
+    /// to stdout; combine with -q). A named file requires a local coordinator.
+    /// Automation schema version 0, an unstable preview
     #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
     results: Option<OsString>,
     /// Keep the ssh control connection alive for 5 minutes after the run and

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,21 @@ pub enum SourceSelection {
     Directory,
 }
 
+/// Endpoint that owns the transfer coordinator for a native copy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum RunAt {
+    /// Preserve the existing behavior: run locally unless both endpoints are
+    /// remote, then run at the source when possible.
+    #[default]
+    Auto,
+    /// Run the coordinator at the source endpoint.
+    Source,
+    /// Run the coordinator at the target endpoint.
+    Target,
+    /// Keep the coordinator on the invoking machine.
+    Local,
+}
+
 #[derive(Parser, Debug, Clone)]
 #[command(
     name = "syq rsync",
@@ -85,6 +100,9 @@ pub struct Args {
     /// `--results` NDJSON outcome stream for native cp (`-` writes stdout).
     #[arg(skip)]
     pub native_results: Option<Vec<u8>>,
+    /// Native coordinator placement. Rsync-shaped commands retain `--relay`.
+    #[arg(skip)]
+    pub run_at: RunAt,
 
     /// Print help
     #[arg(long, action = clap::ArgAction::Help)]
@@ -546,7 +564,7 @@ fn print_root_help() {
 
 #[derive(clap::Args, Debug)]
 struct NativeSelectionArgs {
-    /// Source endpoint ([USER@]HOST); omitted means local
+    /// Source endpoint ([USER@]HOST[:PORT]); omitted means local
     #[arg(long, value_name = "ENDPOINT")]
     from: Option<String>,
     /// Resolve relative source selectors from DIR at the source endpoint
@@ -586,7 +604,7 @@ struct NativeSelectionArgs {
 
 #[derive(clap::Args, Debug)]
 struct NativeRmSelectionArgs {
-    /// Source endpoint ([USER@]HOST); omitted means local
+    /// Source endpoint ([USER@]HOST[:PORT]); omitted means local
     #[arg(long, value_name = "ENDPOINT")]
     from: Option<String>,
     /// Resolve relative selectors from DIR at the source endpoint
@@ -697,6 +715,57 @@ struct NativeCopyOperationalArgs {
     max_runtime: Option<String>,
 }
 
+#[derive(clap::Args, Debug, Default)]
+struct NativeRemoteArgs {
+    /// Choose the endpoint that runs the coordinator
+    #[arg(long, value_enum, default_value_t = RunAt::Auto)]
+    run_at: RunAt,
+    /// Remote shell command (default: ssh); the command owns SSH and agent policy when set
+    #[arg(long = "rsh", value_name = "COMMAND")]
+    rsh: Option<String>,
+    /// Use this exact syq executable on remote endpoints instead of the managed helper
+    #[arg(long, value_name = "PATH")]
+    syq_path: Option<String>,
+    /// Require syq on each remote PATH instead of installing a versioned helper
+    #[arg(long)]
+    no_bootstrap: bool,
+    /// Use TCP data connections without encryption (trusted networks only)
+    #[arg(long)]
+    tcp_plain: bool,
+    /// Send file data through SSH rather than separate TCP data connections
+    #[arg(long)]
+    no_tcp: bool,
+    /// Port range remote listeners use for TCP data connections
+    #[arg(long, default_value = "47600-47699", value_name = "LO-HI")]
+    tcp_ports: String,
+    /// Use this congestion-control algorithm for direct TCP data sockets (Linux only)
+    #[arg(
+        long,
+        value_name = "ALGO",
+        value_parser = parse_tcp_congestion,
+        conflicts_with = "no_tcp"
+    )]
+    tcp_congestion: Option<String>,
+    /// Run a remote-to-remote transfer detached at its coordinator
+    #[arg(long)]
+    detach: bool,
+    /// Give a remote coordinator no forwarded agent; it must own credentials for the peer
+    #[arg(long, conflicts_with = "rsh")]
+    no_forward_agent: bool,
+    /// Expose the complete local SSH agent to a live remote coordinator
+    #[arg(
+        long,
+        conflicts_with_all = ["rsh", "no_forward_agent", "detach"]
+    )]
+    unrestricted_agent_forwarding: bool,
+    /// Use destination-bound authentication without a command-restricted enrollment
+    #[arg(
+        long,
+        conflicts_with_all = ["rsh", "no_forward_agent", "unrestricted_agent_forwarding", "detach"]
+    )]
+    agent_broker_only: bool,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 enum NativePreserve {
     Permissions,
@@ -708,7 +777,7 @@ enum NativePreserve {
 struct NativeCopyFields {
     #[command(flatten)]
     selection: NativeSelectionArgs,
-    /// Target endpoint ([USER@]HOST); omitted means local
+    /// Target endpoint ([USER@]HOST[:PORT]); omitted means local
     #[arg(long, value_name = "ENDPOINT")]
     to: Option<String>,
     /// Put selected names inside DIR, creating it if necessary
@@ -801,6 +870,8 @@ struct NativeCopyCommand {
     copy: NativeCopyFields,
     #[command(flatten)]
     size_selection: NativeSizeSelectionArgs,
+    #[command(flatten)]
+    remote: NativeRemoteArgs,
     /// After copying, remove target-only objects in mapped directory scopes;
     /// ignored and size-excluded source paths remain protected
     #[arg(long, conflicts_with_all = ["mapping", "results"])]
@@ -848,7 +919,7 @@ fn parse_native(argv: &[OsString], interface: Interface) -> Result<Args> {
 fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     let mut full_argv = vec![OsString::from(command_label(interface))];
     full_argv.extend_from_slice(argv);
-    let (mut parsed, matches, prune, max_delete, size_selection) =
+    let (mut parsed, remote, matches, prune, max_delete, size_selection) =
         if interface == Interface::NativeMap {
             let matches = NativeMapCommand::command()
                 .try_get_matches_from(full_argv)
@@ -856,6 +927,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
             let parsed = NativeMapCommand::from_arg_matches(&matches)?;
             (
                 parsed.copy,
+                NativeRemoteArgs::default(),
                 matches,
                 false,
                 None,
@@ -868,6 +940,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
             let parsed = NativeCopyCommand::from_arg_matches(&matches)?;
             (
                 parsed.copy,
+                parsed.remote,
                 matches,
                 parsed.prune,
                 parsed.max_delete,
@@ -1073,6 +1146,9 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
         }
     }
     apply_native_copy_operational(&mut args, parsed.operational, &matches)?;
+    if interface != Interface::NativeMap {
+        apply_native_remote(&mut args, remote)?;
+    }
     if args.max_entries.is_some()
         || args.max_total_bytes.is_some()
         || args.max_runtime_secs.is_some()
@@ -1294,6 +1370,23 @@ fn apply_native_copy_operational(
     Ok(())
 }
 
+fn apply_native_remote(args: &mut Args, remote: NativeRemoteArgs) -> Result<()> {
+    args.run_at = remote.run_at;
+    args.rsh = remote.rsh;
+    args.syq_path = remote.syq_path;
+    args.no_bootstrap = remote.no_bootstrap;
+    args.tcp_plain = remote.tcp_plain;
+    args.no_tcp = remote.no_tcp;
+    crate::transfer::parse_ports(&remote.tcp_ports)?;
+    args.tcp_ports = remote.tcp_ports;
+    args.tcp_congestion = remote.tcp_congestion;
+    args.detach = remote.detach;
+    args.no_forward_agent = remote.no_forward_agent;
+    args.unrestricted_agent_forwarding = remote.unrestricted_agent_forwarding;
+    args.agent_broker_only = remote.agent_broker_only;
+    Ok(())
+}
+
 /// Direct remote-to-remote execution needs a few automatically derived engine
 /// controls on the source host. Keep them out of the native command grammar:
 /// they are carried by the internal launcher environment, so public native
@@ -1310,7 +1403,9 @@ fn apply_internal_native_direct(args: &mut Args) -> Result<()> {
     };
     args.restricted_grant = utf8("SYQ_INTERNAL_NATIVE_RESTRICTED_GRANT")?;
     args.plan_source_host = utf8("SYQ_INTERNAL_NATIVE_PLAN_SOURCE_HOST")?;
-    args.rsh = utf8("SYQ_INTERNAL_NATIVE_RSH")?;
+    if let Some(rsh) = utf8("SYQ_INTERNAL_NATIVE_RSH")? {
+        args.rsh = Some(rsh);
+    }
     if let Some(width) = utf8("SYQ_INTERNAL_NATIVE_PROGRESS_WIDTH")? {
         args.width = Some(
             width
@@ -1378,36 +1473,77 @@ pub(crate) fn native_basename(path: &[u8]) -> Option<&[u8]> {
     (!name.is_empty() && name != b"." && name != b"..").then_some(name)
 }
 
-fn parse_native_endpoint(spec: Option<&str>) -> Result<Option<(Option<String>, String)>> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeEndpoint {
+    pub(crate) user: Option<String>,
+    pub(crate) host: String,
+    pub(crate) port: Option<u16>,
+}
+
+pub(crate) fn parse_native_endpoint(spec: Option<&str>) -> Result<Option<NativeEndpoint>> {
     let Some(spec) = spec else {
         return Ok(None);
     };
-    let (user, host) = match spec.rsplit_once('@') {
-        Some((user, host)) if !user.is_empty() => (Some(user.to_string()), host),
+    let (user, authority) = match spec.rsplit_once('@') {
+        Some((user, authority)) if !user.is_empty() => (Some(user.to_string()), authority),
         Some(_) => bail!("empty user in endpoint {spec:?}"),
         None => (None, spec),
     };
-    let bracketed = host.starts_with('[') && host.ends_with(']');
-    if host.starts_with('[') != host.ends_with(']') {
-        bail!("mismatched brackets in endpoint {spec:?}");
+    if user.as_deref().is_some_and(|user| {
+        user.bytes()
+            .any(|byte| byte == 0 || byte.is_ascii_whitespace() || matches!(byte, b'/' | b'@'))
+    }) {
+        bail!("invalid user in endpoint {spec:?}");
     }
-    if host.contains(':') && !bracketed {
-        bail!(
-            "endpoint {spec:?} contains `:`; pass paths separately and write IPv6 hosts in brackets"
-        );
-    }
-    let host = if bracketed {
-        &host[1..host.len() - 1]
+    let parse_port = |value: &str| -> Result<u16> {
+        let port = value
+            .parse::<u16>()
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "invalid SSH port in endpoint {spec:?}; pass paths separately with --cwd and source/placement arguments"
+                )
+            })?;
+        if port == 0 {
+            bail!("SSH port in endpoint {spec:?} must be between 1 and 65535");
+        }
+        Ok(port)
+    };
+    let (host, port) = if let Some(bracketed) = authority.strip_prefix('[') {
+        let close = bracketed
+            .find(']')
+            .ok_or_else(|| anyhow::anyhow!("mismatched brackets in endpoint {spec:?}"))?;
+        let host = &bracketed[..close];
+        let suffix = &bracketed[close + 1..];
+        let port = if suffix.is_empty() {
+            None
+        } else if let Some(value) = suffix.strip_prefix(':') {
+            Some(parse_port(value)?)
+        } else {
+            bail!("unexpected text after bracketed host in endpoint {spec:?}");
+        };
+        (host, port)
+    } else if let Some((host, value)) = authority.rsplit_once(':') {
+        if host.contains(':') {
+            bail!("IPv6 host in endpoint {spec:?} must be enclosed in brackets");
+        }
+        (host, Some(parse_port(value)?))
     } else {
-        host
+        (authority, None)
     };
     if host.is_empty() {
         bail!("empty host in endpoint {spec:?}");
     }
-    if host.contains('/') {
-        bail!("endpoint {spec:?} contains a path; pass paths separately with --cwd and source/placement arguments");
+    if host
+        .bytes()
+        .any(|byte| byte == 0 || byte.is_ascii_whitespace() || matches!(byte, b'/' | b'[' | b']'))
+    {
+        bail!("invalid host in endpoint {spec:?}; pass paths separately with --cwd and source/placement arguments");
     }
-    Ok(Some((user, host.to_string())))
+    Ok(Some(NativeEndpoint {
+        user,
+        host: host.to_string(),
+        port,
+    }))
 }
 
 /// Read a --files-from list: one path per line (or NUL-separated with --from0),
@@ -1795,16 +1931,69 @@ mod tests {
     }
 
     #[test]
+    fn native_remote_controls_lower_to_the_shared_engine() {
+        let argv = [
+            "--run-at=target",
+            "--rsh=ssh -J jump",
+            "--syq-path=/opt/syq",
+            "--no-bootstrap",
+            "--no-tcp",
+            "--tcp-ports=49000-49010",
+            "--detach",
+            "source",
+            "--into",
+            "destination",
+        ]
+        .map(std::ffi::OsString::from);
+        let args = parse_native_copy(&argv, Interface::NativeCp).unwrap();
+        assert_eq!(args.run_at, super::RunAt::Target);
+        assert_eq!(args.rsh.as_deref(), Some("ssh -J jump"));
+        assert_eq!(args.syq_path.as_deref(), Some("/opt/syq"));
+        assert!(args.no_bootstrap);
+        assert!(args.no_tcp);
+        assert_eq!(args.tcp_ports, "49000-49010");
+        assert!(args.detach);
+    }
+
+    #[test]
     fn native_endpoints_are_separate_from_paths() {
         assert_eq!(
             parse_native_endpoint(Some("alice@example.test")).unwrap(),
-            Some((Some("alice".into()), "example.test".into()))
+            Some(super::NativeEndpoint {
+                user: Some("alice".into()),
+                host: "example.test".into(),
+                port: None,
+            })
         );
         assert_eq!(
             parse_native_endpoint(Some("[2001:db8::1]")).unwrap(),
-            Some((None, "2001:db8::1".into()))
+            Some(super::NativeEndpoint {
+                user: None,
+                host: "2001:db8::1".into(),
+                port: None,
+            })
+        );
+        assert_eq!(
+            parse_native_endpoint(Some("alice@example.test:2222")).unwrap(),
+            Some(super::NativeEndpoint {
+                user: Some("alice".into()),
+                host: "example.test".into(),
+                port: Some(2222),
+            })
+        );
+        assert_eq!(
+            parse_native_endpoint(Some("alice@[2001:db8::1]:2200")).unwrap(),
+            Some(super::NativeEndpoint {
+                user: Some("alice".into()),
+                host: "2001:db8::1".into(),
+                port: Some(2200),
+            })
         );
         assert!(parse_native_endpoint(Some("host:path")).is_err());
+        assert!(parse_native_endpoint(Some("2001:db8::1")).is_err());
+        assert!(parse_native_endpoint(Some("host:0")).is_err());
+        assert!(parse_native_endpoint(Some("host]:2222")).is_err());
+        assert!(parse_native_endpoint(Some("bad user@host")).is_err());
         assert!(parse_native_endpoint(Some("host/path")).is_err());
     }
 
@@ -1837,6 +2026,9 @@ mod tests {
 pub struct Location {
     pub user: Option<String>,
     pub host: Option<String>,
+    /// Explicit native endpoint SSH port. Rsync-shaped operands leave this to
+    /// ssh_config and therefore store no override here.
+    pub port: Option<u16>,
     /// Path as given (may be relative to the remote home).
     pub path: Vec<u8>,
     pub selection: SourceSelection,
@@ -1861,6 +2053,7 @@ impl Location {
             return Ok(Location {
                 user: None,
                 host: None,
+                port: None,
                 path: s.as_bytes().to_vec(),
                 selection: SourceSelection::Rsync,
             });
@@ -1888,25 +2081,27 @@ impl Location {
         Ok(Location {
             user,
             host: Some(host),
+            port: None,
             path,
             selection: SourceSelection::Rsync,
         })
     }
 
     fn native(
-        endpoint: Option<(Option<String>, String)>,
+        endpoint: Option<NativeEndpoint>,
         mut path: Vec<u8>,
         selection: SourceSelection,
     ) -> Location {
         while path.len() > 1 && path.ends_with(b"/") {
             path.pop();
         }
-        let (user, host) = endpoint
-            .map(|(user, host)| (user, Some(host)))
-            .unwrap_or((None, None));
+        let (user, host, port) = endpoint
+            .map(|endpoint| (endpoint.user, Some(endpoint.host), endpoint.port))
+            .unwrap_or((None, None, None));
         Location {
             user,
             host,
+            port,
             path,
             selection,
         }
@@ -1958,7 +2153,7 @@ impl Location {
     }
 
     pub fn same_host(&self, other: &Location) -> bool {
-        self.user == other.user && self.host == other.host
+        self.user == other.user && self.host == other.host && self.port == other.port
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -947,6 +947,9 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
                 parsed.size_selection,
             )
         };
+    if parsed.reuse_connection && remote.rsh.is_some() {
+        bail!("--reuse-connection cannot be used with --rsh");
+    }
     // `syq map` keeps `-C` out of selector paths so emitted `src` values stay
     // relative to it; the walk joins it back.
     let map_cwd = if interface == Interface::NativeMap {
@@ -1953,6 +1956,22 @@ mod tests {
         assert!(args.no_tcp);
         assert_eq!(args.tcp_ports, "49000-49010");
         assert!(args.detach);
+    }
+
+    #[test]
+    fn native_reuse_connection_rejects_an_explicit_remote_shell() {
+        let argv = [
+            "--reuse-connection",
+            "--rsh=ssh -J jump",
+            "source",
+            "--into",
+            "destination",
+        ]
+        .map(std::ffi::OsString::from);
+        let error = parse_native_copy(&argv, Interface::NativeCp).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("--reuse-connection cannot be used with --rsh"));
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2672,8 +2672,7 @@ mod tests {
             SshMultiplexer::persistent_in(base.clone(), Some("u"), "example", None).unwrap();
         assert_eq!(probe.path, multiplexer.path);
         let alternate_port =
-            SshMultiplexer::persistent_in(base.clone(), Some("u"), "example", Some(2222))
-                .unwrap();
+            SshMultiplexer::persistent_in(base.clone(), Some("u"), "example", Some(2222)).unwrap();
         assert_ne!(multiplexer.path, alternate_port.path);
         assert!(!multiplexer.path.exists());
         assert_eq!(

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -813,15 +813,20 @@ impl SshMultiplexer {
         })
     }
 
-    pub(crate) fn persistent(user: Option<&str>, host: &str) -> Result<Self> {
+    pub(crate) fn persistent(user: Option<&str>, host: &str, port: Option<u16>) -> Result<Self> {
         let base = std::env::var_os("XDG_RUNTIME_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(std::env::temp_dir);
         let directory = base.join(format!("syq-cm-{}", unsafe { libc::geteuid() }));
-        Self::persistent_in(directory, user, host)
+        Self::persistent_in(directory, user, host, port)
     }
 
-    fn persistent_in(directory: PathBuf, user: Option<&str>, host: &str) -> Result<Self> {
+    fn persistent_in(
+        directory: PathBuf,
+        user: Option<&str>,
+        host: &str,
+        port: Option<u16>,
+    ) -> Result<Self> {
         use std::os::unix::ffi::OsStrExt;
         use std::os::unix::fs::MetadataExt;
         use std::os::unix::io::{AsRawFd, FromRawFd};
@@ -878,6 +883,10 @@ impl SshMultiplexer {
         hasher.update(user.unwrap_or("").as_bytes());
         hasher.update(b"@");
         hasher.update(host.as_bytes());
+        if let Some(port) = port {
+            hasher.update(b":");
+            hasher.update(port.to_be_bytes());
+        }
         let digest = hasher.finalize();
         let mut name = String::from("cm-");
         for byte in &digest[..8] {
@@ -928,6 +937,7 @@ pub struct RemoteSpec {
     pub local_process: bool,
     pub user: Option<String>,
     pub host: String,
+    pub port: Option<u16>,
     pub rsh: Vec<String>,
     pub syq_path: Option<String>,
     /// Install and use the versioned helper rather than resolving `syq` on PATH.
@@ -956,6 +966,7 @@ impl RemoteSpec {
             local_process: true,
             user: None,
             host: "127.0.0.1".into(),
+            port: None,
             rsh: vec!["local".into()],
             syq_path: None,
             auto_helper: false,
@@ -972,9 +983,18 @@ impl RemoteSpec {
         if self.local_process {
             return "local receiver".into();
         }
-        match &self.user {
-            Some(u) => format!("{u}@{}", self.host),
-            None => self.host.clone(),
+        let host = if self.host.contains(':') {
+            format!("[{}]", self.host)
+        } else {
+            self.host.clone()
+        };
+        let endpoint = match &self.user {
+            Some(user) => format!("{user}@{host}"),
+            None => host,
+        };
+        match self.port {
+            Some(port) => format!("{endpoint}:{port}"),
+            None => endpoint,
         }
     }
 
@@ -1060,6 +1080,9 @@ impl RemoteSpec {
             cmd.args(["-o", CIPHERS]);
             if let Some(u) = &self.user {
                 cmd.args(["-l", u]);
+            }
+            if let Some(port) = self.port {
+                cmd.args(["-p", &port.to_string()]);
             }
             cmd.arg("--");
         } else if let Some(u) = &self.user {
@@ -1455,6 +1478,12 @@ impl RemoteSpec {
         let out = Command::new(&self.rsh[0])
             .args(&self.rsh[1..])
             .arg("-G")
+            .args(
+                self.port
+                    .map(|port| vec!["-p".to_owned(), port.to_string()])
+                    .unwrap_or_default(),
+            )
+            .arg("--")
             .arg(&self.host)
             .output()
             .ok()?;
@@ -2287,6 +2316,7 @@ mod tests {
             local_process: false,
             user: None,
             host: "remote.example".into(),
+            port: None,
             rsh: vec!["ssh".into()],
             syq_path: None,
             auto_helper: false,
@@ -2555,6 +2585,7 @@ mod tests {
             local_process: false,
             user: None,
             host: "example".to_string(),
+            port: None,
             rsh: vec!["ssh".to_string()],
             syq_path: None,
             auto_helper: false,
@@ -2590,6 +2621,7 @@ mod tests {
             local_process: false,
             user: None,
             host: "example".into(),
+            port: None,
             rsh: vec!["ssh".into()],
             syq_path: None,
             auto_helper: false,
@@ -2633,11 +2665,16 @@ mod tests {
         let base = directory.path().to_path_buf();
         // The socket name is stable per endpoint, and a dead leftover at the
         // path is cleared so a fresh master can bind.
-        let probe = SshMultiplexer::persistent_in(base.clone(), Some("u"), "example").unwrap();
+        let probe =
+            SshMultiplexer::persistent_in(base.clone(), Some("u"), "example", None).unwrap();
         std::fs::write(&probe.path, b"stale").unwrap();
         let multiplexer =
-            SshMultiplexer::persistent_in(base.clone(), Some("u"), "example").unwrap();
+            SshMultiplexer::persistent_in(base.clone(), Some("u"), "example", None).unwrap();
         assert_eq!(probe.path, multiplexer.path);
+        let alternate_port =
+            SshMultiplexer::persistent_in(base.clone(), Some("u"), "example", Some(2222))
+                .unwrap();
+        assert_ne!(multiplexer.path, alternate_port.path);
         assert!(!multiplexer.path.exists());
         assert_eq!(
             std::fs::metadata(&base).unwrap().permissions().mode() & 0o777,
@@ -2648,6 +2685,7 @@ mod tests {
             local_process: false,
             user: Some("u".into()),
             host: "example".into(),
+            port: None,
             rsh: vec!["ssh".into()],
             syq_path: None,
             auto_helper: false,
@@ -2687,7 +2725,7 @@ mod tests {
         std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o755)).unwrap();
         let attack = outer.path().join("syq-cm-attack");
         std::os::unix::fs::symlink(&victim, &attack).unwrap();
-        assert!(SshMultiplexer::persistent_in(attack, Some("u"), "example").is_err());
+        assert!(SshMultiplexer::persistent_in(attack, Some("u"), "example", None).is_err());
         // The victim's permissions were never modified through the symlink.
         assert_eq!(
             std::fs::metadata(&victim).unwrap().permissions().mode() & 0o777,

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -83,7 +83,6 @@ fn source_setup_rsh(rsh: &[String], explicit_rsh: bool) -> Vec<String> {
 fn destination_rsh(
     explicit_rsh: Option<&str>,
     same_host: bool,
-    endpoint_port: Option<u16>,
     agent_forwarding: Option<&AgentForwarding>,
     constrained_rsh: Option<&str>,
 ) -> Option<String> {
@@ -91,10 +90,7 @@ fn destination_rsh(
         return None;
     }
     if let Some(explicit) = explicit_rsh {
-        return Some(match endpoint_port {
-            Some(port) => format!("{explicit} -p {port}"),
-            None => explicit.to_owned(),
-        });
+        return Some(explicit.to_owned());
     }
     match agent_forwarding {
         // A uses the broker to authenticate to B, but B must never receive it.
@@ -105,22 +101,11 @@ fn destination_rsh(
         // agent, but does not require host-bound authentication from OpenSSH
         // versions that predate the constrained broker's 8.9 floor.
         Some(AgentForwarding::Unrestricted) => {
-            let mut command =
-                "ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no".to_owned();
-            if let Some(port) = endpoint_port {
-                command.push_str(&format!(" -p {port}"));
-            }
-            Some(command)
+            Some("ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no".to_owned())
         }
         // With no forwarded agent, preserve hostA's own IdentityAgent and
         // authentication configuration while preventing another forwarding hop.
-        Some(AgentForwarding::Disabled) | None => {
-            let mut command = "ssh -a".to_owned();
-            if let Some(port) = endpoint_port {
-                command.push_str(&format!(" -p {port}"));
-            }
-            Some(command)
-        }
+        Some(AgentForwarding::Disabled) | None => Some("ssh -a".to_owned()),
     }
 }
 
@@ -218,18 +203,18 @@ fn endpoint_arg(
     } else {
         host.to_string()
     };
-    match login_user.or(location.user.as_deref()) {
+    let endpoint = match login_user.or(location.user.as_deref()) {
         Some(user) => format!("{user}@{host}"),
         None => host,
-    }
-}
-
-fn endpoint_display(location: &Location) -> String {
-    let endpoint = endpoint_arg(location, None, None);
+    };
     match location.port {
         Some(port) => format!("{endpoint}:{port}"),
         None => endpoint,
     }
+}
+
+fn endpoint_display(location: &Location) -> String {
+    endpoint_arg(location, None, None)
 }
 
 fn native_placement_arg(args: &Args) -> Result<&'static str> {
@@ -530,7 +515,6 @@ fn run_remote(
     if let Some(remote_shell) = destination_rsh(
         args.rsh.as_deref(),
         same_host,
-        peer.port,
         default_ssh_agent_policy.as_ref(),
         constrained_rsh.as_deref(),
     ) {
@@ -671,7 +655,7 @@ fn run_remote(
         if args.dry_run {
             internal_environment.push((
                 "SYQ_INTERNAL_NATIVE_PLAN_SOURCE_HOST",
-                source_target.clone(),
+                coordinator_target.clone(),
             ));
         }
         if !args.no_progress && !args.quiet && std::io::stderr().is_terminal() {
@@ -1029,7 +1013,7 @@ mod tests {
         };
         let hardened = constrained_destination_rsh(2222, "ssh-ed25519");
         assert_eq!(
-            destination_rsh(None, false, None, Some(&constrained), Some(&hardened)),
+            destination_rsh(None, false, Some(&constrained), Some(&hardened)),
             Some(hardened.clone())
         );
         let hardened_words = shell_words::split(&hardened).unwrap();
@@ -1050,29 +1034,23 @@ mod tests {
             assert!(hardened_words.iter().any(|word| word == required));
         }
         assert_eq!(
-            destination_rsh(
-                None,
-                false,
-                None,
-                Some(&AgentForwarding::Unrestricted),
-                None
-            ),
+            destination_rsh(None, false, Some(&AgentForwarding::Unrestricted), None),
             Some("ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no".into())
         );
         assert_eq!(
-            destination_rsh(None, false, None, Some(&AgentForwarding::Disabled), None),
+            destination_rsh(None, false, Some(&AgentForwarding::Disabled), None),
             Some("ssh -a".into())
         );
         assert_eq!(
-            destination_rsh(Some("custom-rsh"), false, None, None, None),
+            destination_rsh(Some("custom-rsh"), false, None, None),
             Some("custom-rsh".into())
         );
         assert_eq!(
-            destination_rsh(Some("ssh -J jump"), false, Some(2200), None, None),
-            Some("ssh -J jump -p 2200".into())
+            destination_rsh(Some("ssh -J jump"), false, None, None),
+            Some("ssh -J jump".into())
         );
         assert_eq!(
-            destination_rsh(None, true, None, Some(&constrained), Some(&hardened)),
+            destination_rsh(None, true, Some(&constrained), Some(&hardened)),
             None
         );
     }
@@ -1102,6 +1080,14 @@ mod tests {
         assert_eq!(
             endpoint_arg(&destination, Some("backup"), Some("2001:db8::1")),
             "backup@[2001:db8::1]"
+        );
+        let destination = Location {
+            port: Some(2200),
+            ..destination
+        };
+        assert_eq!(
+            endpoint_arg(&destination, Some("backup"), Some("vault.internal")),
+            "backup@vault.internal:2200"
         );
     }
 

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -267,6 +267,15 @@ fn run_remote(
     source_operand_count: usize,
     coordinator_at_target: bool,
 ) -> Result<i32> {
+    match args.native_results.as_deref() {
+        Some(b"-") if args.detach => bail!(
+            "--results cannot be used with --detach because the remote result stream would not remain attached"
+        ),
+        Some(b"-") | None => {}
+        Some(_) => bail!(
+            "a remote transfer coordinator accepts only --results -; use --run-at local to create a named results file"
+        ),
+    }
     let rsh = parse_rsh(&args.rsh)?;
     let coordinator = if coordinator_at_target { dst } else { &srcs[0] };
     let peer = if coordinator_at_target { &srcs[0] } else { dst };
@@ -495,6 +504,13 @@ fn run_remote(
     }
     if let Some(n) = args.max_delete {
         remote.push(format!("--max-delete={n}"));
+    }
+    if args.native_results.is_some() {
+        // run_remote accepts only stdout above. The outer SSH process inherits
+        // stdout, so the NDJSON stream and its terminal record reach the
+        // original caller without assigning surprising remote path semantics.
+        remote.push("--results".into());
+        remote.push("-".into());
     }
     if args.no_bootstrap {
         remote.push("--no-bootstrap".into());

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -229,6 +229,18 @@ fn native_placement_arg(args: &Args) -> Result<&'static str> {
     })
 }
 
+fn detached_launcher_command(
+    remote_command: &str,
+    name: &str,
+    readiness_attempts: u32,
+    termination_attempts: u32,
+) -> String {
+    format!(
+        "mkdir -p \"$HOME/.syq\" && [ -x /bin/kill ] || {{ echo 'syq: detached launch requires /bin/kill for process-group cleanup' >&2; exit 1; }}; log=\"$HOME/.syq/{name}-$(date +%Y%m%d-%H%M%S)-$$.log\" && ready=\"$log.ready\" && rm -f -- \"$ready\" && {{ terminate_group() {{ /bin/kill -TERM -- \"-$pid\" 2>/dev/null || :; j=0; while /bin/kill -0 -- \"-$pid\" 2>/dev/null && [ \"$j\" -lt {termination_attempts} ]; do j=$((j + 1)); sleep 1; done; if /bin/kill -0 -- \"-$pid\" 2>/dev/null; then /bin/kill -KILL -- \"-$pid\" 2>/dev/null || :; fi; wait \"$pid\" 2>/dev/null || :; j=0; while /bin/kill -0 -- \"-$pid\" 2>/dev/null && [ \"$j\" -lt {termination_attempts} ]; do j=$((j + 1)); sleep 1; done; ! /bin/kill -0 -- \"-$pid\" 2>/dev/null; }}; SYQ_INTERNAL_DETACH_READY=\"$ready\" setsid nohup sh -c {} > \"$log\" 2>&1 < /dev/null & pid=$!; i=0; while [ \"$i\" -lt {readiness_attempts} ]; do if [ -f \"$ready\" ]; then rm -f -- \"$ready\"; echo \"$log\"; exit 0; fi; if ! kill -0 \"$pid\" 2>/dev/null; then wait \"$pid\"; status=$?; cat -- \"$log\" >&2; exit \"$status\"; fi; i=$((i + 1)); sleep 1; done; if ! terminate_group; then rm -f -- \"$ready\"; cat -- \"$log\" >&2; echo 'syq: could not terminate timed-out detached coordinator process group' >&2; exit 1; fi; rm -f -- \"$ready\"; cat -- \"$log\" >&2; echo 'syq: detached coordinator did not become ready within {readiness_attempts} seconds' >&2; exit 1; }}",
+        shell_words::quote(remote_command)
+    )
+}
+
 pub fn run(
     args: &Args,
     srcs: &[Location],
@@ -721,10 +733,7 @@ fn run_remote(
         } else {
             name
         };
-        format!(
-            "mkdir -p \"$HOME/.syq\" && log=\"$HOME/.syq/{name}-$(date +%Y%m%d-%H%M%S)-$$.log\" && ready=\"$log.ready\" && rm -f -- \"$ready\" && {{ SYQ_INTERNAL_DETACH_READY=\"$ready\" setsid nohup sh -c {} > \"$log\" 2>&1 < /dev/null & pid=$!; i=0; while [ \"$i\" -lt 30 ]; do if [ -f \"$ready\" ]; then rm -f -- \"$ready\"; echo \"$log\"; exit 0; fi; if ! kill -0 \"$pid\" 2>/dev/null; then wait \"$pid\"; status=$?; cat -- \"$log\" >&2; exit \"$status\"; fi; i=$((i + 1)); sleep 1; done; kill \"$pid\" 2>/dev/null; wait \"$pid\" 2>/dev/null; cat -- \"$log\" >&2; echo 'syq: detached coordinator did not become ready within 30 seconds' >&2; exit 1; }}",
-            shell_words::quote(&remote_cmd)
-        )
+        detached_launcher_command(&remote_cmd, &name, 30, 5)
     } else {
         remote_cmd
     };
@@ -966,6 +975,49 @@ mod tests {
         let location = parse_follow_location("[2001:db8::1]:2200:/tmp/run.log").unwrap();
         assert_eq!(location.host.as_deref(), Some("2001:db8::1"));
         assert_eq!(location.port, Some(2200));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn detached_timeout_terminates_the_complete_process_group() {
+        let directory = tempfile::tempdir().unwrap();
+        let pids = directory.path().join("pids");
+        let survived = directory.path().join("survived");
+        let remote_command = format!(
+            "trap '' TERM; (trap '' TERM; sleep 30; printf survived > {}) & child=$!; printf '%s %s\\n' \"$$\" \"$child\" > {}; wait",
+            shell_words::quote(survived.to_str().unwrap()),
+            shell_words::quote(pids.to_str().unwrap()),
+        );
+        let launcher = detached_launcher_command(&remote_command, "timeout-test", 1, 1);
+        let output = Command::new("sh")
+            .args(["-c", &launcher])
+            .env("HOME", directory.path())
+            .output()
+            .unwrap();
+
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("did not become ready within 1 seconds"),
+            "{stderr}"
+        );
+        let process_ids: Vec<i32> = std::fs::read_to_string(pids)
+            .unwrap()
+            .split_whitespace()
+            .map(|pid| pid.parse().unwrap())
+            .collect();
+        assert_eq!(process_ids.len(), 2);
+        let alive: Vec<i32> = process_ids
+            .into_iter()
+            .filter(|pid| unsafe { libc::kill(*pid, 0) == 0 })
+            .collect();
+        for pid in &alive {
+            unsafe {
+                libc::kill(*pid, libc::SIGKILL);
+            }
+        }
+        assert!(alive.is_empty(), "detached processes survived: {alive:?}");
+        assert!(!survived.exists());
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -17,6 +17,7 @@ fn direct_command(
     rsh: &[String],
     user: Option<&str>,
     host: &str,
+    port: Option<u16>,
     remote_cmd: &str,
     default_ssh_forward_agent: Option<&AgentForwarding>,
 ) -> Command {
@@ -59,6 +60,9 @@ fn direct_command(
         if let Some(user) = user {
             cmd.args(["-l", user]);
         }
+        if let Some(port) = port {
+            cmd.args(["-p", &port.to_string()]);
+        }
         cmd.arg("--");
     } else if let Some(user) = user {
         cmd.args(["-l", user]);
@@ -79,6 +83,7 @@ fn source_setup_rsh(rsh: &[String], explicit_rsh: bool) -> Vec<String> {
 fn destination_rsh(
     explicit_rsh: Option<&str>,
     same_host: bool,
+    endpoint_port: Option<u16>,
     agent_forwarding: Option<&AgentForwarding>,
     constrained_rsh: Option<&str>,
 ) -> Option<String> {
@@ -86,7 +91,10 @@ fn destination_rsh(
         return None;
     }
     if let Some(explicit) = explicit_rsh {
-        return Some(explicit.to_owned());
+        return Some(match endpoint_port {
+            Some(port) => format!("{explicit} -p {port}"),
+            None => explicit.to_owned(),
+        });
     }
     match agent_forwarding {
         // A uses the broker to authenticate to B, but B must never receive it.
@@ -97,11 +105,22 @@ fn destination_rsh(
         // agent, but does not require host-bound authentication from OpenSSH
         // versions that predate the constrained broker's 8.9 floor.
         Some(AgentForwarding::Unrestricted) => {
-            Some("ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no".into())
+            let mut command =
+                "ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no".to_owned();
+            if let Some(port) = endpoint_port {
+                command.push_str(&format!(" -p {port}"));
+            }
+            Some(command)
         }
         // With no forwarded agent, preserve hostA's own IdentityAgent and
         // authentication configuration while preventing another forwarding hop.
-        Some(AgentForwarding::Disabled) | None => Some("ssh -a".into()),
+        Some(AgentForwarding::Disabled) | None => {
+            let mut command = "ssh -a".to_owned();
+            if let Some(port) = endpoint_port {
+                command.push_str(&format!(" -p {port}"));
+            }
+            Some(command)
+        }
     }
 }
 
@@ -205,6 +224,14 @@ fn endpoint_arg(
     }
 }
 
+fn endpoint_display(location: &Location) -> String {
+    let endpoint = endpoint_arg(location, None, None);
+    match location.port {
+        Some(port) => format!("{endpoint}:{port}"),
+        None => endpoint,
+    }
+}
+
 fn native_placement_arg(args: &Args) -> Result<&'static str> {
     Ok(match (args.placement, args.target_existence) {
         (Placement::Into, Existence::Any) => "--into",
@@ -223,18 +250,52 @@ pub fn run(
     dst: &Location,
     source_operand_count: usize,
 ) -> Result<i32> {
+    run_remote(args, srcs, dst, source_operand_count, false)
+}
+
+pub fn run_at_target(
+    args: &Args,
+    srcs: &[Location],
+    dst: &Location,
+    source_operand_count: usize,
+) -> Result<i32> {
+    if args.interface == Interface::Rsync {
+        bail!("--run-at target is available only through native copy syntax");
+    }
+    if !srcs[0].same_host(dst)
+        && args.rsh.is_none()
+        && !args.no_forward_agent
+        && !args.unrestricted_agent_forwarding
+        && !args.agent_broker_only
+    {
+        bail!(
+            "--run-at target requires a read-restricted source enrollment, which is not implemented yet; use --agent-broker-only, --no-forward-agent with target-host credentials, or an explicit --rsh policy"
+        );
+    }
+    run_remote(args, srcs, dst, source_operand_count, true)
+}
+
+fn run_remote(
+    args: &Args,
+    srcs: &[Location],
+    dst: &Location,
+    source_operand_count: usize,
+    coordinator_at_target: bool,
+) -> Result<i32> {
     let rsh = parse_rsh(&args.rsh)?;
-    let src_host = srcs[0].host.clone().unwrap();
+    let coordinator = if coordinator_at_target { dst } else { &srcs[0] };
+    let peer = if coordinator_at_target { &srcs[0] } else { dst };
+    let coordinator_host = coordinator.host.clone().unwrap();
     let same_host = srcs[0].same_host(dst);
     if args.detach && args.rsh.is_none() && !same_host && !args.no_forward_agent {
         bail!(
-            "a constrained agent exists only while syq is attached; --detach requires --no-forward-agent and credentials on {src_host}, or an explicit --rsh policy"
+            "a constrained agent exists only while syq is attached; --detach requires --no-forward-agent and credentials on {coordinator_host}, or an explicit --rsh policy"
         );
     }
 
     let mut broker_guard = None;
-    let mut destination_login_user = None;
-    let mut destination_connection_host = None;
+    let mut peer_login_user = None;
+    let mut peer_connection_host = None;
     let mut constrained_rsh = None;
     let mut restricted_destination_path = None;
     let mut restricted_grant = None;
@@ -245,35 +306,37 @@ pub fn run(
     } else if args.unrestricted_agent_forwarding {
         Some(AgentForwarding::Unrestricted)
     } else {
-        let source_policy = crate::agent_broker::resolve_host_policy(
+        let coordinator_policy = crate::agent_broker::resolve_host_policy_at(
             &rsh[0],
-            srcs[0].user.as_deref(),
-            &src_host,
+            coordinator.user.as_deref(),
+            &coordinator_host,
+            coordinator.port,
             false,
         )?;
-        let destination_policy = crate::agent_broker::resolve_host_policy(
+        let peer_policy = crate::agent_broker::resolve_host_policy_at(
             &rsh[0],
-            dst.user.as_deref(),
-            dst.host.as_deref().unwrap(),
+            peer.user.as_deref(),
+            peer.host.as_deref().unwrap(),
+            peer.port,
             args.agent_broker_only,
         )?;
-        destination_login_user = Some(destination_policy.login_user.clone());
-        destination_connection_host = Some(destination_policy.connection_host().to_owned());
+        peer_login_user = Some(peer_policy.login_user.clone());
+        peer_connection_host = Some(peer_policy.connection_host().to_owned());
         constrained_rsh = Some(constrained_destination_rsh(
-            destination_policy.port(),
-            &destination_policy.host_key_algorithms(),
+            peer_policy.port(),
+            &peer_policy.host_key_algorithms(),
         ));
         // Native new/existing placement forms travel in the signed grant as the
         // root-existence precondition, so they use the receiver like any other
         // form instead of silently keeping only the constrained broker.
-        let prepared = (!args.agent_broker_only)
+        let prepared = (!coordinator_at_target && !args.agent_broker_only)
             .then(|| {
                 crate::restricted::prepare_transfer(
                     args,
                     srcs,
                     dst,
-                    &source_policy.login_user,
-                    &destination_policy.login_user,
+                    &coordinator_policy.login_user,
+                    &peer_policy.login_user,
                     automatic_enrollment_allowed(args.dry_run, args.verify_only),
                 )
             })
@@ -281,7 +344,7 @@ pub fn run(
             .context(
                 "prepare command-restricted destination enrollment; use --agent-broker-only to explicitly request authentication-only confinement",
             )?;
-        let policy = crate::agent_broker::BrokerPolicy::new(source_policy, destination_policy);
+        let policy = crate::agent_broker::BrokerPolicy::new(coordinator_policy, peer_policy);
         let limit = broker_connection_limit(args.connections_opt, args.connections)?;
         let broker = if let Some(prepared) = prepared {
             restricted_destination_path = Some(prepared.canonical_destination);
@@ -318,14 +381,13 @@ pub fn run(
         );
     }
     // The follow target must reconnect the way we did: keep an explicit user.
-    let src_target = match &srcs[0].user {
-        Some(user) => format!("{user}@{src_host}"),
-        None => src_host.clone(),
-    };
+    let coordinator_target = endpoint_display(coordinator);
+    let source_target = endpoint_display(&srcs[0]);
     let spec = crate::conn::RemoteSpec {
         local_process: false,
-        user: srcs[0].user.clone(),
-        host: src_host.clone(),
+        user: coordinator.user.clone(),
+        host: coordinator_host.clone(),
+        port: coordinator.port,
         rsh: source_setup_rsh(&rsh, args.rsh.is_some()),
         syq_path: args.syq_path.clone(),
         auto_helper: args.syq_path.is_none() && !args.no_bootstrap,
@@ -449,42 +511,47 @@ pub fn run(
     if let Some(n) = args.max_delete {
         remote.push(format!("--max-delete={n}"));
     }
+    if args.no_bootstrap {
+        remote.push("--no-bootstrap".into());
+    }
+    if args.no_tcp {
+        remote.push("--no-tcp".into());
+    }
+    if args.tcp_plain {
+        remote.push("--tcp-plain".into());
+    }
+    if let Some(algorithm) = &args.tcp_congestion {
+        remote.push(format!("--tcp-congestion={algorithm}"));
+    }
+    remote.push(format!("--tcp-ports={}", args.tcp_ports));
+    if let Some(path) = &args.syq_path {
+        remote.push(format!("--syq-path={path}"));
+    }
+    if let Some(remote_shell) = destination_rsh(
+        args.rsh.as_deref(),
+        same_host,
+        peer.port,
+        default_ssh_agent_policy.as_ref(),
+        constrained_rsh.as_deref(),
+    ) {
+        remote.push(if args.interface == Interface::Rsync {
+            "-e".into()
+        } else {
+            "--rsh".into()
+        });
+        remote.push(remote_shell);
+    }
     if args.interface == Interface::Rsync {
-        if args.no_bootstrap {
-            remote.push("--no-bootstrap".into());
-        }
-        if args.no_tcp {
-            remote.push("--no-tcp".into());
-        }
-        if args.tcp_plain {
-            remote.push("--tcp-plain".into());
-        }
         if let Some(grant) = &restricted_grant {
             remote.push(format!("--restricted-grant={grant}"));
         }
-        if let Some(algorithm) = &args.tcp_congestion {
-            remote.push(format!("--tcp-congestion={algorithm}"));
-        }
-        remote.push(format!("--tcp-ports={}", args.tcp_ports));
         if args.dry_run {
-            remote.push(format!("--plan-source-host={src_target}"));
+            remote.push(format!("--plan-source-host={source_target}"));
         }
         remote.push(format!(
             "--direct-source-operand-count={source_operand_count}"
         ));
         remote.push("--direct-sources-prededuplicated".into());
-        if let Some(p) = &args.syq_path {
-            remote.push(format!("--syq-path={p}"));
-        }
-        if let Some(e) = destination_rsh(
-            args.rsh.as_deref(),
-            same_host,
-            default_ssh_agent_policy.as_ref(),
-            constrained_rsh.as_deref(),
-        ) {
-            remote.push("-e".into());
-            remote.push(e);
-        }
     }
     if args.progress_json && !args.quiet {
         remote.push("--progress-json".into());
@@ -520,7 +587,7 @@ pub fn run(
                 format!("./{dst_path}")
             }
         } else {
-            let host = destination_connection_host
+            let host = peer_connection_host
                 .as_deref()
                 .unwrap_or_else(|| dst.host.as_deref().unwrap());
             let host = if host.contains(':') {
@@ -528,13 +595,21 @@ pub fn run(
             } else {
                 host.to_owned()
             };
-            match destination_login_user.as_deref().or(dst.user.as_deref()) {
+            match peer_login_user.as_deref().or(dst.user.as_deref()) {
                 Some(user) => format!("{user}@{host}:{dst_path}"),
                 None => format!("{host}:{dst_path}"),
             }
         };
         remote.push(dst_arg);
     } else {
+        if coordinator_at_target && !same_host {
+            remote.push("--from".into());
+            remote.push(endpoint_arg(
+                &srcs[0],
+                peer_login_user.as_deref(),
+                peer_connection_host.as_deref(),
+            ));
+        }
         for source in srcs {
             remote.push(
                 match source.selection {
@@ -549,12 +624,12 @@ pub fn run(
             );
             remote.push(utf8_path(&source.path, "source path", args.interface)?);
         }
-        if !srcs[0].same_host(dst) {
+        if !coordinator_at_target && !srcs[0].same_host(dst) {
             remote.push("--to".into());
             remote.push(endpoint_arg(
                 dst,
-                destination_login_user.as_deref(),
-                destination_connection_host.as_deref(),
+                peer_login_user.as_deref(),
+                peer_connection_host.as_deref(),
             ));
         }
         remote.push(native_placement_arg(args)?.into());
@@ -567,7 +642,12 @@ pub fn run(
 
     if args.detach {
         // Detached: log JSON progress instead of a live display.
-        remote.retain(|a| a != "--progress" && !a.starts_with("--width="));
+        remote.retain(|a| {
+            a != "--progress"
+                && a != "--no-progress"
+                && a != "--progress-json"
+                && !a.starts_with("--width=")
+        });
         remote.insert(1, "--no-progress".into());
         remote.insert(1, "--progress-json".into());
         remote.insert(1, "-v".into());
@@ -589,15 +669,10 @@ pub fn run(
             internal_environment.push(("SYQ_INTERNAL_NATIVE_RESTRICTED_GRANT", grant.clone()));
         }
         if args.dry_run {
-            internal_environment.push(("SYQ_INTERNAL_NATIVE_PLAN_SOURCE_HOST", src_target.clone()));
-        }
-        if let Some(rsh) = destination_rsh(
-            args.rsh.as_deref(),
-            same_host,
-            default_ssh_agent_policy.as_ref(),
-            constrained_rsh.as_deref(),
-        ) {
-            internal_environment.push(("SYQ_INTERNAL_NATIVE_RSH", rsh));
+            internal_environment.push((
+                "SYQ_INTERNAL_NATIVE_PLAN_SOURCE_HOST",
+                source_target.clone(),
+            ));
         }
         if !args.no_progress && !args.quiet && std::io::stderr().is_terminal() {
             internal_environment.push((
@@ -647,7 +722,7 @@ pub fn run(
             name
         };
         format!(
-            "mkdir -p \"$HOME/.syq\" && log=\"$HOME/.syq/{name}-$(date +%Y%m%d-%H%M%S).log\" && (setsid nohup sh -c {} > \"$log\" 2>&1 < /dev/null &) && echo \"$log\"",
+            "mkdir -p \"$HOME/.syq\" && log=\"$HOME/.syq/{name}-$(date +%Y%m%d-%H%M%S)-$$.log\" && ready=\"$log.ready\" && rm -f -- \"$ready\" && {{ SYQ_INTERNAL_DETACH_READY=\"$ready\" setsid nohup sh -c {} > \"$log\" 2>&1 < /dev/null & pid=$!; i=0; while [ \"$i\" -lt 30 ]; do if [ -f \"$ready\" ]; then rm -f -- \"$ready\"; echo \"$log\"; exit 0; fi; if ! kill -0 \"$pid\" 2>/dev/null; then wait \"$pid\"; status=$?; cat -- \"$log\" >&2; exit \"$status\"; fi; i=$((i + 1)); sleep 1; done; kill \"$pid\" 2>/dev/null; wait \"$pid\" 2>/dev/null; cat -- \"$log\" >&2; echo 'syq: detached coordinator did not become ready within 30 seconds' >&2; exit 1; }}",
             shell_words::quote(&remote_cmd)
         )
     } else {
@@ -657,15 +732,16 @@ pub fn run(
     let make_command = || {
         direct_command(
             &rsh,
-            srcs[0].user.as_deref(),
-            &src_host,
+            coordinator.user.as_deref(),
+            &coordinator_host,
+            coordinator.port,
             &remote_cmd,
             default_ssh_agent_policy.as_ref(),
         )
     };
     if args.unrestricted_agent_forwarding {
         eprintln!(
-            "syq: warning: --unrestricted-agent-forwarding exposes every capability in your SSH agent to {src_host} for this transfer"
+            "syq: warning: --unrestricted-agent-forwarding exposes every capability in your SSH agent to {coordinator_host} for this transfer"
         );
     }
     if args.detach {
@@ -683,23 +759,30 @@ pub fn run(
         }
         let log = String::from_utf8_lossy(&out.stdout).trim().to_string();
         if !out.status.success() || log.is_empty() {
-            bail!("could not start detached transfer on {src_host}");
+            bail!("could not start detached transfer on {coordinator_host}");
         }
         // The handoff is the command's result, not chatter: -q trims it to
         // the bare follow target rather than suppressing it.
         if args.quiet {
-            println!("{src_target}:{log}");
+            println!("{coordinator_target}:{log}");
         } else {
-            println!("syq: started on {src_target}, log {log}");
-            println!("syq: follow with:  syq rsync --follow {src_target}:{log}");
+            println!("syq: started on {coordinator_target}, log {log}");
+            let remote_shell = args
+                .rsh
+                .as_deref()
+                .map(|rsh| format!(" -e {}", shell_words::quote(rsh)))
+                .unwrap_or_default();
+            println!(
+                "syq: follow with:  syq rsync{remote_shell} --follow {coordinator_target}:{log}"
+            );
         }
         return Ok(0);
     }
     if !args.quiet {
         if args.interface == Interface::Rsync {
-            eprintln!("syq: remote-to-remote: running on {src_host} (use --relay to route data through this machine)");
+            eprintln!("syq: remote-to-remote: running on {coordinator_host} (use --relay to route data through this machine)");
         } else {
-            eprintln!("syq: remote-to-remote: running on {src_host}");
+            eprintln!("syq: remote-to-remote: running on {coordinator_host}");
         }
     }
     let run = || {
@@ -736,16 +819,16 @@ pub fn run(
                 && !same_host
             {
                 if args.interface == Interface::Rsync {
-                    bail!("remote-to-remote transfer on {src_host} failed (exit {c}); constrained authentication permits only {}@{} and requires OpenSSH session-bind/host-bound authentication. Retry with --relay, use --no-forward-agent with source-host credentials, or explicitly accept full agent exposure with --unrestricted-agent-forwarding", destination_login_user.as_deref().unwrap_or("the destination user"), dst.host.as_deref().unwrap_or("the destination"))
+                    bail!("remote-to-remote transfer on {coordinator_host} failed (exit {c}); constrained authentication permits only {}@{} and requires OpenSSH session-bind/host-bound authentication. Retry with --relay, use --no-forward-agent with coordinator-host credentials, or explicitly accept full agent exposure with --unrestricted-agent-forwarding", peer_login_user.as_deref().unwrap_or("the peer user"), peer.host.as_deref().unwrap_or("the peer"))
                 }
-                bail!("remote-to-remote transfer on {src_host} failed (exit {c}); constrained authentication permits only {}@{} and requires OpenSSH session-bind/host-bound authentication. Use --no-forward-agent with source-host credentials, or explicitly accept full agent exposure with --unrestricted-agent-forwarding", destination_login_user.as_deref().unwrap_or("the destination user"), dst.host.as_deref().unwrap_or("the destination"))
+                bail!("remote-to-remote transfer on {coordinator_host} failed (exit {c}); constrained authentication permits only {}@{} and requires OpenSSH session-bind/host-bound authentication. Use --no-forward-agent with coordinator-host credentials, or explicitly accept full agent exposure with --unrestricted-agent-forwarding", peer_login_user.as_deref().unwrap_or("the peer user"), peer.host.as_deref().unwrap_or("the peer"))
             }
             if args.interface == Interface::Rsync {
-                bail!("remote-to-remote transfer on {src_host} failed (exit {c}); if {src_host} cannot reach the destination, retry with --relay")
+                bail!("remote-to-remote transfer on {coordinator_host} failed (exit {c}); if {coordinator_host} cannot reach the destination, retry with --relay")
             }
-            bail!("remote-to-remote transfer on {src_host} failed (exit {c}); {src_host} may not be able to reach the destination")
+            bail!("remote-to-remote transfer on {coordinator_host} failed (exit {c}); {coordinator_host} may not be able to reach the peer endpoint")
         }
-        None => bail!("remote syq on {src_host} killed by signal"),
+        None => bail!("remote syq on {coordinator_host} killed by signal"),
     }
 }
 
@@ -765,7 +848,7 @@ pub fn follow(args: &Args) -> Result<i32> {
         .paths
         .first()
         .ok_or_else(|| anyhow::anyhow!("usage: syq rsync --follow HOST:LOGFILE"))?;
-    let loc = Location::parse(target)?;
+    let loc = parse_follow_location(target)?;
     let (Some(host), log) = (&loc.host, &loc.path) else {
         bail!("usage: syq rsync --follow HOST:LOGFILE")
     };
@@ -775,6 +858,12 @@ pub fn follow(args: &Args) -> Result<i32> {
     cmd.args(&rsh[1..]);
     if let Some(u) = &loc.user {
         cmd.args(["-l", u]);
+    }
+    if let Some(port) = loc.port {
+        if !rsh[0].ends_with("ssh") {
+            bail!("a follow target with an explicit port requires an ssh remote-shell command");
+        }
+        cmd.args(["-p", &port.to_string()]);
     }
     cmd.arg(host)
         .arg(format!("tail -n +1 -f {}", shell_words::quote(&log)));
@@ -841,6 +930,22 @@ pub fn follow(args: &Args) -> Result<i32> {
     Ok(0)
 }
 
+fn parse_follow_location(target: &str) -> Result<Location> {
+    if let Some(separator) = target.find(":/") {
+        let endpoint = &target[..separator];
+        if let Some(endpoint) = crate::cli::parse_native_endpoint(Some(endpoint))? {
+            return Ok(Location {
+                user: endpoint.user,
+                host: Some(endpoint.host),
+                port: endpoint.port,
+                path: target.as_bytes()[separator + 1..].to_vec(),
+                selection: crate::cli::SourceSelection::Rsync,
+            });
+        }
+    }
+    Location::parse(target)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -851,12 +956,26 @@ mod tests {
     }
 
     #[test]
+    fn follow_target_accepts_native_ports_and_ipv6() {
+        let location = parse_follow_location("alice@host:2222:/home/alice/run.log").unwrap();
+        assert_eq!(location.user.as_deref(), Some("alice"));
+        assert_eq!(location.host.as_deref(), Some("host"));
+        assert_eq!(location.port, Some(2222));
+        assert_eq!(location.path, b"/home/alice/run.log");
+
+        let location = parse_follow_location("[2001:db8::1]:2200:/tmp/run.log").unwrap();
+        assert_eq!(location.host.as_deref(), Some("2001:db8::1"));
+        assert_eq!(location.port, Some(2200));
+    }
+
+    #[test]
     fn default_ssh_controls_agent_forwarding_explicitly() {
         let rsh = vec!["ssh".to_string(), "-p".to_string(), "2222".to_string()];
         let forwarded = direct_command(
             &rsh,
             Some("alice"),
             "source",
+            None,
             "syq ...",
             Some(&AgentForwarding::Unrestricted),
         );
@@ -868,6 +987,7 @@ mod tests {
             &rsh,
             Some("alice"),
             "source",
+            None,
             "syq ...",
             Some(&AgentForwarding::Disabled),
         );
@@ -883,7 +1003,7 @@ mod tests {
             ambient: "/tmp/ambient-agent".into(),
             broker: "/tmp/syq-agent".into(),
         };
-        let command = direct_command(&rsh, None, "source", "syq ...", Some(&policy));
+        let command = direct_command(&rsh, None, "source", None, "syq ...", Some(&policy));
         let args = args(&command);
         assert!(args.contains(&OsStr::new("IdentityAgent=/tmp/ambient-agent")));
         assert!(args.contains(&OsStr::new("ForwardAgent=/tmp/syq-agent")));
@@ -909,7 +1029,7 @@ mod tests {
         };
         let hardened = constrained_destination_rsh(2222, "ssh-ed25519");
         assert_eq!(
-            destination_rsh(None, false, Some(&constrained), Some(&hardened)),
+            destination_rsh(None, false, None, Some(&constrained), Some(&hardened)),
             Some(hardened.clone())
         );
         let hardened_words = shell_words::split(&hardened).unwrap();
@@ -930,19 +1050,29 @@ mod tests {
             assert!(hardened_words.iter().any(|word| word == required));
         }
         assert_eq!(
-            destination_rsh(None, false, Some(&AgentForwarding::Unrestricted), None),
+            destination_rsh(
+                None,
+                false,
+                None,
+                Some(&AgentForwarding::Unrestricted),
+                None
+            ),
             Some("ssh -a -o IdentityAgent=SSH_AUTH_SOCK -o IdentitiesOnly=no".into())
         );
         assert_eq!(
-            destination_rsh(None, false, Some(&AgentForwarding::Disabled), None),
+            destination_rsh(None, false, None, Some(&AgentForwarding::Disabled), None),
             Some("ssh -a".into())
         );
         assert_eq!(
-            destination_rsh(Some("custom-rsh"), false, None, None),
+            destination_rsh(Some("custom-rsh"), false, None, None, None),
             Some("custom-rsh".into())
         );
         assert_eq!(
-            destination_rsh(None, true, Some(&constrained), Some(&hardened)),
+            destination_rsh(Some("ssh -J jump"), false, Some(2200), None, None),
+            Some("ssh -J jump -p 2200".into())
+        );
+        assert_eq!(
+            destination_rsh(None, true, None, Some(&constrained), Some(&hardened)),
             None
         );
     }
@@ -978,7 +1108,7 @@ mod tests {
     #[test]
     fn explicit_ssh_does_not_get_agent_flags() {
         let rsh = vec!["ssh".to_string(), "-a".to_string()];
-        let command = direct_command(&rsh, None, "source", "syq ...", None);
+        let command = direct_command(&rsh, None, "source", None, "syq ...", None);
         let args = args(&command);
         assert!(!args.contains(&OsStr::new("-A")));
         assert_eq!(
@@ -990,7 +1120,7 @@ mod tests {
     #[test]
     fn custom_remote_shell_does_not_get_ssh_agent_flags() {
         let rsh = vec!["custom-rsh".to_string()];
-        let command = direct_command(&rsh, None, "source", "syq ...", None);
+        let command = direct_command(&rsh, None, "source", None, "syq ...", None);
         let args = args(&command);
         assert!(!args.contains(&OsStr::new("-a")));
         assert!(!args.contains(&OsStr::new("-A")));

--- a/src/enrollment.rs
+++ b/src/enrollment.rs
@@ -367,12 +367,10 @@ impl SshEndpoint {
         {
             bail!("invalid native enrollment endpoint");
         }
-        let host = if host.contains(':') {
-            format!("[{host}]")
-        } else {
-            host.to_owned()
-        };
         Ok(Self {
+            // OpenSSH takes a literal IPv6 address without URI-style
+            // brackets. Brackets belong only in syq's endpoint grammar and
+            // human-facing labels; -p carries the port separately.
             target: format!("{user}@{host}"),
             port,
         })
@@ -383,9 +381,13 @@ impl SshEndpoint {
     }
 
     pub(crate) fn label(&self) -> String {
+        let target = match self.target.rsplit_once('@') {
+            Some((user, host)) if host.contains(':') => format!("{user}@[{host}]"),
+            _ => self.target.clone(),
+        };
         match self.port {
-            Some(port) => format!("{}:{port}", self.target),
-            None => self.target.clone(),
+            Some(port) => format!("{target}:{port}"),
+            None => target,
         }
     }
 
@@ -735,7 +737,10 @@ mod tests {
                 && arg.contains("-p 2200")
                 && arg.contains("alice@jump.example")
         }));
-        assert!(args.iter().any(|arg| arg == "backup@[2001:db8::1]"));
+        assert_eq!(target.as_str(), "backup@2001:db8::1");
+        assert_eq!(target.label(), "backup@[2001:db8::1]:2222");
+        assert!(args.iter().any(|arg| arg == "backup@2001:db8::1"));
+        assert!(!args.iter().any(|arg| arg.contains("[2001:db8::1]")));
     }
 
     #[test]

--- a/src/enrollment.rs
+++ b/src/enrollment.rs
@@ -322,7 +322,10 @@ fn line_contains_transport_key(line: &[u8], key: &TransportPublicKey) -> bool {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SshEndpoint(String);
+pub struct SshEndpoint {
+    target: String,
+    port: Option<u16>,
+}
 
 impl SshEndpoint {
     /// Parse the deliberately narrow endpoint syntax accepted by automatic
@@ -343,11 +346,63 @@ impl SshEndpoint {
         if host == "none" {
             bail!("none is not an enrollment host");
         }
-        Ok(Self(value.to_owned()))
+        Ok(Self {
+            target: value.to_owned(),
+            port: None,
+        })
+    }
+
+    /// Construct an endpoint already split by the native endpoint parser.
+    /// Arguments are still passed to OpenSSH as distinct words; `target` is
+    /// quoted separately if it must appear inside a ProxyCommand.
+    pub(crate) fn from_parts(user: &str, host: &str, port: Option<u16>) -> Result<Self> {
+        if user.is_empty()
+            || host.is_empty()
+            || user
+                .bytes()
+                .any(|byte| byte == 0 || byte.is_ascii_whitespace())
+            || host
+                .bytes()
+                .any(|byte| byte == 0 || byte.is_ascii_whitespace())
+        {
+            bail!("invalid native enrollment endpoint");
+        }
+        let host = if host.contains(':') {
+            format!("[{host}]")
+        } else {
+            host.to_owned()
+        };
+        Ok(Self {
+            target: format!("{user}@{host}"),
+            port,
+        })
     }
 
     pub fn as_str(&self) -> &str {
-        &self.0
+        &self.target
+    }
+
+    pub(crate) fn label(&self) -> String {
+        match self.port {
+            Some(port) => format!("{}:{port}", self.target),
+            None => self.target.clone(),
+        }
+    }
+
+    fn append_connection_args(&self, args: &mut Vec<String>) {
+        if let Some(port) = self.port {
+            args.extend(["-p".to_owned(), port.to_string()]);
+        }
+        args.extend(["--".to_owned(), self.target.clone()]);
+    }
+
+    fn proxy_target(&self) -> String {
+        let mut words = Vec::new();
+        if let Some(port) = self.port {
+            words.extend(["-p".to_owned(), port.to_string()]);
+        }
+        words.extend(["--".to_owned(), self.target.clone()]);
+        shell_words::join(words)
     }
 }
 
@@ -438,13 +493,12 @@ pub(crate) fn enrollment_ssh_args_raw(
             // end-to-end with HostB.
             args.push("-o".to_owned());
             args.push(format!(
-                "ProxyCommand=ssh -a -x -k -T -o ClearAllForwardings=yes -o ControlMaster=no -o ControlPath=none -o ForwardX11=no -o PermitLocalCommand=no -W '[%h]:%p' -- {}",
-                jump.as_str()
+                "ProxyCommand=ssh -a -x -k -T -o ClearAllForwardings=yes -o ControlMaster=no -o ControlPath=none -o ForwardX11=no -o PermitLocalCommand=no -W '[%h]:%p' {}",
+                jump.proxy_target()
             ));
         }
     }
-    args.push("--".to_owned());
-    args.push(target.as_str().to_owned());
+    target.append_connection_args(&mut args);
     args.push(remote_command.to_owned());
     args
 }
@@ -663,6 +717,25 @@ mod tests {
                 "/opt/syq/enroll",
             ]
         );
+    }
+
+    #[test]
+    fn native_endpoint_port_reaches_direct_and_proxy_routes() {
+        let target = SshEndpoint::from_parts("backup", "2001:db8::1", Some(2222)).unwrap();
+        let jump = SshEndpoint::from_parts("alice", "jump.example", Some(2200)).unwrap();
+        let command = EnrollmentRemoteCommand::new(Path::new("/opt/syq/enroll"), &[]).unwrap();
+        let args = enrollment_ssh_args(
+            &target,
+            EnrollmentRoute::ProxyJump { jump: &jump },
+            &command,
+        );
+        assert!(args.windows(2).any(|args| args == ["-p", "2222"]));
+        assert!(args.iter().any(|arg| {
+            arg.contains("ProxyCommand=")
+                && arg.contains("-p 2200")
+                && arg.contains("alice@jump.example")
+        }));
+        assert!(args.iter().any(|arg| arg == "backup@[2001:db8::1]"));
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -88,6 +88,8 @@ struct LocalEnrollment {
     version: u16,
     id: EnrollmentId,
     host: String,
+    #[serde(default)]
+    port: Option<u16>,
     target_login: String,
     remote_home: String,
     requested_parent: String,
@@ -100,6 +102,8 @@ struct PendingEnrollment {
     version: u16,
     id: EnrollmentId,
     host: String,
+    #[serde(default)]
+    port: Option<u16>,
     target_login: String,
     requested_destination: String,
 }
@@ -2351,12 +2355,13 @@ fn install_over_route(
     Ok(response)
 }
 
-fn endpoint(login: &str, host: &str) -> Result<SshEndpoint> {
-    SshEndpoint::parse(&format!("{login}@{host}"))
+fn endpoint(login: &str, host: &str, port: Option<u16>) -> Result<SshEndpoint> {
+    SshEndpoint::from_parts(login, host, port)
 }
 
 fn enroll(
     host: &str,
+    port: Option<u16>,
     login: &str,
     requested_destination: &str,
     jump: Option<&SshEndpoint>,
@@ -2368,7 +2373,7 @@ fn enroll(
 
     let mut active = None;
     for (metadata, directory) in load_local_enrollments()? {
-        if metadata.host == host && metadata.target_login == login {
+        if metadata.host == host && metadata.port == port && metadata.target_login == login {
             if let Some(canonical_destination) = destination_for(&metadata, requested_destination)?
             {
                 active = Some((metadata, directory, canonical_destination));
@@ -2392,6 +2397,7 @@ fn enroll(
             .into_iter()
             .find(|(pending, _)| {
                 pending.host == host
+                    && pending.port == port
                     && pending.target_login == login
                     && pending.requested_destination == requested_destination
             })
@@ -2405,6 +2411,7 @@ fn enroll(
                 version: CONFIG_VERSION,
                 id: metadata.id,
                 host: metadata.host,
+                port: metadata.port,
                 target_login: metadata.target_login,
                 requested_destination: requested_destination.to_owned(),
             };
@@ -2421,6 +2428,7 @@ fn enroll(
                 version: CONFIG_VERSION,
                 id,
                 host: host.to_owned(),
+                port,
                 target_login: login.to_owned(),
                 requested_destination: requested_destination.to_owned(),
             };
@@ -2436,7 +2444,7 @@ fn enroll(
         requested_destination: requested_destination.to_owned(),
         public_key,
     };
-    let target = endpoint(login, host)?;
+    let target = endpoint(login, host, port)?;
     let direct = install_over_route(&target, EnrollmentRoute::Direct, &request);
     let response = match (direct, jump) {
         (Ok(response), _) => response,
@@ -2457,6 +2465,7 @@ fn enroll(
         version: CONFIG_VERSION,
         id: pending.id,
         host: host.to_owned(),
+        port,
         target_login: login.to_owned(),
         remote_home: response.remote_home,
         requested_parent: response.requested_parent,
@@ -2786,7 +2795,10 @@ pub(crate) fn prepare_transfer(
         .context("restricted destination path is not UTF-8")?;
     let mut selected = None;
     for (metadata, directory) in load_local_enrollments()? {
-        if metadata.host == host && metadata.target_login == destination_login {
+        if metadata.host == host
+            && metadata.port == destination.port
+            && metadata.target_login == destination_login
+        {
             if let Some(canonical_destination) = destination_for(&metadata, requested)? {
                 selected = Some((metadata, directory, canonical_destination));
                 break;
@@ -2804,8 +2816,16 @@ pub(crate) fn prepare_transfer(
             let jump = endpoint(
                 source_login,
                 sources[0].host.as_deref().context("source host missing")?,
+                sources[0].port,
             )?;
-            enroll(host, destination_login, requested, Some(&jump), false)?
+            enroll(
+                host,
+                destination.port,
+                destination_login,
+                requested,
+                Some(&jump),
+                false,
+            )?
         }
     };
     let private_key = load_private_key(&directory)?;
@@ -2935,18 +2955,21 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
                     .map(|(metadata, _)| metadata.id)
                     .collect::<HashSet<_>>();
                 for (metadata, _) in active {
+                    let target = endpoint(&metadata.target_login, &metadata.host, metadata.port)?;
                     println!(
-                        "{}\tactive\t{}@{}\t{}",
-                        metadata.id, metadata.target_login, metadata.host, metadata.canonical_root
+                        "{}\tactive\t{}\t{}",
+                        metadata.id,
+                        target.label(),
+                        metadata.canonical_root
                     );
                 }
                 for (pending, _) in load_pending_enrollments()? {
                     if !active_ids.contains(&pending.id) {
+                        let target = endpoint(&pending.target_login, &pending.host, pending.port)?;
                         println!(
-                            "{}\tpending\t{}@{}\t{}",
+                            "{}\tpending\t{}\t{}",
                             pending.id,
-                            pending.target_login,
-                            pending.host,
+                            target.label(),
                             pending.requested_destination
                         );
                     }
@@ -2979,11 +3002,19 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
                 host,
                 true,
             )?;
-            let (metadata, _, destination) =
-                enroll(host, &policy.login_user, requested, via.as_ref(), true)?;
+            let (metadata, _, destination) = enroll(
+                host,
+                None,
+                &policy.login_user,
+                requested,
+                via.as_ref(),
+                true,
+            )?;
             println!(
-                "enrolled {} for {}@{}:{}",
-                metadata.id, metadata.target_login, metadata.host, destination
+                "enrolled {} for {}:{}",
+                metadata.id,
+                endpoint(&metadata.target_login, &metadata.host, metadata.port)?.label(),
+                destination
             );
             Ok(0)
         })()),
@@ -3002,7 +3033,7 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
             let active = load_local_enrollments()?
                 .into_iter()
                 .find(|(metadata, _)| metadata.id == id);
-            let (target_login, host, remote_command, directory) = match active {
+            let (target_login, host, port, remote_command, directory) = match active {
                 Some((metadata, directory)) => {
                     let command = enrollment::EnrollmentRemoteCommand::new(
                         Path::new(&metadata.receiver_path),
@@ -3011,6 +3042,7 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
                     (
                         metadata.target_login,
                         metadata.host,
+                        metadata.port,
                         command.as_str().to_owned(),
                         directory,
                     )
@@ -3023,6 +3055,7 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
                     (
                         pending.target_login,
                         pending.host,
+                        pending.port,
                         "exec \"$HOME/.local/libexec/syq-receiver\" --restricted-revoke".to_owned(),
                         directory,
                     )
@@ -3035,7 +3068,7 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
                 target_login: target_login.clone(),
                 public_key: private_key.public_key().to_openssh()?,
             };
-            let target = endpoint(&target_login, &host)?;
+            let target = endpoint(&target_login, &host, port)?;
             let encoded = serde_json::to_vec(&request)?;
             let direct = run_ssh(&target, EnrollmentRoute::Direct, &remote_command, &encoded);
             match (direct, via.as_ref()) {
@@ -3054,7 +3087,7 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
             delegation::validate_private_directory_path(&directory)?;
             fs::remove_dir_all(&directory)
                 .with_context(|| format!("remove local enrollment {}", directory.display()))?;
-            println!("revoked {id} from {target_login}@{host}");
+            println!("revoked {id} from {}", target.label());
             Ok(0)
         })()),
         _ => None,
@@ -3252,6 +3285,7 @@ mod tests {
             version: CONFIG_VERSION,
             id,
             host: "host-b".into(),
+            port: None,
             target_login: "backup".into(),
             requested_destination: "/archive/item".into(),
         };
@@ -3275,6 +3309,7 @@ mod tests {
             version: CONFIG_VERSION,
             id,
             host: pending.host,
+            port: pending.port,
             target_login: pending.target_login,
             remote_home: "/home/backup".into(),
             requested_parent: "/archive".into(),

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -511,13 +511,25 @@ fn semantic_flags(opts: &Opts, args: &Args, srcs: &[Location]) -> String {
     flags.to_string()
 }
 
-/// The endpoint half of a job identity: `user@host` (the user matters — two
-/// accounts on one host see different destinations), or `local`.
+/// The endpoint half of a job identity: `user@host[:port]` (the user and an
+/// explicit port matter — they may select different filesystems), or `local`.
 fn endpoint_identity(l: &Location) -> String {
     match (&l.user, &l.host) {
         (_, None) => "local".into(),
-        (Some(u), Some(h)) => format!("{u}@{h}"),
-        (None, Some(h)) => h.clone(),
+        (user, Some(host)) => {
+            // Preserve the established portless identity byte-for-byte. A
+            // port-qualified native endpoint gets a distinct, unambiguous
+            // spelling; IPv6 needs brackets before the port separator.
+            let host = match l.port {
+                Some(port) if host.contains(':') => format!("[{host}]:{port}"),
+                Some(port) => format!("{host}:{port}"),
+                None => host.clone(),
+            };
+            match user {
+                Some(user) => format!("{user}@{host}"),
+                None => host,
+            }
+        }
     }
 }
 
@@ -720,11 +732,21 @@ pub fn run(args: Args) -> Result<i32> {
         .map(|(_, sources)| sources)
         .unwrap_or(&[]);
     let (dst, original_srcs) = locs.split_last().unwrap();
+    let direct_paths_are_utf8 = original_srcs
+        .iter()
+        .chain(std::iter::once(dst))
+        .all(|location| std::str::from_utf8(&location.path).is_ok());
     let direct_remote_to_remote = original_srcs[0].is_remote()
         && dst.is_remote()
         && !original_srcs[0].same_host(dst)
         && !args.relay
-        && (args.interface == Interface::Rsync || args.run_at != RunAt::Local);
+        && (args.interface == Interface::Rsync || args.run_at != RunAt::Local)
+        // Native auto placement relays raw path bytes because they cannot be
+        // represented in the remote coordinator's argv. Validate direct-only
+        // controls against the topology that will actually run.
+        && (args.interface == Interface::Rsync
+            || args.run_at != RunAt::Auto
+            || direct_paths_are_utf8);
     if (args.detach || args.no_forward_agent || args.agent_broker_only) && !direct_remote_to_remote
     {
         bail!(
@@ -847,10 +869,6 @@ pub fn run(args: Args) -> Result<i32> {
                     "--reuse-connection is not supported for direct remote-to-remote transfers; add --relay to keep the reusable connections on this machine"
                 );
             }
-            let direct_paths_are_utf8 = srcs
-                .iter()
-                .chain(std::iter::once(dst))
-                .all(|location| std::str::from_utf8(&location.path).is_ok());
             if args.interface == Interface::Rsync
                 || direct_paths_are_utf8
                 || args.run_at == RunAt::Source
@@ -2576,9 +2594,13 @@ fn display_location(loc: &Location, path: &[u8]) -> String {
     } else {
         host.clone()
     };
-    match &loc.user {
-        Some(user) => format!("{user}@{host}:{path}"),
-        None => format!("{host}:{path}"),
+    let endpoint = match &loc.user {
+        Some(user) => format!("{user}@{host}"),
+        None => host,
+    };
+    match loc.port {
+        Some(port) => format!("{endpoint}:{port}:{path}"),
+        None => format!("{endpoint}:{path}"),
     }
 }
 
@@ -6276,6 +6298,51 @@ mod tests {
         let second = std::path::Path::new(std::ffi::OsStr::from_bytes(b"/tmp/raw-\xfe"));
         assert_ne!(path_identity(first), path_identity(second));
         assert!(path_identity(first).starts_with('\0'));
+    }
+
+    #[test]
+    fn explicit_ssh_port_is_part_of_endpoint_identity() {
+        let location = |host: &str, port| Location {
+            user: Some("alice".into()),
+            host: Some(host.into()),
+            port,
+            path: b"/data".to_vec(),
+            selection: SourceSelection::Named,
+        };
+
+        assert_eq!(endpoint_identity(&location("backup", None)), "alice@backup");
+        assert_eq!(
+            endpoint_identity(&location("backup", Some(2200))),
+            "alice@backup:2200"
+        );
+        assert_eq!(
+            endpoint_identity(&location("backup", Some(2222))),
+            "alice@backup:2222"
+        );
+        assert_eq!(
+            endpoint_identity(&location("2001:db8::1", Some(2200))),
+            "alice@[2001:db8::1]:2200"
+        );
+    }
+
+    #[test]
+    fn dry_run_location_labels_include_explicit_ssh_port() {
+        let location = |host: &str, port| Location {
+            user: Some("alice".into()),
+            host: Some(host.into()),
+            port: Some(port),
+            path: b"/data".to_vec(),
+            selection: SourceSelection::Named,
+        };
+
+        assert_eq!(
+            display_location(&location("backup", 2200), b"/data"),
+            "alice@backup:2200:/data"
+        );
+        assert_eq!(
+            display_location(&location("2001:db8::1", 2222), b"/data"),
+            "alice@[2001:db8::1]:2222:/data"
+        );
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -736,6 +736,13 @@ pub fn run(args: Args) -> Result<i32> {
         .iter()
         .chain(std::iter::once(dst))
         .all(|location| std::str::from_utf8(&location.path).is_ok());
+    let coordinator_is_remote = original_srcs[0].is_remote()
+        && dst.is_remote()
+        && !args.relay
+        && (args.interface == Interface::Rsync || args.run_at != RunAt::Local)
+        && (args.interface == Interface::Rsync
+            || args.run_at != RunAt::Auto
+            || direct_paths_are_utf8);
     let direct_remote_to_remote = original_srcs[0].is_remote()
         && dst.is_remote()
         && !original_srcs[0].same_host(dst)
@@ -751,6 +758,21 @@ pub fn run(args: Args) -> Result<i32> {
     {
         bail!(
             "--detach, --no-forward-agent, and --agent-broker-only apply only to a direct copy between two different remote endpoints"
+        );
+    }
+    if args.detach && args.native_results.is_some() {
+        bail!(
+            "--results cannot be used with --detach because the remote result stream would not remain attached"
+        );
+    }
+    if args
+        .native_results
+        .as_deref()
+        .is_some_and(|results| results != b"-")
+        && coordinator_is_remote
+    {
+        bail!(
+            "--results FILE is written by the transfer coordinator, which is remote for this copy; use --results - to stream NDJSON here or --run-at local to create a local file"
         );
     }
     if args.restricted_grant.is_some()

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -2,7 +2,7 @@
 
 use crate::bwlimit::BandwidthLimit;
 use crate::cli::{
-    parse_rsh, parse_size, Args, Existence, Interface, Location, Placement, SourceSelection,
+    parse_rsh, parse_size, Args, Existence, Interface, Location, Placement, RunAt, SourceSelection,
 };
 use crate::conn::{
     ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, SshMultiplexer, TcpCandidate,
@@ -16,6 +16,7 @@ use crate::tune::{self, Gate};
 use anyhow::{bail, Context, Result};
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::OpenOptionsExt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -97,12 +98,18 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
         None => Endpoint::Local,
         Some(h) => {
             let rsh = parse_rsh(&args.rsh)?;
+            if loc.port.is_some() && args.rsh.is_some() && !rsh[0].ends_with("ssh") {
+                bail!(
+                    "an explicit endpoint SSH port requires the default ssh or an --rsh command whose executable is ssh"
+                );
+            }
             let ssh_multiplexer = if args.rsh.is_some() {
                 None
             } else if args.reuse_connection && args.restricted_grant.is_none() {
                 Some(Arc::new(SshMultiplexer::persistent(
                     loc.user.as_deref(),
                     h,
+                    loc.port,
                 )?))
             } else {
                 Some(Arc::new(SshMultiplexer::new()?))
@@ -111,6 +118,7 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
                 local_process: false,
                 user: loc.user.clone(),
                 host: h.clone(),
+                port: loc.port,
                 rsh,
                 syq_path: args.syq_path.clone(),
                 auto_helper: args.restricted_grant.is_none()
@@ -667,6 +675,22 @@ fn handle_tcp_setup_error(
     Ok(())
 }
 
+fn announce_detached_ready() -> Result<()> {
+    let Some(path) = std::env::var_os("SYQ_INTERNAL_DETACH_READY") else {
+        return Ok(());
+    };
+    let path = std::path::PathBuf::from(path);
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&path)
+        .with_context(|| format!("create detached-readiness marker {}", path.display()))?;
+    use std::io::Write as _;
+    file.write_all(b"ready\n")?;
+    Ok(())
+}
+
 pub fn run(args: Args) -> Result<i32> {
     let mut args = args;
     // A block becomes one WriteRange frame, so it must stay well under MAX_FRAME.
@@ -696,6 +720,17 @@ pub fn run(args: Args) -> Result<i32> {
         .map(|(_, sources)| sources)
         .unwrap_or(&[]);
     let (dst, original_srcs) = locs.split_last().unwrap();
+    let direct_remote_to_remote = original_srcs[0].is_remote()
+        && dst.is_remote()
+        && !original_srcs[0].same_host(dst)
+        && !args.relay
+        && (args.interface == Interface::Rsync || args.run_at != RunAt::Local);
+    if (args.detach || args.no_forward_agent || args.agent_broker_only) && !direct_remote_to_remote
+    {
+        bail!(
+            "--detach, --no-forward-agent, and --agent-broker-only apply only to a direct copy between two different remote endpoints"
+        );
+    }
     if args.restricted_grant.is_some()
         && (args.no_tcp
             || args.tcp_plain
@@ -712,12 +747,7 @@ pub fn run(args: Args) -> Result<i32> {
             bail!("all sources must be on the same host");
         }
     }
-    if args.unrestricted_agent_forwarding
-        && (!original_srcs[0].is_remote()
-            || !dst.is_remote()
-            || original_srcs[0].same_host(dst)
-            || args.relay)
-    {
+    if args.unrestricted_agent_forwarding && !direct_remote_to_remote {
         bail!(
             "--unrestricted-agent-forwarding is only valid for a live direct transfer between two different remote hosts"
         );
@@ -801,6 +831,12 @@ pub fn run(args: Args) -> Result<i32> {
         };
     }
     if src_ep.is_remote() && dst_ep.is_remote() {
+        if args.interface != Interface::Rsync && args.run_at == RunAt::Local {
+            args.relay = true;
+        }
+        if args.interface != Interface::Rsync && args.run_at == RunAt::Target {
+            return crate::direct::run_at_target(&args, srcs, dst, source_operand_count);
+        }
         if !args.relay {
             // The direct orchestrator runs on the source host and rebuilds
             // the command; no direct leg holds a reusable local master, so
@@ -815,7 +851,10 @@ pub fn run(args: Args) -> Result<i32> {
                 .iter()
                 .chain(std::iter::once(dst))
                 .all(|location| std::str::from_utf8(&location.path).is_ok());
-            if args.interface == Interface::Rsync || direct_paths_are_utf8 {
+            if args.interface == Interface::Rsync
+                || direct_paths_are_utf8
+                || args.run_at == RunAt::Source
+            {
                 // Let the remote orchestrator observe the original source count so
                 // repeated file sources keep multi-source destination semantics.
                 return crate::direct::run(&args, srcs, dst, source_operand_count);
@@ -829,6 +868,8 @@ pub fn run(args: Args) -> Result<i32> {
         if args.relay && !args.quiet {
             eprintln!("syq: remote-to-remote transfer: relaying data through this machine");
         }
+    } else if args.interface != Interface::Rsync && args.run_at != RunAt::Auto {
+        bail!("--run-at currently applies only to copies between two remote endpoints");
     }
     #[cfg(not(target_os = "linux"))]
     if let Some(algorithm) = &args.tcp_congestion {
@@ -1546,6 +1587,7 @@ pub fn run(args: Args) -> Result<i32> {
             t0.elapsed().as_secs_f64()
         );
     }
+    announce_detached_ready()?;
     let all_remote_endpoints_use_tcp = use_tcp
         && [&src_ep, &dst_ep]
             .into_iter()

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -760,6 +760,16 @@ pub fn run(args: Args) -> Result<i32> {
             "--detach, --no-forward-agent, and --agent-broker-only apply only to a direct copy between two different remote endpoints"
         );
     }
+    if args.reuse_connection && coordinator_is_remote {
+        if args.interface == Interface::Rsync {
+            bail!(
+                "--reuse-connection is not supported for direct remote-to-remote transfers; add --relay to keep the reusable connections on this machine"
+            );
+        }
+        bail!(
+            "--reuse-connection is not supported with a remote transfer coordinator; use --run-at local to keep the reusable connections on this machine"
+        );
+    }
     if args.detach && args.native_results.is_some() {
         bail!(
             "--results cannot be used with --detach because the remote result stream would not remain attached"
@@ -882,15 +892,6 @@ pub fn run(args: Args) -> Result<i32> {
             return crate::direct::run_at_target(&args, srcs, dst, source_operand_count);
         }
         if !args.relay {
-            // The direct orchestrator runs on the source host and rebuilds
-            // the command; no direct leg holds a reusable local master, so
-            // refuse rather than silently ignore the flag. --relay keeps the
-            // orchestrator (and its persistent masters) on this machine.
-            if args.reuse_connection {
-                bail!(
-                    "--reuse-connection is not supported for direct remote-to-remote transfers; add --relay to keep the reusable connections on this machine"
-                );
-            }
             if args.interface == Interface::Rsync
                 || direct_paths_are_utf8
                 || args.run_at == RunAt::Source

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1055,6 +1055,7 @@ mod tests {
             local_process: false,
             user: Some("user".into()),
             host: host.into(),
+            port: None,
             rsh: vec!["ssh".into()],
             syq_path: None,
             auto_helper: false,

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -8264,6 +8264,167 @@ fn native_auto_raw_path_relay_rejects_direct_only_controls() {
 }
 
 #[test]
+fn native_remote_coordinator_streams_results_to_the_invoker() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"result stream");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--rsh"])
+        .arg(&rsh)
+        .args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args([
+            "--no-tcp",
+            "-j",
+            "1",
+            "--from",
+            "hostA",
+            "--src",
+            &t.s("src"),
+            "--to",
+            "hostB",
+            "--run-at",
+            "target",
+            "--as",
+            &t.s("dst"),
+            "--results",
+            "-",
+            "-q",
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .run()
+        .expect("stream target-coordinator results");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"result stream");
+    let records: Vec<serde_json::Value> = String::from_utf8(out.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("results line is JSON"))
+        .collect();
+    assert_eq!(records.first().unwrap()["type"], "run");
+    let terminal = records.last().unwrap();
+    assert_eq!(terminal["type"], "result");
+    assert_eq!(terminal["status"], "success");
+    assert_eq!(terminal["exit_code"], 0);
+}
+
+#[test]
+fn native_named_results_require_a_local_coordinator() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"local results");
+
+    for placement in ["source", "target"] {
+        let destination = t.s(&format!("dst-{placement}"));
+        let results = t.s(&format!("results-{placement}.ndjson"));
+        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(["cp", "--rsh"])
+            .arg(&rsh)
+            .args([
+                "--from",
+                "hostA",
+                "--src",
+                &t.s("src"),
+                "--to",
+                "hostB",
+                "--run-at",
+                placement,
+                "--as",
+                &destination,
+                "--results",
+                &results,
+                "-q",
+            ])
+            .run()
+            .expect("reject a remote named results file");
+
+        assert!(!out.status.success(), "{placement} unexpectedly succeeded");
+        let stderr = stderr_of(&out);
+        assert!(stderr.contains("transfer coordinator"), "{stderr}");
+        assert!(stderr.contains("--results -"), "{stderr}");
+        assert!(stderr.contains("--run-at local"), "{stderr}");
+        assert!(!Path::new(&destination).exists());
+        assert!(!Path::new(&results).exists());
+    }
+
+    let results = t.s("results-local.ndjson");
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--rsh"])
+        .arg(&rsh)
+        .args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args([
+            "--no-tcp",
+            "-j",
+            "1",
+            "--from",
+            "hostA",
+            "--src",
+            &t.s("src"),
+            "--to",
+            "hostB",
+            "--run-at",
+            "local",
+            "--as",
+            &t.s("dst-local"),
+            "--results",
+            &results,
+            "-q",
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .run()
+        .expect("write local-coordinator results");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst-local")), b"local results");
+    let terminal: serde_json::Value = fs::read_to_string(results)
+        .unwrap()
+        .lines()
+        .last()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .unwrap();
+    assert_eq!(terminal["type"], "result");
+    assert_eq!(terminal["status"], "success");
+}
+
+#[test]
+fn native_detach_rejects_an_unattached_results_stream() {
+    let t = Tmp::new();
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--rsh",
+            "ssh",
+            "--detach",
+            "--from",
+            "hostA",
+            "--src",
+            "/source",
+            "--to",
+            "hostB",
+            "--as",
+            &t.s("dst"),
+            "--results",
+            "-",
+            "-q",
+        ])
+        .run()
+        .expect("reject detached streamed results");
+
+    assert!(!out.status.success());
+    assert!(
+        stderr_of(&out).contains("result stream would not remain attached"),
+        "{}",
+        stderr_of(&out)
+    );
+    assert!(!t.path("dst").exists());
+}
+
+#[test]
 fn native_run_at_local_relays_between_remote_endpoints() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -8181,6 +8181,89 @@ fn native_run_at_target_reverses_the_remote_ssh_edge() {
 }
 
 #[test]
+fn native_target_dry_run_labels_the_real_endpoints_and_ports() {
+    let t = Tmp::new();
+    let ssh = fake_ssh(&t);
+    write(&t.path("src/file"), b"planned");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--rsh"])
+        .arg(&ssh)
+        .args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args([
+            "--no-tcp",
+            "--dry-run",
+            "--from",
+            "hostA:2200",
+            "--src-src",
+            &t.s("src"),
+            "--to",
+            "hostB:2222",
+            "--run-at",
+            "target",
+            "--into",
+            &t.s("dst"),
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .run()
+        .expect("run target-side native dry-run");
+
+    assert_output_ok(&out);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(&format!(
+            "mapping: hostA:2200:{} -> hostB:2222:{}",
+            t.s("src"),
+            t.s("dst")
+        )),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("-> hostA:2200:"), "{stdout}");
+    let ssh_log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    assert!(
+        ssh_log.lines().any(|line| line.contains("-p 2222")),
+        "{ssh_log}"
+    );
+    assert!(
+        ssh_log.lines().any(|line| line.contains("-p 2200")),
+        "{ssh_log}"
+    );
+}
+
+#[test]
+fn native_auto_raw_path_relay_rejects_direct_only_controls() {
+    let mut raw_source = b"/source-".to_vec();
+    raw_source.push(0xff);
+    let raw_source = std::ffi::OsString::from_vec(raw_source);
+
+    for option in [
+        "--detach",
+        "--no-forward-agent",
+        "--agent-broker-only",
+        "--unrestricted-agent-forwarding",
+    ] {
+        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .arg("cp")
+            .arg(option)
+            .args(["--from", "hostA", "--src"])
+            .arg(&raw_source)
+            .args(["--to", "hostB", "--as", "/target"])
+            .run()
+            .expect("reject a direct-only option before automatic relay");
+
+        assert!(!out.status.success(), "{option} unexpectedly succeeded");
+        let stderr = stderr_of(&out);
+        assert!(stderr.contains("direct"), "{option}: {stderr}");
+        assert!(
+            !stderr.contains("relaying raw path bytes"),
+            "{option} entered relay execution: {stderr}"
+        );
+    }
+}
+
+#[test]
 fn native_run_at_local_relays_between_remote_endpoints() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -9687,4 +9687,23 @@ fn reuse_connection_refused_for_direct_remote_to_remote() {
         stderr.contains("direct remote-to-remote"),
         "stderr: {stderr}"
     );
+
+    let out = native_syq(&[
+        "cp",
+        "--reuse-connection",
+        "--from",
+        "hostA",
+        "--src-src",
+        "src",
+        "--to",
+        "hostB",
+        "--run-at",
+        "target",
+        "--into",
+        "dst",
+    ]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("remote transfer coordinator"), "{stderr}");
+    assert!(stderr.contains("--run-at local"), "{stderr}");
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1082,19 +1082,17 @@ fn native_receiver_ceilings_apply_only_to_direct_remote_copies() {
 }
 
 #[test]
-fn native_rejects_transport_configuration() {
-    for option in ["--rsh", "--syq-path", "--no-tcp", "--relay"] {
-        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
-            .args(["cp", option, "value", "source", "--into", "target"])
-            .run()
-            .unwrap();
-        assert_eq!(out.status.code(), Some(2), "{option}");
-        assert!(
-            String::from_utf8_lossy(&out.stderr).contains("unexpected argument"),
-            "{option}: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-    }
+fn native_keeps_rsync_only_relay_out_of_its_transport_surface() {
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--relay", "source", "--into", "target"])
+        .run()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("unexpected argument"),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 }
 
 #[test]
@@ -1575,6 +1573,34 @@ else
 fi
 export HOME PATH
 printf '%s\n' "$1" >> "$FAKE_RSH_LOG"
+exec /bin/sh -c "$1"
+"#,
+    );
+    path
+}
+
+/// An ssh-shaped fixture that records the connection arguments, including
+/// native endpoint ports and control-master policy, then runs the remote
+/// command locally.
+fn fake_ssh(t: &Tmp) -> PathBuf {
+    let path = t.path("bin/ssh");
+    executable(
+        &path,
+        br#"#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_RSH_LOG"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o|-l|-p) shift 2 ;;
+        -a|-A|-x|-k|-T) shift ;;
+        --) shift; break ;;
+        -*) shift ;;
+        *) break ;;
+    esac
+done
+shift
+HOME="$FAKE_REMOTE_HOME"
+PATH="$FAKE_REMOTE_BIN:/usr/bin:/bin"
+export HOME PATH
 exec /bin/sh -c "$1"
 "#,
     );
@@ -8052,8 +8078,9 @@ fn native_direct_remote_to_remote_forwards_copy_policies() {
     let original_inode = fs::metadata(t.path("dst/keep")).unwrap().ino();
 
     let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--rsh"])
+        .arg(&rsh)
         .args([
-            "cp",
             "--from",
             "fake",
             "--follow",
@@ -8070,7 +8097,6 @@ fn native_direct_remote_to_remote_forwards_copy_policies() {
             &t.s("dst"),
             "-q",
         ])
-        .env("SYQ_INTERNAL_NATIVE_RSH", rsh)
         .env("FAKE_REMOTE_HOME", t.path("remote-home"))
         .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
         .env("FAKE_RSH_LOG", t.path("rsh.log"))
@@ -8102,6 +8128,249 @@ fn native_direct_remote_to_remote_forwards_copy_policies() {
             "source command omitted {option}: {log}"
         );
     }
+}
+
+#[test]
+fn native_run_at_target_reverses_the_remote_ssh_edge() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src/file"), b"pulled");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--rsh"])
+        .arg(&rsh)
+        .args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args([
+            "--no-tcp",
+            "--tcp-ports=49000-49002",
+            "-j",
+            "1",
+            "--from",
+            "hostA",
+            "--src-src",
+            &t.s("src"),
+            "--to",
+            "hostB",
+            "--run-at",
+            "target",
+            "--into",
+            &t.s("dst"),
+            "-q",
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .run()
+        .expect("run native pull through fake remote shell");
+
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst/file")), b"pulled");
+    let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    let mut invocations = log.lines();
+    let target_command = invocations.next().expect("target coordinator launch");
+    assert!(target_command.contains("--from hostA"), "{target_command}");
+    assert!(target_command.contains("--no-tcp"), "{target_command}");
+    assert!(
+        target_command.contains("--tcp-ports=49000-49002"),
+        "{target_command}"
+    );
+    assert!(
+        invocations.next().is_some(),
+        "the target coordinator never opened the reversed edge to hostA: {log}"
+    );
+}
+
+#[test]
+fn native_run_at_local_relays_between_remote_endpoints() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src/file"), b"relayed");
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--rsh"])
+        .arg(&rsh)
+        .args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args([
+            "--no-tcp",
+            "-j",
+            "1",
+            "--from",
+            "hostA",
+            "--src-src",
+            &t.s("src"),
+            "--to",
+            "hostB",
+            "--run-at",
+            "local",
+            "--into",
+            &t.s("dst"),
+            "-q",
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .run()
+        .expect("run native relay through fake remote shell");
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst/file")), b"relayed");
+    assert!(
+        fs::read_to_string(t.path("rsh.log"))
+            .unwrap()
+            .lines()
+            .count()
+            >= 2,
+        "relay did not connect to both endpoints"
+    );
+}
+
+#[test]
+fn native_run_at_target_fails_closed_without_read_enrollment_support() {
+    let t = Tmp::new();
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--from",
+            "hostA",
+            "--src",
+            &t.s("src"),
+            "--to",
+            "hostB",
+            "--run-at",
+            "target",
+            "--into",
+            &t.s("dst"),
+        ])
+        .run()
+        .expect("reject unavailable default pull mode");
+
+    assert_eq!(out.status.code(), Some(1));
+    assert!(
+        stderr_of(&out).contains("read-restricted source enrollment"),
+        "{}",
+        stderr_of(&out)
+    );
+    assert!(!t.path("dst").exists());
+}
+
+#[test]
+fn native_endpoint_port_reaches_ssh() {
+    let t = Tmp::new();
+    let ssh = fake_ssh(&t);
+    write(&t.path("src"), b"first");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+    command
+        .arg("cp")
+        .args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args([
+            "--no-tcp",
+            "-j",
+            "1",
+            &t.s("src"),
+            "--to",
+            "backup.example:2222",
+            "--as",
+            &t.s("dst"),
+            "-q",
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", ssh.parent().unwrap().to_string_lossy()),
+        );
+    assert_output_ok(&command.run().unwrap());
+    assert_eq!(read(&t.path("dst")), b"first");
+    let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    assert!(log.lines().all(|line| line.contains("-p 2222")), "{log}");
+
+    assert!(log.contains("ControlMaster=yes"), "{log}");
+    assert!(log.contains("ControlPersist=no"), "{log}");
+}
+
+#[test]
+fn native_detach_waits_for_coordinator_readiness() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"detached");
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--rsh"])
+        .arg(&rsh)
+        .args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args([
+            "--no-tcp",
+            "-j",
+            "1",
+            "--detach",
+            "--from",
+            "hostA",
+            "--src",
+            &t.s("src"),
+            "--to",
+            "hostB",
+            "--as",
+            &t.s("dst"),
+            "-q",
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .run()
+        .expect("launch detached native transfer");
+    assert_output_ok(&out);
+    let follow_target = String::from_utf8(out.stdout).unwrap();
+    assert!(follow_target.starts_with("hostA:"), "{follow_target}");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !t.path("dst").exists() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert_eq!(read(&t.path("dst")), b"detached");
+    let ready_files = fs::read_dir(t.path("remote-home/.syq"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().ends_with(".ready"))
+        .count();
+    assert_eq!(ready_files, 0, "launcher left its readiness marker behind");
+}
+
+#[test]
+fn native_detach_does_not_report_an_immediate_setup_failure_as_started() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    let started = std::time::Instant::now();
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--rsh"])
+        .arg(&rsh)
+        .args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args([
+            "--no-tcp",
+            "--detach",
+            "--from",
+            "hostA",
+            "--src",
+            &t.s("missing"),
+            "--to",
+            "hostB",
+            "--as",
+            &t.s("dst"),
+            "-q",
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .run()
+        .expect("reject failed detached launch");
+    assert!(!out.status.success());
+    assert!(
+        out.stdout.is_empty(),
+        "failed launch returned a follow target"
+    );
+    assert!(stderr_of(&out).contains("source"), "{}", stderr_of(&out));
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(5),
+        "immediate setup failure waited for the full readiness timeout"
+    );
+    assert!(!t.path("dst").exists());
 }
 
 // ----------------------------------------------------------- review round 13


### PR DESCRIPTION
## Summary

- accept native remote endpoints as `[USER@]HOST[:PORT]`, including bracketed IPv6, and propagate ports through SSH execution, policy resolution, enrollment metadata, and follow commands
- add explicit `--run-at source|target|local` topology selection, including a reversed SSH edge for target-run copies and local relay mode
- expose native SSH/runtime controls including `--rsh`, `--syq-path`, bootstrap, TCP, forwarding, and broker policy options
- make detached coordinators report success only after transport setup and preflight complete
- document the topology, transport, and current restricted-channel boundaries

## Security boundaries

- implicit target-run authentication fails closed until the read-capable receiver grant from the receiver-policy stream is available; explicit SSH trust modes remain usable
- restricted `--no-tcp` and TCP fallback still need the authenticated worker session-join work from that stream; this change does not silently weaken authentication
- cross-run SSH connection reuse remains isolated in #102

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`