### PR TITLE
Group the enrollment commands under syq enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ refuses `--max-size` with `--prune`, as described below. A
 command-restricted remote-to-remote receiver independently enforces the signed
 aggregate limit, signed filters, and the selected staged or in-place publication
 policy. A receiver installed by an older syq rejects an extension or unsupported
-policy safely; rerun `syq enroll HOST:DEST` to refresh an existing enrollment
+policy safely; rerun `syq enrollment add HOST:DEST` to refresh an existing enrollment
 to the current binary. On a direct remote-to-remote copy through that
 receiver, `cp` also accepts the receiver ceilings
 `--max-entries N`, `--max-total-bytes SIZE`, and `--max-runtime DURATION`
@@ -639,7 +639,7 @@ of its output; the local machine verifies it against the public key recorded
 at enrollment and fails the transfer if the receipt is missing, does not
 verify, names a different grant, or records refused requests, whatever hostA
 reported. `-v` prints the verified totals. Enrollments made before receipts
-existed must be refreshed with `syq enroll` first. The receipt is hostB's view
+existed must be refreshed with `syq enrollment add` first. The receipt is hostB's view
 of hostB: it says nothing about what hostA omitted or invented. The boundary runs between the two hosts, not inside hostB: the receiver
 runs as the enrolled account and remembers what it created by pathname, so a
 local writer who can already modify the destination tree is outside its
@@ -668,7 +668,7 @@ an observed object.
 Native `--into-new`/`--as-new` and `--into-existing`/`--as-existing` travel as
 a signed root precondition in a V4 grant, checked against the enrolled root
 when the grant is claimed; an older installed receiver rejects that grant
-safely until `syq enroll` refreshes it. `--update` still fails closed because
+safely until `syq enrollment add` refreshes it. `--update` still fails closed because
 it compares against source modification times that only hostA reports.
 `--no-tcp`, `--tcp-plain`, `--tcp-congestion`, `--files-from`, `--mapping`,
 `--min-size`, `--syq-path`, and `--no-bootstrap` also fail closed because the
@@ -690,7 +690,7 @@ them for one transfer, which bounds what a claimed grant is worth to hostA.
 `--dry-run` and `--verify-only` are cryptographically read-only: the signed
 grant marks them as such and the receiver rejects every mutation even if hostA
 sends one. They use an existing enrollment but do not install one; run
-`syq enroll` first when previewing or verifying a new destination.
+`syq enrollment add` first when previewing or verifying a new destination.
 Destination-root symlinks are also refused in this mode; enroll the explicit
 referent so the signed pathname and opened root identify the same object.
 
@@ -702,18 +702,20 @@ exact-path interpretation is denied. Use a trailing slash (`hostA:dir/`), the
 native `--as`/`--into` placement spelling, or create the destination directory
 first when that distinction matters.
 
-Use `syq enroll [USER@]HOST:DEST [--via [USER@]HOST]` to pre-enroll,
-`syq enrollments` to list local enrollments, and `syq revoke ID [--via ...]` to
+Use `syq enrollment add [USER@]HOST:DEST [--via [USER@]HOST]` to pre-enroll,
+`syq enrollment list` to list local enrollments, and
+`syq enrollment revoke ID [--via ...]` to
 remove the forced key and both sides' per-enrollment state. Before changing
 hostB, syq durably records a pending enrollment and its private key locally. If
 the installation response is lost, the next enrollment of the same endpoint
-and destination retries the same ID safely; `syq enrollments` labels that state
-`pending`, and `syq revoke` can remove either pending or active state. Running
-`syq enroll` again for an active destination also refreshes the installed
+and destination retries the same ID safely; `syq enrollment list` labels that
+state `pending`, and `syq enrollment revoke` can remove either pending or
+active state. Running `syq enrollment add` again for an active destination
+also refreshes the installed
 receiver to the exact local syq binary; the receipt key is kept for the life
 of the enrollment, so a refresh, or a retry after a lost reply, never leaves
 the two sides holding different keys. To rotate it, revoke and enroll again.
-`syq enrollments` marks enrollments made before receipt keys existed as
+`syq enrollment list` marks enrollments made before receipt keys existed as
 `no-receipt-key` until refreshed. Revocation leaves that shared binary
 because other enrollments may use it. It prevents new receiver sessions. A
 session that already claimed its signed request can finish an operation already

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -564,7 +564,7 @@ fn ordered_ignore_lines(
 
 fn print_root_help() {
     println!(
-        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning target-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a copy's resolved selection and placement as NDJSON\n  rsync        Use the retained rsync-shaped command surface\n  enroll       Pre-enroll a command-restricted remote destination\n  enrollments  List local command-restricted enrollments\n  revoke       Revoke a command-restricted enrollment\n\nRun `syq <COMMAND> --help` for command-specific help."
+        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning target-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a copy's resolved selection and placement as NDJSON\n  rsync        Use the retained rsync-shaped command surface\n  enrollment   Manage command-restricted receiver enrollments (add, list, revoke)\n\nRun `syq <COMMAND> --help` for command-specific help."
     );
 }
 

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -100,7 +100,7 @@ struct LocalEnrollment {
     canonical_root: String,
     receiver_path: String,
     /// Absent for enrollments installed before receivers had receipt keys;
-    /// rerunning `syq enroll` refreshes them.
+    /// rerunning `syq enrollment add` refreshes them.
     #[serde(default)]
     receipt_public_key: Option<String>,
 }
@@ -313,7 +313,7 @@ impl RestrictedAuthority {
         } = extensions;
         if receipt_policy.required && receipt_key.is_none() {
             bail!(
-                "the grant requires a receipt but this receiver has no receipt key; rerun `syq enroll` to refresh the enrollment"
+                "the grant requires a receipt but this receiver has no receipt key; rerun `syq enrollment add` to refresh the enrollment"
             );
         }
         let enrollment_id = grant.enrollment_id;
@@ -404,7 +404,7 @@ impl RestrictedAuthority {
     /// Sign hostB's account of this grant and close it to further mutation.
     pub(crate) fn issue_receipt(&self) -> Result<Vec<u8>> {
         let key = self.receipt_key.as_ref().context(
-            "this receiver has no receipt key; rerun `syq enroll` to refresh the enrollment",
+            "this receiver has no receipt key; rerun `syq enrollment add` to refresh the enrollment",
         )?;
         // Close the grant first, then wait for every request already
         // authorized on any connection to execute and settle, so the receipt
@@ -3154,7 +3154,7 @@ pub(crate) fn prepare_transfer(
         None => {
             if !allow_enrollment {
                 bail!(
-                    "read-only operations will not install a receiver enrollment; pre-enroll this destination with `syq enroll` or explicitly use --agent-broker-only"
+                    "read-only operations will not install a receiver enrollment; pre-enroll this destination with `syq enrollment add` or explicitly use --agent-broker-only"
                 );
             }
             let jump = endpoint(
@@ -3175,7 +3175,7 @@ pub(crate) fn prepare_transfer(
     let private_key = load_private_key(&directory)?;
     let receipt_public_key = metadata.receipt_public_key.clone().with_context(|| {
         format!(
-            "enrollment {} predates receipts and cannot verify one; rerun `syq enroll {}:{}` to refresh it",
+            "enrollment {} predates receipts and cannot verify one; rerun `syq enrollment add {}:{}` to refresh it",
             metadata.id, host, requested
         )
     })?;
@@ -3302,62 +3302,74 @@ fn management_via(arguments: &[OsString]) -> Result<Option<SshEndpoint>> {
     )?))
 }
 
+const ENROLLMENT_USAGE: &str = "Usage: syq enrollment <COMMAND>\n\nManage command-restricted receiver enrollments.\n\nCommands:\n  add     Enroll a remote destination, or refresh an existing enrollment\n  list    List local enrollments\n  revoke  Remove an enrollment from both machines\n\nRun `syq enrollment <COMMAND> --help` for command-specific help.";
+
+/// `syq enrollment add|list|revoke`: the receiver enrollment system is one
+/// subcommand with its verbs beneath it. `argv[1]` is `enrollment`.
 pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
-    let command = argv.get(1)?.to_str()?;
+    if argv.get(1)?.to_str()? != "enrollment" {
+        return None;
+    }
+    let Some(command) = argv.get(2).and_then(|argument| argument.to_str()) else {
+        eprintln!("{ENROLLMENT_USAGE}");
+        return Some(Ok(2));
+    };
     match command {
-        "enrollments" => {
-            Some((|| {
-                if argv.get(2).is_some_and(|argument| argument == "--help") {
-                    println!("Usage: syq enrollments\n\nList local command-restricted receiver enrollments.");
-                    return Ok(0);
-                }
-                if argv.len() != 2 {
-                    bail!("usage: syq enrollments");
-                }
-                let active = load_local_enrollments()?;
-                let active_ids = active
-                    .iter()
-                    .map(|(metadata, _)| metadata.id)
-                    .collect::<HashSet<_>>();
-                for (metadata, _) in active {
-                    let target = endpoint(&metadata.target_login, &metadata.host, metadata.port)?;
+        "--help" | "-h" => {
+            println!("{ENROLLMENT_USAGE}");
+            Some(Ok(0))
+        }
+        "list" => Some((|| {
+            if argv.get(3).is_some_and(|argument| argument == "--help") {
+                println!("Usage: syq enrollment list\n\nList local command-restricted receiver enrollments.");
+                return Ok(0);
+            }
+            if argv.len() != 3 {
+                bail!("usage: syq enrollment list");
+            }
+            let active = load_local_enrollments()?;
+            let active_ids = active
+                .iter()
+                .map(|(metadata, _)| metadata.id)
+                .collect::<HashSet<_>>();
+            for (metadata, _) in active {
+                let target = endpoint(&metadata.target_login, &metadata.host, metadata.port)?;
+                println!(
+                    "{}\tactive\t{}\t{}\t{}",
+                    metadata.id,
+                    target.label(),
+                    metadata.canonical_root,
+                    if metadata.receipt_public_key.is_some() {
+                        "receipt-key"
+                    } else {
+                        "no-receipt-key"
+                    }
+                );
+            }
+            for (pending, _) in load_pending_enrollments()? {
+                if !active_ids.contains(&pending.id) {
+                    let target = endpoint(&pending.target_login, &pending.host, pending.port)?;
                     println!(
-                        "{}\tactive\t{}\t{}\t{}",
-                        metadata.id,
+                        "{}\tpending\t{}\t{}",
+                        pending.id,
                         target.label(),
-                        metadata.canonical_root,
-                        if metadata.receipt_public_key.is_some() {
-                            "receipt-key"
-                        } else {
-                            "no-receipt-key"
-                        }
+                        pending.requested_destination
                     );
                 }
-                for (pending, _) in load_pending_enrollments()? {
-                    if !active_ids.contains(&pending.id) {
-                        let target = endpoint(&pending.target_login, &pending.host, pending.port)?;
-                        println!(
-                            "{}\tpending\t{}\t{}",
-                            pending.id,
-                            target.label(),
-                            pending.requested_destination
-                        );
-                    }
-                }
-                Ok(0)
-            })())
-        }
-        "enroll" => Some((|| {
-            if argv.get(2).is_some_and(|argument| argument == "--help") {
+            }
+            Ok(0)
+        })()),
+        "add" => Some((|| {
+            if argv.get(3).is_some_and(|argument| argument == "--help") {
                 println!(
-                    "Usage: syq enroll [USER@]HOST:DESTINATION [--via [USER@]HOST]\n\nPre-enroll a command-restricted receiver for DESTINATION's existing parent."
+                    "Usage: syq enrollment add [USER@]HOST:DESTINATION [--via [USER@]HOST]\n\nEnroll a command-restricted receiver for DESTINATION's existing parent, or refresh an existing enrollment's receiver."
                 );
                 return Ok(0);
             }
-            if argv.len() < 3 {
-                bail!("usage: syq enroll [USER@]HOST:DESTINATION [--via [USER@]HOST]");
+            if argv.len() < 4 {
+                bail!("usage: syq enrollment add [USER@]HOST:DESTINATION [--via [USER@]HOST]");
             }
-            let target = argv[2].to_str().context("enrollment target is not UTF-8")?;
+            let target = argv[3].to_str().context("enrollment target is not UTF-8")?;
             let location = Location::parse(target)?;
             let host = location
                 .host
@@ -3365,7 +3377,7 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
                 .context("enrollment target must be remote")?;
             let requested = std::str::from_utf8(&location.path)
                 .context("enrollment destination is not UTF-8")?;
-            let via = management_via(&argv[3..])?;
+            let via = management_via(&argv[4..])?;
             let policy = crate::agent_broker::resolve_host_policy(
                 "ssh",
                 location.user.as_deref(),
@@ -3389,17 +3401,17 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
             Ok(0)
         })()),
         "revoke" => Some((|| {
-            if argv.get(2).is_some_and(|argument| argument == "--help") {
+            if argv.get(3).is_some_and(|argument| argument == "--help") {
                 println!(
-                    "Usage: syq revoke ENROLLMENT-ID [--via [USER@]HOST]\n\nRemove the forced key and per-enrollment state from both machines."
+                    "Usage: syq enrollment revoke ENROLLMENT-ID [--via [USER@]HOST]\n\nRemove the forced key and per-enrollment state from both machines."
                 );
                 return Ok(0);
             }
-            if argv.len() < 3 {
-                bail!("usage: syq revoke ENROLLMENT-ID [--via [USER@]HOST]");
+            if argv.len() < 4 {
+                bail!("usage: syq enrollment revoke ENROLLMENT-ID [--via [USER@]HOST]");
             }
-            let id = EnrollmentId::parse(argv[2].to_str().context("enrollment ID is not UTF-8")?)?;
-            let via = management_via(&argv[3..])?;
+            let id = EnrollmentId::parse(argv[3].to_str().context("enrollment ID is not UTF-8")?)?;
+            let via = management_via(&argv[4..])?;
             let active = load_local_enrollments()?
                 .into_iter()
                 .find(|(metadata, _)| metadata.id == id);
@@ -3460,7 +3472,9 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
             println!("revoked {id} from {}", target.label());
             Ok(0)
         })()),
-        _ => None,
+        other => Some(Err(anyhow::anyhow!(
+            "unknown enrollment command {other:?}\n{ENROLLMENT_USAGE}"
+        ))),
     }
 }
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1032,6 +1032,45 @@ fn native_cp_with_prune_removes_only_target_extras_after_copy() {
 }
 
 #[test]
+fn enrollment_is_one_subcommand_with_its_verbs_beneath_it() {
+    let run = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(args)
+            .run()
+            .unwrap()
+    };
+    let help = run(&["enrollment", "--help"]);
+    assert!(help.status.success());
+    let text = String::from_utf8_lossy(&help.stdout);
+    for verb in ["add", "list", "revoke"] {
+        assert!(text.contains(verb), "{text}");
+    }
+    let bare = run(&["enrollment"]);
+    assert_eq!(bare.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&bare.stderr).contains("Usage: syq enrollment"));
+    let bogus = run(&["enrollment", "rotate"]);
+    assert!(!bogus.status.success());
+    assert!(String::from_utf8_lossy(&bogus.stderr).contains("unknown enrollment command"));
+    for verb in ["add", "list", "revoke"] {
+        let verb_help = run(&["enrollment", verb, "--help"]);
+        assert!(verb_help.status.success(), "{verb}");
+        assert!(
+            String::from_utf8_lossy(&verb_help.stdout).contains(&format!("syq enrollment {verb}")),
+            "{verb}"
+        );
+    }
+    // The old top-level spellings are gone.
+    for old in [
+        &["enroll", "host:dst"][..],
+        &["enrollments"],
+        &["revoke", "id"],
+    ] {
+        let out = run(old);
+        assert!(!out.status.success(), "{old:?}");
+    }
+}
+
+#[test]
 fn native_receiver_ceilings_apply_only_to_direct_remote_copies() {
     let t = Tmp::new();
     write(&t.path("src/file"), b"data");


### PR DESCRIPTION
Fourth in the receipts stack, on #112 (`receipt-verify`). Independent in substance; stacked only because it renames commands the receipt PRs mention.

## Summary

- `syq enroll`, `syq enrollments`, and `syq revoke` become `syq enrollment add`, `syq enrollment list`, and `syq enrollment revoke`, under one parent with its own help page. `add` on an already-enrolled destination refreshes its receiver, as `enroll` did.
- Every "rerun `syq enroll`" message and README passage uses the new spelling. The old top-level spellings are removed, not aliased, since nothing has shipped.
- Verb names are a first cut: `add`/`list`/`revoke`. Renaming is a one-line change per verb if another set reads better.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (257 unit, 289 local integration, 9 update)
- New test `enrollment_is_one_subcommand_with_its_verbs_beneath_it` drives the binary: parent help, bare invocation, unknown verb, per-verb help, and rejection of the old spellings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqM3Msd5sJYmuYjguVBB5E
