### PR TITLE
Issue signed receipts from the command-restricted receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,10 @@ policy safely; rerun `syq enroll HOST:DEST` to refresh an existing enrollment
 to the current binary. On a direct remote-to-remote copy through that
 receiver, `cp` and `cp-prune` also accept the receiver ceilings
 `--max-entries N`, `--max-total-bytes SIZE`, and `--max-runtime DURATION`
-(`s`, `m`, or `h`; at most 23h). They are signed into the grant and enforced
-by hostB, and are refused anywhere else because nothing would enforce them.
+(`s`, `m`, or `h`; at most 23h), and `--receipt hashed`, which asks the
+receiver to record a BLAKE3 digest of every file it publishes in its signed
+receipt. They are signed into the grant and enforced or honored by hostB, and
+are refused anywhere else because nothing would act on them.
 `cp` additionally accepts `--mapping` and `--results`
 (see [MAPPINGS.md](MAPPINGS.md)). `cp-prune` additionally
 accepts `--max-delete`; `rm` additionally accepts `--root` plus

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,6 +323,9 @@ pub struct Args {
     pub max_total_bytes: Option<u64>,
     #[arg(skip)]
     pub max_runtime_secs: Option<u32>,
+    /// Native-only: ask the command-restricted receiver for a hashed receipt.
+    #[arg(skip)]
+    pub receipt_hashed: bool,
     /// Skip regular files that are newer on the destination (directories,
     /// symlinks and specials are unaffected)
     #[arg(short = 'u', long)]
@@ -697,6 +700,15 @@ struct NativeCopyOperationalArgs {
     /// Command-restricted receiver ceiling: the signed grant expires DURATION after it is issued, e.g. 30m or 2h (direct remote-to-remote only; at most 23h)
     #[arg(long, value_name = "DURATION")]
     max_runtime: Option<String>,
+    /// Receipt detail from the command-restricted receiver: sizes of published files (default) or also a BLAKE3 digest of each (direct remote-to-remote only)
+    #[arg(long, value_name = "MODE", value_enum)]
+    receipt: Option<ReceiptMode>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum ReceiptMode {
+    Sizes,
+    Hashed,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -1095,6 +1107,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     if args.max_entries.is_some()
         || args.max_total_bytes.is_some()
         || args.max_runtime_secs.is_some()
+        || args.receipt_hashed
     {
         // These are assertions for hostB's enrolled receiver to enforce; with
         // no such receiver in the topology, nothing would enforce them, so
@@ -1103,7 +1116,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
         let dst_remote = args.locations.last().is_some_and(|l| l.host.is_some());
         if !(src_remote && dst_remote) {
             bail!(
-                "--max-entries, --max-total-bytes, and --max-runtime are command-restricted receiver ceilings; they apply only to direct remote-to-remote copies"
+                "--max-entries, --max-total-bytes, --max-runtime, and --receipt address the command-restricted receiver; they apply only to direct remote-to-remote copies"
             );
         }
     }
@@ -1276,7 +1289,9 @@ fn apply_native_copy_operational(
         max_entries,
         max_total_bytes,
         max_runtime,
+        receipt,
     } = operational;
+    args.receipt_hashed = receipt == Some(ReceiptMode::Hashed);
     args.max_entries = max_entries;
     args.max_total_bytes = max_total_bytes.as_deref().map(parse_size).transpose()?;
     args.max_runtime_secs = max_runtime

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,7 +323,10 @@ pub struct Args {
     pub max_total_bytes: Option<u64>,
     #[arg(skip)]
     pub max_runtime_secs: Option<u32>,
-    /// Native-only: ask the command-restricted receiver for a hashed receipt.
+    /// Native-only: `--receipt` was given at all, and whether it asked the
+    /// command-restricted receiver for a hashed receipt.
+    #[arg(skip)]
+    pub receipt_requested: bool,
     #[arg(skip)]
     pub receipt_hashed: bool,
     /// Skip regular files that are newer on the destination (directories,
@@ -1107,7 +1110,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     if args.max_entries.is_some()
         || args.max_total_bytes.is_some()
         || args.max_runtime_secs.is_some()
-        || args.receipt_hashed
+        || args.receipt_requested
     {
         // These are assertions for hostB's enrolled receiver to enforce; with
         // no such receiver in the topology, nothing would enforce them, so
@@ -1291,6 +1294,7 @@ fn apply_native_copy_operational(
         max_runtime,
         receipt,
     } = operational;
+    args.receipt_requested = receipt.is_some();
     args.receipt_hashed = receipt == Some(ReceiptMode::Hashed);
     args.max_entries = max_entries;
     args.max_total_bytes = max_total_bytes.as_deref().map(parse_size).transpose()?;

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -62,8 +62,11 @@ const WIRE_MAGIC: &[u8; 8] = b"SYQGRNT\0";
 // enrollment policies authorize this protocol family by that namespace.
 const WIRE_VERSION_V1: u16 = 1;
 const WIRE_VERSION_V2: u16 = 2;
+// V5 adds the receipt policy: whether the receiver must issue a signed
+// receipt and whether it hashes what it publishes.
 const WIRE_VERSION_V3: u16 = 3;
-const WIRE_VERSION: u16 = 4;
+const WIRE_VERSION_V4: u16 = 4;
+const WIRE_VERSION: u16 = 5;
 const WIRE_HEADER_LEN: usize = WIRE_MAGIC.len() + 2 + 4 + 4;
 const MAX_GRANT_BYTES: usize = 32 * 1024;
 const MAX_SIGNATURE_BYTES: usize = 16 * 1024;
@@ -426,12 +429,45 @@ struct GrantBodyV4 {
     root_existence: RootExistenceV4,
 }
 
+/// Whether the receiver must issue a signed receipt for this grant, and how
+/// much it records. A required receipt is what lets the invoking machine
+/// check hostA's report against hostB's own account.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ReceiptPolicyV5 {
+    pub required: bool,
+    /// Also record a BLAKE3 digest of every published file.
+    pub hashed: bool,
+}
+
+impl ReceiptPolicyV5 {
+    pub(crate) fn is_active(self) -> bool {
+        self.required || self.hashed
+    }
+
+    fn validate(self) -> Result<()> {
+        if self.hashed && !self.required {
+            bail!("hashed receipts require a receipt");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct GrantBodyV5 {
+    grant: GrantV1,
+    max_file_data_bytes_per_second: u64,
+    filters: FilterPolicyV3,
+    root_existence: RootExistenceV4,
+    receipt: ReceiptPolicyV5,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct SignedGrantEnvelope {
     pub grant: GrantV1,
     pub max_file_data_bytes_per_second: u64,
     pub filters: FilterPolicyV3,
     pub root_existence: RootExistenceV4,
+    pub receipt: ReceiptPolicyV5,
     /// Canonical OpenSSH armored SSHSIG bytes.
     pub signature: Vec<u8>,
     wire_version: u16,
@@ -445,6 +481,7 @@ impl SignedGrantEnvelope {
             max_file_data_bytes_per_second,
             filters: FilterPolicyV3::default(),
             root_existence: RootExistenceV4::Any,
+            receipt: ReceiptPolicyV5::default(),
             signature,
             wire_version: WIRE_VERSION,
         }
@@ -459,6 +496,7 @@ impl SignedGrantEnvelope {
             self.max_file_data_bytes_per_second,
             &self.filters,
             self.root_existence,
+            self.receipt,
         )?;
         if body.len() > MAX_GRANT_BYTES {
             bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
@@ -486,7 +524,7 @@ impl SignedGrantEnvelope {
         let version = u16::from_be_bytes(bytes[8..10].try_into().expect("fixed header"));
         if !matches!(
             version,
-            WIRE_VERSION_V1 | WIRE_VERSION_V2 | WIRE_VERSION_V3 | WIRE_VERSION
+            WIRE_VERSION_V1 | WIRE_VERSION_V2 | WIRE_VERSION_V3 | WIRE_VERSION_V4 | WIRE_VERSION
         ) {
             bail!("unsupported signed grant envelope version {version}");
         }
@@ -508,50 +546,73 @@ impl SignedGrantEnvelope {
             bail!("signed grant envelope length is noncanonical");
         }
         let body_bytes = &bytes[WIRE_HEADER_LEN..WIRE_HEADER_LEN + grant_len];
-        let (grant, max_file_data_bytes_per_second, filters, root_existence) = match version {
-            WIRE_VERSION_V1 => {
-                let grant: GrantV1 =
-                    postcard::from_bytes(body_bytes).context("decode signed grant")?;
-                (grant, 0, FilterPolicyV3::default(), RootExistenceV4::Any)
-            }
-            WIRE_VERSION_V2 => {
-                let body: GrantBodyV2 =
-                    postcard::from_bytes(body_bytes).context("decode signed grant")?;
-                (
-                    body.grant,
-                    body.max_file_data_bytes_per_second,
-                    FilterPolicyV3::default(),
-                    RootExistenceV4::Any,
-                )
-            }
-            WIRE_VERSION_V3 => {
-                let body: GrantBodyV3 =
-                    postcard::from_bytes(body_bytes).context("decode signed grant")?;
-                (
-                    body.grant,
-                    body.max_file_data_bytes_per_second,
-                    body.filters,
-                    RootExistenceV4::Any,
-                )
-            }
-            WIRE_VERSION => {
-                let body: GrantBodyV4 =
-                    postcard::from_bytes(body_bytes).context("decode signed grant")?;
-                (
-                    body.grant,
-                    body.max_file_data_bytes_per_second,
-                    body.filters,
-                    body.root_existence,
-                )
-            }
-            _ => unreachable!(),
-        };
+        let no_receipt = ReceiptPolicyV5::default();
+        let (grant, max_file_data_bytes_per_second, filters, root_existence, receipt) =
+            match version {
+                WIRE_VERSION_V1 => {
+                    let grant: GrantV1 =
+                        postcard::from_bytes(body_bytes).context("decode signed grant")?;
+                    (
+                        grant,
+                        0,
+                        FilterPolicyV3::default(),
+                        RootExistenceV4::Any,
+                        no_receipt,
+                    )
+                }
+                WIRE_VERSION_V2 => {
+                    let body: GrantBodyV2 =
+                        postcard::from_bytes(body_bytes).context("decode signed grant")?;
+                    (
+                        body.grant,
+                        body.max_file_data_bytes_per_second,
+                        FilterPolicyV3::default(),
+                        RootExistenceV4::Any,
+                        no_receipt,
+                    )
+                }
+                WIRE_VERSION_V3 => {
+                    let body: GrantBodyV3 =
+                        postcard::from_bytes(body_bytes).context("decode signed grant")?;
+                    (
+                        body.grant,
+                        body.max_file_data_bytes_per_second,
+                        body.filters,
+                        RootExistenceV4::Any,
+                        no_receipt,
+                    )
+                }
+                WIRE_VERSION_V4 => {
+                    let body: GrantBodyV4 =
+                        postcard::from_bytes(body_bytes).context("decode signed grant")?;
+                    (
+                        body.grant,
+                        body.max_file_data_bytes_per_second,
+                        body.filters,
+                        body.root_existence,
+                        no_receipt,
+                    )
+                }
+                WIRE_VERSION => {
+                    let body: GrantBodyV5 =
+                        postcard::from_bytes(body_bytes).context("decode signed grant")?;
+                    (
+                        body.grant,
+                        body.max_file_data_bytes_per_second,
+                        body.filters,
+                        body.root_existence,
+                        body.receipt,
+                    )
+                }
+                _ => unreachable!(),
+            };
         if canonical_body_bytes(
             version,
             &grant,
             max_file_data_bytes_per_second,
             &filters,
             root_existence,
+            receipt,
         )? != body_bytes
         {
             bail!("signed grant uses a noncanonical encoding");
@@ -565,6 +626,7 @@ impl SignedGrantEnvelope {
             max_file_data_bytes_per_second,
             filters,
             root_existence,
+            receipt,
             signature,
             wire_version: version,
         })
@@ -577,17 +639,22 @@ impl SignedGrantEnvelope {
             self.max_file_data_bytes_per_second,
             &self.filters,
             self.root_existence,
+            self.receipt,
         )
     }
 }
 
 pub(crate) fn sign_grant(
     grant: GrantV1,
-    max_file_data_bytes_per_second: u64,
-    mut filters: FilterPolicyV3,
-    root_existence: RootExistenceV4,
+    extensions: GrantExtensions,
     private_key: &PrivateKey,
 ) -> Result<Vec<u8>> {
+    let GrantExtensions {
+        max_file_data_bytes_per_second,
+        mut filters,
+        root_existence,
+        receipt,
+    } = extensions;
     if private_key.is_encrypted() {
         bail!("cannot sign a grant with an encrypted transport key");
     }
@@ -603,8 +670,10 @@ pub(crate) fn sign_grant(
     filters.validate(&grant)?;
     // Keep emitting the oldest form capable of representing the request so
     // ordinary transfers remain usable with existing receiver enrollments.
-    let wire_version = if root_existence != RootExistenceV4::Any {
+    let wire_version = if receipt.is_active() {
         WIRE_VERSION
+    } else if root_existence != RootExistenceV4::Any {
+        WIRE_VERSION_V4
     } else if filters.is_active() {
         WIRE_VERSION_V3
     } else if max_file_data_bytes_per_second == 0 {
@@ -618,6 +687,7 @@ pub(crate) fn sign_grant(
         max_file_data_bytes_per_second,
         &filters,
         root_existence,
+        receipt,
     )?;
     let signature = private_key
         .sign(SSHSIG_NAMESPACE, HashAlg::Sha256, &payload)
@@ -630,6 +700,7 @@ pub(crate) fn sign_grant(
         max_file_data_bytes_per_second,
         filters,
         root_existence,
+        receipt,
         signature,
         wire_version,
     }
@@ -644,6 +715,7 @@ fn signing_payload(grant: &GrantV1, max_file_data_bytes_per_second: u64) -> Resu
         max_file_data_bytes_per_second,
         &FilterPolicyV3::default(),
         RootExistenceV4::Any,
+        ReceiptPolicyV5::default(),
     )
 }
 
@@ -653,6 +725,7 @@ fn signing_payload_for_version(
     max_file_data_bytes_per_second: u64,
     filters: &FilterPolicyV3,
     root_existence: RootExistenceV4,
+    receipt: ReceiptPolicyV5,
 ) -> Result<Vec<u8>> {
     grant.validate_static()?;
     filters.validate(grant)?;
@@ -662,6 +735,7 @@ fn signing_payload_for_version(
         max_file_data_bytes_per_second,
         filters,
         root_existence,
+        receipt,
     )?;
     if body.len() > MAX_GRANT_BYTES {
         bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
@@ -680,18 +754,25 @@ fn canonical_body_bytes(
     max_file_data_bytes_per_second: u64,
     filters: &FilterPolicyV3,
     root_existence: RootExistenceV4,
+    receipt: ReceiptPolicyV5,
 ) -> Result<Vec<u8>> {
+    receipt.validate()?;
     let root_constrained = root_existence != RootExistenceV4::Any;
+    let receipt_requested = receipt.is_active();
     match wire_version {
         WIRE_VERSION_V1 => {
-            if max_file_data_bytes_per_second != 0 || filters.is_active() || root_constrained {
+            if max_file_data_bytes_per_second != 0
+                || filters.is_active()
+                || root_constrained
+                || receipt_requested
+            {
                 bail!("version-one grants cannot carry signed extensions");
             }
             canonical_grant_bytes(grant)
         }
         WIRE_VERSION_V2 => {
-            if filters.is_active() || root_constrained {
-                bail!("version-two grants cannot carry filter or root-existence policy");
+            if filters.is_active() || root_constrained || receipt_requested {
+                bail!("version-two grants cannot carry filter, root-existence, or receipt policy");
             }
             postcard::to_stdvec(&GrantBodyV2 {
                 grant: grant.clone(),
@@ -700,8 +781,8 @@ fn canonical_body_bytes(
             .context("encode canonical signed grant")
         }
         WIRE_VERSION_V3 => {
-            if root_constrained {
-                bail!("version-three grants cannot carry root-existence policy");
+            if root_constrained || receipt_requested {
+                bail!("version-three grants cannot carry root-existence or receipt policy");
             }
             postcard::to_stdvec(&GrantBodyV3 {
                 grant: grant.clone(),
@@ -710,11 +791,24 @@ fn canonical_body_bytes(
             })
             .context("encode canonical signed grant")
         }
-        WIRE_VERSION => postcard::to_stdvec(&GrantBodyV4 {
+        WIRE_VERSION_V4 => {
+            if receipt_requested {
+                bail!("version-four grants cannot carry receipt policy");
+            }
+            postcard::to_stdvec(&GrantBodyV4 {
+                grant: grant.clone(),
+                max_file_data_bytes_per_second,
+                filters: filters.clone(),
+                root_existence,
+            })
+            .context("encode canonical signed grant")
+        }
+        WIRE_VERSION => postcard::to_stdvec(&GrantBodyV5 {
             grant: grant.clone(),
             max_file_data_bytes_per_second,
             filters: filters.clone(),
             root_existence,
+            receipt,
         })
         .context("encode canonical signed grant"),
         _ => bail!("unsupported signed grant envelope version {wire_version}"),
@@ -1134,14 +1228,17 @@ pub(crate) struct VerifiedGrant {
     max_file_data_bytes_per_second: u64,
     filters: FilterPolicyV3,
     root_existence: RootExistenceV4,
+    receipt: ReceiptPolicyV5,
     execution_deadline: Instant,
 }
 
-/// The signed extensions a verified grant carries beyond its frozen V1 body.
+/// The signed extensions a grant carries beyond its frozen V1 body.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct GrantExtensions {
     pub max_file_data_bytes_per_second: u64,
     pub filters: FilterPolicyV3,
     pub root_existence: RootExistenceV4,
+    pub receipt: ReceiptPolicyV5,
 }
 
 impl VerifiedGrant {
@@ -1157,6 +1254,7 @@ impl VerifiedGrant {
                 max_file_data_bytes_per_second: self.max_file_data_bytes_per_second,
                 filters: self.filters,
                 root_existence: self.root_existence,
+                receipt: self.receipt,
             },
             self.execution_deadline,
         )
@@ -1196,6 +1294,7 @@ pub(crate) fn verify_and_claim(
         max_file_data_bytes_per_second: envelope.max_file_data_bytes_per_second,
         filters: envelope.filters,
         root_existence: envelope.root_existence,
+        receipt: envelope.receipt,
         execution_deadline,
     })
 }
@@ -2258,6 +2357,7 @@ mod tests {
             max_file_data_bytes_per_second,
             &FilterPolicyV3::default(),
             RootExistenceV4::Any,
+            ReceiptPolicyV5::default(),
         )
         .expect("encode test grant");
         let mut out = Vec::new();
@@ -2285,6 +2385,7 @@ mod tests {
             0,
             &FilterPolicyV3::default(),
             RootExistenceV4::Any,
+            ReceiptPolicyV5::default(),
         )
         .expect("make legacy signing payload");
         let legacy_signature = sign(&legacy_payload, &fixture.key, SSHSIG_NAMESPACE, None);
@@ -2293,6 +2394,7 @@ mod tests {
             max_file_data_bytes_per_second: 0,
             filters: FilterPolicyV3::default(),
             root_existence: RootExistenceV4::Any,
+            receipt: ReceiptPolicyV5::default(),
             signature: legacy_signature,
             wire_version: WIRE_VERSION_V1,
         }
@@ -2343,14 +2445,7 @@ mod tests {
         let public = private.public_key().to_openssh().unwrap();
         fs::write(&fixture.allowed_signers, format!("{SIGNER} {public}\n")).unwrap();
         let replay = fixture.replay("in-process-signature-replay");
-        let encoded = sign_grant(
-            fixture_grant(44),
-            0,
-            FilterPolicyV3::default(),
-            RootExistenceV4::Any,
-            &private,
-        )
-        .unwrap();
+        let encoded = sign_grant(fixture_grant(44), GrantExtensions::default(), &private).unwrap();
         assert_eq!(
             SignedGrantEnvelope::decode(&encoded).unwrap().wire_version,
             WIRE_VERSION_V1
@@ -2365,9 +2460,10 @@ mod tests {
 
         let rate_limited = sign_grant(
             fixture_grant(45),
-            4096,
-            FilterPolicyV3::default(),
-            RootExistenceV4::Any,
+            GrantExtensions {
+                max_file_data_bytes_per_second: 4096,
+                ..GrantExtensions::default()
+            },
             &private,
         )
         .unwrap();
@@ -2389,9 +2485,10 @@ mod tests {
         };
         let filtered = sign_grant(
             fixture_grant(46),
-            0,
-            filters.clone(),
-            RootExistenceV4::Any,
+            GrantExtensions {
+                filters: filters.clone(),
+                ..GrantExtensions::default()
+            },
             &private,
         )
         .unwrap();
@@ -2415,9 +2512,10 @@ mod tests {
         };
         assert!(sign_grant(
             fixture_grant(47),
-            0,
-            outside,
-            RootExistenceV4::Any,
+            GrantExtensions {
+                filters: outside,
+                ..GrantExtensions::default()
+            },
             &private
         )
         .is_err());
@@ -2426,14 +2524,15 @@ mod tests {
         // other extensions, and survives verification unchanged.
         let rooted = sign_grant(
             fixture_grant(48),
-            0,
-            FilterPolicyV3::default(),
-            RootExistenceV4::New,
+            GrantExtensions {
+                root_existence: RootExistenceV4::New,
+                ..GrantExtensions::default()
+            },
             &private,
         )
         .unwrap();
         let decoded = SignedGrantEnvelope::decode(&rooted).unwrap();
-        assert_eq!(decoded.wire_version, WIRE_VERSION);
+        assert_eq!(decoded.wire_version, WIRE_VERSION_V4);
         assert_eq!(decoded.root_existence, RootExistenceV4::New);
         let verified = verify_and_claim(
             &rooted,
@@ -2449,6 +2548,54 @@ mod tests {
             0,
             &FilterPolicyV3::default(),
             RootExistenceV4::Existing,
+            ReceiptPolicyV5::default(),
+        )
+        .is_err());
+
+        // A receipt policy needs the V5 body and survives verification.
+        let policy = ReceiptPolicyV5 {
+            required: true,
+            hashed: true,
+        };
+        let receipted = sign_grant(
+            fixture_grant(50),
+            GrantExtensions {
+                receipt: policy,
+                ..GrantExtensions::default()
+            },
+            &private,
+        )
+        .unwrap();
+        let decoded = SignedGrantEnvelope::decode(&receipted).unwrap();
+        assert_eq!(decoded.wire_version, WIRE_VERSION);
+        assert_eq!(decoded.receipt, policy);
+        let verified = verify_and_claim(
+            &receipted,
+            &context(SIGNER, TARGET, NOW, 0),
+            &fixture.policy(),
+            &fixture.replay("in-process-receipt-signature-replay"),
+        )
+        .expect("OpenSSH must accept the signed receipt extension");
+        assert_eq!(verified.into_parts().1.receipt, policy);
+        assert!(canonical_body_bytes(
+            WIRE_VERSION_V4,
+            &fixture_grant(51),
+            0,
+            &FilterPolicyV3::default(),
+            RootExistenceV4::Any,
+            policy,
+        )
+        .is_err());
+        assert!(sign_grant(
+            fixture_grant(52),
+            GrantExtensions {
+                receipt: ReceiptPolicyV5 {
+                    required: false,
+                    hashed: true,
+                },
+                ..GrantExtensions::default()
+            },
+            &private,
         )
         .is_err());
     }
@@ -2512,6 +2659,7 @@ mod tests {
                 0,
                 &FilterPolicyV3::default(),
                 RootExistenceV4::Any,
+                ReceiptPolicyV5::default(),
             )
             .expect("encode version-one signing payload");
             transcript.extend_from_slice(&(payload.len() as u32).to_be_bytes());

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -311,7 +311,7 @@ pub fn run(
     if (args.max_entries.is_some()
         || args.max_total_bytes.is_some()
         || args.max_runtime_secs.is_some()
-        || args.receipt_hashed)
+        || args.receipt_requested)
         && restricted_grant.is_none()
     {
         bail!(

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -310,11 +310,12 @@ pub fn run(
     };
     if (args.max_entries.is_some()
         || args.max_total_bytes.is_some()
-        || args.max_runtime_secs.is_some())
+        || args.max_runtime_secs.is_some()
+        || args.receipt_hashed)
         && restricted_grant.is_none()
     {
         bail!(
-            "--max-entries, --max-total-bytes, and --max-runtime are command-restricted receiver ceilings, but this transfer does not use the enrolled receiver"
+            "--max-entries, --max-total-bytes, --max-runtime, and --receipt address the command-restricted receiver, but this transfer does not use the enrolled receiver"
         );
     }
     // The follow target must reconnect the way we did: keep an explicit user.

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1171,6 +1171,7 @@ impl FsOps {
             | Request::CreateOperatorDirectory { .. }
             | Request::AnchorDestination { .. }
             | Request::TransportStats
+            | Request::Receipt
             | Request::Shutdown => {}
         }
         Ok(req)
@@ -3519,6 +3520,7 @@ impl FsOps {
             | Request::Scan { .. }
             | Request::NativeRemove { .. }
             | Request::TransportStats
+            | Request::Receipt
             | Request::Shutdown
             | Request::TcpListen { .. } => Err(anyhow!("unexpected request")),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod native_map;
 mod native_rm;
 mod progress;
 mod proto;
+mod receipt;
 mod remote_helper;
 mod restricted;
 mod results;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -466,6 +466,9 @@ pub enum Request {
     /// socket. SSH data transports report None at the orchestrator instead of
     /// sending this request.
     TransportStats,
+    /// Ask a command-restricted receiver for its signed receipt. Issuing it
+    /// ends the grant's mutation authority.
+    Receipt,
     Shutdown,
 }
 
@@ -527,6 +530,8 @@ pub enum Response {
     },
     Path(PathBytes),
     TransportStats(Option<TcpSocketStats>),
+    /// A signed receipt envelope (see receipt.rs).
+    Receipt(#[serde(with = "serde_bytes")] Vec<u8>),
     Ok,
     Err(String),
 }

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -34,8 +34,12 @@ pub(crate) const MAX_REFUSAL_SAMPLES: usize = 8;
 pub(crate) struct PublishedV1 {
     pub path: Vec<u8>,
     pub size: u64,
-    /// BLAKE3 of the published contents, present only for hashed receipts.
+    /// BLAKE3 of the published contents, present only for hashed receipts
+    /// and only once the file is complete.
     pub digest: Option<[u8; 32]>,
+    /// False for an in-place file whose bytes changed but whose final step
+    /// never ran; staged files appear only once complete.
+    pub complete: bool,
 }
 
 /// One file the receiver hashed for the orchestrator (`--verify-only`,
@@ -54,6 +58,8 @@ pub(crate) struct ReceiptV1 {
     pub issued_at: i64,
     pub published_count: u64,
     pub published_bytes: u64,
+    /// Published entries that were left incomplete.
+    pub incomplete_count: u64,
     pub deleted_count: u64,
     pub observed_count: u64,
     /// Requests the grant refused, with the first few messages.
@@ -73,14 +79,25 @@ pub(crate) struct ReceiptV1 {
     pub observed: Vec<ObservedV1>,
 }
 
+/// One published path as the receiver tracks it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct Published {
+    pub size: u64,
+    pub digest: Option<[u8; 32]>,
+    pub complete: bool,
+}
+
 /// What the receiver accumulates while a grant runs.
 #[derive(Debug, Default)]
 pub(crate) struct Ledger {
-    pub published: BTreeMap<Vec<u8>, (u64, Option<[u8; 32]>)>,
+    pub published: BTreeMap<Vec<u8>, Published>,
     pub deleted: BTreeSet<Vec<u8>>,
     pub observed: BTreeMap<Vec<u8>, (u64, [u8; 32])>,
     pub refused: u64,
     pub refusal_samples: Vec<String>,
+    /// Files a hashed receipt could not read back; any entry here means no
+    /// receipt can be issued.
+    pub hash_failures: Vec<String>,
 }
 
 impl Ledger {
@@ -104,12 +121,14 @@ impl Ledger {
         let published: Vec<PublishedV1> = self
             .published
             .iter()
-            .map(|(path, (size, digest))| PublishedV1 {
+            .map(|(path, state)| PublishedV1 {
                 path: path.clone(),
-                size: *size,
-                digest: *digest,
+                size: state.size,
+                digest: state.digest,
+                complete: state.complete,
             })
             .collect();
+        let incomplete_count = published.iter().filter(|item| !item.complete).count() as u64;
         let deleted: Vec<Vec<u8>> = self.deleted.iter().cloned().collect();
         let observed: Vec<ObservedV1> = self
             .observed
@@ -138,6 +157,7 @@ impl Ledger {
             issued_at,
             published_count: published.len() as u64,
             published_bytes,
+            incomplete_count,
             deleted_count: deleted.len() as u64,
             observed_count: observed.len() as u64,
             refused: self.refused,
@@ -282,10 +302,22 @@ mod tests {
 
     fn ledger() -> Ledger {
         let mut ledger = Ledger::default();
-        ledger
-            .published
-            .insert(b"/srv/dst/b".to_vec(), (4, Some([7; 32])));
-        ledger.published.insert(b"/srv/dst/a".to_vec(), (10, None));
+        ledger.published.insert(
+            b"/srv/dst/b".to_vec(),
+            Published {
+                size: 4,
+                digest: Some([7; 32]),
+                complete: true,
+            },
+        );
+        ledger.published.insert(
+            b"/srv/dst/a".to_vec(),
+            Published {
+                size: 10,
+                digest: None,
+                complete: false,
+            },
+        );
         ledger.deleted.insert(b"/srv/dst/gone".to_vec());
         ledger
             .observed
@@ -303,6 +335,7 @@ mod tests {
             .unwrap();
         assert_eq!(receipt.published_count, 2);
         assert_eq!(receipt.published_bytes, 14);
+        assert_eq!(receipt.incomplete_count, 1);
         assert_eq!(receipt.deleted_count, 1);
         assert_eq!(receipt.observed_count, 1);
         assert_eq!(receipt.refused, 1);
@@ -332,7 +365,14 @@ mod tests {
         for index in 0..(MAX_LIST_BYTES / 4096 + 2) {
             let mut path = format!("/{index:08}/").into_bytes();
             path.extend_from_slice(&long);
-            ledger.published.insert(path, (1, None));
+            ledger.published.insert(
+                path,
+                Published {
+                    size: 1,
+                    digest: None,
+                    complete: true,
+                },
+            );
         }
         let receipt = ledger
             .receipt(
@@ -355,9 +395,14 @@ mod tests {
     fn oversized_lists_travel_as_their_digest() {
         let mut ledger = Ledger::default();
         for index in 0..=LIST_LIMIT {
-            ledger
-                .published
-                .insert(format!("/srv/dst/{index:08}").into_bytes(), (1, None));
+            ledger.published.insert(
+                format!("/srv/dst/{index:08}").into_bytes(),
+                Published {
+                    size: 1,
+                    digest: None,
+                    complete: true,
+                },
+            );
         }
         let receipt = ledger
             .receipt(

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -23,6 +23,9 @@ const WIRE_HEADER_LEN: usize = WIRE_MAGIC.len() + 2 + 4 + 4;
 /// very large transfer stays a bounded single line on the relay path.
 pub(crate) const LIST_LIMIT: usize = 65_536;
 const MAX_BODY_BYTES: usize = 64 * 1024 * 1024;
+/// Lists whose encodings together exceed this travel as their digest only,
+/// whatever their entry count, so a receipt of long paths still fits.
+pub(crate) const MAX_LIST_BYTES: usize = 16 * 1024 * 1024;
 const MAX_SIGNATURE_BYTES: usize = 16 * 1024;
 pub(crate) const MAX_REFUSAL_SAMPLES: usize = 8;
 
@@ -118,9 +121,13 @@ impl Ledger {
             })
             .collect();
         let list_digest = list_digest(&published, &deleted, &observed)?;
+        let encoded_lists = postcard::to_stdvec(&published)?.len()
+            + postcard::to_stdvec(&deleted)?.len()
+            + postcard::to_stdvec(&observed)?.len();
         let lists_truncated = published.len() > LIST_LIMIT
             || deleted.len() > LIST_LIMIT
-            || observed.len() > LIST_LIMIT;
+            || observed.len() > LIST_LIMIT
+            || encoded_lists > MAX_LIST_BYTES;
         let published_bytes = published
             .iter()
             .try_fold(0u64, |total, item| total.checked_add(item.size))
@@ -316,6 +323,32 @@ mod tests {
         let mut truncated = envelope.clone();
         truncated.pop();
         assert!(verify(&truncated, &public).is_err());
+    }
+
+    #[test]
+    fn long_paths_truncate_by_encoded_size() {
+        let mut ledger = Ledger::default();
+        let long = vec![b'p'; 4096];
+        for index in 0..(MAX_LIST_BYTES / 4096 + 2) {
+            let mut path = format!("/{index:08}/").into_bytes();
+            path.extend_from_slice(&long);
+            ledger.published.insert(path, (1, None));
+        }
+        let receipt = ledger
+            .receipt(
+                EnrollmentId::random(),
+                RequestId::fresh(1_900_000_000).unwrap(),
+                1_900_000_000,
+                0,
+                0,
+            )
+            .unwrap();
+        assert!(receipt.lists_truncated);
+        assert!(receipt.published.is_empty());
+        let signer = key(4);
+        let envelope = sign(&receipt, &signer).unwrap();
+        assert!(envelope.len() < MAX_LIST_BYTES);
+        verify(&envelope, &signer.public_key().to_openssh().unwrap()).unwrap();
     }
 
     #[test]

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -1,0 +1,349 @@
+//! Signed receipts: hostB's own account of what a command-restricted
+//! transfer did to its disk.
+//!
+//! Nothing from the receiver reaches the invoking machine except through the
+//! source-side orchestrator, so the receiver signs a summary bound to the
+//! grant's request ID with a key only it holds. The orchestrator relays the
+//! envelope opaquely; the invoking machine verifies it against the public key
+//! recorded at enrollment. The receipt attests hostB's view; it says nothing
+//! about the source's completeness or authenticity.
+
+use crate::delegation::RequestId;
+use crate::enrollment::EnrollmentId;
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use ssh_key::{HashAlg, LineEnding, PrivateKey, PublicKey, SshSig};
+use std::collections::{BTreeMap, BTreeSet};
+
+pub(crate) const RECEIPT_NAMESPACE: &str = "syq-receipt-v1@greaber.github";
+const WIRE_MAGIC: &[u8; 8] = b"SYQRCPT\0";
+const WIRE_VERSION: u16 = 1;
+const WIRE_HEADER_LEN: usize = WIRE_MAGIC.len() + 2 + 4 + 4;
+/// Lists longer than this travel as their digest only, so a receipt for a
+/// very large transfer stays a bounded single line on the relay path.
+pub(crate) const LIST_LIMIT: usize = 65_536;
+const MAX_BODY_BYTES: usize = 64 * 1024 * 1024;
+const MAX_SIGNATURE_BYTES: usize = 16 * 1024;
+pub(crate) const MAX_REFUSAL_SAMPLES: usize = 8;
+
+/// One file the receiver published under a final name.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PublishedV1 {
+    pub path: Vec<u8>,
+    pub size: u64,
+    /// BLAKE3 of the published contents, present only for hashed receipts.
+    pub digest: Option<[u8; 32]>,
+}
+
+/// One file the receiver hashed for the orchestrator (`--verify-only`,
+/// `--hash`); this is hostB's view of that object.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ObservedV1 {
+    pub path: Vec<u8>,
+    pub size: u64,
+    pub digest: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ReceiptV1 {
+    pub enrollment_id: EnrollmentId,
+    pub request_id: RequestId,
+    pub issued_at: i64,
+    pub published_count: u64,
+    pub published_bytes: u64,
+    pub deleted_count: u64,
+    pub observed_count: u64,
+    /// Requests the grant refused, with the first few messages.
+    pub refused: u64,
+    pub refusal_samples: Vec<String>,
+    /// Distinct destination entries the grant observed or mutated, and file
+    /// bytes it accepted.
+    pub entries: u64,
+    pub transferred_bytes: u64,
+    /// BLAKE3 over the canonical encoding of the complete sorted lists, so
+    /// the lists can be checked or omitted independently of the signature.
+    pub list_digest: [u8; 32],
+    /// True when a list exceeded `LIST_LIMIT` and was omitted below.
+    pub lists_truncated: bool,
+    pub published: Vec<PublishedV1>,
+    pub deleted: Vec<Vec<u8>>,
+    pub observed: Vec<ObservedV1>,
+}
+
+/// What the receiver accumulates while a grant runs.
+#[derive(Debug, Default)]
+pub(crate) struct Ledger {
+    pub published: BTreeMap<Vec<u8>, (u64, Option<[u8; 32]>)>,
+    pub deleted: BTreeSet<Vec<u8>>,
+    pub observed: BTreeMap<Vec<u8>, (u64, [u8; 32])>,
+    pub refused: u64,
+    pub refusal_samples: Vec<String>,
+}
+
+impl Ledger {
+    pub(crate) fn record_refusal(&mut self, message: &str) {
+        self.refused += 1;
+        if self.refusal_samples.len() < MAX_REFUSAL_SAMPLES {
+            self.refusal_samples.push(message.to_owned());
+        }
+    }
+
+    /// Build the receipt body. `entries` and `transferred_bytes` come from the
+    /// authority's own counters.
+    pub(crate) fn receipt(
+        &self,
+        enrollment_id: EnrollmentId,
+        request_id: RequestId,
+        issued_at: i64,
+        entries: u64,
+        transferred_bytes: u64,
+    ) -> Result<ReceiptV1> {
+        let published: Vec<PublishedV1> = self
+            .published
+            .iter()
+            .map(|(path, (size, digest))| PublishedV1 {
+                path: path.clone(),
+                size: *size,
+                digest: *digest,
+            })
+            .collect();
+        let deleted: Vec<Vec<u8>> = self.deleted.iter().cloned().collect();
+        let observed: Vec<ObservedV1> = self
+            .observed
+            .iter()
+            .map(|(path, (size, digest))| ObservedV1 {
+                path: path.clone(),
+                size: *size,
+                digest: *digest,
+            })
+            .collect();
+        let list_digest = list_digest(&published, &deleted, &observed)?;
+        let lists_truncated = published.len() > LIST_LIMIT
+            || deleted.len() > LIST_LIMIT
+            || observed.len() > LIST_LIMIT;
+        let published_bytes = published
+            .iter()
+            .try_fold(0u64, |total, item| total.checked_add(item.size))
+            .context("published byte total overflow")?;
+        Ok(ReceiptV1 {
+            enrollment_id,
+            request_id,
+            issued_at,
+            published_count: published.len() as u64,
+            published_bytes,
+            deleted_count: deleted.len() as u64,
+            observed_count: observed.len() as u64,
+            refused: self.refused,
+            refusal_samples: self.refusal_samples.clone(),
+            entries,
+            transferred_bytes,
+            list_digest,
+            lists_truncated,
+            published: if lists_truncated {
+                Vec::new()
+            } else {
+                published
+            },
+            deleted: if lists_truncated { Vec::new() } else { deleted },
+            observed: if lists_truncated {
+                Vec::new()
+            } else {
+                observed
+            },
+        })
+    }
+}
+
+pub(crate) fn list_digest(
+    published: &[PublishedV1],
+    deleted: &[Vec<u8>],
+    observed: &[ObservedV1],
+) -> Result<[u8; 32]> {
+    let mut hasher = blake3::Hasher::new();
+    for (label, bytes) in [
+        ("published", postcard::to_stdvec(published)?),
+        ("deleted", postcard::to_stdvec(deleted)?),
+        ("observed", postcard::to_stdvec(observed)?),
+    ] {
+        hasher.update(&(label.len() as u32).to_be_bytes());
+        hasher.update(label.as_bytes());
+        hasher.update(&(bytes.len() as u64).to_be_bytes());
+        hasher.update(&bytes);
+    }
+    Ok(*hasher.finalize().as_bytes())
+}
+
+fn signing_payload(body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(WIRE_MAGIC.len() + 2 + 4 + body.len());
+    out.extend_from_slice(WIRE_MAGIC);
+    out.extend_from_slice(&WIRE_VERSION.to_be_bytes());
+    out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    out.extend_from_slice(body);
+    out
+}
+
+/// Sign a receipt with the receiver's key into a self-describing envelope.
+pub(crate) fn sign(receipt: &ReceiptV1, private_key: &PrivateKey) -> Result<Vec<u8>> {
+    if private_key.is_encrypted() {
+        bail!("cannot sign a receipt with an encrypted key");
+    }
+    let body = postcard::to_stdvec(receipt).context("encode receipt")?;
+    if body.len() > MAX_BODY_BYTES {
+        bail!("receipt exceeds {MAX_BODY_BYTES} bytes");
+    }
+    let signature = private_key
+        .sign(RECEIPT_NAMESPACE, HashAlg::Sha256, &signing_payload(&body))
+        .context("sign receipt")?
+        .to_pem(LineEnding::LF)
+        .context("encode receipt signature")?
+        .into_bytes();
+    if signature.len() > MAX_SIGNATURE_BYTES {
+        bail!("receipt signature exceeds {MAX_SIGNATURE_BYTES} bytes");
+    }
+    let mut out = Vec::with_capacity(WIRE_HEADER_LEN + body.len() + signature.len());
+    out.extend_from_slice(WIRE_MAGIC);
+    out.extend_from_slice(&WIRE_VERSION.to_be_bytes());
+    out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    out.extend_from_slice(&(signature.len() as u32).to_be_bytes());
+    out.extend_from_slice(&body);
+    out.extend_from_slice(&signature);
+    Ok(out)
+}
+
+/// Verify an envelope against the enrollment's receipt public key and return
+/// the receipt. The caller still checks that the IDs are the ones it signed.
+#[cfg_attr(not(test), allow(dead_code))] // used by the local verifier
+pub(crate) fn verify(envelope: &[u8], public_key: &str) -> Result<ReceiptV1> {
+    let public_key =
+        PublicKey::from_openssh(public_key).context("parse enrollment receipt public key")?;
+    if envelope.len() < WIRE_HEADER_LEN || &envelope[..WIRE_MAGIC.len()] != WIRE_MAGIC {
+        bail!("not a syq receipt envelope");
+    }
+    let version = u16::from_be_bytes(envelope[8..10].try_into().expect("fixed header"));
+    if version != WIRE_VERSION {
+        bail!("unsupported receipt envelope version {version}");
+    }
+    let body_len = u32::from_be_bytes(envelope[10..14].try_into().expect("fixed header")) as usize;
+    let signature_len =
+        u32::from_be_bytes(envelope[14..18].try_into().expect("fixed header")) as usize;
+    if body_len == 0 || body_len > MAX_BODY_BYTES {
+        bail!("receipt length is outside the supported range");
+    }
+    if signature_len == 0 || signature_len > MAX_SIGNATURE_BYTES {
+        bail!("receipt signature length is outside the supported range");
+    }
+    let expected = WIRE_HEADER_LEN
+        .checked_add(body_len)
+        .and_then(|length| length.checked_add(signature_len))
+        .ok_or_else(|| anyhow!("receipt envelope length overflow"))?;
+    if envelope.len() != expected {
+        bail!("receipt envelope length is noncanonical");
+    }
+    let body = &envelope[WIRE_HEADER_LEN..WIRE_HEADER_LEN + body_len];
+    let signature = std::str::from_utf8(&envelope[WIRE_HEADER_LEN + body_len..])
+        .context("receipt signature is not text")?;
+    let signature = SshSig::from_pem(signature).context("parse receipt signature")?;
+    public_key
+        .verify(RECEIPT_NAMESPACE, &signing_payload(body), &signature)
+        .context("receipt signature does not verify against the enrollment's receipt key")?;
+    let receipt: ReceiptV1 = postcard::from_bytes(body).context("decode receipt")?;
+    if postcard::to_stdvec(&receipt)? != body {
+        bail!("receipt uses a noncanonical encoding");
+    }
+    if !receipt.lists_truncated
+        && list_digest(&receipt.published, &receipt.deleted, &receipt.observed)?
+            != receipt.list_digest
+    {
+        bail!("receipt lists do not match their digest");
+    }
+    if receipt.refusal_samples.len() > MAX_REFUSAL_SAMPLES
+        || receipt.refusal_samples.len() as u64 > receipt.refused
+    {
+        bail!("receipt refusal samples are inconsistent");
+    }
+    Ok(receipt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(seed: u8) -> PrivateKey {
+        let keypair = ssh_key::private::Ed25519Keypair::from_seed(&[seed; 32]);
+        PrivateKey::new(keypair.into(), "syq-receipt-test").unwrap()
+    }
+
+    fn ledger() -> Ledger {
+        let mut ledger = Ledger::default();
+        ledger
+            .published
+            .insert(b"/srv/dst/b".to_vec(), (4, Some([7; 32])));
+        ledger.published.insert(b"/srv/dst/a".to_vec(), (10, None));
+        ledger.deleted.insert(b"/srv/dst/gone".to_vec());
+        ledger
+            .observed
+            .insert(b"/srv/dst/kept".to_vec(), (3, [9; 32]));
+        ledger.record_refusal("out of scope");
+        ledger
+    }
+
+    #[test]
+    fn receipts_round_trip_and_bind_to_the_signing_key() {
+        let enrollment_id = EnrollmentId::random();
+        let request_id = RequestId::fresh(1_900_000_000).unwrap();
+        let receipt = ledger()
+            .receipt(enrollment_id, request_id, 1_900_000_000, 5, 14)
+            .unwrap();
+        assert_eq!(receipt.published_count, 2);
+        assert_eq!(receipt.published_bytes, 14);
+        assert_eq!(receipt.deleted_count, 1);
+        assert_eq!(receipt.observed_count, 1);
+        assert_eq!(receipt.refused, 1);
+        assert_eq!(receipt.published[0].path, b"/srv/dst/a");
+        assert!(!receipt.lists_truncated);
+
+        let signer = key(1);
+        let envelope = sign(&receipt, &signer).unwrap();
+        let public = signer.public_key().to_openssh().unwrap();
+        assert_eq!(verify(&envelope, &public).unwrap(), receipt);
+
+        let other = key(2).public_key().to_openssh().unwrap();
+        assert!(verify(&envelope, &other).is_err());
+        let mut tampered = envelope.clone();
+        let body_start = WIRE_HEADER_LEN + 40;
+        tampered[body_start] ^= 1;
+        assert!(verify(&tampered, &public).is_err());
+        let mut truncated = envelope.clone();
+        truncated.pop();
+        assert!(verify(&truncated, &public).is_err());
+    }
+
+    #[test]
+    fn oversized_lists_travel_as_their_digest() {
+        let mut ledger = Ledger::default();
+        for index in 0..=LIST_LIMIT {
+            ledger
+                .published
+                .insert(format!("/srv/dst/{index:08}").into_bytes(), (1, None));
+        }
+        let receipt = ledger
+            .receipt(
+                EnrollmentId::random(),
+                RequestId::fresh(1_900_000_000).unwrap(),
+                1_900_000_000,
+                0,
+                0,
+            )
+            .unwrap();
+        assert!(receipt.lists_truncated);
+        assert!(receipt.published.is_empty());
+        assert_eq!(receipt.published_count, LIST_LIMIT as u64 + 1);
+        let signer = key(3);
+        let envelope = sign(&receipt, &signer).unwrap();
+        let public = signer.public_key().to_openssh().unwrap();
+        assert_eq!(
+            verify(&envelope, &public).unwrap().published_count,
+            receipt.published_count
+        );
+    }
+}

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -430,35 +430,53 @@ impl RestrictedAuthority {
             state = self.settled.wait_timeout(state, remaining).unwrap().0;
         }
         state.receipt_issued = true;
-        let unhashed: Vec<Vec<u8>> = if self.receipt_policy.hashed {
-            state
-                .ledger
-                .published
-                .iter()
-                .filter(|(_, (_, digest))| digest.is_none())
-                .map(|(path, _)| path.clone())
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let published: Vec<Vec<u8>> = state.ledger.published.keys().cloned().collect();
+        let deleted: Vec<Vec<u8>> = state.ledger.deleted.iter().cloned().collect();
         drop(state);
-        // Hashed receipts must carry a digest for every published file; a
-        // file that cannot be read back is a receipt failure, not a gap.
-        let mut digests = Vec::with_capacity(unhashed.len());
-        for path in unhashed {
-            let digest = self.digest_published(&path).with_context(|| {
-                format!(
-                    "hash published file {} for the receipt",
+        // The grant is closed and nothing is in flight, so the tree is final.
+        // Settlement order need not match filesystem order when hostA raced
+        // a publication against a deletion of the same path, so the receipt
+        // states what is there now: a published path that is gone counts as
+        // deleted, a deleted path that is back is dropped, and sizes (and
+        // digests, for hashed receipts) come from the files themselves. A
+        // published file that cannot be read back is a receipt failure.
+        let mut final_published = Vec::with_capacity(published.len());
+        let mut final_deleted = Vec::new();
+        for path in published {
+            match self.observe_final(&path)? {
+                Some(metadata) if metadata.is_file() => {
+                    let digest = if self.receipt_policy.hashed {
+                        Some(self.digest_published(&path).with_context(|| {
+                            format!(
+                                "hash published file {} for the receipt",
+                                String::from_utf8_lossy(&path)
+                            )
+                        })?)
+                    } else {
+                        None
+                    };
+                    final_published.push((path, metadata.len, digest));
+                }
+                Some(_) => bail!(
+                    "published file {} is no longer a regular file",
                     String::from_utf8_lossy(&path)
-                )
-            })?;
-            digests.push((path, digest));
+                ),
+                None => final_deleted.push(path),
+            }
+        }
+        for path in deleted {
+            if self.observe_final(&path)?.is_none() {
+                final_deleted.push(path);
+            }
         }
         let mut state = self.state.lock().unwrap();
-        for (path, digest) in digests {
-            if let Some(entry) = state.ledger.published.get_mut(&path) {
-                entry.1 = Some(digest);
-            }
+        state.ledger.published.clear();
+        state.ledger.deleted.clear();
+        for (path, size, digest) in final_published {
+            state.ledger.published.insert(path, (size, digest));
+        }
+        for path in final_deleted {
+            state.ledger.deleted.insert(path);
         }
         let receipt = state.ledger.receipt(
             self.enrollment_id,
@@ -469,6 +487,24 @@ impl RestrictedAuthority {
         )?;
         drop(state);
         crate::receipt::sign(&receipt, key)
+    }
+
+    /// Metadata of a touched path in the final tree, with a missing path or
+    /// a missing ancestor reported as absent rather than as an error.
+    fn observe_final(&self, path: &[u8]) -> Result<Option<RootMetadata>> {
+        match self.rooted_metadata(path) {
+            Ok(observed) => Ok(observed),
+            Err(error)
+                if error.chain().any(|cause| {
+                    cause
+                        .downcast_ref::<std::io::Error>()
+                        .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
+                }) =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// BLAKE3 of a file this grant published, read back through the root.
@@ -1529,26 +1565,34 @@ impl RestrictedAuthority {
                 | Request::Receipt
                 | Request::Shutdown
         );
-        match self.authorize_inner(request, over_ssh, &mut pending, &mut outcomes) {
-            Ok(()) => {
-                if tracked {
-                    self.state.lock().unwrap().in_flight += 1;
-                }
-                Ok(Settlement {
-                    creations: pending,
-                    outcomes,
-                    tracked,
-                })
+        // Admission and closure are decided under one lock: a request either
+        // counts as in flight before the receipt can observe the count, or
+        // it is refused because the receipt has started. Authorization may
+        // block afterwards (the file-data limiter, say) without letting the
+        // receipt slip past it.
+        if tracked {
+            let mut state = self.state.lock().unwrap();
+            if state.receipt_issued || state.receipt_closing {
+                bail!("the signed grant is closed: its receipt has been issued");
             }
+            state.in_flight += 1;
+        }
+        match self.authorize_inner(request, over_ssh, &mut pending, &mut outcomes) {
+            Ok(()) => Ok(Settlement {
+                creations: pending,
+                outcomes,
+                tracked,
+            }),
             Err(error) => {
                 // Nothing of a refused request executes, including the
                 // entries authorized before the refusing one.
                 self.forget_provisional(&pending);
-                self.state
-                    .lock()
-                    .unwrap()
-                    .ledger
-                    .record_refusal(&format!("{error:#}"));
+                let mut state = self.state.lock().unwrap();
+                if tracked {
+                    state.in_flight = state.in_flight.saturating_sub(1);
+                    self.settled.notify_all();
+                }
+                state.ledger.record_refusal(&format!("{error:#}"));
                 Err(error)
             }
         }
@@ -4695,6 +4739,7 @@ mod tests {
             path: path_bytes(&gone),
         });
         let settlement = authority.authorize(&mut delete, false).unwrap();
+        fs::remove_file(&gone).unwrap();
         authority.settle(settlement, &proto::Response::Applied(vec![None]));
         let mut outside = prepare_request(&root.join("elsewhere"));
         assert!(authority.authorize(&mut outside, false).is_err());
@@ -4757,14 +4802,54 @@ mod tests {
         hashing.settle(settlement, &proto::Response::Ok);
         let mut publish = finalize_request(&unreadable, proto::TargetCondition::Any);
         let settlement = hashing.authorize(&mut publish, false).unwrap();
+        fs::write(&unreadable, b"sealed").unwrap();
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
         hashing.settle(settlement, &proto::Response::Ok);
         assert!(hashing.issue_receipt().is_err());
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o600)).unwrap();
         let mut observe = Request::StatMany {
             paths: vec![path_bytes(&kept)],
             follow: false,
             guard: None,
         };
-        authority.authorize(&mut observe, false).unwrap();
+        assert!(authority.authorize(&mut observe, false).is_err());
+
+        // The receipt states the final tree, not settlement order: a file
+        // whose publication settled after its deletion but is gone counts as
+        // deleted, and a deletion that settled after a republication of a
+        // file that is present is dropped.
+        let racing = existence_authority_with_receipt(&root, false, 5_000);
+        let vanished = target.join("vanished");
+        let returned = target.join("returned");
+        fs::write(&returned, b"back").unwrap();
+        for path in [&vanished, &returned] {
+            let settlement = racing.authorize(&mut prepare_request(path), false).unwrap();
+            racing.settle(settlement, &proto::Response::Ok);
+            let mut publish = finalize_request(path, proto::TargetCondition::Any);
+            let settlement = racing.authorize(&mut publish, false).unwrap();
+            racing.settle(settlement, &proto::Response::Ok);
+            let mut delete = apply(Op::Unlink {
+                path: path_bytes(path),
+            });
+            let settlement = racing.authorize(&mut delete, false).unwrap();
+            racing.settle(settlement, &proto::Response::Applied(vec![None]));
+        }
+        let envelope = racing.issue_receipt().unwrap();
+        let receipt = crate::receipt::verify(&envelope, &racing_public(&racing)).unwrap();
+        assert_eq!(receipt.deleted, vec![path_bytes(&vanished)]);
+        assert_eq!(receipt.published.len(), 1);
+        assert_eq!(receipt.published[0].path, path_bytes(&returned));
+        assert_eq!(receipt.published[0].size, 4);
+    }
+
+    fn racing_public(authority: &RestrictedAuthority) -> String {
+        authority
+            .receipt_key
+            .as_ref()
+            .unwrap()
+            .public_key()
+            .to_openssh()
+            .unwrap()
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -3205,19 +3205,6 @@ pub(crate) fn run_receiver(enrollment: &str) -> Result<()> {
     crate::server::run_restricted(authority)
 }
 
-/// The receipt signing key an install left in the state directory, if any;
-/// enrollments installed before receipts existed have none.
-fn load_receipt_key(state: &Path) -> Result<Option<PrivateKey>> {
-    let path = state.join(RECEIPT_KEY_FILE);
-    if !path.exists() {
-        return Ok(None);
-    }
-    let encoded = delegation::read_secure_regular(&path, "receipt signing key", 128 * 1024)?;
-    PrivateKey::from_openssh(&encoded)
-        .context("parse receipt signing key")
-        .map(Some)
-}
-
 fn decode_receiver_command(original: &str) -> Result<Vec<u8>> {
     if original.len() > 128 * 1024 {
         bail!("restricted receiver command exceeds size limit");

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -149,7 +149,12 @@ struct AuthorityState {
     tcp_listener_started: bool,
     /// What hostB will attest to in its receipt.
     ledger: crate::receipt::Ledger,
-    /// Once the receipt is issued nothing may change what it describes.
+    /// Requests authorized for execution whose outcome has not been settled
+    /// yet, across every connection. The receipt waits for zero.
+    in_flight: u64,
+    /// Set when the receipt is being issued: no new mutation is authorized
+    /// from then on, so the receipt describes a final state.
+    receipt_closing: bool,
     receipt_issued: bool,
 }
 
@@ -286,6 +291,8 @@ pub(crate) struct RestrictedAuthority {
     deadline: Instant,
     control_open: AtomicBool,
     state: Mutex<AuthorityState>,
+    /// Signalled whenever an in-flight request settles.
+    settled: std::sync::Condvar,
 }
 
 impl RestrictedAuthority {
@@ -370,6 +377,7 @@ impl RestrictedAuthority {
             receiver_umask,
             deadline,
             control_open: AtomicBool::new(true),
+            settled: std::sync::Condvar::new(),
             state: Mutex::new(AuthorityState {
                 paths: HashSet::new(),
                 receiver_modes: HashMap::new(),
@@ -382,6 +390,8 @@ impl RestrictedAuthority {
                 live_connections: 0,
                 tcp_listener_started: false,
                 ledger: crate::receipt::Ledger::default(),
+                in_flight: 0,
+                receipt_closing: false,
                 receipt_issued: false,
             }),
         };
@@ -394,20 +404,66 @@ impl RestrictedAuthority {
         let key = self.receipt_key.as_ref().context(
             "this receiver has no receipt key; rerun `syq enroll` to refresh the enrollment",
         )?;
-        let receipt = {
-            let mut state = self.state.lock().unwrap();
-            if state.receipt_issued {
-                bail!("the receipt for this grant has already been issued");
+        // Close the grant first, then wait for every request already
+        // authorized on any connection to execute and settle, so the receipt
+        // describes a final state rather than a snapshot with work in flight.
+        let mut state = self.state.lock().unwrap();
+        if state.receipt_issued || state.receipt_closing {
+            bail!("the receipt for this grant has already been issued");
+        }
+        state.receipt_closing = true;
+        while state.in_flight > 0 {
+            let remaining = self
+                .deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or_default();
+            if remaining.is_zero() {
+                bail!(
+                    "{} request(s) were still in flight at the grant deadline; no receipt can be issued",
+                    state.in_flight
+                );
             }
-            state.receipt_issued = true;
-            state.ledger.receipt(
-                self.enrollment_id,
-                self.request_id,
-                now()?,
-                state.paths.len() as u64,
-                state.transferred_bytes,
-            )?
+            state = self.settled.wait_timeout(state, remaining).unwrap().0;
+        }
+        state.receipt_issued = true;
+        let unhashed: Vec<Vec<u8>> = if self.receipt_policy.hashed {
+            state
+                .ledger
+                .published
+                .iter()
+                .filter(|(_, (_, digest))| digest.is_none())
+                .map(|(path, _)| path.clone())
+                .collect()
+        } else {
+            Vec::new()
         };
+        drop(state);
+        // Hashed receipts must carry a digest for every published file; a
+        // file that cannot be read back is a receipt failure, not a gap.
+        let mut digests = Vec::with_capacity(unhashed.len());
+        for path in unhashed {
+            let digest = self.digest_published(&path).with_context(|| {
+                format!(
+                    "hash published file {} for the receipt",
+                    String::from_utf8_lossy(&path)
+                )
+            })?;
+            digests.push((path, digest));
+        }
+        let mut state = self.state.lock().unwrap();
+        for (path, digest) in digests {
+            if let Some(entry) = state.ledger.published.get_mut(&path) {
+                entry.1 = Some(digest);
+            }
+        }
+        let receipt = state.ledger.receipt(
+            self.enrollment_id,
+            self.request_id,
+            now()?,
+            state.paths.len() as u64,
+            state.transferred_bytes,
+        )?;
+        drop(state);
         crate::receipt::sign(&receipt, key)
     }
 
@@ -672,9 +728,11 @@ impl RestrictedAuthority {
         if self.copy.options.dry_run || self.copy.options.verify_only {
             bail!("signed read-only transfer forbids destination mutations");
         }
-        if self.state.lock().unwrap().receipt_issued {
+        let state = self.state.lock().unwrap();
+        if state.receipt_issued || state.receipt_closing {
             bail!("the signed grant is closed: its receipt has been issued");
         }
+        drop(state);
         Self::validate_request_path(path)?;
         if !self
             .copy
@@ -707,8 +765,9 @@ impl RestrictedAuthority {
         let Settlement {
             creations,
             outcomes,
+            tracked,
         } = settlement;
-        if creations.is_empty() && outcomes.is_empty() {
+        if creations.is_empty() && outcomes.is_empty() && !tracked {
             return;
         }
         let failed = |index: usize| match response {
@@ -716,34 +775,24 @@ impl RestrictedAuthority {
             proto::Response::Applied(results) => results.get(index).is_some_and(Option::is_some),
             _ => false,
         };
-        // Hash published files before taking the state lock so other
-        // connections are not held up behind the read.
-        let outcomes: Vec<(PendingOutcome, Option<[u8; 32]>)> = outcomes
-            .into_iter()
-            .map(|outcome| {
-                let digest = match &outcome {
-                    PendingOutcome::Publish { index, path, .. }
-                        if self.receipt_policy.hashed && !failed(*index) =>
-                    {
-                        self.digest_published(path).ok()
-                    }
-                    _ => None,
-                };
-                (outcome, digest)
-            })
-            .collect();
         let mut state = self.state.lock().unwrap();
+        if tracked {
+            state.in_flight = state.in_flight.saturating_sub(1);
+            self.settled.notify_all();
+        }
         for creation in creations {
             state.provisional.remove(&creation.path);
             if creation.persist && !failed(creation.index) {
                 state.created.insert(creation.path);
             }
         }
-        for (outcome, digest) in outcomes {
+        for outcome in outcomes {
             match outcome {
                 PendingOutcome::Publish { index, path, size } if !failed(index) => {
                     state.ledger.deleted.remove(&path);
-                    state.ledger.published.insert(path, (size, digest));
+                    // Digests for hashed receipts are computed when the
+                    // receipt is issued, once the file is final.
+                    state.ledger.published.insert(path, (size, None));
                 }
                 PendingOutcome::Delete { index, path } if !failed(index) => {
                     state.ledger.published.remove(&path);
@@ -1465,11 +1514,28 @@ impl RestrictedAuthority {
     pub(crate) fn authorize(&self, request: &mut Request, over_ssh: bool) -> Result<Settlement> {
         let mut pending = Vec::new();
         let mut outcomes = Vec::new();
+        // Requests the server executes and then settles; the receipt waits
+        // for all of them. The others are answered inline without settling.
+        let tracked = !matches!(
+            request,
+            Request::Hello { .. }
+                | Request::Scan { .. }
+                | Request::TcpListen { .. }
+                | Request::TransportStats
+                | Request::Receipt
+                | Request::Shutdown
+        );
         match self.authorize_inner(request, over_ssh, &mut pending, &mut outcomes) {
-            Ok(()) => Ok(Settlement {
-                creations: pending,
-                outcomes,
-            }),
+            Ok(()) => {
+                if tracked {
+                    self.state.lock().unwrap().in_flight += 1;
+                }
+                Ok(Settlement {
+                    creations: pending,
+                    outcomes,
+                    tracked,
+                })
+            }
             Err(error) => {
                 // Nothing of a refused request executes, including the
                 // entries authorized before the refusing one.
@@ -1789,6 +1855,8 @@ impl RestrictedAuthority {
 pub(crate) struct Settlement {
     creations: Vec<PendingCreation>,
     outcomes: Vec<PendingOutcome>,
+    /// The request counts as in flight until settled.
+    tracked: bool,
 }
 
 /// One receipt-relevant effect of a request, confirmed by `settle`.
@@ -4477,6 +4545,31 @@ mod tests {
         );
     }
 
+    fn existence_authority_with_receipt(
+        root: &Path,
+        hashed: bool,
+        deadline_ms: u64,
+    ) -> RestrictedAuthority {
+        let key = generate_receipt_key(EnrollmentId::random()).unwrap();
+        let mut authority = test_authority_with_receipt(
+            root,
+            DeletionPolicyV1::DeleteDestinationOnly,
+            1024,
+            0,
+            FilterPolicyV3::default(),
+            PublicationPolicyV1::AtomicStaged,
+            ExistingDestinationPolicyV1::Replace,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+            Some((key, hashed)),
+        )
+        .unwrap();
+        // Waiting for in-flight requests is bounded by the grant deadline;
+        // keep tests from sitting out the full minute.
+        authority.deadline = Instant::now() + std::time::Duration::from_millis(deadline_ms);
+        authority
+    }
+
     #[test]
     fn receipt_attests_confirmed_outcomes_and_closes_the_grant() {
         let temporary = tempfile::tempdir().unwrap();
@@ -4530,10 +4623,12 @@ mod tests {
             },
         );
 
-        // A confirmed staged publication is hashed from the published file.
-        authority
+        // A confirmed staged publication is hashed from the published file
+        // when the receipt is issued.
+        let settlement = authority
             .authorize(&mut prepare_request(&fresh), false)
             .unwrap();
+        authority.settle(settlement, &proto::Response::Ok);
         let mut publish = finalize_request(&fresh, proto::TargetCondition::Any);
         let settlement = authority.authorize(&mut publish, false).unwrap();
         fs::write(&fresh, b"data").unwrap();
@@ -4598,6 +4693,25 @@ mod tests {
             .authorize(&mut prepare_request(&target.join("late")), false)
             .is_err());
         assert!(authority.issue_receipt().is_err());
+
+        // A request still in flight holds the receipt back; a hashed receipt
+        // fails outright when a published file cannot be read back.
+        let waiting = existence_authority_with_receipt(&root, true, 200);
+        let settlement = waiting
+            .authorize(&mut prepare_request(&target.join("inflight")), false)
+            .unwrap();
+        assert!(waiting.issue_receipt().is_err());
+        waiting.settle(settlement, &proto::Response::Ok);
+        let hashing = existence_authority_with_receipt(&root, true, 5_000);
+        let unreadable = target.join("unreadable");
+        let settlement = hashing
+            .authorize(&mut prepare_request(&unreadable), false)
+            .unwrap();
+        hashing.settle(settlement, &proto::Response::Ok);
+        let mut publish = finalize_request(&unreadable, proto::TargetCondition::Any);
+        let settlement = hashing.authorize(&mut publish, false).unwrap();
+        hashing.settle(settlement, &proto::Response::Ok);
+        assert!(hashing.issue_receipt().is_err());
         let mut observe = Request::StatMany {
             paths: vec![path_bytes(&kept)],
             follow: false,

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -4,7 +4,8 @@ use crate::cli::{Args, Existence, Interface, Location, Placement};
 use crate::delegation::{
     self, CopyLimitsV1, CopyOperationV1, CopyOptionsV1, CopyPolicyV1, DeletionPolicyV1,
     DestinationPlacementV1, ExistingDestinationPolicyV1, FilterPolicyV3, GrantExtensions,
-    GrantOperationV1, GrantV1, MutationScopeV1, PublicationPolicyV1, RequestId, RootExistenceV4,
+    GrantOperationV1, GrantV1, MutationScopeV1, PublicationPolicyV1, ReceiptPolicyV5, RequestId,
+    RootExistenceV4,
 };
 use crate::enrollment::{
     self, AuthorizedKeyEntry, AuthorizedKeysChange, EnrollmentId, EnrollmentRoute, SshEndpoint,
@@ -116,6 +117,12 @@ pub(crate) struct PreparedTransfer {
     pub(crate) canonical_destination: String,
     pub(crate) grant: String,
     pub(crate) enrollment_id: EnrollmentId,
+    /// The nonce the grant was signed with; the receipt must name it.
+    #[allow(dead_code)]
+    pub(crate) request_id: RequestId,
+    /// Verifier for the receipt hostB will issue.
+    #[allow(dead_code)]
+    pub(crate) receipt_public_key: String,
 }
 
 struct AuthorityState {
@@ -140,6 +147,10 @@ struct AuthorityState {
     deletions: u64,
     live_connections: u16,
     tcp_listener_started: bool,
+    /// What hostB will attest to in its receipt.
+    ledger: crate::receipt::Ledger,
+    /// Once the receipt is issued nothing may change what it describes.
+    receipt_issued: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -266,6 +277,10 @@ pub(crate) struct RestrictedAuthority {
     filter_matcher: Option<ignore::gitignore::Gitignore>,
     filter_roots: Vec<Vec<u8>>,
     root_existence: RootExistenceV4,
+    enrollment_id: EnrollmentId,
+    request_id: RequestId,
+    receipt_policy: ReceiptPolicyV5,
+    receipt_key: Option<PrivateKey>,
     file_data_limit: Option<crate::bwlimit::BandwidthLimit>,
     receiver_umask: u32,
     deadline: Instant,
@@ -278,13 +293,22 @@ impl RestrictedAuthority {
         config: &ReceiverEnrollment,
         grant: GrantV1,
         extensions: GrantExtensions,
+        receipt_key: Option<PrivateKey>,
         deadline: Instant,
     ) -> Result<Self> {
         let GrantExtensions {
             max_file_data_bytes_per_second,
             filters,
             root_existence,
+            receipt: receipt_policy,
         } = extensions;
+        if receipt_policy.required && receipt_key.is_none() {
+            bail!(
+                "the grant requires a receipt but this receiver has no receipt key; rerun `syq enroll` to refresh the enrollment"
+            );
+        }
+        let enrollment_id = grant.enrollment_id;
+        let request_id = grant.request_id;
         let GrantOperationV1::Copy(copy) = grant.operation;
         if copy.policy.existing == ExistingDestinationPolicyV1::UpdateIfOlder {
             // The comparison depends on a source mtime only the remote
@@ -338,6 +362,10 @@ impl RestrictedAuthority {
             filter_matcher,
             filter_roots,
             root_existence,
+            enrollment_id,
+            request_id,
+            receipt_policy,
+            receipt_key,
             file_data_limit,
             receiver_umask,
             deadline,
@@ -353,10 +381,54 @@ impl RestrictedAuthority {
                 deletions: 0,
                 live_connections: 0,
                 tcp_listener_started: false,
+                ledger: crate::receipt::Ledger::default(),
+                receipt_issued: false,
             }),
         };
         authority.check_root_existence()?;
         Ok(authority)
+    }
+
+    /// Sign hostB's account of this grant and close it to further mutation.
+    pub(crate) fn issue_receipt(&self) -> Result<Vec<u8>> {
+        let key = self.receipt_key.as_ref().context(
+            "this receiver has no receipt key; rerun `syq enroll` to refresh the enrollment",
+        )?;
+        let receipt = {
+            let mut state = self.state.lock().unwrap();
+            if state.receipt_issued {
+                bail!("the receipt for this grant has already been issued");
+            }
+            state.receipt_issued = true;
+            state.ledger.receipt(
+                self.enrollment_id,
+                self.request_id,
+                now()?,
+                state.paths.len() as u64,
+                state.transferred_bytes,
+            )?
+        };
+        crate::receipt::sign(&receipt, key)
+    }
+
+    /// BLAKE3 of a file this grant published, read back through the root.
+    fn digest_published(&self, path: &[u8]) -> Result<[u8; 32]> {
+        let root_path = Path::new(OsStr::from_bytes(&self.guard.root));
+        let relative = Path::new(OsStr::from_bytes(path))
+            .strip_prefix(root_path)
+            .context("published path is outside the enrolled root")?;
+        let relative = RelativePath::new(relative.as_os_str().as_bytes())?;
+        let root = Root::open_verified(
+            root_path,
+            RootIdentity {
+                dev: self.guard.dev,
+                ino: self.guard.ino,
+            },
+        )?;
+        let mut file = root.open_regular_read(&relative)?;
+        let mut hasher = blake3::Hasher::new();
+        std::io::copy(&mut file, &mut hasher)?;
+        Ok(*hasher.finalize().as_bytes())
     }
 
     /// Check the signed placement-root precondition once, against the
@@ -600,6 +672,9 @@ impl RestrictedAuthority {
         if self.copy.options.dry_run || self.copy.options.verify_only {
             bail!("signed read-only transfer forbids destination mutations");
         }
+        if self.state.lock().unwrap().receipt_issued {
+            bail!("the signed grant is closed: its receipt has been issued");
+        }
         Self::validate_request_path(path)?;
         if !self
             .copy
@@ -629,7 +704,11 @@ impl RestrictedAuthority {
     /// dropped so the path cannot later be replaced as if it were.
     /// `response` is the executor's answer to the authorized request.
     pub(crate) fn settle(&self, settlement: Settlement, response: &proto::Response) {
-        if settlement.0.is_empty() {
+        let Settlement {
+            creations,
+            outcomes,
+        } = settlement;
+        if creations.is_empty() && outcomes.is_empty() {
             return;
         }
         let failed = |index: usize| match response {
@@ -637,11 +716,45 @@ impl RestrictedAuthority {
             proto::Response::Applied(results) => results.get(index).is_some_and(Option::is_some),
             _ => false,
         };
+        // Hash published files before taking the state lock so other
+        // connections are not held up behind the read.
+        let outcomes: Vec<(PendingOutcome, Option<[u8; 32]>)> = outcomes
+            .into_iter()
+            .map(|outcome| {
+                let digest = match &outcome {
+                    PendingOutcome::Publish { index, path, .. }
+                        if self.receipt_policy.hashed && !failed(*index) =>
+                    {
+                        self.digest_published(path).ok()
+                    }
+                    _ => None,
+                };
+                (outcome, digest)
+            })
+            .collect();
         let mut state = self.state.lock().unwrap();
-        for creation in settlement.0 {
+        for creation in creations {
             state.provisional.remove(&creation.path);
             if creation.persist && !failed(creation.index) {
                 state.created.insert(creation.path);
+            }
+        }
+        for (outcome, digest) in outcomes {
+            match outcome {
+                PendingOutcome::Publish { index, path, size } if !failed(index) => {
+                    state.ledger.deleted.remove(&path);
+                    state.ledger.published.insert(path, (size, digest));
+                }
+                PendingOutcome::Delete { index, path } if !failed(index) => {
+                    state.ledger.published.remove(&path);
+                    state.ledger.deleted.insert(path);
+                }
+                PendingOutcome::Observe { path } => {
+                    if let proto::Response::FileHash { size, hash } = response {
+                        state.ledger.observed.insert(path, (*size, *hash));
+                    }
+                }
+                PendingOutcome::Publish { .. } | PendingOutcome::Delete { .. } => {}
             }
         }
     }
@@ -1231,6 +1344,7 @@ impl RestrictedAuthority {
         operation: &mut Op,
         index: usize,
         pending: &mut Vec<PendingCreation>,
+        outcomes: &mut Vec<PendingOutcome>,
     ) -> Result<()> {
         let path = match &*operation {
             Op::Mkdir { path, .. }
@@ -1254,11 +1368,19 @@ impl RestrictedAuthority {
             Op::Rmdir { path } => {
                 self.charge_deletion(path, true)?;
                 self.state.lock().unwrap().receiver_modes.remove(path);
+                outcomes.push(PendingOutcome::Delete {
+                    index,
+                    path: path.clone(),
+                });
                 return Ok(());
             }
             Op::Unlink { path } => {
                 self.charge_deletion(path, false)?;
                 self.state.lock().unwrap().receiver_modes.remove(path);
+                outcomes.push(PendingOutcome::Delete {
+                    index,
+                    path: path.clone(),
+                });
                 return Ok(());
             }
         };
@@ -1342,12 +1464,21 @@ impl RestrictedAuthority {
     /// response so provisional creations are forgotten when execution fails.
     pub(crate) fn authorize(&self, request: &mut Request, over_ssh: bool) -> Result<Settlement> {
         let mut pending = Vec::new();
-        match self.authorize_inner(request, over_ssh, &mut pending) {
-            Ok(()) => Ok(Settlement(pending)),
+        let mut outcomes = Vec::new();
+        match self.authorize_inner(request, over_ssh, &mut pending, &mut outcomes) {
+            Ok(()) => Ok(Settlement {
+                creations: pending,
+                outcomes,
+            }),
             Err(error) => {
                 // Nothing of a refused request executes, including the
                 // entries authorized before the refusing one.
                 self.forget_provisional(&pending);
+                self.state
+                    .lock()
+                    .unwrap()
+                    .ledger
+                    .record_refusal(&format!("{error:#}"));
                 Err(error)
             }
         }
@@ -1358,6 +1489,7 @@ impl RestrictedAuthority {
         request: &mut Request,
         over_ssh: bool,
         pending: &mut Vec<PendingCreation>,
+        outcomes: &mut Vec<PendingOutcome>,
     ) -> Result<()> {
         self.check_deadline()?;
         match request {
@@ -1452,14 +1584,17 @@ impl RestrictedAuthority {
             }
             Request::Apply { ops, guard } => {
                 for (index, operation) in ops.iter_mut().enumerate() {
-                    self.authorize_op(operation, index, pending)?;
+                    self.authorize_op(operation, index, pending, outcomes)?;
                 }
                 *guard = Some(self.guard.clone());
             }
-            Request::ProbePartial { path, guard, .. }
-            | Request::FileHash { path, guard }
-            | Request::Canonicalize { path, guard } => {
+            Request::ProbePartial { path, guard, .. } | Request::Canonicalize { path, guard } => {
                 self.check_observation_path(path)?;
+                *guard = Some(self.guard.clone());
+            }
+            Request::FileHash { path, guard } => {
+                self.check_observation_path(path)?;
+                outcomes.push(PendingOutcome::Observe { path: path.clone() });
                 *guard = Some(self.guard.clone());
             }
             Request::HashBlocks {
@@ -1578,6 +1713,11 @@ impl RestrictedAuthority {
                 self.check_mutation_path(path, false)?;
                 self.check_published_length(path, *partial_id, *inplace)?;
                 self.constrain_creation(path, condition, false, 0, pending)?;
+                outcomes.push(PendingOutcome::Publish {
+                    index: 0,
+                    path: path.clone(),
+                    size: self.declared_size(path, *partial_id)?,
+                });
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1604,6 +1744,11 @@ impl RestrictedAuthority {
                 for (index, put) in puts.iter_mut().enumerate() {
                     self.charge_bytes(&put.path, 0, put.data.len())?;
                     self.constrain_creation(&put.path, &mut put.condition, false, index, pending)?;
+                    outcomes.push(PendingOutcome::Publish {
+                        index,
+                        path: put.path.clone(),
+                        size: put.data.len() as u64,
+                    });
                     self.constrain_receiver_mode(
                         &put.path,
                         &mut put.meta,
@@ -1626,16 +1771,42 @@ impl RestrictedAuthority {
                 bail!("native removal is not valid on a command-restricted destination")
             }
             Request::Hello { .. } => bail!("unexpected second receiver handshake"),
+            Request::Receipt => {
+                if !over_ssh {
+                    bail!("the receipt is issued only on the signed control connection");
+                }
+            }
             Request::TransportStats | Request::Shutdown => {}
         }
         Ok(())
     }
 }
 
-/// Creations an authorized request recorded provisionally, keyed by the
-/// operation or small-put index the executor reports on.
+/// What an authorized request recorded provisionally: creations, keyed by
+/// the operation or small-put index the executor reports on, and the
+/// outcomes the receipt will attest to once the executor confirms them.
 #[derive(Debug, Default)]
-pub(crate) struct Settlement(Vec<PendingCreation>);
+pub(crate) struct Settlement {
+    creations: Vec<PendingCreation>,
+    outcomes: Vec<PendingOutcome>,
+}
+
+/// One receipt-relevant effect of a request, confirmed by `settle`.
+#[derive(Debug)]
+enum PendingOutcome {
+    Publish {
+        index: usize,
+        path: Vec<u8>,
+        size: u64,
+    },
+    Delete {
+        index: usize,
+        path: Vec<u8>,
+    },
+    Observe {
+        path: Vec<u8>,
+    },
+}
 
 /// One object a request creates or replaces. Only creations that `persist`
 /// become the grant's own once confirmed; a `MustExist` replacement counts
@@ -2856,29 +3027,45 @@ pub(crate) fn prepare_transfer(
         }
     };
     let private_key = load_private_key(&directory)?;
+    let receipt_public_key = metadata.receipt_public_key.clone().with_context(|| {
+        format!(
+            "enrollment {} predates receipts and cannot verify one; rerun `syq enroll {}:{}` to refresh it",
+            metadata.id, host, requested
+        )
+    })?;
+    let grant = grant_for(
+        args,
+        sources,
+        metadata.id,
+        destination_login,
+        &canonical_destination,
+    )?;
+    let request_id = grant.request_id;
     let grant = delegation::sign_grant(
-        grant_for(
-            args,
-            sources,
-            metadata.id,
-            destination_login,
-            &canonical_destination,
-        )?,
-        args.bwlimit_bytes,
-        FilterPolicyV3 {
-            ignore: args.ignore_lines.clone(),
-            destination_roots: filter_destination_roots(
-                args,
-                sources,
-                canonical_destination.as_bytes(),
-            )?,
-            delete_excluded: args.delete_excluded,
+        grant,
+        GrantExtensions {
+            max_file_data_bytes_per_second: args.bwlimit_bytes,
+            filters: FilterPolicyV3 {
+                ignore: args.ignore_lines.clone(),
+                destination_roots: filter_destination_roots(
+                    args,
+                    sources,
+                    canonical_destination.as_bytes(),
+                )?,
+                delete_excluded: args.delete_excluded,
+            },
+            root_existence: root_existence_for(args.target_existence),
+            receipt: ReceiptPolicyV5 {
+                required: true,
+                hashed: args.receipt_hashed,
+            },
         },
-        root_existence_for(args.target_existence),
         &private_key,
     )?;
     Ok(PreparedTransfer {
         private_key,
+        request_id,
+        receipt_public_key,
         canonical_destination,
         grant: base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(grant),
         enrollment_id: metadata.id,
@@ -2927,10 +3114,28 @@ pub(crate) fn run_receiver(enrollment: &str) -> Result<()> {
     };
     let verified = delegation::verify_and_claim(&envelope, &context, &policy, &replay)?;
     let (grant, extensions, deadline) = verified.into_parts();
+    let receipt_key = load_receipt_key(replay_path.parent().context("receiver state directory")?)?;
     let authority = std::sync::Arc::new(RestrictedAuthority::new(
-        &config, grant, extensions, deadline,
+        &config,
+        grant,
+        extensions,
+        receipt_key,
+        deadline,
     )?);
     crate::server::run_restricted(authority)
+}
+
+/// The receipt signing key an install left in the state directory, if any;
+/// enrollments installed before receipts existed have none.
+fn load_receipt_key(state: &Path) -> Result<Option<PrivateKey>> {
+    let path = state.join(RECEIPT_KEY_FILE);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let encoded = delegation::read_secure_regular(&path, "receipt signing key", 128 * 1024)?;
+    PrivateKey::from_openssh(&encoded)
+        .context("parse receipt signing key")
+        .map(Some)
 }
 
 fn decode_receiver_command(original: &str) -> Result<Vec<u8>> {
@@ -3174,11 +3379,38 @@ mod tests {
         deletion: DeletionPolicyV1,
         maximum_bytes: u64,
         max_file_data_bytes_per_second: u64,
+        filters: FilterPolicyV3,
+        publication: PublicationPolicyV1,
+        existing: ExistingDestinationPolicyV1,
+        placement: DestinationPlacementV1,
+        root_existence: RootExistenceV4,
+    ) -> Result<RestrictedAuthority> {
+        test_authority_with_receipt(
+            root,
+            deletion,
+            maximum_bytes,
+            max_file_data_bytes_per_second,
+            filters,
+            publication,
+            existing,
+            placement,
+            root_existence,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn test_authority_with_receipt(
+        root: &Path,
+        deletion: DeletionPolicyV1,
+        maximum_bytes: u64,
+        max_file_data_bytes_per_second: u64,
         mut filters: FilterPolicyV3,
         publication: PublicationPolicyV1,
         existing: ExistingDestinationPolicyV1,
         placement: DestinationPlacementV1,
         root_existence: RootExistenceV4,
+        receipt: Option<(PrivateKey, bool)>,
     ) -> Result<RestrictedAuthority> {
         let opened = Root::open(root).unwrap();
         let identity = opened.identity();
@@ -3245,6 +3477,13 @@ mod tests {
                 },
             }),
         };
+        let receipt_policy = receipt
+            .as_ref()
+            .map(|(_, hashed)| ReceiptPolicyV5 {
+                required: true,
+                hashed: *hashed,
+            })
+            .unwrap_or_default();
         RestrictedAuthority::new(
             &config,
             grant,
@@ -3252,7 +3491,9 @@ mod tests {
                 max_file_data_bytes_per_second,
                 filters,
                 root_existence,
+                receipt: receipt_policy,
             },
+            receipt.map(|(key, _)| key),
             Instant::now() + std::time::Duration::from_secs(60),
         )
     }
@@ -4234,6 +4475,135 @@ mod tests {
                 ino: after.ino(),
             }
         );
+    }
+
+    #[test]
+    fn receipt_attests_confirmed_outcomes_and_closes_the_grant() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let kept = target.join("kept");
+        let fresh = target.join("fresh");
+        let small = target.join("small");
+        let failed = target.join("failed");
+        let gone = target.join("gone");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(&kept, b"old").unwrap();
+        fs::write(&gone, b"bye").unwrap();
+        let key = generate_receipt_key(EnrollmentId::random()).unwrap();
+        let public = key.public_key().to_openssh().unwrap();
+        let authority = test_authority_with_receipt(
+            &root,
+            DeletionPolicyV1::DeleteDestinationOnly,
+            1024,
+            0,
+            FilterPolicyV3::default(),
+            PublicationPolicyV1::AtomicStaged,
+            ExistingDestinationPolicyV1::Replace,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+            Some((key, true)),
+        )
+        .unwrap();
+        let put = |path: &Path| proto::SmallPut {
+            path: path_bytes(path),
+            partial_id: [1; 16],
+            data: b"new".to_vec(),
+            hash: crate::fsops::content_digest(b"new"),
+            meta: plain_meta(),
+            flags: 0,
+            condition: proto::TargetCondition::Any,
+            guard: None,
+        };
+
+        // An observation the orchestrator asked for is hostB's own view.
+        let mut hash = Request::FileHash {
+            path: path_bytes(&kept),
+            guard: None,
+        };
+        let settlement = authority.authorize(&mut hash, false).unwrap();
+        authority.settle(
+            settlement,
+            &proto::Response::FileHash {
+                size: 3,
+                hash: [9; 32],
+            },
+        );
+
+        // A confirmed staged publication is hashed from the published file.
+        authority
+            .authorize(&mut prepare_request(&fresh), false)
+            .unwrap();
+        let mut publish = finalize_request(&fresh, proto::TargetCondition::Any);
+        let settlement = authority.authorize(&mut publish, false).unwrap();
+        fs::write(&fresh, b"data").unwrap();
+        authority.settle(settlement, &proto::Response::Ok);
+
+        // Only the confirmed half of a small-file batch is attested.
+        let mut batch = Request::PutSmallBatch(vec![put(&small), put(&failed)]);
+        let settlement = authority.authorize(&mut batch, false).unwrap();
+        fs::write(&small, b"new").unwrap();
+        authority.settle(
+            settlement,
+            &proto::Response::Applied(vec![None, Some("raced".into())]),
+        );
+
+        // A confirmed deletion, and a refused request.
+        let mut delete = apply(Op::Unlink {
+            path: path_bytes(&gone),
+        });
+        let settlement = authority.authorize(&mut delete, false).unwrap();
+        authority.settle(settlement, &proto::Response::Applied(vec![None]));
+        let mut outside = prepare_request(&root.join("elsewhere"));
+        assert!(authority.authorize(&mut outside, false).is_err());
+
+        let envelope = authority.issue_receipt().unwrap();
+        let receipt = crate::receipt::verify(&envelope, &public).unwrap();
+        assert_eq!(receipt.enrollment_id, authority.enrollment_id);
+        assert_eq!(receipt.request_id, authority.request_id);
+        assert_eq!(receipt.published_count, 2);
+        assert_eq!(receipt.published_bytes, 7);
+        let published: Vec<_> = receipt
+            .published
+            .iter()
+            .map(|item| (item.path.clone(), item.size, item.digest))
+            .collect();
+        assert_eq!(
+            published,
+            vec![
+                (
+                    path_bytes(&fresh),
+                    4,
+                    Some(*blake3::hash(b"data").as_bytes())
+                ),
+                (
+                    path_bytes(&small),
+                    3,
+                    Some(*blake3::hash(b"new").as_bytes())
+                ),
+            ]
+        );
+        assert_eq!(receipt.deleted, vec![path_bytes(&gone)]);
+        assert_eq!(receipt.observed.len(), 1);
+        assert_eq!(receipt.observed[0].path, path_bytes(&kept));
+        assert_eq!(receipt.observed[0].size, 3);
+        assert_eq!(receipt.observed[0].digest, [9; 32]);
+        assert_eq!(receipt.refused, 1);
+        assert_eq!(receipt.refusal_samples.len(), 1);
+        assert!(receipt.entries >= 4, "{}", receipt.entries);
+        assert_eq!(receipt.transferred_bytes, 6);
+
+        // Issuing the receipt closes the grant: no mutation, no second copy.
+        assert!(authority
+            .authorize(&mut prepare_request(&target.join("late")), false)
+            .is_err());
+        assert!(authority.issue_receipt().is_err());
+        let mut observe = Request::StatMany {
+            paths: vec![path_bytes(&kept)],
+            follow: false,
+            guard: None,
+        };
+        authority.authorize(&mut observe, false).unwrap();
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -430,59 +430,40 @@ impl RestrictedAuthority {
             state = self.settled.wait_timeout(state, remaining).unwrap().0;
         }
         state.receipt_issued = true;
-        let published: Vec<Vec<u8>> = state.ledger.published.keys().cloned().collect();
-        let deleted_only: Vec<Vec<u8>> = state
+        if let Some(first) = state.ledger.hash_failures.first() {
+            bail!(
+                "{} published file(s) could not be hashed for the receipt; first: {first}",
+                state.ledger.hash_failures.len()
+            );
+        }
+        // A path both published and deleted under this grant is the one case
+        // where settlement order may differ from filesystem order (hostA
+        // raced the two). Now that the grant is closed and quiet, the tree
+        // decides those, and only those: everything else keeps the
+        // disposition its settlement recorded, so the receipt never needs
+        // to reopen files after final directory modes are restored.
+        let contested: Vec<Vec<u8>> = state
             .ledger
             .deleted
             .iter()
-            .filter(|path| !state.ledger.published.contains_key(*path))
+            .filter(|path| state.ledger.published.contains_key(*path))
             .cloned()
             .collect();
         drop(state);
-        // The grant is closed and nothing is in flight, so the tree is final.
-        // Settlement order need not match filesystem order when hostA raced
-        // a publication against a deletion of the same path, so the receipt
-        // states what is there now: a published path that is gone counts as
-        // deleted, a deleted path that is back is dropped, and sizes (and
-        // digests, for hashed receipts) come from the files themselves. A
-        // published file that cannot be read back is a receipt failure.
-        let mut final_published = Vec::with_capacity(published.len());
-        let mut final_deleted = Vec::new();
-        for path in published {
+        let mut present = Vec::new();
+        let mut absent = Vec::new();
+        for path in contested {
             match self.observe_final(&path)? {
-                Some(metadata) if metadata.is_file() => {
-                    let digest = if self.receipt_policy.hashed {
-                        Some(self.digest_published(&path).with_context(|| {
-                            format!(
-                                "hash published file {} for the receipt",
-                                String::from_utf8_lossy(&path)
-                            )
-                        })?)
-                    } else {
-                        None
-                    };
-                    final_published.push((path, metadata.len, digest));
-                }
-                Some(_) => bail!(
-                    "published file {} is no longer a regular file",
-                    String::from_utf8_lossy(&path)
-                ),
-                None => final_deleted.push(path),
-            }
-        }
-        for path in deleted_only {
-            if self.observe_final(&path)?.is_none() {
-                final_deleted.push(path);
+                Some(_) => present.push(path),
+                None => absent.push(path),
             }
         }
         let mut state = self.state.lock().unwrap();
-        state.ledger.published.clear();
-        state.ledger.deleted.clear();
-        for (path, size, digest) in final_published {
-            state.ledger.published.insert(path, (size, digest));
+        for path in present {
+            state.ledger.deleted.remove(&path);
         }
-        for path in final_deleted {
-            state.ledger.deleted.insert(path);
+        for path in absent {
+            state.ledger.published.remove(&path);
         }
         let receipt = state.ledger.receipt(
             self.enrollment_id,
@@ -821,6 +802,26 @@ impl RestrictedAuthority {
             proto::Response::Applied(results) => results.get(index).is_some_and(Option::is_some),
             _ => false,
         };
+        // Hash completed publications for a hashed receipt now, before the
+        // orchestrator's deferred directory modes can make them unreadable,
+        // and before taking the state lock.
+        let outcomes: Vec<(PendingOutcome, Option<Result<[u8; 32]>>)> = outcomes
+            .into_iter()
+            .map(|outcome| {
+                let digest = match &outcome {
+                    PendingOutcome::Publish {
+                        index,
+                        path,
+                        complete: true,
+                        ..
+                    } if self.receipt_policy.hashed && !failed(*index) => {
+                        Some(self.digest_published(path))
+                    }
+                    _ => None,
+                };
+                (outcome, digest)
+            })
+            .collect();
         let mut state = self.state.lock().unwrap();
         if tracked {
             state.in_flight = state.in_flight.saturating_sub(1);
@@ -832,12 +833,35 @@ impl RestrictedAuthority {
                 state.created.insert(creation.path);
             }
         }
-        for outcome in outcomes {
+        for (outcome, digest) in outcomes {
             match outcome {
                 // Both dispositions are kept; the receipt decides between
                 // them from the final tree once the grant is closed.
-                PendingOutcome::Publish { index, path, size } if !failed(index) => {
-                    state.ledger.published.insert(path, (size, None));
+                PendingOutcome::Publish {
+                    index,
+                    path,
+                    size,
+                    complete,
+                } if !failed(index) => {
+                    let digest = match digest {
+                        Some(Ok(digest)) => Some(digest),
+                        Some(Err(error)) => {
+                            state
+                                .ledger
+                                .hash_failures
+                                .push(format!("{}: {error:#}", String::from_utf8_lossy(&path)));
+                            None
+                        }
+                        None => None,
+                    };
+                    state.ledger.published.insert(
+                        path,
+                        crate::receipt::Published {
+                            size,
+                            digest,
+                            complete,
+                        },
+                    );
                 }
                 PendingOutcome::Delete { index, path } if !failed(index) => {
                     state.ledger.deleted.insert(path);
@@ -1791,6 +1815,16 @@ impl RestrictedAuthority {
                 self.check_mutation_path(path, false)?;
                 self.constrain_prepare(path)?;
                 self.reserve_bytes(path, *partial_id, *size)?;
+                if *inplace {
+                    // In-place preparation resizes the final file itself:
+                    // the receipt must know even if no final step follows.
+                    outcomes.push(PendingOutcome::Publish {
+                        index: 0,
+                        path: path.clone(),
+                        size: *size,
+                        complete: false,
+                    });
+                }
                 *guard = Some(self.guard.clone());
             }
             Request::WriteRange {
@@ -1811,6 +1845,14 @@ impl RestrictedAuthority {
                     .is_none_or(|end| end > declared)
                 {
                     bail!("file write extends past the size declared for it");
+                }
+                if *inplace {
+                    outcomes.push(PendingOutcome::Publish {
+                        index: 0,
+                        path: path.clone(),
+                        size: declared,
+                        complete: false,
+                    });
                 }
                 self.charge_bytes(path, *off, data.len())?;
                 *guard = Some(self.guard.clone());
@@ -1835,6 +1877,7 @@ impl RestrictedAuthority {
                     index: 0,
                     path: path.clone(),
                     size: self.declared_size(path, *partial_id)?,
+                    complete: true,
                 });
                 self.constrain_receiver_mode(
                     path,
@@ -1866,6 +1909,7 @@ impl RestrictedAuthority {
                         index,
                         path: put.path.clone(),
                         size: put.data.len() as u64,
+                        complete: true,
                     });
                     self.constrain_receiver_mode(
                         &put.path,
@@ -1918,6 +1962,9 @@ enum PendingOutcome {
         index: usize,
         path: Vec<u8>,
         size: u64,
+        /// False for in-place preparation and writes, which change the
+        /// final file before its final step; true once that step ran.
+        complete: bool,
     },
     Delete {
         index: usize,
@@ -4844,6 +4891,104 @@ mod tests {
         assert_eq!(receipt.published.len(), 1);
         assert_eq!(receipt.published[0].path, path_bytes(&returned));
         assert_eq!(receipt.published[0].size, 4);
+    }
+
+    #[test]
+    fn in_place_files_appear_in_the_receipt_before_their_final_step() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let image = target.join("image");
+        fs::create_dir_all(&target).unwrap();
+        let key = generate_receipt_key(EnrollmentId::random()).unwrap();
+        let public = key.public_key().to_openssh().unwrap();
+        let authority = test_authority_with_receipt(
+            &root,
+            DeletionPolicyV1::Forbid,
+            1024,
+            0,
+            FilterPolicyV3::default(),
+            PublicationPolicyV1::InPlace,
+            ExistingDestinationPolicyV1::Replace,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+            Some((key, false)),
+        )
+        .unwrap();
+        let mut prepare = Request::Prepare {
+            path: path_bytes(&image),
+            size: 4,
+            inplace: true,
+            partial_id: [1; 16],
+            mode: 0o600,
+            guard: None,
+        };
+        let settlement = authority.authorize(&mut prepare, false).unwrap();
+        fs::write(&image, b"half").unwrap();
+        authority.settle(settlement, &proto::Response::Ok);
+        let mut write = Request::WriteRange {
+            path: path_bytes(&image),
+            inplace: true,
+            partial_id: [1; 16],
+            attempt: 0,
+            off: 0,
+            hash: crate::fsops::content_digest(b"ha"),
+            data: b"ha".to_vec(),
+            guard: None,
+        };
+        let settlement = authority.authorize(&mut write, false).unwrap();
+        authority.settle(settlement, &proto::Response::Ok);
+
+        // Without a final step the receipt still lists the file, incomplete.
+        let envelope = authority.issue_receipt().unwrap();
+        let receipt = crate::receipt::verify(&envelope, &public).unwrap();
+        assert_eq!(receipt.published_count, 1);
+        assert_eq!(receipt.incomplete_count, 1);
+        assert_eq!(receipt.published[0].path, path_bytes(&image));
+        assert_eq!(receipt.published[0].size, 4);
+        assert!(!receipt.published[0].complete);
+
+        // With it, the same file is complete.
+        let key = generate_receipt_key(EnrollmentId::random()).unwrap();
+        let public = key.public_key().to_openssh().unwrap();
+        let finished = test_authority_with_receipt(
+            &root,
+            DeletionPolicyV1::Forbid,
+            1024,
+            0,
+            FilterPolicyV3::default(),
+            PublicationPolicyV1::InPlace,
+            ExistingDestinationPolicyV1::Replace,
+            DestinationPlacementV1::ExactPath,
+            RootExistenceV4::Any,
+            Some((key, false)),
+        )
+        .unwrap();
+        let mut prepare = Request::Prepare {
+            path: path_bytes(&image),
+            size: 4,
+            inplace: true,
+            partial_id: [2; 16],
+            mode: 0o600,
+            guard: None,
+        };
+        let settlement = finished.authorize(&mut prepare, false).unwrap();
+        finished.settle(settlement, &proto::Response::Ok);
+        let mut finalize = Request::Finalize {
+            path: path_bytes(&image),
+            inplace: true,
+            partial_id: [2; 16],
+            meta: plain_meta(),
+            flags: 0,
+            condition: proto::TargetCondition::Any,
+            guard: None,
+        };
+        let settlement = finished.authorize(&mut finalize, false).unwrap();
+        finished.settle(settlement, &proto::Response::Ok);
+        let receipt = crate::receipt::verify(&finished.issue_receipt().unwrap(), &public).unwrap();
+        assert_eq!(receipt.published_count, 1);
+        assert_eq!(receipt.incomplete_count, 0);
+        assert!(receipt.published[0].complete);
     }
 
     fn racing_public(authority: &RestrictedAuthority) -> String {

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -431,7 +431,13 @@ impl RestrictedAuthority {
         }
         state.receipt_issued = true;
         let published: Vec<Vec<u8>> = state.ledger.published.keys().cloned().collect();
-        let deleted: Vec<Vec<u8>> = state.ledger.deleted.iter().cloned().collect();
+        let deleted_only: Vec<Vec<u8>> = state
+            .ledger
+            .deleted
+            .iter()
+            .filter(|path| !state.ledger.published.contains_key(*path))
+            .cloned()
+            .collect();
         drop(state);
         // The grant is closed and nothing is in flight, so the tree is final.
         // Settlement order need not match filesystem order when hostA raced
@@ -464,7 +470,7 @@ impl RestrictedAuthority {
                 None => final_deleted.push(path),
             }
         }
-        for path in deleted {
+        for path in deleted_only {
             if self.observe_final(&path)?.is_none() {
                 final_deleted.push(path);
             }
@@ -828,14 +834,12 @@ impl RestrictedAuthority {
         }
         for outcome in outcomes {
             match outcome {
+                // Both dispositions are kept; the receipt decides between
+                // them from the final tree once the grant is closed.
                 PendingOutcome::Publish { index, path, size } if !failed(index) => {
-                    state.ledger.deleted.remove(&path);
-                    // Digests for hashed receipts are computed when the
-                    // receipt is issued, once the file is final.
                     state.ledger.published.insert(path, (size, None));
                 }
                 PendingOutcome::Delete { index, path } if !failed(index) => {
-                    state.ledger.published.remove(&path);
                     state.ledger.deleted.insert(path);
                 }
                 PendingOutcome::Observe { path } => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -334,6 +334,15 @@ fn serve<R: Read + Send + 'static, W: Write>(
             Request::TransportStats => {
                 w.write_msg(&Response::TransportStats(reader.tcp_stats()))?;
             }
+            Request::Receipt => match &authority {
+                Some(authority) => match authority.issue_receipt() {
+                    Ok(envelope) => w.write_msg(&Response::Receipt(envelope))?,
+                    Err(error) => w.write_msg(&Response::Err(format!("{error:#}")))?,
+                },
+                None => w.write_msg(&Response::Err(
+                    "receipts are issued only by a command-restricted receiver".into(),
+                ))?,
+            },
             other => {
                 let t0 = std::time::Instant::now();
                 let resp = ops.handle(&other);

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1040,6 +1040,7 @@ fn native_receiver_ceilings_apply_only_to_direct_remote_copies() {
         "--max-entries=5",
         "--max-total-bytes=1M",
         "--max-runtime=30m",
+        "--receipt=sizes",
     ] {
         let out = Command::new(env!("CARGO_BIN_EXE_syq"))
             .args([


### PR DESCRIPTION
Second of three stacked pull requests for signed receipts; stacked on #110 (`receipt-key`).

## Summary

- **V5 grant body** adds `ReceiptPolicyV5 { required, hashed }`. Every grant the orchestrator signs now requires a receipt, so a receiver installed before this change rejects it with the existing "rerun `syq enroll`" message instead of silently omitting the receipt. `sign_grant` now takes `GrantExtensions` as one value; V1–V4 decoding is retained.
- **`src/receipt.rs`**: the receipt body (enrollment and request IDs, published files with sizes and optional BLAKE3 digests, deletions, hashes computed for the orchestrator, refusal count with samples, entry and byte totals), a bounded envelope signed with the receiver's Ed25519 receipt key in a dedicated SSHSIG namespace, and in-process verification. Lists beyond 65,536 entries travel as their digest only.
- **Receiver**: a ledger fed by settlement of confirmed outcomes (Finalize, small-put batches, Unlink/Rmdir, FileHash) and by refused requests. A new `Request::Receipt` on the control connection returns `Response::Receipt(envelope)` and closes the grant to further mutation; a second request or a mutation after issue is refused.
- **CLI**: native `--receipt sizes|hashed`; `hashed` is refused where no enrolled receiver is in play, like the ceilings.

Not in this PR: the orchestrator does not yet request the receipt and the local machine does not verify it. That is the third PR.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (247 unit, 277 local integration, 9 update)
- New tests: `receipt::tests::*` (round trip, key binding, tampering, list truncation), `receipt_attests_confirmed_outcomes_and_closes_the_grant`, V5 grant round trip and downgrade refusal in `delegation.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqM3Msd5sJYmuYjguVBB5E
