### PR TITLE
Relay and verify the receiver's receipt on the invoking machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ refuses `--max-size` with `--prune`, as described below. A
 command-restricted remote-to-remote receiver independently enforces the signed
 aggregate limit, signed filters, and the selected staged or in-place publication
 policy. A receiver installed by an older syq rejects an extension or unsupported
-policy safely; rerun `syq enroll HOST:DEST` to refresh an existing enrollment
+policy safely; rerun `syq enrollment add HOST:DEST` to refresh an existing enrollment
 to the current binary. On a direct remote-to-remote copy through that
 receiver, `cp` also accepts the receiver ceilings
 `--max-entries N`, `--max-total-bytes SIZE`, and `--max-runtime DURATION`
@@ -639,7 +639,7 @@ of its output; the local machine verifies it against the public key recorded
 at enrollment and fails the transfer if the receipt is missing, does not
 verify, names a different grant, or records refused requests, whatever hostA
 reported. `-v` prints the verified totals. Enrollments made before receipts
-existed must be refreshed with `syq enroll` first. The receipt is hostB's view
+existed must be refreshed with `syq enrollment add` first. The receipt is hostB's view
 of hostB: it says nothing about what hostA omitted or invented. The boundary runs between the two hosts, not inside hostB: the receiver
 runs as the enrolled account and remembers what it created by pathname, so a
 local writer who can already modify the destination tree is outside its
@@ -668,7 +668,7 @@ an observed object.
 Native `--into-new`/`--as-new` and `--into-existing`/`--as-existing` travel as
 a signed root precondition in a V4 grant, checked against the enrolled root
 when the grant is claimed; an older installed receiver rejects that grant
-safely until `syq enroll` refreshes it. `--update` still fails closed because
+safely until `syq enrollment add` refreshes it. `--update` still fails closed because
 it compares against source modification times that only hostA reports.
 `--no-tcp`, `--tcp-plain`, `--tcp-congestion`, `--files-from`, `--mapping`,
 `--min-size`, `--syq-path`, and `--no-bootstrap` also fail closed because the
@@ -690,7 +690,7 @@ them for one transfer, which bounds what a claimed grant is worth to hostA.
 `--dry-run` and `--verify-only` are cryptographically read-only: the signed
 grant marks them as such and the receiver rejects every mutation even if hostA
 sends one. They use an existing enrollment but do not install one; run
-`syq enroll` first when previewing or verifying a new destination.
+`syq enrollment add` first when previewing or verifying a new destination.
 Destination-root symlinks are also refused in this mode; enroll the explicit
 referent so the signed pathname and opened root identify the same object.
 
@@ -702,18 +702,20 @@ exact-path interpretation is denied. Use a trailing slash (`hostA:dir/`), the
 native `--as`/`--into` placement spelling, or create the destination directory
 first when that distinction matters.
 
-Use `syq enroll [USER@]HOST:DEST [--via [USER@]HOST]` to pre-enroll,
-`syq enrollments` to list local enrollments, and `syq revoke ID [--via ...]` to
+Use `syq enrollment add [USER@]HOST:DEST [--via [USER@]HOST]` to pre-enroll,
+`syq enrollment list` to list local enrollments, and
+`syq enrollment revoke ID [--via ...]` to
 remove the forced key and both sides' per-enrollment state. Before changing
 hostB, syq durably records a pending enrollment and its private key locally. If
 the installation response is lost, the next enrollment of the same endpoint
-and destination retries the same ID safely; `syq enrollments` labels that state
-`pending`, and `syq revoke` can remove either pending or active state. Running
-`syq enroll` again for an active destination also refreshes the installed
+and destination retries the same ID safely; `syq enrollment list` labels that
+state `pending`, and `syq enrollment revoke` can remove either pending or
+active state. Running `syq enrollment add` again for an active destination
+also refreshes the installed
 receiver to the exact local syq binary; the receipt key is kept for the life
 of the enrollment, so a refresh, or a retry after a lost reply, never leaves
 the two sides holding different keys. To rotate it, revoke and enroll again.
-`syq enrollments` marks enrollments made before receipt keys existed as
+`syq enrollment list` marks enrollments made before receipt keys existed as
 `no-receipt-key` until refreshed. Revocation leaves that shared binary
 because other enrollments may use it. It prevents new receiver sessions. A
 session that already claimed its signed request can finish an operation already

--- a/README.md
+++ b/README.md
@@ -631,14 +631,16 @@ key.
 
 HostA also cannot misreport what landed. Every command-restricted transfer
 ends with hostB issuing a signed receipt: the files it published with their
-sizes (and BLAKE3 digests with `--receipt hashed`), what it deleted, the hashes
+sizes (and BLAKE3 digests with `--receipt hashed`), in-place files from the
+moment their bytes change and marked complete only once their final step ran,
+what it deleted, the hashes
 it computed for `--verify-only` and `--hash`, how many requests it refused, and
 its entry and byte totals, bound to the enrollment and the one-time request ID
 and signed with a key only hostB holds. HostA relays the receipt as one line
 of its output; the local machine verifies it against the public key recorded
 at enrollment and fails the transfer if the receipt is missing, does not
-verify, names a different grant, or records refused requests, whatever hostA
-reported. `-v` prints the verified totals. Enrollments made before receipts
+verify, names a different grant, records refused requests, or lists an
+incomplete in-place file while hostA reported success. `-v` prints the verified totals. Enrollments made before receipts
 existed must be refreshed with `syq enrollment add` first. The receipt is hostB's view
 of hostB: it says nothing about what hostA omitted or invented. The boundary runs between the two hosts, not inside hostB: the receiver
 runs as the enrolled account and remembers what it created by pathname, so a

--- a/README.md
+++ b/README.md
@@ -582,7 +582,20 @@ command properties visible in receiver requests, such as destination scopes,
 publication, preservation, and existing-object policy, resource limits, and
 whether a requested mutation could have survived the signed filter traversal. HostA still cannot
 escape those checks or independently authenticate to hostB with the enrollment
-key. The boundary runs between the two hosts, not inside hostB: the receiver
+key.
+
+HostA also cannot misreport what landed. Every command-restricted transfer
+ends with hostB issuing a signed receipt: the files it published with their
+sizes (and BLAKE3 digests with `--receipt hashed`), what it deleted, the hashes
+it computed for `--verify-only` and `--hash`, how many requests it refused, and
+its entry and byte totals, bound to the enrollment and the one-time request ID
+and signed with a key only hostB holds. HostA relays the receipt as one line
+of its output; the local machine verifies it against the public key recorded
+at enrollment and fails the transfer if the receipt is missing, does not
+verify, names a different grant, or records refused requests, whatever hostA
+reported. `-v` prints the verified totals. Enrollments made before receipts
+existed must be refreshed with `syq enroll` first. The receipt is hostB's view
+of hostB: it says nothing about what hostA omitted or invented. The boundary runs between the two hosts, not inside hostB: the receiver
 runs as the enrolled account and remembers what it created by pathname, so a
 local writer who can already modify the destination tree is outside its
 guarantee, exactly as for the ordinary engine.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -564,7 +564,7 @@ fn ordered_ignore_lines(
 
 fn print_root_help() {
     println!(
-        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning target-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a copy's resolved selection and placement as NDJSON\n  rsync        Use the retained rsync-shaped command surface\n  enroll       Pre-enroll a command-restricted remote destination\n  enrollments  List local command-restricted enrollments\n  revoke       Revoke a command-restricted enrollment\n\nRun `syq <COMMAND> --help` for command-specific help."
+        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning target-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a copy's resolved selection and placement as NDJSON\n  rsync        Use the retained rsync-shaped command surface\n  enrollment   Manage command-restricted receiver enrollments (add, list, revoke)\n\nRun `syq <COMMAND> --help` for command-specific help."
     );
 }
 

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -125,6 +125,7 @@ fn settle_receipt(
     payload: Option<&[u8]>,
     src_host: &str,
     dst_host: &str,
+    orchestrator_succeeded: bool,
     verbose: bool,
 ) -> Result<()> {
     let Some(payload) = payload else {
@@ -154,6 +155,16 @@ fn settle_receipt(
                 .map(String::as_str)
                 .unwrap_or("(no message recorded)")
         );
+    }
+    if receipt.incomplete_count > 0 {
+        let message = format!(
+            "{} in-place file(s) on {dst_host} were written but never completed",
+            receipt.incomplete_count
+        );
+        if orchestrator_succeeded {
+            bail!("{message}, yet {src_host} reported success");
+        }
+        eprintln!("syq: warning: {message}");
     }
     if verbose {
         eprintln!(
@@ -1029,6 +1040,7 @@ fn run_remote(
             receipt_payload.as_deref(),
             &coordinator_host,
             peer.host.as_deref().unwrap_or("the peer endpoint"),
+            code == 0,
             args.verbose > 0,
         )?;
     }
@@ -1336,7 +1348,14 @@ mod tests {
             request_id,
         };
         let mut ledger = crate::receipt::Ledger::default();
-        ledger.published.insert(b"/dst/a".to_vec(), (3, None));
+        ledger.published.insert(
+            b"/dst/a".to_vec(),
+            crate::receipt::Published {
+                size: 3,
+                digest: None,
+                complete: true,
+            },
+        );
         let encode = |ledger: &crate::receipt::Ledger, request_id| {
             let receipt = ledger
                 .receipt(enrollment_id, request_id, 1_900_000_000, 1, 3)
@@ -1350,6 +1369,7 @@ mod tests {
                 payload.map(str::as_bytes),
                 "host-a",
                 "host-b",
+                true,
                 false,
             )
         };
@@ -1368,6 +1388,29 @@ mod tests {
         refused.record_refusal("receiver mutation is outside the signed destination scopes");
         let refused = encode(&refused, request_id);
         assert!(settle(&expectation, Some(&refused)).is_err());
+
+        // An incomplete in-place file contradicts a successful orchestrator
+        // but is only a warning beside a failure it already reported.
+        let mut partial = crate::receipt::Ledger::default();
+        partial.published.insert(
+            b"/dst/image".to_vec(),
+            crate::receipt::Published {
+                size: 9,
+                digest: None,
+                complete: false,
+            },
+        );
+        let partial = encode(&partial, request_id);
+        assert!(settle(&expectation, Some(&partial)).is_err());
+        settle_receipt(
+            &expectation,
+            Some(partial.as_bytes()),
+            "host-a",
+            "host-b",
+            false,
+            false,
+        )
+        .unwrap();
 
         // And it must verify against the enrollment's key.
         let stranger = ssh_key::PrivateKey::new(

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -2,9 +2,85 @@
 //! flows source→destination without passing through this machine.
 
 use crate::cli::{parse_rsh, Args, Existence, Interface, Location, Placement, SourceSelection};
+use crate::delegation::RequestId;
+use crate::enrollment::EnrollmentId;
 use anyhow::{bail, Context, Result};
-use std::io::IsTerminal;
+use base64::Engine as _;
+use std::io::{BufRead, IsTerminal};
 use std::process::{Command, Stdio};
+
+/// What the invoking machine expects hostB's receipt to say about itself.
+#[derive(Clone, Debug)]
+struct ReceiptExpectation {
+    public_key: String,
+    enrollment_id: EnrollmentId,
+    request_id: RequestId,
+}
+
+/// Pass the orchestrator's stdout through line by line, keeping the receipt
+/// line to ourselves when one is expected. Returns the last receipt payload.
+fn relay_stdout(stdout: impl std::io::Read, expect_receipt: bool) -> Result<Option<String>> {
+    let mut receipt = None;
+    for line in std::io::BufReader::new(stdout).lines() {
+        let line = line.context("read remote orchestrator output")?;
+        match line.strip_prefix(crate::receipt::RECEIPT_LINE_PREFIX) {
+            Some(payload) if expect_receipt => receipt = Some(payload.to_owned()),
+            _ => println!("{line}"),
+        }
+    }
+    Ok(receipt)
+}
+
+/// Verify hostB's receipt against the grant this machine signed. A missing,
+/// unverifiable, or mismatching receipt fails the transfer regardless of
+/// what the source-side orchestrator reported.
+fn settle_receipt(
+    expectation: &ReceiptExpectation,
+    payload: Option<&str>,
+    src_host: &str,
+    dst_host: &str,
+    verbose: bool,
+) -> Result<()> {
+    let Some(payload) = payload else {
+        bail!(
+            "the command-restricted receiver on {dst_host} issued no receipt through {src_host}; what landed cannot be verified"
+        );
+    };
+    let envelope = base64::engine::general_purpose::STANDARD_NO_PAD
+        .decode(payload.trim())
+        .context("decode the receipt relayed from the source host")?;
+    let receipt = crate::receipt::verify(&envelope, &expectation.public_key)
+        .with_context(|| format!("verify the receipt from {dst_host}"))?;
+    if receipt.enrollment_id != expectation.enrollment_id
+        || receipt.request_id != expectation.request_id
+    {
+        bail!(
+            "the receipt from {dst_host} names a different grant than the one this transfer signed"
+        );
+    }
+    if receipt.refused > 0 {
+        bail!(
+            "the receiver on {dst_host} refused {} request(s) from {src_host}; first: {}",
+            receipt.refused,
+            receipt
+                .refusal_samples
+                .first()
+                .map(String::as_str)
+                .unwrap_or("(no message recorded)")
+        );
+    }
+    if verbose {
+        eprintln!(
+            "syq: receipt from {dst_host} verified: {} files published ({}), {} deleted, {} hashed, {} entries touched",
+            receipt.published_count,
+            crate::progress::human(receipt.published_bytes),
+            receipt.deleted_count,
+            receipt.observed_count,
+            receipt.entries
+        );
+    }
+    Ok(())
+}
 
 #[derive(Clone, Debug)]
 enum AgentForwarding {
@@ -238,6 +314,7 @@ pub fn run(
     let mut constrained_rsh = None;
     let mut restricted_destination_path = None;
     let mut restricted_grant = None;
+    let mut receipt_expectation = None;
     let default_ssh_agent_policy = if args.rsh.is_some() {
         None
     } else if same_host || args.no_forward_agent {
@@ -286,6 +363,11 @@ pub fn run(
         let broker = if let Some(prepared) = prepared {
             restricted_destination_path = Some(prepared.canonical_destination);
             restricted_grant = Some(prepared.grant);
+            receipt_expectation = Some(ReceiptExpectation {
+                public_key: prepared.receipt_public_key.clone(),
+                enrollment_id: prepared.enrollment_id,
+                request_id: prepared.request_id,
+            });
             if !args.quiet {
                 eprintln!(
                     "syq: using command-restricted destination enrollment {}",
@@ -704,19 +786,25 @@ pub fn run(
     let run = || {
         let mut cmd = make_command();
         cmd.stdin(Stdio::null())
-            .stdout(Stdio::inherit())
+            .stdout(Stdio::piped())
             .stderr(Stdio::inherit());
-        cmd.status().with_context(|| format!("spawn {:?}", rsh[0]))
+        let mut child = cmd.spawn().with_context(|| format!("spawn {:?}", rsh[0]))?;
+        let stdout = child.stdout.take().expect("piped stdout");
+        let receipt = relay_stdout(stdout, receipt_expectation.is_some())?;
+        let status = child
+            .wait()
+            .with_context(|| format!("wait for {:?}", rsh[0]))?;
+        Ok::<_, anyhow::Error>((status, receipt))
     };
-    let mut status = run()?;
+    let (mut status, mut receipt_payload) = run()?;
     if helper_missing(status.code(), spec.auto_helper) {
         spec.install_helper()?;
-        status = run()?;
+        (status, receipt_payload) = run()?;
     }
     // Keep the broker alive until the outer SSH connection and all forwarded
     // channels have closed.
     drop(broker_guard);
-    match status.code() {
+    let outcome: Result<i32> = match status.code() {
         Some(0) => Ok(0),
         // 23 (some files failed) and 25 (--max-delete refused) pass through:
         // they are transfer results, and the remote's stderr was inherited so
@@ -745,7 +833,18 @@ pub fn run(
             bail!("remote-to-remote transfer on {src_host} failed (exit {c}); {src_host} may not be able to reach the destination")
         }
         None => bail!("remote syq on {src_host} killed by signal"),
+    };
+    let code = outcome?;
+    if let Some(expectation) = &receipt_expectation {
+        settle_receipt(
+            expectation,
+            receipt_payload.as_deref(),
+            &src_host,
+            dst.host.as_deref().unwrap_or("the destination"),
+            args.verbose > 0,
+        )?;
     }
+    Ok(code)
 }
 
 fn helper_missing(code: Option<i32>, automatic: bool) -> bool {
@@ -951,6 +1050,69 @@ mod tests {
         assert_eq!(broker_connection_limit(None, 8).unwrap(), 65);
         assert_eq!(broker_connection_limit(Some(128), 128).unwrap(), 129);
         assert!(broker_connection_limit(Some(usize::MAX), usize::MAX).is_err());
+    }
+
+    #[test]
+    fn receipts_are_verified_against_the_signed_grant() {
+        let keypair = ssh_key::private::Ed25519Keypair::from_seed(&[5; 32]);
+        let key = ssh_key::PrivateKey::new(keypair.into(), "syq-receipt-test").unwrap();
+        let enrollment_id = EnrollmentId::random();
+        let request_id = RequestId::fresh(1_900_000_000).unwrap();
+        let expectation = ReceiptExpectation {
+            public_key: key.public_key().to_openssh().unwrap(),
+            enrollment_id,
+            request_id,
+        };
+        let mut ledger = crate::receipt::Ledger::default();
+        ledger.published.insert(b"/dst/a".to_vec(), (3, None));
+        let encode = |ledger: &crate::receipt::Ledger, request_id| {
+            let receipt = ledger
+                .receipt(enrollment_id, request_id, 1_900_000_000, 1, 3)
+                .unwrap();
+            base64::engine::general_purpose::STANDARD_NO_PAD
+                .encode(crate::receipt::sign(&receipt, &key).unwrap())
+        };
+        let settle = |expectation: &ReceiptExpectation, payload: Option<&str>| {
+            settle_receipt(expectation, payload, "host-a", "host-b", false)
+        };
+
+        let good = encode(&ledger, request_id);
+        settle(&expectation, Some(&good)).unwrap();
+        assert!(settle(&expectation, None).is_err());
+        assert!(settle(&expectation, Some("not a receipt")).is_err());
+
+        // The receipt must name the grant this machine signed.
+        let other = encode(&ledger, RequestId::fresh(1_900_000_001).unwrap());
+        assert!(settle(&expectation, Some(&other)).is_err());
+
+        // A refused request fails the transfer whatever hostA reported.
+        let mut refused = crate::receipt::Ledger::default();
+        refused.record_refusal("receiver mutation is outside the signed destination scopes");
+        let refused = encode(&refused, request_id);
+        assert!(settle(&expectation, Some(&refused)).is_err());
+
+        // And it must verify against the enrollment's key.
+        let stranger = ssh_key::PrivateKey::new(
+            ssh_key::private::Ed25519Keypair::from_seed(&[6; 32]).into(),
+            "stranger",
+        )
+        .unwrap();
+        let mismatched = ReceiptExpectation {
+            public_key: stranger.public_key().to_openssh().unwrap(),
+            ..expectation.clone()
+        };
+        assert!(settle(&mismatched, Some(&good)).is_err());
+
+        // The relay keeps the receipt line and passes everything else on.
+        let output = format!(
+            "syq: transferred 1 files\n{}{good}\n",
+            crate::receipt::RECEIPT_LINE_PREFIX
+        );
+        assert_eq!(
+            relay_stdout(output.as_bytes(), true).unwrap().as_deref(),
+            Some(good.as_str())
+        );
+        assert_eq!(relay_stdout(output.as_bytes(), false).unwrap(), None);
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -17,16 +17,42 @@ struct ReceiptExpectation {
     request_id: RequestId,
 }
 
-/// Pass the orchestrator's stdout through line by line, keeping the receipt
-/// line to ourselves when one is expected. Returns the last receipt payload.
-fn relay_stdout(stdout: impl std::io::Read, expect_receipt: bool) -> Result<Option<String>> {
+/// The receipt envelope is bounded at 64 MiB; allow for base64 and slack.
+const MAX_RECEIPT_LINE_BYTES: usize = 96 * 1024 * 1024;
+
+/// Pass the orchestrator's stdout through byte for byte, keeping only the
+/// receipt line to ourselves. Used only when a receipt is expected; other
+/// transfers inherit stdout untouched. Returns the last receipt payload.
+fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<Vec<u8>>> {
+    use std::io::Write;
+    let prefix = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes();
+    let mut reader = std::io::BufReader::new(stdout);
+    let mut out = std::io::stdout().lock();
+    let mut line = Vec::new();
     let mut receipt = None;
-    for line in std::io::BufReader::new(stdout).lines() {
-        let line = line.context("read remote orchestrator output")?;
-        match line.strip_prefix(crate::receipt::RECEIPT_LINE_PREFIX) {
-            Some(payload) if expect_receipt => receipt = Some(payload.to_owned()),
-            _ => println!("{line}"),
+    loop {
+        line.clear();
+        let read = reader
+            .read_until(b'\n', &mut line)
+            .context("read remote orchestrator output")?;
+        if read == 0 {
+            break;
         }
+        if let Some(payload) = line.strip_prefix(prefix) {
+            if payload.len() > MAX_RECEIPT_LINE_BYTES {
+                bail!("the relayed receipt line exceeds {MAX_RECEIPT_LINE_BYTES} bytes");
+            }
+            let payload = payload
+                .strip_suffix(b"\n")
+                .unwrap_or(payload)
+                .strip_suffix(b"\r")
+                .unwrap_or(payload);
+            receipt = Some(payload.to_vec());
+            continue;
+        }
+        out.write_all(&line)
+            .and_then(|()| out.flush())
+            .context("relay remote orchestrator output")?;
     }
     Ok(receipt)
 }
@@ -36,7 +62,7 @@ fn relay_stdout(stdout: impl std::io::Read, expect_receipt: bool) -> Result<Opti
 /// what the source-side orchestrator reported.
 fn settle_receipt(
     expectation: &ReceiptExpectation,
-    payload: Option<&str>,
+    payload: Option<&[u8]>,
     src_host: &str,
     dst_host: &str,
     verbose: bool,
@@ -47,7 +73,7 @@ fn settle_receipt(
         );
     };
     let envelope = base64::engine::general_purpose::STANDARD_NO_PAD
-        .decode(payload.trim())
+        .decode(payload.trim_ascii())
         .context("decode the receipt relayed from the source host")?;
     let receipt = crate::receipt::verify(&envelope, &expectation.public_key)
         .with_context(|| format!("verify the receipt from {dst_host}"))?;
@@ -785,16 +811,24 @@ pub fn run(
     }
     let run = || {
         let mut cmd = make_command();
-        cmd.stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit());
+        cmd.stdin(Stdio::null()).stderr(Stdio::inherit());
+        if receipt_expectation.is_none() {
+            // Nothing to intercept: leave stdout to the terminal or pipe the
+            // user gave us, bytes and all.
+            let status = cmd
+                .status()
+                .with_context(|| format!("spawn {:?}", rsh[0]))?;
+            return Ok::<_, anyhow::Error>((status, None));
+        }
+        cmd.stdout(Stdio::piped());
         let mut child = cmd.spawn().with_context(|| format!("spawn {:?}", rsh[0]))?;
         let stdout = child.stdout.take().expect("piped stdout");
-        let receipt = relay_stdout(stdout, receipt_expectation.is_some())?;
+        // Always reap the child, even when relaying its output failed.
+        let relayed = relay_stdout(stdout);
         let status = child
             .wait()
             .with_context(|| format!("wait for {:?}", rsh[0]))?;
-        Ok::<_, anyhow::Error>((status, receipt))
+        Ok((status, relayed?))
     };
     let (mut status, mut receipt_payload) = run()?;
     if helper_missing(status.code(), spec.auto_helper) {
@@ -1073,7 +1107,13 @@ mod tests {
                 .encode(crate::receipt::sign(&receipt, &key).unwrap())
         };
         let settle = |expectation: &ReceiptExpectation, payload: Option<&str>| {
-            settle_receipt(expectation, payload, "host-a", "host-b", false)
+            settle_receipt(
+                expectation,
+                payload.map(str::as_bytes),
+                "host-a",
+                "host-b",
+                false,
+            )
         };
 
         let good = encode(&ledger, request_id);
@@ -1103,16 +1143,17 @@ mod tests {
         };
         assert!(settle(&mismatched, Some(&good)).is_err());
 
-        // The relay keeps the receipt line and passes everything else on.
-        let output = format!(
-            "syq: transferred 1 files\n{}{good}\n",
-            crate::receipt::RECEIPT_LINE_PREFIX
-        );
+        // The relay keeps the receipt line, byte for byte, and passes
+        // everything else on, including bytes that are not UTF-8.
+        let mut output = b"syq: transferred 1 files\xff\r\n".to_vec();
+        output.extend_from_slice(crate::receipt::RECEIPT_LINE_PREFIX.as_bytes());
+        output.extend_from_slice(good.as_bytes());
+        output.extend_from_slice(b"\r\n");
         assert_eq!(
-            relay_stdout(output.as_bytes(), true).unwrap().as_deref(),
-            Some(good.as_str())
+            relay_stdout(output.as_slice()).unwrap().as_deref(),
+            Some(good.as_bytes())
         );
-        assert_eq!(relay_stdout(output.as_bytes(), false).unwrap(), None);
+        assert_eq!(relay_stdout(b"plain\n".as_slice()).unwrap(), None);
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -24,36 +24,96 @@ const MAX_RECEIPT_LINE_BYTES: usize = 96 * 1024 * 1024;
 /// receipt line to ourselves. Used only when a receipt is expected; other
 /// transfers inherit stdout untouched. Returns the last receipt payload.
 fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<Vec<u8>>> {
+    relay_stdout_bounded(stdout, MAX_RECEIPT_LINE_BYTES)
+}
+
+/// Streams every ordinary line straight through without holding more than
+/// one buffer of it, so a hostile orchestrator cannot make this machine
+/// buffer an arbitrarily long line; only a receipt line is collected, up to
+/// `limit` bytes.
+fn relay_stdout_bounded(stdout: impl std::io::Read, limit: usize) -> Result<Option<Vec<u8>>> {
     use std::io::Write;
     let prefix = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes();
-    let mut reader = std::io::BufReader::new(stdout);
+    let mut reader = std::io::BufReader::with_capacity(64 * 1024, stdout);
     let mut out = std::io::stdout().lock();
-    let mut line = Vec::new();
     let mut receipt = None;
+    // The first bytes of the current line, held only until the prefix
+    // decision; then either the receipt payload being collected or nothing.
+    let mut head: Vec<u8> = Vec::with_capacity(prefix.len());
+    let mut decided = false;
+    let mut capturing: Option<Vec<u8>> = None;
+    let finish_capture = |payload: &mut Vec<u8>| {
+        while payload
+            .last()
+            .is_some_and(|byte| matches!(byte, b'\n' | b'\r'))
+        {
+            payload.pop();
+        }
+        std::mem::take(payload)
+    };
     loop {
-        line.clear();
-        let read = reader
-            .read_until(b'\n', &mut line)
+        let buffer = reader
+            .fill_buf()
             .context("read remote orchestrator output")?;
-        if read == 0 {
+        if buffer.is_empty() {
             break;
         }
-        if let Some(payload) = line.strip_prefix(prefix) {
-            if payload.len() > MAX_RECEIPT_LINE_BYTES {
-                bail!("the relayed receipt line exceeds {MAX_RECEIPT_LINE_BYTES} bytes");
+        let mut consumed = 0;
+        while consumed < buffer.len() {
+            let chunk = &buffer[consumed..];
+            let (segment, ends_line) = match chunk.iter().position(|byte| *byte == b'\n') {
+                Some(index) => (&chunk[..=index], true),
+                None => (chunk, false),
+            };
+            consumed += segment.len();
+            if !decided {
+                head.extend_from_slice(segment);
+                if head.len() >= prefix.len() || ends_line {
+                    decided = true;
+                    if head.starts_with(prefix) {
+                        capturing = Some(head[prefix.len()..].to_vec());
+                    } else {
+                        out.write_all(&head)
+                            .context("relay remote orchestrator output")?;
+                    }
+                    head.clear();
+                }
+            } else if let Some(payload) = capturing.as_mut() {
+                payload.extend_from_slice(segment);
+            } else {
+                out.write_all(segment)
+                    .context("relay remote orchestrator output")?;
             }
-            let payload = payload
-                .strip_suffix(b"\n")
-                .unwrap_or(payload)
-                .strip_suffix(b"\r")
-                .unwrap_or(payload);
-            receipt = Some(payload.to_vec());
-            continue;
+            if let Some(payload) = capturing.as_mut() {
+                if payload.len() > limit {
+                    bail!("the relayed receipt line exceeds {limit} bytes");
+                }
+            }
+            if ends_line {
+                if let Some(payload) = capturing.as_mut() {
+                    receipt = Some(finish_capture(payload));
+                    capturing = None;
+                } else {
+                    out.flush().context("relay remote orchestrator output")?;
+                }
+                decided = false;
+            }
         }
-        out.write_all(&line)
-            .and_then(|()| out.flush())
-            .context("relay remote orchestrator output")?;
+        reader.consume(consumed);
     }
+    // Output that ended without a newline.
+    if !head.is_empty() {
+        if head.starts_with(prefix) {
+            capturing = Some(head[prefix.len()..].to_vec());
+        } else {
+            out.write_all(&head)
+                .context("relay remote orchestrator output")?;
+        }
+    }
+    if let Some(payload) = capturing.as_mut() {
+        receipt = Some(finish_capture(payload));
+    }
+    out.flush().context("relay remote orchestrator output")?;
     Ok(receipt)
 }
 
@@ -1332,6 +1392,24 @@ mod tests {
             Some(good.as_bytes())
         );
         assert_eq!(relay_stdout(b"plain\n".as_slice()).unwrap(), None);
+
+        // Ordinary lines stream through however long they are, a receipt
+        // line without a trailing newline still counts, and an oversized
+        // receipt line is refused instead of buffered.
+        let mut long = vec![b'x'; 300 * 1024];
+        long.push(b'\n');
+        long.extend_from_slice(crate::receipt::RECEIPT_LINE_PREFIX.as_bytes());
+        long.extend_from_slice(good.as_bytes());
+        assert_eq!(
+            relay_stdout_bounded(long.as_slice(), 4096)
+                .unwrap()
+                .as_deref(),
+            Some(good.as_bytes())
+        );
+        let mut oversized = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes().to_vec();
+        oversized.extend(std::iter::repeat_n(b'A', 5000));
+        oversized.push(b'\n');
+        assert!(relay_stdout_bounded(oversized.as_slice(), 4096).is_err());
     }
 
     #[test]

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -16,6 +16,9 @@ use ssh_key::{HashAlg, LineEnding, PrivateKey, PublicKey, SshSig};
 use std::collections::{BTreeMap, BTreeSet};
 
 pub(crate) const RECEIPT_NAMESPACE: &str = "syq-receipt-v1@greaber.github";
+/// The orchestrator prints the base64 envelope after this prefix as one
+/// stdout line; the invoking machine filters that line out and verifies it.
+pub(crate) const RECEIPT_LINE_PREFIX: &str = "syq-receipt-v1:";
 const WIRE_MAGIC: &[u8; 8] = b"SYQRCPT\0";
 const WIRE_VERSION: u16 = 1;
 const WIRE_HEADER_LEN: usize = WIRE_MAGIC.len() + 2 + 4 + 4;

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -118,10 +118,8 @@ pub(crate) struct PreparedTransfer {
     pub(crate) grant: String,
     pub(crate) enrollment_id: EnrollmentId,
     /// The nonce the grant was signed with; the receipt must name it.
-    #[allow(dead_code)]
     pub(crate) request_id: RequestId,
     /// Verifier for the receipt hostB will issue.
-    #[allow(dead_code)]
     pub(crate) receipt_public_key: String,
 }
 

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -100,7 +100,7 @@ struct LocalEnrollment {
     canonical_root: String,
     receiver_path: String,
     /// Absent for enrollments installed before receivers had receipt keys;
-    /// rerunning `syq enroll` refreshes them.
+    /// rerunning `syq enrollment add` refreshes them.
     #[serde(default)]
     receipt_public_key: Option<String>,
 }
@@ -313,7 +313,7 @@ impl RestrictedAuthority {
         } = extensions;
         if receipt_policy.required && receipt_key.is_none() {
             bail!(
-                "the grant requires a receipt but this receiver has no receipt key; rerun `syq enroll` to refresh the enrollment"
+                "the grant requires a receipt but this receiver has no receipt key; rerun `syq enrollment add` to refresh the enrollment"
             );
         }
         let enrollment_id = grant.enrollment_id;
@@ -404,7 +404,7 @@ impl RestrictedAuthority {
     /// Sign hostB's account of this grant and close it to further mutation.
     pub(crate) fn issue_receipt(&self) -> Result<Vec<u8>> {
         let key = self.receipt_key.as_ref().context(
-            "this receiver has no receipt key; rerun `syq enroll` to refresh the enrollment",
+            "this receiver has no receipt key; rerun `syq enrollment add` to refresh the enrollment",
         )?;
         // Close the grant first, then wait for every request already
         // authorized on any connection to execute and settle, so the receipt
@@ -3154,7 +3154,7 @@ pub(crate) fn prepare_transfer(
         None => {
             if !allow_enrollment {
                 bail!(
-                    "read-only operations will not install a receiver enrollment; pre-enroll this destination with `syq enroll` or explicitly use --agent-broker-only"
+                    "read-only operations will not install a receiver enrollment; pre-enroll this destination with `syq enrollment add` or explicitly use --agent-broker-only"
                 );
             }
             let jump = endpoint(
@@ -3175,7 +3175,7 @@ pub(crate) fn prepare_transfer(
     let private_key = load_private_key(&directory)?;
     let receipt_public_key = metadata.receipt_public_key.clone().with_context(|| {
         format!(
-            "enrollment {} predates receipts and cannot verify one; rerun `syq enroll {}:{}` to refresh it",
+            "enrollment {} predates receipts and cannot verify one; rerun `syq enrollment add {}:{}` to refresh it",
             metadata.id, host, requested
         )
     })?;
@@ -3302,62 +3302,74 @@ fn management_via(arguments: &[OsString]) -> Result<Option<SshEndpoint>> {
     )?))
 }
 
+const ENROLLMENT_USAGE: &str = "Usage: syq enrollment <COMMAND>\n\nManage command-restricted receiver enrollments.\n\nCommands:\n  add     Enroll a remote destination, or refresh an existing enrollment\n  list    List local enrollments\n  revoke  Remove an enrollment from both machines\n\nRun `syq enrollment <COMMAND> --help` for command-specific help.";
+
+/// `syq enrollment add|list|revoke`: the receiver enrollment system is one
+/// subcommand with its verbs beneath it. `argv[1]` is `enrollment`.
 pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
-    let command = argv.get(1)?.to_str()?;
+    if argv.get(1)?.to_str()? != "enrollment" {
+        return None;
+    }
+    let Some(command) = argv.get(2).and_then(|argument| argument.to_str()) else {
+        eprintln!("{ENROLLMENT_USAGE}");
+        return Some(Ok(2));
+    };
     match command {
-        "enrollments" => {
-            Some((|| {
-                if argv.get(2).is_some_and(|argument| argument == "--help") {
-                    println!("Usage: syq enrollments\n\nList local command-restricted receiver enrollments.");
-                    return Ok(0);
-                }
-                if argv.len() != 2 {
-                    bail!("usage: syq enrollments");
-                }
-                let active = load_local_enrollments()?;
-                let active_ids = active
-                    .iter()
-                    .map(|(metadata, _)| metadata.id)
-                    .collect::<HashSet<_>>();
-                for (metadata, _) in active {
-                    let target = endpoint(&metadata.target_login, &metadata.host, metadata.port)?;
+        "--help" | "-h" => {
+            println!("{ENROLLMENT_USAGE}");
+            Some(Ok(0))
+        }
+        "list" => Some((|| {
+            if argv.get(3).is_some_and(|argument| argument == "--help") {
+                println!("Usage: syq enrollment list\n\nList local command-restricted receiver enrollments.");
+                return Ok(0);
+            }
+            if argv.len() != 3 {
+                bail!("usage: syq enrollment list");
+            }
+            let active = load_local_enrollments()?;
+            let active_ids = active
+                .iter()
+                .map(|(metadata, _)| metadata.id)
+                .collect::<HashSet<_>>();
+            for (metadata, _) in active {
+                let target = endpoint(&metadata.target_login, &metadata.host, metadata.port)?;
+                println!(
+                    "{}\tactive\t{}\t{}\t{}",
+                    metadata.id,
+                    target.label(),
+                    metadata.canonical_root,
+                    if metadata.receipt_public_key.is_some() {
+                        "receipt-key"
+                    } else {
+                        "no-receipt-key"
+                    }
+                );
+            }
+            for (pending, _) in load_pending_enrollments()? {
+                if !active_ids.contains(&pending.id) {
+                    let target = endpoint(&pending.target_login, &pending.host, pending.port)?;
                     println!(
-                        "{}\tactive\t{}\t{}\t{}",
-                        metadata.id,
+                        "{}\tpending\t{}\t{}",
+                        pending.id,
                         target.label(),
-                        metadata.canonical_root,
-                        if metadata.receipt_public_key.is_some() {
-                            "receipt-key"
-                        } else {
-                            "no-receipt-key"
-                        }
+                        pending.requested_destination
                     );
                 }
-                for (pending, _) in load_pending_enrollments()? {
-                    if !active_ids.contains(&pending.id) {
-                        let target = endpoint(&pending.target_login, &pending.host, pending.port)?;
-                        println!(
-                            "{}\tpending\t{}\t{}",
-                            pending.id,
-                            target.label(),
-                            pending.requested_destination
-                        );
-                    }
-                }
-                Ok(0)
-            })())
-        }
-        "enroll" => Some((|| {
-            if argv.get(2).is_some_and(|argument| argument == "--help") {
+            }
+            Ok(0)
+        })()),
+        "add" => Some((|| {
+            if argv.get(3).is_some_and(|argument| argument == "--help") {
                 println!(
-                    "Usage: syq enroll [USER@]HOST:DESTINATION [--via [USER@]HOST]\n\nPre-enroll a command-restricted receiver for DESTINATION's existing parent."
+                    "Usage: syq enrollment add [USER@]HOST:DESTINATION [--via [USER@]HOST]\n\nEnroll a command-restricted receiver for DESTINATION's existing parent, or refresh an existing enrollment's receiver."
                 );
                 return Ok(0);
             }
-            if argv.len() < 3 {
-                bail!("usage: syq enroll [USER@]HOST:DESTINATION [--via [USER@]HOST]");
+            if argv.len() < 4 {
+                bail!("usage: syq enrollment add [USER@]HOST:DESTINATION [--via [USER@]HOST]");
             }
-            let target = argv[2].to_str().context("enrollment target is not UTF-8")?;
+            let target = argv[3].to_str().context("enrollment target is not UTF-8")?;
             let location = Location::parse(target)?;
             let host = location
                 .host
@@ -3365,7 +3377,7 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
                 .context("enrollment target must be remote")?;
             let requested = std::str::from_utf8(&location.path)
                 .context("enrollment destination is not UTF-8")?;
-            let via = management_via(&argv[3..])?;
+            let via = management_via(&argv[4..])?;
             let policy = crate::agent_broker::resolve_host_policy(
                 "ssh",
                 location.user.as_deref(),
@@ -3389,17 +3401,17 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
             Ok(0)
         })()),
         "revoke" => Some((|| {
-            if argv.get(2).is_some_and(|argument| argument == "--help") {
+            if argv.get(3).is_some_and(|argument| argument == "--help") {
                 println!(
-                    "Usage: syq revoke ENROLLMENT-ID [--via [USER@]HOST]\n\nRemove the forced key and per-enrollment state from both machines."
+                    "Usage: syq enrollment revoke ENROLLMENT-ID [--via [USER@]HOST]\n\nRemove the forced key and per-enrollment state from both machines."
                 );
                 return Ok(0);
             }
-            if argv.len() < 3 {
-                bail!("usage: syq revoke ENROLLMENT-ID [--via [USER@]HOST]");
+            if argv.len() < 4 {
+                bail!("usage: syq enrollment revoke ENROLLMENT-ID [--via [USER@]HOST]");
             }
-            let id = EnrollmentId::parse(argv[2].to_str().context("enrollment ID is not UTF-8")?)?;
-            let via = management_via(&argv[3..])?;
+            let id = EnrollmentId::parse(argv[3].to_str().context("enrollment ID is not UTF-8")?)?;
+            let via = management_via(&argv[4..])?;
             let active = load_local_enrollments()?
                 .into_iter()
                 .find(|(metadata, _)| metadata.id == id);
@@ -3460,7 +3472,9 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
             println!("revoked {id} from {}", target.label());
             Ok(0)
         })()),
-        _ => None,
+        other => Some(Err(anyhow::anyhow!(
+            "unknown enrollment command {other:?}\n{ENROLLMENT_USAGE}"
+        ))),
     }
 }
 

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1890,6 +1890,24 @@ pub fn run(args: Args) -> Result<i32> {
     let created_counts = (st.dirs_created, st.links_created, st.specials_created);
     drop(st);
 
+    // With a command-restricted receiver, ask for its signed receipt now that
+    // every mutation is settled, and hand it to the invoking machine as one
+    // marked line. That machine verifies it; this orchestrator's own report
+    // is not trusted for what landed.
+    if args.restricted_grant.is_some() {
+        use base64::Engine as _;
+        match dst_ctl.call(Request::Receipt) {
+            Ok(Response::Receipt(envelope)) => println!(
+                "{}{}",
+                crate::receipt::RECEIPT_LINE_PREFIX,
+                base64::engine::general_purpose::STANDARD_NO_PAD.encode(envelope)
+            ),
+            Ok(Response::Err(error)) => progress.error(&format!("syq: receipt: {error}")),
+            Ok(other) => progress.error(&format!("syq: receipt: unexpected response {other:?}")),
+            Err(error) => progress.error(&format!("syq: receipt: {error:#}")),
+        }
+    }
+
     progress.stop();
     if let Some(t) = ticker {
         let _ = t.join();

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1032,6 +1032,45 @@ fn native_cp_with_prune_removes_only_target_extras_after_copy() {
 }
 
 #[test]
+fn enrollment_is_one_subcommand_with_its_verbs_beneath_it() {
+    let run = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(args)
+            .run()
+            .unwrap()
+    };
+    let help = run(&["enrollment", "--help"]);
+    assert!(help.status.success());
+    let text = String::from_utf8_lossy(&help.stdout);
+    for verb in ["add", "list", "revoke"] {
+        assert!(text.contains(verb), "{text}");
+    }
+    let bare = run(&["enrollment"]);
+    assert_eq!(bare.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&bare.stderr).contains("Usage: syq enrollment"));
+    let bogus = run(&["enrollment", "rotate"]);
+    assert!(!bogus.status.success());
+    assert!(String::from_utf8_lossy(&bogus.stderr).contains("unknown enrollment command"));
+    for verb in ["add", "list", "revoke"] {
+        let verb_help = run(&["enrollment", verb, "--help"]);
+        assert!(verb_help.status.success(), "{verb}");
+        assert!(
+            String::from_utf8_lossy(&verb_help.stdout).contains(&format!("syq enrollment {verb}")),
+            "{verb}"
+        );
+    }
+    // The old top-level spellings are gone.
+    for old in [
+        &["enroll", "host:dst"][..],
+        &["enrollments"],
+        &["revoke", "id"],
+    ] {
+        let out = run(old);
+        assert!(!out.status.success(), "{old:?}");
+    }
+}
+
+#[test]
 fn native_receiver_ceilings_apply_only_to_direct_remote_copies() {
     let t = Tmp::new();
     write(&t.path("src/file"), b"data");


### PR DESCRIPTION
Third of three stacked pull requests for signed receipts; stacked on #111 (`receipt-receiver`), which is stacked on #110 (`receipt-key`).

## Summary

- **Orchestrator (hostA)**: after deletions and deferred metadata settle, a command-restricted transfer sends `Request::Receipt` on the control connection and prints the envelope as one `syq-receipt-v1:` line on stdout. A failed request is reported as a transfer error.
- **Invoking machine**: the direct launcher now pipes the orchestrator's stdout, passes every other line through unchanged, and keeps the receipt line. After the orchestrator exits with a result code, the receipt is decoded and verified in-process against the enrollment's receipt public key; it must name the enrollment and request ID this machine signed and record zero refused requests. Missing, unverifiable, mismatching, or refusing receipts fail the run. `-v` prints the verified totals.
- **README**: the remote-to-remote guarantee section explains what the receipt attests and what it does not (hostB's view of hostB only).

Enrollments made before #110 have no receipt key; `prepare_transfer` refuses them with a "rerun `syq enroll`" message, and an older installed receiver rejects the V5 grant the same way.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (248 unit, 277 local integration, 9 update). The fake-rsh direct remote-to-remote integration test still passes with stdout piped.
- New test: `receipts_are_verified_against_the_signed_grant` (valid receipt, missing, garbage, wrong request ID, refusals, wrong key, relay filtering).
- Not verified: a live two-host transfer through an enrolled receiver. The receipt request, relay line, and verification are covered at the unit level only; nothing in the tree drives a real receiver session end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqM3Msd5sJYmuYjguVBB5E
