### PR TITLE
Replace cp-prune with cp --prune

### DIFF
--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -255,8 +255,8 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
   a policy exclusion like `--min-size`: the run still succeeds and the
   entry appears only in the excluded aggregate. Filter with
   `jq -c 'select(.kind != "special")'` to drop such entries up front.
-- Mappings define no deletion region, so `--mapping` is not available
-  on `cp-prune`.
+- Mappings define no deletion region, so `--mapping` cannot be combined
+  with `--prune`.
 - Duplicate lines are errors, even identical ones: a duplicate almost
   always means a generator bug. Deduplicate in your generator if you
   union overlapping fragments.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ syq cp --ignore '*.tmp' --src-src project --to server --into /app
 syq cp --follow --src-src current-project --to server --into /app
 syq cp --preserve=permissions,ownership project --to server --into /backup
 syq cp --inplace disk.img --to server --as-existing /images/disk.img
-syq cp-prune --src-src build --to server --into-existing /srv/app
+syq cp --prune --src-src build --to server --into-existing /srv/app
 syq rm cache old-output
 syq rm --from server --cwd /srv --src old-output
 syq rm --root /srv --src-dir cache
@@ -179,8 +179,7 @@ symlink. A trailing slash is ordinary path spelling and has no semantic effect.
 directory, while `--src-dir DIR` requires a directory. Without `--follow`, a
 symlink satisfies `--src-file` and is copied as a symlink, while it fails the
 `--src-dir` precondition. With `--follow`, the precondition and copy both apply
-to the referent. These typed selectors are available to `cp`, `cp-prune`, and
-`rm`.
+to the referent. These typed selectors are available to `cp` and `rm`.
 `--src-src DIR` selects a directory's contents and merges them directly into
 the target container. `--srcs PATH...`, `--src-srcs DIR...`, `--src-files
 PATH...`, and `--src-dirs DIR...` are bulk conveniences for the corresponding
@@ -267,11 +266,11 @@ command-restricted remote-to-remote path the precondition is also signed: the
 receiver checks it against the enrolled root when it claims the grant, and a
 `new` root can only be created without replacing anything.
 
-`cp` copies or updates mapped source objects and keeps unrelated target
-objects. `cp-prune` uses the same mapping and transfer engine, then applies the
-existing safe deletion planner to remove target-only descendants in mapped
-directory scopes. It never removes a source and requires explicit placement;
-`--max-delete N` keeps its all-or-nothing deletion budget.
+`cp` copies or updates mapped source objects and keeps unrelated target objects
+by default. With `--prune`, it then applies the existing safe deletion planner
+to remove target-only descendants in mapped directory scopes. Pruning never
+removes a source and requires explicit placement; `--max-delete N` keeps its
+all-or-nothing deletion budget.
 
 Native `rm` resolves every explicit selector at the endpoint and pins the
 result before it makes its first change. Missing selectors are successful and
@@ -323,34 +322,35 @@ ACLs, and xattrs are not preserved.
 
 All native commands accept `--follow`, `-n`/`--dry-run`, `-v`/`--verbose`,
 `-q`/`--quiet`, `-j`/`--connections`, `--progress`/`--no-progress`, and
-`--progress-json` in addition to their endpoint and selector options. `cp` and `cp-prune` also
-accept `--hash`, `--no-compress`, `--bwlimit RATE`, `--stats`,
+`--progress-json` in addition to their endpoint and selector options. `cp` also
+accepts `--hash`, `--no-compress`, `--bwlimit RATE`, `--stats`,
 `--reuse-connection`, repeatable
 `--ignore PATTERN`/`--ignore-from FILE`, `--preserve`, and `--inplace`. Filters
 use the gitignore semantics described below and apply at every source root;
-`cp-prune` protects excluded destination paths from pruning. `--hash`
+`--prune` protects excluded destination paths from pruning. `--hash`
 compares existing regular-file contents with full BLAKE3 digests instead of
 trusting equal size and modification time; it does not add a second
 post-transfer verification pass. The bandwidth limit applies only to file
 data, not scanning, hashing, metadata, or pruning. A
 native copy may also use `--max-size SIZE` or `--min-size SIZE` to skip regular
 source files outside that inclusive range. Those files remain part of the
-source population, so `cp-prune` protects any corresponding destination paths.
+source population, so `--prune` protects any corresponding destination paths.
 A command-restricted remote-to-remote copy currently refuses `--min-size` and
-refuses `--max-size` with `cp-prune`, as described below. A
+refuses `--max-size` with `--prune`, as described below. A
 command-restricted remote-to-remote receiver independently enforces the signed
 aggregate limit, signed filters, and the selected staged or in-place publication
 policy. A receiver installed by an older syq rejects an extension or unsupported
 policy safely; rerun `syq enroll HOST:DEST` to refresh an existing enrollment
 to the current binary. On a direct remote-to-remote copy through that
-receiver, `cp` and `cp-prune` also accept the receiver ceilings
+receiver, `cp` also accepts the receiver ceilings
 `--max-entries N`, `--max-total-bytes SIZE`, and `--max-runtime DURATION`
 (`s`, `m`, or `h`; at most 23h). They are signed into the grant and enforced
 by hostB, and are refused anywhere else because nothing would enforce them.
 `cp` additionally accepts `--mapping` and `--results`
-(see [MAPPINGS.md](MAPPINGS.md)). `cp-prune` additionally
-accepts `--max-delete`; `rm` additionally accepts `--root` plus
-its endpoint-side removal semantics.
+(see [MAPPINGS.md](MAPPINGS.md)), but neither can be combined with `--prune`:
+mapping manifests define no deletion region, and the preview results schema
+does not yet represent deletions. `--max-delete` requires `--prune`; `rm`
+additionally accepts `--root` plus its endpoint-side removal semantics.
 
 Other comparison and selection controls, block and split sizing, and
 SSH/transport configuration remain available only through `syq rsync`.
@@ -616,7 +616,7 @@ with deletion because filtered source files could otherwise make hostA's
 deletion plan ambiguous. Explicit `-j` values above 64 are also refused; auto
 tuning may use up to that signed ceiling.
 
-Deletion through the receiver (`cp-prune`, or `--delete` on the rsync-shaped
+Deletion through the receiver (`cp --prune`, or `--delete` on the rsync-shaped
 command) requires an explicit `--max-delete`, so the deletion authority a
 compromised hostA could exercise inside the scope is always stated on the
 command line rather than defaulting to a hundred million; `--max-delete 0`
@@ -1269,7 +1269,7 @@ syq rsync -a --ignore 'logs/*' --ignore '!logs/keep/' src/ dst/ # everything in 
 syq rsync -a --ignore-from .gitignore --ignore '!dist/' repo/ host:repo/
 syq rsync -a --ignore '*' --ignore '!*/' --ignore '!*.jpg' photos/ bak/ # copy only *.jpg
 syq cp --ignore-from .gitignore --src-src repo --to host --into repo
-syq cp-prune --ignore cache/ --src-src build --into-existing deploy
+syq cp --prune --ignore cache/ --src-src build --into-existing deploy
 ```
 
 Rules of thumb (they're git's): `foo` matches a file or directory named `foo`
@@ -1280,8 +1280,9 @@ it is transferred or even scanned — which is why "only `*.jpg`" needs the
 (this is a filter on the walk, not git's notion of what's tracked). The source
 root itself is never ignored; with several sources each is filtered from its
 own root. `-n` previews the selected scope and intended changes. The same rules
-are available on native `cp` and `cp-prune`. Neither native `rm` nor compatibility
-`--rm` takes filters: removal always selects the whole explicit tree.
+are available on native `cp`, with or without `--prune`. Neither native `rm`
+nor compatibility `--rm` takes filters: removal always selects the whole
+explicit tree.
 
 As in git, a `!` rule cannot re-include something whose parent directory is
 ignored: `logs/**` prunes `logs/keep` itself, so `!logs/keep/**` after it has

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,6 @@ pub enum Interface {
     #[default]
     Rsync,
     NativeCp,
-    NativeCpPrune,
     NativeRm,
     NativeMap,
 }
@@ -386,7 +385,6 @@ impl Args {
         match command {
             "rsync" => Self::parse_rsync(&argv[1..]),
             "cp" => parse_native(&argv[1..], Interface::NativeCp),
-            "cp-prune" => parse_native(&argv[1..], Interface::NativeCpPrune),
             "rm" => parse_native(&argv[1..], Interface::NativeRm),
             "map" => parse_native(&argv[1..], Interface::NativeMap),
             "--help" | "-h" => {
@@ -401,7 +399,7 @@ impl Args {
             // remain top-level. Internal helper switches are handled in main.
             "--self-update" | "--register-standalone-install" => Self::parse_rsync(&argv),
             _ => bail!(
-                "expected a command (`cp`, `cp-prune`, `rm`, `map`, or `rsync`); rsync-shaped syntax now starts with `syq rsync`"
+                "expected a command (`cp`, `rm`, `map`, or `rsync`); rsync-shaped syntax now starts with `syq rsync`"
             ),
         }
     }
@@ -542,7 +540,7 @@ fn ordered_ignore_lines(
 
 fn print_root_help() {
     println!(
-        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects without removing target-only objects\n  cp-prune     Copy, then remove target-only objects in the mapped scope\n  rm           Remove explicitly selected object trees\n  map          Print a copy's resolved selection and placement as NDJSON\n  rsync        Use the retained rsync-shaped command surface\n  enroll       Pre-enroll a command-restricted remote destination\n  enrollments  List local command-restricted enrollments\n  revoke       Revoke a command-restricted enrollment\n\nRun `syq <COMMAND> --help` for command-specific help."
+        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning target-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a copy's resolved selection and placement as NDJSON\n  rsync        Use the retained rsync-shaped command surface\n  enroll       Pre-enroll a command-restricted remote destination\n  enrollments  List local command-restricted enrollments\n  revoke       Revoke a command-restricted enrollment\n\nRun `syq <COMMAND> --help` for command-specific help."
     );
 }
 
@@ -782,10 +780,10 @@ struct NativeCopyFields {
 
 #[derive(clap::Args, Debug, Default)]
 struct NativeSizeSelectionArgs {
-    /// Skip regular source files larger than SIZE; cp-prune protects their destination paths
+    /// Skip regular source files larger than SIZE; --prune protects their destination paths
     #[arg(long, value_name = "SIZE")]
     max_size: Option<String>,
-    /// Skip regular source files smaller than SIZE; cp-prune protects their destination paths
+    /// Skip regular source files smaller than SIZE; --prune protects their destination paths
     #[arg(long, value_name = "SIZE")]
     min_size: Option<String>,
 }
@@ -795,7 +793,7 @@ struct NativeSizeSelectionArgs {
     name = "syq cp",
     version,
     about = "Copy selected objects with explicit endpoint and placement syntax",
-    long_about = "Copy selected objects with explicit endpoint and placement syntax.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files.",
+    long_about = "Copy selected objects with explicit endpoint and placement syntax.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files. By default, destination-only objects remain in place. --prune removes them from mapped directory scopes after copying, while protecting ignored and size-excluded paths.",
     override_usage = "syq cp [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]... PLACEMENT"
 )]
 struct NativeCopyCommand {
@@ -803,23 +801,12 @@ struct NativeCopyCommand {
     copy: NativeCopyFields,
     #[command(flatten)]
     size_selection: NativeSizeSelectionArgs,
-}
-
-#[derive(Parser, Debug)]
-#[command(
-    name = "syq cp-prune",
-    version,
-    about = "Copy selected objects, then remove target-only objects in mapped scopes",
-    long_about = "Copy selected objects, then remove target-only objects in mapped scopes.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files. Removal uses the current post-transfer deletion scopes and guards; ignored paths remain protected.",
-    override_usage = "syq cp-prune [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]... PLACEMENT"
-)]
-struct NativeCopyPruneCommand {
-    #[command(flatten)]
-    copy: NativeCopyFields,
-    #[command(flatten)]
-    size_selection: NativeSizeSelectionArgs,
-    /// Refuse all removals if more than N are planned
-    #[arg(long, value_name = "N")]
+    /// After copying, remove target-only objects in mapped directory scopes;
+    /// ignored and size-excluded source paths remain protected
+    #[arg(long, conflicts_with_all = ["mapping", "results"])]
+    prune: bool,
+    /// With --prune, refuse all removals if more than N are planned
+    #[arg(long, value_name = "N", requires = "prune")]
     max_delete: Option<u64>,
 }
 
@@ -852,9 +839,7 @@ struct NativeRmCommand {
 
 fn parse_native(argv: &[OsString], interface: Interface) -> Result<Args> {
     match interface {
-        Interface::NativeCp | Interface::NativeCpPrune | Interface::NativeMap => {
-            parse_native_copy(argv, interface)
-        }
+        Interface::NativeCp | Interface::NativeMap => parse_native_copy(argv, interface),
         Interface::NativeRm => parse_native_rm(argv),
         Interface::Rsync => unreachable!(),
     }
@@ -863,36 +848,32 @@ fn parse_native(argv: &[OsString], interface: Interface) -> Result<Args> {
 fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     let mut full_argv = vec![OsString::from(command_label(interface))];
     full_argv.extend_from_slice(argv);
-    let (mut parsed, matches, max_delete, size_selection) = if interface == Interface::NativeCpPrune
-    {
-        let matches = NativeCopyPruneCommand::command()
-            .try_get_matches_from(full_argv)
-            .unwrap_or_else(|error| error.exit());
-        let parsed = NativeCopyPruneCommand::from_arg_matches(&matches)?;
-        (
-            parsed.copy,
-            matches,
-            parsed.max_delete,
-            parsed.size_selection,
-        )
-    } else if interface == Interface::NativeMap {
-        let matches = NativeMapCommand::command()
-            .try_get_matches_from(full_argv)
-            .unwrap_or_else(|error| error.exit());
-        let parsed = NativeMapCommand::from_arg_matches(&matches)?;
-        (
-            parsed.copy,
-            matches,
-            None,
-            NativeSizeSelectionArgs::default(),
-        )
-    } else {
-        let matches = NativeCopyCommand::command()
-            .try_get_matches_from(full_argv)
-            .unwrap_or_else(|error| error.exit());
-        let parsed = NativeCopyCommand::from_arg_matches(&matches)?;
-        (parsed.copy, matches, None, parsed.size_selection)
-    };
+    let (mut parsed, matches, prune, max_delete, size_selection) =
+        if interface == Interface::NativeMap {
+            let matches = NativeMapCommand::command()
+                .try_get_matches_from(full_argv)
+                .unwrap_or_else(|error| error.exit());
+            let parsed = NativeMapCommand::from_arg_matches(&matches)?;
+            (
+                parsed.copy,
+                matches,
+                false,
+                None,
+                NativeSizeSelectionArgs::default(),
+            )
+        } else {
+            let matches = NativeCopyCommand::command()
+                .try_get_matches_from(full_argv)
+                .unwrap_or_else(|error| error.exit());
+            let parsed = NativeCopyCommand::from_arg_matches(&matches)?;
+            (
+                parsed.copy,
+                matches,
+                parsed.prune,
+                parsed.max_delete,
+                parsed.size_selection,
+            )
+        };
     // `syq map` keeps `-C` out of selector paths so emitted `src` values stay
     // relative to it; the walk joins it back.
     let map_cwd = if interface == Interface::NativeMap {
@@ -909,7 +890,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
         bail!("--results is only available on syq cp");
     }
     if parsed.reuse_connection && interface == Interface::NativeMap {
-        bail!("--reuse-connection is only available on syq cp and cp-prune");
+        bail!("--reuse-connection is only available on syq cp");
     }
     if results.is_some() && parsed.operational.common.dry_run {
         // Dry-run trace output is a deliberately deferred automation
@@ -1071,7 +1052,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     args.placement = placement;
     args.target_existence = existence;
     args.locations = locations;
-    args.delete = interface == Interface::NativeCpPrune;
+    args.delete = prune;
     args.max_delete = max_delete;
     args.max_size = size_selection.max_size;
     args.min_size = size_selection.min_size;
@@ -1345,7 +1326,6 @@ fn command_label(interface: Interface) -> &'static str {
     match interface {
         Interface::Rsync => "syq rsync",
         Interface::NativeCp => "syq cp",
-        Interface::NativeCpPrune => "syq cp-prune",
         Interface::NativeRm => "syq rm",
         Interface::NativeMap => "syq map",
     }
@@ -1797,6 +1777,21 @@ mod tests {
         assert!(args.inplace);
         assert_eq!(args.min_size.as_deref(), Some("1K"));
         assert_eq!(args.max_size.as_deref(), Some("1M"));
+    }
+
+    #[test]
+    fn native_prune_lowers_to_shared_deletion_policy() {
+        let argv = [
+            "--prune",
+            "--max-delete=3",
+            "source",
+            "--into",
+            "destination",
+        ]
+        .map(std::ffi::OsString::from);
+        let args = parse_native_copy(&argv, Interface::NativeCp).unwrap();
+        assert!(args.delete);
+        assert_eq!(args.max_delete, Some(3));
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -343,7 +343,6 @@ pub fn run(
     let mut remote: Vec<String> = vec![match args.interface {
         Interface::Rsync => "rsync",
         Interface::NativeCp => "cp",
-        Interface::NativeCpPrune => "cp-prune",
         Interface::NativeRm => bail!("native rm cannot be a remote-to-remote transfer"),
         Interface::NativeMap => bail!("syq map runs locally and is never remoted"),
     }
@@ -385,6 +384,9 @@ pub fn run(
     }
     if args.interface != Interface::Rsync && args.native_follow {
         remote.push("--follow".into());
+    }
+    if args.interface == Interface::NativeCp && args.delete {
+        remote.push("--prune".into());
     }
     if args.inplace {
         remote.push("--inplace".into());

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -1,6 +1,6 @@
 //! End-to-end enrollment and signed restricted-transfer integration.
 
-use crate::cli::{Args, Existence, Interface, Location, Placement};
+use crate::cli::{Args, Existence, Location, Placement};
 use crate::delegation::{
     self, CopyLimitsV1, CopyOperationV1, CopyOptionsV1, CopyPolicyV1, DeletionPolicyV1,
     DestinationPlacementV1, ExistingDestinationPolicyV1, FilterPolicyV3, GrantExtensions,
@@ -2518,11 +2518,7 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
             "--inplace cannot be combined with --ignore-existing, --existing, or --as-new on the command-restricted path: in-place writes open the final pathname directly, so the receiver can neither make them no-replace nor pin them to an observed object"
         );
     }
-    if !args.dry_run
-        && !args.verify_only
-        && (args.delete || args.interface == Interface::NativeCpPrune)
-        && args.max_delete.is_none()
-    {
+    if !args.dry_run && !args.verify_only && args.delete && args.max_delete.is_none() {
         // The signed deletion count is the only bound on what a compromised
         // hostA can remove inside the scope, so make it an explicit choice
         // instead of a silent hundred-million default.
@@ -2579,11 +2575,7 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
             "--reuse-connection is not available with the command-restricted receiver: its host-bound authentication is verified per fresh connection"
         );
     }
-    if !args.dry_run
-        && !args.verify_only
-        && (args.delete || args.interface == Interface::NativeCpPrune)
-        && args.max_size.is_some()
-    {
+    if !args.dry_run && !args.verify_only && args.delete && args.max_size.is_some() {
         bail!(
             "--max-size with deletion is not yet independently enforceable by the command-restricted receiver"
         );
@@ -2613,10 +2605,7 @@ fn grant_for(
     let read_only = args.dry_run || args.verify_only;
     // `--max-delete 0` means nothing may be deleted, which the grant states
     // directly as a forbidding policy rather than a zero budget.
-    let deletion = if !read_only
-        && (args.delete || args.interface == Interface::NativeCpPrune)
-        && args.max_delete != Some(0)
-    {
+    let deletion = if !read_only && args.delete && args.max_delete != Some(0) {
         DeletionPolicyV1::DeleteDestinationOnly
     } else {
         DeletionPolicyV1::Forbid

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -447,7 +447,7 @@ fn native_copy_typed_selectors_are_source_preconditions() {
 }
 
 #[test]
-fn native_cp_prune_checks_all_typed_sources_before_mutation() {
+fn native_cp_with_prune_checks_all_typed_sources_before_mutation() {
     let t = Tmp::new();
     write(&t.path("src/good"), b"new");
     write(&t.path("src/not-a-file/child"), b"child");
@@ -455,7 +455,8 @@ fn native_cp_prune_checks_all_typed_sources_before_mutation() {
     write(&t.path("dst/extra"), b"keep");
 
     let output = native_syq(&[
-        "cp-prune",
+        "cp",
+        "--prune",
         "--src-file",
         &t.s("src/good"),
         "--src-file",
@@ -519,35 +520,30 @@ fn native_hash_repairs_equal_metadata_content_mismatches() {
     write(&t.path("src/file"), &expected);
     set_mtime(&t.path("src/file"), 1_600_000_000);
 
-    for (command, destination) in [("cp", "copied"), ("cp-prune", "pruned")] {
+    for (prune, destination) in [(false, "copied"), (true, "pruned")] {
         write(&t.path(&format!("{destination}/file")), &corrupted);
         set_mtime(&t.path(&format!("{destination}/file")), 1_600_000_000);
-        if command == "cp-prune" {
+        if prune {
             write(&t.path(&format!("{destination}/extra")), b"remove");
         }
 
-        run_native_ok(&[
-            command,
-            "--src-src",
-            &t.s("src"),
-            "--into-existing",
-            &t.s(destination),
-        ]);
+        let source = t.s("src");
+        let target = t.s(destination);
+        let mut args = vec!["cp"];
+        if prune {
+            args.push("--prune");
+        }
+        args.extend(["--src-src", &source, "--into-existing", &target]);
+        run_native_ok(&args);
         assert_eq!(read(&t.path(&format!("{destination}/file"))), corrupted);
-        if command == "cp-prune" {
+        if prune {
             write(&t.path(&format!("{destination}/extra")), b"remove");
         }
 
-        run_native_ok(&[
-            command,
-            "--hash",
-            "--src-src",
-            &t.s("src"),
-            "--into-existing",
-            &t.s(destination),
-        ]);
+        args.insert(1, "--hash");
+        run_native_ok(&args);
         assert_eq!(read(&t.path(&format!("{destination}/file"))), expected);
-        if command == "cp-prune" {
+        if prune {
             assert!(!t.path(&format!("{destination}/extra")).exists());
         }
     }
@@ -575,7 +571,8 @@ fn native_filters_apply_to_copy_and_protect_pruned_paths() {
     write(&t.path("pruned/discard.tmp"), b"protected-old-copy");
     write(&t.path("pruned/extra"), b"remove");
     run_native_ok(&[
-        "cp-prune",
+        "cp",
+        "--prune",
         "--ignore-from",
         &t.s("patterns"),
         "--ignore",
@@ -616,7 +613,8 @@ fn native_size_limits_select_regular_files_and_protect_pruned_paths() {
     write(&t.path("pruned/large"), b"old-large");
     write(&t.path("pruned/extra"), b"remove");
     run_native_ok(&[
-        "cp-prune",
+        "cp",
+        "--prune",
         "--min-size=2",
         "--max-size=4",
         "--src-src",
@@ -1014,14 +1012,15 @@ fn native_copy_preserves_non_utf8_selector_bytes() {
 }
 
 #[test]
-fn native_cp_prune_removes_only_target_extras_after_copy() {
+fn native_cp_with_prune_removes_only_target_extras_after_copy() {
     let t = Tmp::new();
     write(&t.path("src/keep"), b"new content");
     write(&t.path("dst/keep"), b"old");
     write(&t.path("dst/extra"), b"extra");
 
     run_native_ok(&[
-        "cp-prune",
+        "cp",
+        "--prune",
         "--src-src",
         &t.s("src"),
         "--into-existing",
@@ -4489,7 +4488,7 @@ fn native_cp_matches_rsync_rlt() {
 }
 
 #[test]
-fn native_cp_prune_matches_rsync_delete() {
+fn native_cp_with_prune_matches_rsync_delete() {
     let t = Tmp::new();
     write(&t.path("src/keep"), b"source");
     for destination in ["rsync", "native"] {
@@ -4499,7 +4498,8 @@ fn native_cp_prune_matches_rsync_delete() {
 
     run_ok(&["-rlt", "--delete", &t.s("src/"), &t.s("rsync/")]);
     run_native_ok(&[
-        "cp-prune",
+        "cp",
+        "--prune",
         "--src-src",
         &t.s("src"),
         "--into-existing",
@@ -4650,6 +4650,13 @@ fn native_rejects_positional_destinations_implicit_verbs_and_compat_flags() {
     assert_eq!(implicit.status.code(), Some(2));
     assert!(String::from_utf8_lossy(&implicit.stderr).contains("expected a command"));
 
+    let removed = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp-prune", "source", "--into", "dest"])
+        .run()
+        .unwrap();
+    assert_eq!(removed.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&removed.stderr).contains("expected a command"));
+
     for args in [
         ["cp", "-a", "source", "--into", "dest"].as_slice(),
         ["cp", "--delete", "source", "--into", "dest"].as_slice(),
@@ -4668,17 +4675,23 @@ fn native_rejects_positional_destinations_implicit_verbs_and_compat_flags() {
             String::from_utf8_lossy(&out.stderr)
         );
     }
+
+    let max_delete_without_prune =
+        native_syq(&["cp", "--max-delete", "0", "source", "--into", "dest"]);
+    assert_eq!(max_delete_without_prune.status.code(), Some(2));
+    assert!(stderr_of(&max_delete_without_prune).contains("--prune"));
 }
 
 #[test]
-fn native_cp_prune_keeps_placement_siblings_and_honors_max_delete() {
+fn native_cp_with_prune_keeps_placement_siblings_and_honors_max_delete() {
     let t = Tmp::new();
     write(&t.path("source/tree/keep"), b"keep");
     write(&t.path("named/tree/keep"), b"old");
     write(&t.path("named/tree/extra"), b"extra");
     write(&t.path("named/outside"), b"outside");
     run_native_ok(&[
-        "cp-prune",
+        "cp",
+        "--prune",
         "--src",
         &t.s("source/tree"),
         "--into-existing",
@@ -4689,7 +4702,8 @@ fn native_cp_prune_keeps_placement_siblings_and_honors_max_delete() {
 
     write(&t.path("contents/extra"), b"extra");
     let refused = native_syq(&[
-        "cp-prune",
+        "cp",
+        "--prune",
         "--max-delete",
         "0",
         "--src-src",
@@ -8034,6 +8048,7 @@ fn native_direct_remote_to_remote_forwards_copy_policies() {
     write(&t.path("src/skip.tmp"), b"excluded");
     fs::set_permissions(t.path("src/keep"), fs::Permissions::from_mode(0o640)).unwrap();
     write(&t.path("dst/keep"), b"old");
+    write(&t.path("dst/extra"), b"remove");
     let original_inode = fs::metadata(t.path("dst/keep")).unwrap().ino();
 
     let out = Command::new(env!("CARGO_BIN_EXE_syq"))
@@ -8049,6 +8064,8 @@ fn native_direct_remote_to_remote_forwards_copy_policies() {
             "--ignore=*.tmp",
             "--preserve=permissions",
             "--inplace",
+            "--prune",
+            "--max-delete=1",
             "--into-existing",
             &t.s("dst"),
             "-q",
@@ -8070,12 +8087,15 @@ fn native_direct_remote_to_remote_forwards_copy_policies() {
     );
     assert_eq!(metadata.mode() & 0o777, 0o640);
     assert!(!t.path("dst/skip.tmp").exists());
+    assert!(!t.path("dst/extra").exists());
     let log = fs::read_to_string(t.path("rsh.log")).unwrap();
     for option in [
         "--follow",
         "--ignore=*.tmp",
         "--preserve=permissions",
         "--inplace",
+        "--prune",
+        "--max-delete=1",
     ] {
         assert!(
             log.contains(option),
@@ -8479,6 +8499,15 @@ fn native_cp_mapping_hard_refusals() {
     let out = syq_cp_in(&t.path(""), &["--mapping", "-", "--as", "exact"], Some(b""));
     assert!(!out.status.success());
     assert!(String::from_utf8_lossy(&out.stderr).contains("--as conflicts with --mapping"));
+    let out = syq_cp_in(
+        &t.path(""),
+        &["--prune", "--mapping", "-", "-C", "src", "--into", "dst"],
+        Some(b""),
+    );
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("cannot be used with"), "{stderr}");
+    assert!(stderr.contains("--prune"), "{stderr}");
 }
 
 #[test]
@@ -8667,10 +8696,27 @@ fn native_cp_results_without_mapping_and_refusals() {
     assert_eq!(op["disposition"], "succeeded");
     assert!(op.get("src").is_none(), "non-mapping records carry no src");
     assert_eq!(lines.last().unwrap()["status"], "success");
-    // map and cp-prune refuse --results.
+    // map and pruning copies refuse --results.
     let out = syq_map_in(&t.path(""), &["--src-src", "src", "--results", "r.ndjson"]);
     assert!(!out.status.success());
     assert!(String::from_utf8_lossy(&out.stderr).contains("only available on syq cp"));
+    let out = syq_cp_in(
+        &t.path(""),
+        &[
+            "--prune",
+            "--src-src",
+            "src",
+            "--into",
+            "pruned",
+            "--results",
+            "r.ndjson",
+        ],
+        None,
+    );
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("cannot be used with"), "{stderr}");
+    assert!(stderr.contains("--prune"), "{stderr}");
 }
 
 // ---- review-round fixes ----


### PR DESCRIPTION
## Summary

- replace the separate `cp-prune` command with explicit `syq cp --prune`
- keep ordinary `cp` non-destructive by default and require `--prune` for `--max-delete`
- preserve mapped-scope deletion safeguards, exclusions, restricted grants, and direct remote forwarding
- reject `--prune` with `--mapping` or `--results`, whose current contracts do not define deletion behavior
- update the user-facing documentation and integration coverage

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`