### PR TITLE
Add managed SSH persistence scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,9 @@ All native commands accept `--follow`, `-n`/`--dry-run`, `-v`/`--verbose`,
 `-q`/`--quiet`, `-j`/`--connections`, `--progress`/`--no-progress`, and
 `--progress-json` in addition to their endpoint and selector options. `cp` also
 accepts `--hash`, `--no-compress`, `--bwlimit RATE`, `--stats`,
-`--reuse-connection`, repeatable
-`--ignore PATTERN`/`--ignore-from FILE`, `--preserve`, and `--inplace`. Filters
+repeatable `--ignore PATTERN`/`--ignore-from FILE`, `--preserve`, and
+`--inplace`. Native `cp` and `rm` also accept an isolated SSH persistence
+scope through `--pscope PATH`. Filters
 use the gitignore semantics described below and apply at every source root;
 `--prune` protects excluded destination paths from pruning. `--hash`
 compares existing regular-file contents with full BLAKE3 digests instead of
@@ -406,6 +407,58 @@ and `--tcp-congestion` work with ordinary and explicitly managed SSH modes but
 remain fail-closed on that receiver until its authenticated worker-session
 join protocol represents them. Other comparison and selection controls, and
 block and split sizing, remain available only through `syq rsync`.
+
+## Persistent SSH connections
+
+For interactive use, enable SSH connection persistence once:
+
+```sh
+syq persist on
+syq persist status
+syq persist off
+```
+
+While it is on, transfer and removal commands that use syq's implicit SSH
+transport keep one control connection per `user@host:port` alive for five
+minutes after its last session (OpenSSH `ControlMaster` with
+`ControlPersist`). Later commands reuse that authenticated connection, cutting
+per-command setup to milliseconds and avoiding another hardware-token
+interaction. `status` shows the global scope and its recorded endpoints;
+`off` disables the policy, asks every live syq-owned master to exit, and
+removes the global runtime scope. The durable preference lives in
+`$XDG_CONFIG_HOME/syq/persistence-v1.json` (normally under `~/.config`), while
+control sockets live in a private per-user runtime directory.
+
+Scripts can avoid changing that shared preference by creating an isolated
+persistence scope:
+
+```sh
+pscope=$(syq persist on --ephemeral) || exit
+trap 'syq persist off --pscope "$pscope"' EXIT
+
+syq cp --pscope "$pscope" first --to server --into /backup
+syq cp --pscope "$pscope" second --to server --into /backup
+syq persist status --pscope "$pscope"
+```
+
+`on --ephemeral` prints exactly the new private scope path. Passing that path
+with `--pscope` lets separately launched or parallel commands share only that
+scope, independently of the global setting. `off --pscope` closes its live
+masters and removes it. If a script is killed before its cleanup trap runs,
+the masters still leave after their five-minute idle limit; the inert scope
+can be inspected or removed later with the printed path.
+
+During either persistence window, anything able to act as the same local user
+can open sessions through the socket without touching the key or agent. This
+is comparable to sudo's credential cache; do not enable it where that window
+is unacceptable. Data connections are unaffected: they remain separate TCP
+streams (or independent SSH processes under `--no-tcp`), so bulk throughput
+does not change. Persistence is not applied to an explicit `--rsh`, a remote
+transfer coordinator, or command-restricted receiver authentication. A global
+preference is simply ignored on those paths; an explicit `--pscope` is refused
+when the requested topology cannot honor it. Use `--relay` with `syq rsync` or
+`--run-at local` with native syntax to keep a remote-to-remote copy's reusable
+connections on the invoking machine.
 
 ## Mappings
 
@@ -481,7 +534,7 @@ explicitly say otherwise.
 | `--tcp-plain` | TCP data connections without encryption (trusted networks only) |
 | `--tcp-ports LO-HI` | Port range the remote listens on for TCP data (default 47600-47699) |
 | `--tcp-congestion ALGO` | Linux: use `ALGO` on both ends of direct TCP data sockets; the host default is unchanged |
-| `--reuse-connection` | Keep the implicit ssh control connection alive 5 minutes after the run and reuse it on later runs to the same endpoint (see below) |
+| `--pscope PATH` | Use an isolated SSH persistence scope created by `syq persist on --ephemeral` |
 | `--ignore PATTERN` | Skip paths matching a gitignore-style pattern (repeatable; see below) |
 | `--ignore-from FILE` | Read ignore patterns from a file (repeatable, stacks with `--ignore`) |
 | `--delete` | Remove destination paths the source doesn't have (see below); `--delete-after`/`--delete-delay` are synonyms |
@@ -514,24 +567,6 @@ per-connection limit. As in rsync, a bare rate is KiB/s, suffixes such as `K`,
 value by one byte, and `0` means unlimited. SYQ counts uncompressed file bytes;
 protocol overhead is not counted, and transport compression may make the actual
 network rate lower. Scanning, hashing, and metadata operations are not limited.
-
-`--reuse-connection` keeps the implicit ssh control connection alive in the
-background for five minutes after a run (OpenSSH ControlMaster with
-ControlPersist) and reuses it on later runs to the same `user@host`, cutting
-per-run connection setup to milliseconds — useful for scripted bursts of small
-copies. The socket lives in a private per-user runtime directory. During the
-window, anyone able to act as your local user can open sessions to that host
-through the socket without touching your key or agent — comparable to sudo's
-credential caching, and notably a hardware-token approval is not required for
-reuse; do not enable it where that window is unacceptable. Data connections
-are unaffected: they remain separate TCP streams (or independent ssh
-processes under `--no-tcp`), so throughput does not change. Not available
-with an explicit `-e`/`--rsh`. Explicit endpoint ports are part of the reuse
-identity. Direct remote-to-remote transfers refuse it because a remote
-coordinator has no reusable local master, so use `--relay` with `syq rsync` or
-`--run-at local` with native syntax; the command-restricted path additionally
-refuses it because its host-bound authentication is verified on each fresh
-connection.
 
 Remote transfers use fast zstd level-1 compression by default. Each protocol
 frame is sent compressed only when that representation is smaller, so archives,

--- a/README.md
+++ b/README.md
@@ -446,7 +446,9 @@ with `--pscope` lets separately launched or parallel commands share only that
 scope, independently of the global setting. `off --pscope` closes its live
 masters and removes it. If a script is killed before its cleanup trap runs,
 the masters still leave after their five-minute idle limit; the inert scope
-can be inspected or removed later with the printed path.
+can be inspected or removed later with the printed path. Scope paths beginning
+with a literal `~` or containing `${...}` are refused because OpenSSH expands
+those forms before opening a control socket.
 
 During either persistence window, anything able to act as the same local user
 can open sessions through the socket without touching the key or agent. This

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use clap::{CommandFactory, FromArgMatches, Parser, ValueEnum};
 use std::ffi::OsString;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Interface {
@@ -252,11 +253,12 @@ pub struct Args {
         conflicts_with_all = ["no_tcp", "rm", "follow"]
     )]
     pub tcp_congestion: Option<String>,
-    /// Keep the implicit ssh control connection alive for 5 minutes after the
-    /// run and reuse it on later runs to the same endpoint (OpenSSH
-    /// ControlMaster); reused runs skip connection setup and re-authentication
-    #[arg(long, conflicts_with = "rsh")]
-    pub reuse_connection: bool,
+    /// Use an isolated SSH persistence scope created by `syq persist on --ephemeral`
+    #[arg(long, value_name = "PATH", conflicts_with = "rsh")]
+    pub pscope: Option<PathBuf>,
+    /// Whether --pscope was supplied rather than selected by the user-level policy
+    #[arg(skip)]
+    pub pscope_explicit: bool,
     /// Remote-to-remote: start the transfer detached on the source host (survives losing this
     /// ssh session) and return; progress goes to a log you can watch with --follow
     #[arg(long)]
@@ -423,7 +425,7 @@ impl Args {
             // remain top-level. Internal helper switches are handled in main.
             "--self-update" | "--register-standalone-install" => Self::parse_rsync(&argv),
             _ => bail!(
-                "expected a command (`cp`, `rm`, `map`, or `rsync`); rsync-shaped syntax now starts with `syq rsync`"
+                "expected a command (`cp`, `rm`, `map`, `rsync`, or `persist`); rsync-shaped syntax now starts with `syq rsync`"
             ),
         }
     }
@@ -564,7 +566,7 @@ fn ordered_ignore_lines(
 
 fn print_root_help() {
     println!(
-        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning target-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a copy's resolved selection and placement as NDJSON\n  rsync        Use the retained rsync-shaped command surface\n  enrollment   Manage command-restricted receiver enrollments (add, list, revoke)\n\nRun `syq <COMMAND> --help` for command-specific help."
+        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning target-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a copy's resolved selection and placement as NDJSON\n  rsync        Use the retained rsync-shaped command surface\n  persist      Manage reusable SSH control connections\n  enrollment   Manage command-restricted receiver enrollments (add, list, revoke)\n\nRun `syq <COMMAND> --help` for command-specific help."
     );
 }
 
@@ -853,11 +855,6 @@ struct NativeCopyFields {
     /// Automation schema version 0, an unstable preview
     #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
     results: Option<OsString>,
-    /// Keep the ssh control connection alive for 5 minutes after the run and
-    /// reuse it on later runs to the same endpoint (OpenSSH ControlMaster);
-    /// reused runs skip connection setup and re-authentication
-    #[arg(long)]
-    reuse_connection: bool,
     #[command(flatten)]
     operational: NativeCopyOperationalArgs,
 }
@@ -887,6 +884,9 @@ struct NativeCopyCommand {
     size_selection: NativeSizeSelectionArgs,
     #[command(flatten)]
     remote: NativeRemoteArgs,
+    /// Use an isolated SSH persistence scope created by `syq persist on --ephemeral`
+    #[arg(long, value_name = "PATH")]
+    pscope: Option<PathBuf>,
     /// After copying, remove target-only objects in mapped directory scopes;
     /// ignored and size-excluded source paths remain protected
     #[arg(long, conflicts_with_all = ["mapping", "results"])]
@@ -921,6 +921,9 @@ struct NativeRmCommand {
     selection: NativeRmSelectionArgs,
     #[command(flatten)]
     operational: NativeOperationalArgs,
+    /// Use an isolated SSH persistence scope created by `syq persist on --ephemeral`
+    #[arg(long, value_name = "PATH")]
+    pscope: Option<PathBuf>,
 }
 
 fn parse_native(argv: &[OsString], interface: Interface) -> Result<Args> {
@@ -934,7 +937,7 @@ fn parse_native(argv: &[OsString], interface: Interface) -> Result<Args> {
 fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     let mut full_argv = vec![OsString::from(command_label(interface))];
     full_argv.extend_from_slice(argv);
-    let (mut parsed, remote, matches, prune, max_delete, size_selection) =
+    let (mut parsed, remote, pscope, matches, prune, max_delete, size_selection) =
         if interface == Interface::NativeMap {
             let matches = NativeMapCommand::command()
                 .try_get_matches_from(full_argv)
@@ -943,6 +946,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
             (
                 parsed.copy,
                 NativeRemoteArgs::default(),
+                None,
                 matches,
                 false,
                 None,
@@ -956,14 +960,15 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
             (
                 parsed.copy,
                 parsed.remote,
+                parsed.pscope,
                 matches,
                 parsed.prune,
                 parsed.max_delete,
                 parsed.size_selection,
             )
         };
-    if parsed.reuse_connection && remote.rsh.is_some() {
-        bail!("--reuse-connection cannot be used with --rsh");
+    if pscope.is_some() && remote.rsh.is_some() {
+        bail!("--pscope cannot be used with --rsh");
     }
     // `syq map` keeps `-C` out of selector paths so emitted `src` values stay
     // relative to it; the walk joins it back.
@@ -979,9 +984,6 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     let results = parsed.results.take();
     if results.is_some() && interface != Interface::NativeCp {
         bail!("--results is only available on syq cp");
-    }
-    if parsed.reuse_connection && interface == Interface::NativeMap {
-        bail!("--reuse-connection is only available on syq cp");
     }
     if results.is_some() && parsed.operational.common.dry_run {
         // Dry-run trace output is a deliberately deferred automation
@@ -1151,7 +1153,7 @@ fn parse_native_copy(argv: &[OsString], interface: Interface) -> Result<Args> {
     args.native_map_target = native_map_target;
     args.native_mapping = mapping.map(OsStringExt::into_vec);
     args.native_results = results.map(OsStringExt::into_vec);
-    args.reuse_connection = parsed.reuse_connection;
+    args.pscope = pscope;
     args.native_follow = parsed.selection.follow;
     if args.native_mapping.is_some() {
         // The manifest is read on this machine and its entries are stat'ed
@@ -1265,6 +1267,7 @@ fn parse_native_rm(argv: &[OsString]) -> Result<Args> {
     args.native_rm_cwd = parsed.selection.cwd.map(OsStringExt::into_vec);
     args.native_rm_root = parsed.selection.root.map(OsStringExt::into_vec);
     args.native_follow = parsed.selection.follow;
+    args.pscope = parsed.pscope;
     args.rm = true;
     apply_native_operational(&mut args, parsed.operational);
     Ok(args)
@@ -1978,9 +1981,9 @@ mod tests {
     }
 
     #[test]
-    fn native_reuse_connection_rejects_an_explicit_remote_shell() {
+    fn native_persistence_scope_rejects_an_explicit_remote_shell() {
         let argv = [
-            "--reuse-connection",
+            "--pscope=/tmp/scope",
             "--rsh=ssh -J jump",
             "source",
             "--into",
@@ -1990,7 +1993,7 @@ mod tests {
         let error = parse_native_copy(&argv, Interface::NativeCp).unwrap_err();
         assert!(error
             .to_string()
-            .contains("--reuse-connection cannot be used with --rsh"));
+            .contains("--pscope cannot be used with --rsh"));
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -806,6 +806,7 @@ impl SshMultiplexer {
             .tempdir()
             .context("create private SSH control directory")?;
         let path = directory.path().join("socket");
+        crate::persistence::validate_openssh_control_path(&path)?;
         Ok(Self {
             _directory: Some(directory),
             path,

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -967,8 +967,8 @@ impl RemoteSpec {
                     // skips the handshake.
                     cmd.arg("-o")
                         .arg("ControlMaster=auto")
-                        .arg("-o")
-                        .arg(format!("ControlPath={}", multiplexer.path.display()))
+                        .arg("-S")
+                        .arg(crate::persistence::openssh_control_path(&multiplexer.path))
                         .arg("-o")
                         .arg(format!("ControlPersist={REUSE_PERSIST_SECONDS}"));
                 } else {
@@ -984,8 +984,8 @@ impl RemoteSpec {
                             "ControlMaster={}",
                             if master { "yes" } else { "no" }
                         ))
-                        .arg("-o")
-                        .arg(format!("ControlPath={}", multiplexer.path.display()))
+                        .arg("-S")
+                        .arg(crate::persistence::openssh_control_path(&multiplexer.path))
                         .arg("-o")
                         .arg("ControlPersist=no");
                 }
@@ -2537,7 +2537,7 @@ mod tests {
     #[test]
     fn ssh_workers_reuse_the_private_control_socket_only_when_enabled() {
         let multiplexer = std::sync::Arc::new(SshMultiplexer::new().unwrap());
-        let control_path = format!("ControlPath={}", multiplexer.path.display());
+        let control_path = multiplexer.path.to_string_lossy().into_owned();
         let spec = RemoteSpec {
             local_process: false,
             user: None,
@@ -2562,7 +2562,9 @@ mod tests {
 
         let control = args(SshConnection::Control);
         assert!(control.iter().any(|arg| arg == "ControlMaster=yes"));
-        assert!(control.iter().any(|arg| arg == &control_path));
+        assert!(control
+            .windows(2)
+            .any(|pair| pair[0] == "-S" && pair[1] == control_path));
         assert!(control.iter().any(|arg| arg == "ControlPersist=no"));
 
         let worker = args(spec.ssh_connection(true));
@@ -2572,7 +2574,9 @@ mod tests {
         spec.set_ssh_multiplexing(true);
         let worker = args(spec.ssh_connection(true));
         assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
-        assert!(worker.iter().any(|arg| arg == &control_path));
+        assert!(worker
+            .windows(2)
+            .any(|pair| pair[0] == "-S" && pair[1] == control_path));
         assert!(!worker.iter().any(|arg| arg == "ControlPath=none"));
 
         let independent = args(SshConnection::Independent);
@@ -2599,7 +2603,7 @@ mod tests {
             std::fs::metadata(&base).unwrap().permissions().mode() & 0o777,
             0o700
         );
-        let control_path = format!("ControlPath={}", multiplexer.path.display());
+        let control_path = multiplexer.path.to_string_lossy().into_owned();
         let spec = RemoteSpec {
             local_process: false,
             user: Some("u".into()),
@@ -2623,7 +2627,9 @@ mod tests {
         };
         let control = args(SshConnection::Control);
         assert!(control.iter().any(|arg| arg == "ControlMaster=auto"));
-        assert!(control.iter().any(|arg| arg == &control_path));
+        assert!(control
+            .windows(2)
+            .any(|pair| pair[0] == "-S" && pair[1] == control_path));
         assert!(control
             .iter()
             .any(|arg| arg == &format!("ControlPersist={REUSE_PERSIST_SECONDS}")));
@@ -2633,5 +2639,46 @@ mod tests {
         let worker = args(spec.ssh_connection(true));
         assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
         assert!(worker.iter().any(|arg| arg == "ControlPath=none"));
+    }
+
+    #[test]
+    fn persistent_control_path_is_one_byte_exact_openssh_argument() {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let path = PathBuf::from(std::ffi::OsString::from_vec(
+            b"/tmp/scope with space/%h/non-utf8-\xff/socket".to_vec(),
+        ));
+        let multiplexer = SshMultiplexer {
+            _directory: None,
+            path,
+            persistent: true,
+            reuse_for_workers: AtomicBool::new(false),
+        };
+        let spec = RemoteSpec {
+            local_process: false,
+            user: None,
+            host: "example".into(),
+            port: None,
+            rsh: vec!["ssh".into()],
+            syq_path: None,
+            auto_helper: false,
+            restricted_grant: None,
+            helper_install: Default::default(),
+            ssh_multiplexer: Some(std::sync::Arc::new(multiplexer)),
+            quiet: false,
+            tcp: Default::default(),
+            diagnostics: Default::default(),
+        };
+
+        let command = spec.ssh_command(SshConnection::Control);
+        let args: Vec<_> = command.get_args().collect();
+        let control_index = args
+            .iter()
+            .position(|arg| *arg == OsStr::new("-S"))
+            .unwrap();
+        assert_eq!(
+            args[control_index + 1].as_bytes(),
+            b"/tmp/scope with space/%%h/non-utf8-\xff/socket"
+        );
     }
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -787,8 +787,9 @@ pub(crate) struct SshMultiplexer {
     /// deliberately outlives this process.
     _directory: Option<tempfile::TempDir>,
     path: PathBuf,
-    /// --reuse-connection: ControlMaster=auto with a ControlPersist window,
-    /// so later syq runs to the same endpoint skip the SSH handshake.
+    /// A managed persistence scope uses ControlMaster=auto with a
+    /// ControlPersist window, so later syq runs in that scope skip the SSH
+    /// handshake.
     persistent: bool,
     reuse_for_workers: AtomicBool,
 }
@@ -813,93 +814,13 @@ impl SshMultiplexer {
         })
     }
 
-    pub(crate) fn persistent(user: Option<&str>, host: &str, port: Option<u16>) -> Result<Self> {
-        let base = std::env::var_os("XDG_RUNTIME_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(std::env::temp_dir);
-        let directory = base.join(format!("syq-cm-{}", unsafe { libc::geteuid() }));
-        Self::persistent_in(directory, user, host, port)
-    }
-
-    fn persistent_in(
-        directory: PathBuf,
+    pub(crate) fn persistent(
+        scope: &std::path::Path,
         user: Option<&str>,
         host: &str,
         port: Option<u16>,
     ) -> Result<Self> {
-        use std::os::unix::ffi::OsStrExt;
-        use std::os::unix::fs::MetadataExt;
-        use std::os::unix::io::{AsRawFd, FromRawFd};
-        // Create and validate without ever following a symlink: in a shared
-        // parent such as /tmp, another user can pre-create this name as a
-        // symlink to a victim path, and a path-based chmod would follow it.
-        // mkdir + O_NOFOLLOW open + fstat + fchmod act only on the inode we
-        // verified, never on a path an attacker can redirect.
-        let c = std::ffi::CString::new(directory.as_os_str().as_bytes())
-            .context("SSH control directory path contains NUL")?;
-        if unsafe { libc::mkdir(c.as_ptr(), 0o700) } != 0 {
-            let error = std::io::Error::last_os_error();
-            if error.kind() != std::io::ErrorKind::AlreadyExists {
-                return Err(error).with_context(|| format!("create {}", directory.display()));
-            }
-        }
-        let fd = unsafe {
-            libc::open(
-                c.as_ptr(),
-                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-            )
-        };
-        if fd < 0 {
-            return Err(std::io::Error::last_os_error()).with_context(|| {
-                format!(
-                    "open SSH control directory {} (symlinks are refused)",
-                    directory.display()
-                )
-            });
-        }
-        let handle = unsafe { std::fs::File::from_raw_fd(fd) };
-        let metadata = handle
-            .metadata()
-            .with_context(|| format!("inspect {}", directory.display()))?;
-        if !metadata.is_dir() || metadata.uid() != unsafe { libc::geteuid() } {
-            anyhow::bail!(
-                "SSH control directory {} must be a directory owned by the current user",
-                directory.display()
-            );
-        }
-        if metadata.mode() & 0o077 != 0 {
-            // Verified as ours above; tighten through the descriptor so the
-            // permission change cannot be redirected either.
-            if unsafe { libc::fchmod(handle.as_raw_fd(), 0o700) } != 0 {
-                return Err(std::io::Error::last_os_error())
-                    .with_context(|| format!("restrict {}", directory.display()));
-            }
-        }
-        // A stable per-endpoint name: reuse must find the same socket across
-        // runs. Hashing keeps it short (Unix socket paths are length-limited)
-        // and avoids spelling the host in the filename.
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(user.unwrap_or("").as_bytes());
-        hasher.update(b"@");
-        hasher.update(host.as_bytes());
-        if let Some(port) = port {
-            hasher.update(b":");
-            hasher.update(port.to_be_bytes());
-        }
-        let digest = hasher.finalize();
-        let mut name = String::from("cm-");
-        for byte in &digest[..8] {
-            name.push_str(&format!("{byte:02x}"));
-        }
-        let path = directory.join(name);
-        // A dead socket file blocks OpenSSH from creating a fresh master
-        // (auto then silently degrades to unmultiplexed connections). The
-        // directory is syq-private, so clearing an unconnectable leftover is
-        // safe; a live master answers the probe and is kept.
-        if path.exists() && std::os::unix::net::UnixStream::connect(&path).is_err() {
-            let _ = std::fs::remove_file(&path);
-        }
+        let path = crate::persistence::prepare_endpoint(scope, user, host, port)?;
         Ok(Self {
             _directory: None,
             path,
@@ -2662,17 +2583,16 @@ mod tests {
     fn persistent_reuse_uses_auto_master_and_never_shares_with_workers() {
         use std::os::unix::fs::PermissionsExt;
         let directory = tempfile::tempdir().unwrap();
-        let base = directory.path().to_path_buf();
+        let base = directory.path().join("scope");
+        crate::persistence::initialize_scope(&base).unwrap();
         // The socket name is stable per endpoint, and a dead leftover at the
         // path is cleared so a fresh master can bind.
-        let probe =
-            SshMultiplexer::persistent_in(base.clone(), Some("u"), "example", None).unwrap();
+        let probe = SshMultiplexer::persistent(&base, Some("u"), "example", None).unwrap();
         std::fs::write(&probe.path, b"stale").unwrap();
-        let multiplexer =
-            SshMultiplexer::persistent_in(base.clone(), Some("u"), "example", None).unwrap();
+        let multiplexer = SshMultiplexer::persistent(&base, Some("u"), "example", None).unwrap();
         assert_eq!(probe.path, multiplexer.path);
         let alternate_port =
-            SshMultiplexer::persistent_in(base.clone(), Some("u"), "example", Some(2222)).unwrap();
+            SshMultiplexer::persistent(&base, Some("u"), "example", Some(2222)).unwrap();
         assert_ne!(multiplexer.path, alternate_port.path);
         assert!(!multiplexer.path.exists());
         assert_eq!(
@@ -2713,22 +2633,5 @@ mod tests {
         let worker = args(spec.ssh_connection(true));
         assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
         assert!(worker.iter().any(|arg| arg == "ControlPath=none"));
-    }
-
-    #[test]
-    fn persistent_reuse_refuses_symlinked_directory_without_touching_target() {
-        use std::os::unix::fs::PermissionsExt;
-        let outer = tempfile::tempdir().unwrap();
-        let victim = outer.path().join("victim");
-        std::fs::create_dir(&victim).unwrap();
-        std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let attack = outer.path().join("syq-cm-attack");
-        std::os::unix::fs::symlink(&victim, &attack).unwrap();
-        assert!(SshMultiplexer::persistent_in(attack, Some("u"), "example", None).is_err());
-        // The victim's permissions were never modified through the symlink.
-        assert_eq!(
-            std::fs::metadata(&victim).unwrap().permissions().mode() & 0o777,
-            0o755
-        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod identity;
 mod janky_cat;
 mod native_map;
 mod native_rm;
+mod persistence;
 mod progress;
 mod proto;
 mod receipt;
@@ -143,6 +144,15 @@ fn main() {
             }
         }
     }
+    if argv.get(1).and_then(|arg| arg.to_str()) == Some("persist") {
+        match persistence::run(&argv[2..]) {
+            Ok(code) => std::process::exit(code),
+            Err(error) => {
+                eprintln!("syq persist: {error:#}");
+                std::process::exit(1);
+            }
+        }
+    }
     if let Some(result) = restricted::dispatch_management(&argv) {
         match result {
             Ok(code) => std::process::exit(code),
@@ -173,6 +183,10 @@ fn main() {
             std::process::exit(1);
         }
         return;
+    }
+    if let Err(error) = persistence::resolve_for_command(&mut args) {
+        eprintln!("syq: {error:#}");
+        std::process::exit(1);
     }
     let quiet = args.quiet;
     let result = if args.follow {

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,10 +184,7 @@ fn main() {
         }
         return;
     }
-    if let Err(error) = persistence::resolve_for_command(&mut args) {
-        eprintln!("syq: {error:#}");
-        std::process::exit(1);
-    }
+    persistence::mark_explicit_scope(&mut args);
     let quiet = args.quiet;
     let result = if args.follow {
         direct::follow(&args)

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -196,6 +196,7 @@ pub(crate) fn scope_for_implicit_ssh(explicit_scope: Option<&Path>) -> Result<Op
 /// lossy UTF-8 conversion and makes whitespace one argv value rather than SSH
 /// configuration syntax.
 pub(crate) fn openssh_control_path(path: &Path) -> OsString {
+    debug_assert!(validate_openssh_control_path(path).is_ok());
     let bytes = path.as_os_str().as_bytes();
     let mut escaped =
         Vec::with_capacity(bytes.len() + bytes.iter().filter(|&&b| b == b'%').count());
@@ -206,6 +207,21 @@ pub(crate) fn openssh_control_path(path: &Path) -> OsString {
         escaped.push(byte);
     }
     OsString::from_vec(escaped)
+}
+
+/// OpenSSH expands a leading `~` and `${ENV}` in `ControlPath` even when the
+/// path is supplied as a separate `-S` argument. Those forms have no escaping
+/// contract comparable to `%%`, so refuse them before creating or accepting a
+/// control directory.
+pub(crate) fn validate_openssh_control_path(path: &Path) -> Result<()> {
+    let bytes = path.as_os_str().as_bytes();
+    if bytes.first() == Some(&b'~') || bytes.windows(2).any(|pair| pair == b"${") {
+        bail!(
+            "SSH control path {} contains OpenSSH expansion syntax; it may not begin with `~` or contain `${{`",
+            path.display()
+        );
+    }
+    Ok(())
 }
 
 /// Return the stable socket path for one endpoint and record enough metadata
@@ -372,6 +388,7 @@ fn is_global_scope(scope: &Path) -> Result<bool> {
 
 fn ensure_runtime_parent() -> Result<PathBuf> {
     let path = runtime_parent_path();
+    validate_openssh_control_path(&path)?;
     secure_directory(&path, true, true)?;
     Ok(path)
 }
@@ -426,6 +443,7 @@ fn create_marker(scope: &Path) -> Result<()> {
 }
 
 fn validate_scope(scope: &Path) -> Result<()> {
+    validate_openssh_control_path(scope)?;
     secure_directory(scope, false, false)?;
     let marker_path = scope.join(SCOPE_MARKER);
     let mut marker = OpenOptions::new()
@@ -778,5 +796,12 @@ mod tests {
             args[1].as_bytes(),
             b"/tmp/scope with space/%%h/non-utf8-\xff/socket"
         );
+    }
+
+    #[test]
+    fn openssh_environment_and_tilde_expansion_forms_are_refused() {
+        assert!(validate_openssh_control_path(Path::new("/tmp/scope with space/%h")).is_ok());
+        assert!(validate_openssh_control_path(Path::new("~/scope")).is_err());
+        assert!(validate_openssh_control_path(Path::new("/tmp/${HOME}/scope")).is_err());
     }
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::ffi::{OsStr, OsString};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
-use std::os::unix::ffi::OsStrExt;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::path::{Path, PathBuf};
@@ -168,20 +168,44 @@ pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
     Ok(0)
 }
 
-/// Resolve the command's effective persistence context. An explicit scope is
-/// validated even for a local-only command, while the durable policy supplies
-/// the global scope only when enabled.
-pub(crate) fn resolve_for_command(args: &mut Args) -> Result<()> {
+/// Remember whether the command explicitly selected a scope without touching
+/// configuration or runtime state. Commands that never construct an eligible
+/// implicit SSH endpoint must not depend on either location being accessible.
+pub(crate) fn mark_explicit_scope(args: &mut Args) {
     args.pscope_explicit = args.pscope.is_some();
-    args.pscope = match args.pscope.as_deref() {
+}
+
+/// Resolve persistence only for an implicit local SSH edge. Explicit scopes
+/// are validated here, and the durable policy is read here, so local commands,
+/// custom remote shells, remote coordinators, and restricted receivers do not
+/// acquire an unrelated filesystem dependency.
+pub(crate) fn scope_for_implicit_ssh(explicit_scope: Option<&Path>) -> Result<Option<PathBuf>> {
+    match explicit_scope {
         Some(scope) => {
             validate_scope(scope)?;
-            Some(scope.to_path_buf())
+            Ok(Some(scope.to_path_buf()))
         }
-        None if global_enabled()? => Some(ensure_global_scope()?),
-        None => None,
-    };
-    Ok(())
+        None if global_enabled()? => Ok(Some(ensure_global_scope()?)),
+        None => Ok(None),
+    }
+}
+
+/// OpenSSH expands percent tokens in control paths, including paths supplied
+/// through `-S`. Double each percent byte so that expansion yields the literal,
+/// byte-exact filesystem path. Keeping the path in an `OsString` also avoids
+/// lossy UTF-8 conversion and makes whitespace one argv value rather than SSH
+/// configuration syntax.
+pub(crate) fn openssh_control_path(path: &Path) -> OsString {
+    let bytes = path.as_os_str().as_bytes();
+    let mut escaped =
+        Vec::with_capacity(bytes.len() + bytes.iter().filter(|&&b| b == b'%').count());
+    for &byte in bytes {
+        if byte == b'%' {
+            escaped.push(b'%');
+        }
+        escaped.push(byte);
+    }
+    OsString::from_vec(escaped)
 }
 
 /// Return the stable socket path for one endpoint and record enough metadata
@@ -646,7 +670,10 @@ fn close_master(socket: &Path, record: &EndpointRecord) -> Result<()> {
 
 fn master_exit_command(socket: &Path, record: &EndpointRecord) -> Command {
     let mut command = Command::new("ssh");
-    command.arg("-S").arg(socket).args(["-O", "exit"]);
+    command
+        .arg("-S")
+        .arg(openssh_control_path(socket))
+        .args(["-O", "exit"]);
     if let Some(user) = &record.user {
         command.args(["-l", user]);
     }
@@ -736,6 +763,20 @@ mod tests {
                 "--",
                 "example"
             ]
+        );
+    }
+
+    #[test]
+    fn master_exit_preserves_path_bytes_and_escapes_openssh_percent_tokens() {
+        let path = PathBuf::from(OsString::from_vec(
+            b"/tmp/scope with space/%h/non-utf8-\xff/socket".to_vec(),
+        ));
+        let command = master_exit_command(&path, &EndpointRecord::new(None, "example", None));
+        let args: Vec<_> = command.get_args().collect();
+        assert_eq!(args[0], OsStr::new("-S"));
+        assert_eq!(
+            args[1].as_bytes(),
+            b"/tmp/scope with space/%%h/non-utf8-\xff/socket"
         );
     }
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,741 @@
+//! User-managed OpenSSH control-connection persistence.
+//!
+//! A durable preference selects a well-known per-user runtime scope. Scripts
+//! can instead create an isolated scope and pass its path back with
+//! `--pscope`, avoiding shared configuration state.
+
+use crate::cli::Args;
+use anyhow::{bail, Context, Result};
+use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use std::ffi::{OsStr, OsString};
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const CONFIG_VERSION: u8 = 1;
+const CONFIG_FILE: &str = "persistence-v1.json";
+const SCOPE_MARKER: &str = ".syq-persistence-v1";
+const SCOPE_MARKER_CONTENT: &[u8] = b"syq persistence scope v1\n";
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "syq persist",
+    about = "Manage reusable SSH control connections",
+    long_about = "Manage reusable SSH control connections. The durable setting applies to later syq transfer commands. An ephemeral scope is isolated from that setting and is selected by passing its printed path back with --pscope."
+)]
+struct PersistCommand {
+    #[command(subcommand)]
+    action: PersistAction,
+}
+
+#[derive(Subcommand, Debug)]
+enum PersistAction {
+    /// Enable reusable SSH control connections
+    On {
+        /// Create an isolated scope and print its path instead of changing the user setting
+        #[arg(long)]
+        ephemeral: bool,
+    },
+    /// Disable persistence and close its live SSH control connections
+    Off {
+        /// Operate on this isolated persistence scope instead of the user setting
+        #[arg(long, value_name = "PATH")]
+        pscope: Option<PathBuf>,
+    },
+    /// Show the configured policy and live SSH control connections
+    Status {
+        /// Inspect this isolated persistence scope instead of the user setting
+        #[arg(long, value_name = "PATH")]
+        pscope: Option<PathBuf>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistenceConfig {
+    version: u8,
+    enabled: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EndpointRecord {
+    version: u8,
+    user: Option<String>,
+    host: String,
+    port: Option<u16>,
+}
+
+impl EndpointRecord {
+    fn new(user: Option<&str>, host: &str, port: Option<u16>) -> Self {
+        Self {
+            version: CONFIG_VERSION,
+            user: user.map(str::to_owned),
+            host: host.to_owned(),
+            port,
+        }
+    }
+
+    fn label(&self) -> String {
+        let host = if self.host.contains(':') {
+            format!("[{}]", self.host)
+        } else {
+            self.host.clone()
+        };
+        let endpoint = match &self.user {
+            Some(user) => format!("{user}@{host}"),
+            None => host,
+        };
+        match self.port {
+            Some(port) => format!("{endpoint}:{port}"),
+            None => endpoint,
+        }
+    }
+}
+
+pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
+    let mut full_argv = vec![OsString::from("syq persist")];
+    full_argv.extend_from_slice(argv);
+    let command = PersistCommand::try_parse_from(full_argv).unwrap_or_else(|error| error.exit());
+    match command.action {
+        PersistAction::On { ephemeral: true } => {
+            let scope = create_ephemeral_scope()?;
+            // This is a scripting contract: stdout is exactly the native path
+            // followed by one newline, with no diagnostic prose mixed in.
+            let mut stdout = std::io::stdout().lock();
+            stdout.write_all(scope.as_os_str().as_bytes())?;
+            stdout.write_all(b"\n")?;
+        }
+        PersistAction::On { ephemeral: false } => {
+            let scope = ensure_global_scope()?;
+            write_global_config(true)?;
+            println!("SSH connection persistence is on");
+            println!("scope: {}", scope.display());
+        }
+        PersistAction::Off {
+            pscope: Some(scope),
+        } => {
+            if is_global_scope(&scope)? {
+                bail!(
+                    "the global persistence scope is controlled by `syq persist off` without --pscope"
+                );
+            }
+            close_scope(&scope)?;
+            println!("persistence scope closed: {}", scope.display());
+        }
+        PersistAction::Off { pscope: None } => {
+            // Disable first so a later command cannot intentionally join the
+            // global scope while its existing masters are being closed.
+            write_global_config(false)?;
+            let scope = global_scope_path()?;
+            match scope.symlink_metadata() {
+                Ok(_) => close_scope(&scope)?,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("inspect global scope {}", scope.display()));
+                }
+            }
+            println!("SSH connection persistence is off");
+        }
+        PersistAction::Status {
+            pscope: Some(scope),
+        } => print_scope_status(&scope, Some("ephemeral"))?,
+        PersistAction::Status { pscope: None } => {
+            let enabled = global_enabled()?;
+            println!(
+                "SSH connection persistence is {}",
+                if enabled { "on" } else { "off" }
+            );
+            let scope = global_scope_path()?;
+            match scope.symlink_metadata() {
+                Ok(_) => print_scope_status(&scope, Some("global"))?,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    println!("connections: 0");
+                }
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("inspect global scope {}", scope.display()));
+                }
+            }
+        }
+    }
+    Ok(0)
+}
+
+/// Resolve the command's effective persistence context. An explicit scope is
+/// validated even for a local-only command, while the durable policy supplies
+/// the global scope only when enabled.
+pub(crate) fn resolve_for_command(args: &mut Args) -> Result<()> {
+    args.pscope_explicit = args.pscope.is_some();
+    args.pscope = match args.pscope.as_deref() {
+        Some(scope) => {
+            validate_scope(scope)?;
+            Some(scope.to_path_buf())
+        }
+        None if global_enabled()? => Some(ensure_global_scope()?),
+        None => None,
+    };
+    Ok(())
+}
+
+/// Return the stable socket path for one endpoint and record enough metadata
+/// for `persist status` and `persist off` to inspect or close it later.
+pub(crate) fn prepare_endpoint(
+    scope: &Path,
+    user: Option<&str>,
+    host: &str,
+    port: Option<u16>,
+) -> Result<PathBuf> {
+    validate_scope(scope)?;
+    let key = endpoint_key(user, host, port);
+    let socket = scope.join(&key);
+    let record_path = scope.join(format!("{key}.json"));
+    let expected = EndpointRecord::new(user, host, port);
+    let record_bytes = serde_json::to_vec(&expected)?;
+    let mut temporary = tempfile::NamedTempFile::new_in(scope)
+        .with_context(|| format!("create endpoint record in {}", scope.display()))?;
+    temporary
+        .write_all(&record_bytes)
+        .and_then(|()| temporary.write_all(b"\n"))
+        .with_context(|| format!("write endpoint record {}", record_path.display()))?;
+    match temporary.persist_noclobber(&record_path) {
+        Ok(_) => {}
+        Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let actual = read_endpoint_record(&record_path)?;
+            if actual != expected {
+                bail!(
+                    "persistence scope endpoint-key collision at {}",
+                    record_path.display()
+                );
+            }
+        }
+        Err(error) => {
+            return Err(error.error)
+                .with_context(|| format!("create endpoint record {}", record_path.display()));
+        }
+    }
+
+    if let Ok(metadata) = socket.symlink_metadata() {
+        if !socket_is_live(&socket) {
+            if metadata.is_dir() {
+                bail!(
+                    "SSH control socket path {} is unexpectedly a directory",
+                    socket.display()
+                );
+            }
+            std::fs::remove_file(&socket)
+                .with_context(|| format!("remove stale SSH control socket {}", socket.display()))?;
+        }
+    }
+    Ok(socket)
+}
+
+fn config_path() -> Option<PathBuf> {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|path| !path.is_empty())
+                .map(|home| PathBuf::from(home).join(".config"))
+        })
+        .map(|root| root.join("syq").join(CONFIG_FILE))
+}
+
+fn read_global_config() -> Result<Option<PersistenceConfig>> {
+    let Some(path) = config_path() else {
+        return Ok(None);
+    };
+    let mut file = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if error.raw_os_error() == Some(libc::ENOTDIR) => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| format!("open {}", path.display()));
+        }
+    };
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } {
+        bail!(
+            "persistence configuration {} must be a regular file owned by the current user",
+            path.display()
+        );
+    }
+    if metadata.mode() & 0o022 != 0 {
+        bail!(
+            "persistence configuration {} must not be group- or other-writable",
+            path.display()
+        );
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    let config: PersistenceConfig = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse persistence configuration {}", path.display()))?;
+    if config.version != CONFIG_VERSION {
+        bail!(
+            "unsupported persistence configuration version {} in {}",
+            config.version,
+            path.display()
+        );
+    }
+    Ok(Some(config))
+}
+
+fn global_enabled() -> Result<bool> {
+    Ok(read_global_config()?.is_some_and(|config| config.enabled))
+}
+
+fn write_global_config(enabled: bool) -> Result<()> {
+    let path = config_path()
+        .context("cannot change persistence: both XDG_CONFIG_HOME and HOME are unset")?;
+    let parent = path.parent().expect("configuration path has a parent");
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("create configuration directory {}", parent.display()))?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("create temporary configuration in {}", parent.display()))?;
+    serde_json::to_writer_pretty(
+        &mut temporary,
+        &PersistenceConfig {
+            version: CONFIG_VERSION,
+            enabled,
+        },
+    )?;
+    temporary.write_all(b"\n")?;
+    temporary.as_file().sync_all()?;
+    temporary
+        .persist(&path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("replace persistence configuration {}", path.display()))?;
+    Ok(())
+}
+
+fn runtime_parent_path() -> PathBuf {
+    let base = std::env::var_os("XDG_RUNTIME_DIR")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    base.join(format!("syq-persist-{}", unsafe { libc::geteuid() }))
+}
+
+fn global_scope_path() -> Result<PathBuf> {
+    Ok(runtime_parent_path().join("global"))
+}
+
+fn is_global_scope(scope: &Path) -> Result<bool> {
+    let global = global_scope_path()?;
+    let global = match std::fs::canonicalize(&global) {
+        Ok(global) => global,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("resolve global persistence scope {}", global.display()));
+        }
+    };
+    let candidate = std::fs::canonicalize(scope)
+        .with_context(|| format!("resolve persistence scope {}", scope.display()))?;
+    Ok(candidate == global)
+}
+
+fn ensure_runtime_parent() -> Result<PathBuf> {
+    let path = runtime_parent_path();
+    secure_directory(&path, true, true)?;
+    Ok(path)
+}
+
+fn ensure_global_scope() -> Result<PathBuf> {
+    let parent = ensure_runtime_parent()?;
+    let scope = parent.join("global");
+    initialize_scope(&scope)?;
+    Ok(scope)
+}
+
+fn create_ephemeral_scope() -> Result<PathBuf> {
+    let parent = ensure_runtime_parent()?;
+    let temporary = tempfile::Builder::new()
+        .prefix("scope-")
+        .tempdir_in(&parent)
+        .with_context(|| format!("create persistence scope in {}", parent.display()))?;
+    let scope = temporary.keep();
+    secure_directory(&scope, false, true)?;
+    create_marker(&scope)?;
+    validate_scope(&scope)?;
+    if scope.as_os_str().as_bytes().contains(&b'\n') {
+        let _ = std::fs::remove_file(scope.join(SCOPE_MARKER));
+        let _ = std::fs::remove_dir(&scope);
+        bail!("persistence scope path contains a newline and cannot be returned safely");
+    }
+    Ok(scope)
+}
+
+pub(crate) fn initialize_scope(scope: &Path) -> Result<()> {
+    secure_directory(scope, true, true)?;
+    create_marker(scope)?;
+    validate_scope(scope)
+}
+
+fn create_marker(scope: &Path) -> Result<()> {
+    let path = scope.join(SCOPE_MARKER);
+    match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&path)
+    {
+        Ok(mut marker) => marker.write_all(SCOPE_MARKER_CONTENT)?,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(error).with_context(|| format!("create scope marker {}", path.display()));
+        }
+    }
+    Ok(())
+}
+
+fn validate_scope(scope: &Path) -> Result<()> {
+    secure_directory(scope, false, false)?;
+    let marker_path = scope.join(SCOPE_MARKER);
+    let mut marker = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&marker_path)
+        .with_context(|| {
+            format!(
+                "open persistence scope marker {} (is this a path printed by `syq persist on --ephemeral`?)",
+                marker_path.display()
+            )
+        })?;
+    let metadata = marker.metadata()?;
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } {
+        bail!(
+            "persistence scope marker {} must be a regular file owned by the current user",
+            marker_path.display()
+        );
+    }
+    let mut content = Vec::new();
+    marker.read_to_end(&mut content)?;
+    if content != SCOPE_MARKER_CONTENT {
+        bail!("invalid persistence scope marker {}", marker_path.display());
+    }
+    Ok(())
+}
+
+/// Open and validate a directory without following a final-component symlink.
+/// Only internally selected directories are permission-tightened; an explicit
+/// `--pscope` that is too broad is refused without modifying it.
+fn secure_directory(path: &Path, create: bool, tighten: bool) -> Result<File> {
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .context("persistence directory path contains NUL")?;
+    if create && unsafe { libc::mkdir(c_path.as_ptr(), 0o700) } != 0 {
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::AlreadyExists {
+            return Err(error).with_context(|| format!("create {}", path.display()));
+        }
+    }
+    let descriptor = unsafe {
+        libc::open(
+            c_path.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        return Err(std::io::Error::last_os_error()).with_context(|| {
+            format!(
+                "open persistence directory {} (symlinks are refused)",
+                path.display()
+            )
+        });
+    }
+    let directory = unsafe { File::from_raw_fd(descriptor) };
+    let metadata = directory.metadata()?;
+    if !metadata.is_dir() || metadata.uid() != unsafe { libc::geteuid() } {
+        bail!(
+            "persistence directory {} must be owned by the current user",
+            path.display()
+        );
+    }
+    if metadata.mode() & 0o077 != 0 {
+        if !tighten {
+            bail!(
+                "persistence directory {} must not be accessible by group or other users",
+                path.display()
+            );
+        }
+        if unsafe { libc::fchmod(directory.as_raw_fd(), 0o700) } != 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("restrict {}", path.display()));
+        }
+    }
+    Ok(directory)
+}
+
+fn endpoint_key(user: Option<&str>, host: &str, port: Option<u16>) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(user.unwrap_or("").as_bytes());
+    hasher.update(b"@");
+    hasher.update(host.as_bytes());
+    if let Some(port) = port {
+        hasher.update(b":");
+        hasher.update(port.to_be_bytes());
+    }
+    let digest = hasher.finalize();
+    let mut name = String::from("cm-");
+    for byte in &digest[..8] {
+        name.push_str(&format!("{byte:02x}"));
+    }
+    name
+}
+
+fn read_endpoint_record(path: &Path) -> Result<EndpointRecord> {
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)
+        .with_context(|| format!("open endpoint record {}", path.display()))?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } {
+        bail!(
+            "endpoint record {} must be a regular file owned by the current user",
+            path.display()
+        );
+    }
+    let record: EndpointRecord = serde_json::from_reader(file)
+        .with_context(|| format!("parse endpoint record {}", path.display()))?;
+    if record.version != CONFIG_VERSION {
+        bail!(
+            "unsupported endpoint record version {} in {}",
+            record.version,
+            path.display()
+        );
+    }
+    Ok(record)
+}
+
+fn record_key(name: &OsStr) -> Option<&str> {
+    let name = name.to_str()?;
+    let key = name.strip_suffix(".json")?;
+    valid_endpoint_key(key).then_some(key)
+}
+
+fn valid_endpoint_key(name: &str) -> bool {
+    name.len() == 19
+        && name.starts_with("cm-")
+        && name[3..].bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn scope_records(scope: &Path) -> Result<Vec<(String, EndpointRecord)>> {
+    validate_scope(scope)?;
+    let mut records = Vec::new();
+    for entry in std::fs::read_dir(scope)
+        .with_context(|| format!("read persistence scope {}", scope.display()))?
+    {
+        let entry = entry?;
+        if let Some(key) = record_key(&entry.file_name()) {
+            let record = read_endpoint_record(&entry.path())?;
+            let expected_key = endpoint_key(record.user.as_deref(), &record.host, record.port);
+            if key != expected_key {
+                bail!(
+                    "endpoint record {} does not match its recorded endpoint {}",
+                    entry.path().display(),
+                    record.label()
+                );
+            }
+            records.push((key.to_owned(), record));
+        }
+    }
+    records.sort_by(|left, right| left.1.label().cmp(&right.1.label()));
+    Ok(records)
+}
+
+fn socket_is_live(path: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(path).is_ok()
+}
+
+fn print_scope_status(scope: &Path, kind: Option<&str>) -> Result<()> {
+    let records = scope_records(scope)?;
+    if let Some(kind) = kind {
+        println!("scope ({kind}): {}", scope.display());
+    } else {
+        println!("scope: {}", scope.display());
+    }
+    println!("connections: {}", records.len());
+    for (key, record) in records {
+        let state = if socket_is_live(&scope.join(key)) {
+            "live"
+        } else {
+            "inactive"
+        };
+        println!("  {}  {state}", record.label());
+    }
+    Ok(())
+}
+
+fn close_scope(scope: &Path) -> Result<()> {
+    let records = scope_records(scope)?;
+    let record_keys: std::collections::HashSet<&str> =
+        records.iter().map(|(key, _)| key.as_str()).collect();
+    for entry in std::fs::read_dir(scope)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if name == OsStr::new(SCOPE_MARKER) || record_key(&name).is_some() {
+            continue;
+        }
+        if let Some(name) = name.to_str() {
+            if valid_endpoint_key(name) && record_keys.contains(name) {
+                continue;
+            }
+        }
+        bail!(
+            "refusing to remove persistence scope {} because it contains unrecognized entry {:?}",
+            scope.display(),
+            name
+        );
+    }
+
+    for (key, record) in records {
+        let socket = scope.join(&key);
+        if socket_is_live(&socket) {
+            close_master(&socket, &record)?;
+        }
+        if let Ok(metadata) = socket.symlink_metadata() {
+            if metadata.is_dir() {
+                bail!(
+                    "refusing to remove unexpected directory at SSH control path {}",
+                    socket.display()
+                );
+            }
+            std::fs::remove_file(&socket)
+                .with_context(|| format!("remove SSH control socket {}", socket.display()))?;
+        }
+        let record_path = scope.join(format!("{key}.json"));
+        std::fs::remove_file(&record_path)
+            .with_context(|| format!("remove endpoint record {}", record_path.display()))?;
+    }
+    std::fs::remove_file(scope.join(SCOPE_MARKER))
+        .with_context(|| format!("remove persistence marker from {}", scope.display()))?;
+    std::fs::remove_dir(scope)
+        .with_context(|| format!("remove persistence scope {}", scope.display()))?;
+    Ok(())
+}
+
+fn close_master(socket: &Path, record: &EndpointRecord) -> Result<()> {
+    let output = master_exit_command(socket, record)
+        .output()
+        .with_context(|| format!("ask SSH master for {} to exit", record.label()))?;
+    if output.status.success() || !socket_is_live(socket) {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    bail!(
+        "SSH master for {} refused to exit ({}): {}",
+        record.label(),
+        output.status,
+        stderr.trim()
+    )
+}
+
+fn master_exit_command(socket: &Path, record: &EndpointRecord) -> Command {
+    let mut command = Command::new("ssh");
+    command.arg("-S").arg(socket).args(["-O", "exit"]);
+    if let Some(user) = &record.user {
+        command.args(["-l", user]);
+    }
+    if let Some(port) = record.port {
+        command.args(["-p", &port.to_string()]);
+    }
+    command.arg("--").arg(&record.host);
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn endpoint_records_are_stable_and_inactive_scopes_close_cleanly() {
+        let temporary = tempfile::tempdir().unwrap();
+        let scope = temporary.path().join("scope");
+        initialize_scope(&scope).unwrap();
+        let first = prepare_endpoint(&scope, Some("alice"), "example", None).unwrap();
+        let same = prepare_endpoint(&scope, Some("alice"), "example", None).unwrap();
+        let alternate = prepare_endpoint(&scope, Some("alice"), "example", Some(2222)).unwrap();
+        assert_eq!(first, same);
+        assert_ne!(first, alternate);
+        assert_eq!(scope_records(&scope).unwrap().len(), 2);
+        close_scope(&scope).unwrap();
+        assert!(!scope.exists());
+    }
+
+    #[test]
+    fn concurrent_endpoint_registration_publishes_one_complete_record() {
+        let temporary = tempfile::tempdir().unwrap();
+        let scope = temporary.path().join("scope");
+        initialize_scope(&scope).unwrap();
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let joins: Vec<_> = (0..8)
+            .map(|_| {
+                let scope = scope.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    prepare_endpoint(&scope, Some("alice"), "example", Some(2222)).unwrap()
+                })
+            })
+            .collect();
+        let sockets: Vec<_> = joins.into_iter().map(|join| join.join().unwrap()).collect();
+        assert!(sockets.iter().all(|socket| socket == &sockets[0]));
+        assert_eq!(scope_records(&scope).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn explicit_scope_validation_never_follows_or_chmods_a_symlink() {
+        let temporary = tempfile::tempdir().unwrap();
+        let victim = temporary.path().join("victim");
+        std::fs::create_dir(&victim).unwrap();
+        std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let attack = temporary.path().join("scope");
+        std::os::unix::fs::symlink(&victim, &attack).unwrap();
+        assert!(validate_scope(&attack).is_err());
+        assert_eq!(
+            std::fs::metadata(&victim).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+    }
+
+    #[test]
+    fn master_exit_targets_the_recorded_endpoint_and_socket() {
+        let record = EndpointRecord::new(Some("alice"), "example", Some(2222));
+        let command =
+            master_exit_command(Path::new("/run/user/1/scope/cm-deadbeefdeadbeef"), &record);
+        let args: Vec<_> = command
+            .get_args()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            [
+                "-S",
+                "/run/user/1/scope/cm-deadbeefdeadbeef",
+                "-O",
+                "exit",
+                "-l",
+                "alice",
+                "-p",
+                "2222",
+                "--",
+                "example"
+            ]
+        );
+    }
+}

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -2970,9 +2970,9 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
             "--syq-path and --no-bootstrap cannot select the pre-enrolled command-restricted receiver"
         );
     }
-    if args.reuse_connection {
+    if args.pscope_explicit {
         bail!(
-            "--reuse-connection is not available with the command-restricted receiver: its host-bound authentication is verified per fresh connection"
+            "--pscope is not available with the command-restricted receiver: its host-bound authentication is verified per fresh connection"
         );
     }
     if !args.dry_run && !args.verify_only && args.delete && args.max_size.is_some() {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -901,6 +901,47 @@ pub fn run(args: Args) -> Result<i32> {
             }
         }
     }
+    // A remote coordinator owns both SSH edges. Hand off before constructing
+    // local endpoints so the invoking machine neither reads its persistence
+    // policy nor creates records for connections it will never open.
+    if coordinator_is_remote {
+        if args.rsh.is_some() {
+            let rsh = parse_rsh(&args.rsh)?;
+            if !rsh[0].ends_with("ssh")
+                && srcs
+                    .iter()
+                    .chain(std::iter::once(dst))
+                    .any(|location| location.port.is_some())
+            {
+                bail!(
+                    "an explicit endpoint SSH port requires the default ssh or an --rsh command whose executable is ssh"
+                );
+            }
+        }
+        if args.connections_default {
+            args.connections = tune::START_SSH;
+        }
+        if args.interface != Interface::Rsync && args.run_at == RunAt::Target {
+            return crate::direct::run_at_target(&args, srcs, dst, source_operand_count);
+        }
+        return crate::direct::run(&args, srcs, dst, source_operand_count);
+    }
+    if srcs[0].is_remote() && dst.is_remote() {
+        if args.interface != Interface::Rsync && args.run_at == RunAt::Local {
+            args.relay = true;
+        }
+        if !args.quiet {
+            if args.relay {
+                eprintln!("syq: remote-to-remote transfer: relaying data through this machine");
+            } else {
+                eprintln!(
+                    "syq: remote-to-remote transfer: relaying raw path bytes through this machine"
+                );
+            }
+        }
+    } else if args.interface != Interface::Rsync && args.run_at != RunAt::Auto {
+        bail!("--run-at currently applies only to copies between two remote endpoints");
+    }
     let src_ep = endpoint(&srcs[0], &args)?;
     let mut dst_ep = endpoint(dst, &args)?;
     if args.tcp_congestion.is_some() && !src_ep.is_remote() && !dst_ep.is_remote() {
@@ -924,34 +965,6 @@ pub fn run(args: Args) -> Result<i32> {
         } else {
             tune::START_LOCAL
         };
-    }
-    if src_ep.is_remote() && dst_ep.is_remote() {
-        if args.interface != Interface::Rsync && args.run_at == RunAt::Local {
-            args.relay = true;
-        }
-        if args.interface != Interface::Rsync && args.run_at == RunAt::Target {
-            return crate::direct::run_at_target(&args, srcs, dst, source_operand_count);
-        }
-        if !args.relay {
-            if args.interface == Interface::Rsync
-                || direct_paths_are_utf8
-                || args.run_at == RunAt::Source
-            {
-                // Let the remote orchestrator observe the original source count so
-                // repeated file sources keep multi-source destination semantics.
-                return crate::direct::run(&args, srcs, dst, source_operand_count);
-            }
-            if !args.quiet {
-                eprintln!(
-                    "syq: remote-to-remote transfer: relaying raw path bytes through this machine"
-                );
-            }
-        }
-        if args.relay && !args.quiet {
-            eprintln!("syq: remote-to-remote transfer: relaying data through this machine");
-        }
-    } else if args.interface != Interface::Rsync && args.run_at != RunAt::Auto {
-        bail!("--run-at currently applies only to copies between two remote endpoints");
     }
     #[cfg(not(target_os = "linux"))]
     if let Some(algorithm) = &args.tcp_congestion {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -105,15 +105,17 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
             }
             let ssh_multiplexer = if args.rsh.is_some() {
                 None
+            } else if args.restricted_grant.is_some() {
+                Some(Arc::new(SshMultiplexer::new()?))
             } else {
-                match (args.pscope.as_deref(), args.restricted_grant.is_none()) {
-                    (Some(scope), true) => Some(Arc::new(SshMultiplexer::persistent(
-                        scope,
+                match crate::persistence::scope_for_implicit_ssh(args.pscope.as_deref())? {
+                    Some(scope) => Some(Arc::new(SshMultiplexer::persistent(
+                        &scope,
                         loc.user.as_deref(),
                         h,
                         loc.port,
                     )?)),
-                    _ => Some(Arc::new(SshMultiplexer::new()?)),
+                    None => Some(Arc::new(SshMultiplexer::new()?)),
                 }
             };
             Endpoint::Remote(RemoteSpec {
@@ -808,12 +810,6 @@ pub fn run(args: Args) -> Result<i32> {
         bail!(
             "--pscope is not supported with a remote transfer coordinator; use --run-at local to keep the reusable connections on this machine"
         );
-    }
-    if coordinator_is_remote {
-        // A durable local preference is a capability, not a demand that every
-        // topology support persistence. The remote coordinator owns its SSH
-        // edges, so do not create misleading local endpoint records for them.
-        args.pscope = None;
     }
     if args.detach && args.native_results.is_some() {
         bail!(

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -105,14 +105,16 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
             }
             let ssh_multiplexer = if args.rsh.is_some() {
                 None
-            } else if args.reuse_connection && args.restricted_grant.is_none() {
-                Some(Arc::new(SshMultiplexer::persistent(
-                    loc.user.as_deref(),
-                    h,
-                    loc.port,
-                )?))
             } else {
-                Some(Arc::new(SshMultiplexer::new()?))
+                match (args.pscope.as_deref(), args.restricted_grant.is_none()) {
+                    (Some(scope), true) => Some(Arc::new(SshMultiplexer::persistent(
+                        scope,
+                        loc.user.as_deref(),
+                        h,
+                        loc.port,
+                    )?)),
+                    _ => Some(Arc::new(SshMultiplexer::new()?)),
+                }
             };
             Endpoint::Remote(RemoteSpec {
                 local_process: false,
@@ -797,15 +799,21 @@ pub fn run(args: Args) -> Result<i32> {
             "--detach, --no-forward-agent, and --agent-broker-only apply only to a direct copy between two different remote endpoints"
         );
     }
-    if args.reuse_connection && coordinator_is_remote {
+    if args.pscope_explicit && coordinator_is_remote {
         if args.interface == Interface::Rsync {
             bail!(
-                "--reuse-connection is not supported for direct remote-to-remote transfers; add --relay to keep the reusable connections on this machine"
+                "--pscope is not supported for direct remote-to-remote transfers; add --relay to keep the reusable connections on this machine"
             );
         }
         bail!(
-            "--reuse-connection is not supported with a remote transfer coordinator; use --run-at local to keep the reusable connections on this machine"
+            "--pscope is not supported with a remote transfer coordinator; use --run-at local to keep the reusable connections on this machine"
         );
+    }
+    if coordinator_is_remote {
+        // A durable local preference is a capability, not a demand that every
+        // topology support persistence. The remote coordinator owns its SSH
+        // edges, so do not create misleading local endpoint records for them.
+        args.pscope = None;
     }
     if args.detach && args.native_results.is_some() {
         bail!(

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1679,7 +1679,7 @@ fn fake_ssh(t: &Tmp) -> PathBuf {
 printf '%s\n' "$*" >> "$FAKE_RSH_LOG"
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        -o|-l|-p) shift 2 ;;
+        -o|-l|-p|-S) shift 2 ;;
         -a|-A|-x|-k|-T) shift ;;
         --) shift; break ;;
         -*) shift ;;
@@ -1717,6 +1717,10 @@ while [ "$#" -gt 0 ]; do
             esac
             ;;
         -l)
+            shift 2
+            ;;
+        -S)
+            control_path=$2
             shift 2
             ;;
         --)
@@ -6006,6 +6010,22 @@ fn ordinary_copy_needs_no_writable_history_directory() {
     assert_eq!(read(&t.path("dst/f")), b"data");
 }
 
+#[test]
+fn local_copy_does_not_read_the_global_persistence_configuration() {
+    let t = Tmp::new();
+    write(&t.path("src/f"), b"data");
+    // An eligible implicit SSH endpoint would report this malformed policy,
+    // but a local copy has no persistence decision to make.
+    write(&t.path("config/syq/persistence-v1.json"), b"not valid JSON");
+    let out = compat_command()
+        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .run()
+        .unwrap();
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst/f")), b"data");
+}
+
 // A read-only source root: the copy succeeds, the root ends up 0555, and a
 // rerun into the now read-only destination works too.
 #[test]
@@ -9858,10 +9878,7 @@ fn durable_and_ephemeral_policies_reach_implicit_ssh_connections() {
     let log = fs::read_to_string(t.path("rsh.log")).unwrap();
     assert!(log.contains("ControlMaster=auto"), "{log}");
     assert!(log.contains("ControlPersist=300"), "{log}");
-    assert!(
-        log.contains(&format!("ControlPath={global_scope}/cm-")),
-        "{log}"
-    );
+    assert!(log.contains(&format!("-S {global_scope}/cm-")), "{log}");
     let status = persistence_command(&t, &["status"]).run().unwrap();
     assert_output_ok(&status);
     assert!(String::from_utf8_lossy(&status.stdout).contains("backup.example:2222"));
@@ -9930,7 +9947,7 @@ exit 0
     assert_output_ok(&output);
     let log = fs::read_to_string(t.path("rsh.log")).unwrap();
     assert!(
-        log.contains(&format!("ControlPath={}/cm-", scope.display())),
+        log.contains(&format!("-S {}/cm-", scope.display())),
         "{log}"
     );
     assert_output_ok(
@@ -9992,7 +10009,15 @@ fn pscope_is_shared_by_transfer_surfaces_and_refuses_unrelated_directories() {
     let refused = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args(["cp", "--pscope"])
         .arg(&attack)
-        .args(["--src", &t.s("src/a"), "--as", &t.s("no-copy"), "-q"])
+        .args([
+            "--src",
+            &t.s("src/a"),
+            "--to",
+            "backup.example",
+            "--as",
+            &t.s("no-copy"),
+            "-q",
+        ])
         .env("XDG_CONFIG_HOME", t.path("config"))
         .env("XDG_RUNTIME_DIR", t.path("runtime"))
         .run()

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -9843,6 +9843,80 @@ fn absent_user_config_environment_keeps_ordinary_commands_nonpersistent() {
 }
 
 #[test]
+fn remote_coordinator_does_not_resolve_local_persistence() {
+    let t = Tmp::new();
+    fs::create_dir(t.path("runtime")).unwrap();
+    write(&t.path("config/syq/persistence-v1.json"), b"not valid JSON");
+    let ssh = t.path("bin/ssh");
+    executable(
+        &ssh,
+        br#"#!/bin/sh
+: > "$FAKE_RSH_MARKER"
+exit 23
+"#,
+    );
+    let run = || {
+        Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "rsync",
+                "-a",
+                "--no-forward-agent",
+                "hostA:src/",
+                "hostB:dst/",
+                "--no-progress",
+            ])
+            .env("XDG_CONFIG_HOME", t.path("config"))
+            .env("XDG_RUNTIME_DIR", t.path("runtime"))
+            .env("FAKE_RSH_MARKER", t.path("ssh-called"))
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", ssh.parent().unwrap().to_string_lossy()),
+            )
+            .run()
+            .unwrap()
+    };
+
+    let output = run();
+    assert_eq!(output.status.code(), Some(23), "{}", stderr_of(&output));
+    assert!(t.path("ssh-called").exists());
+    assert!(!stderr_of(&output).contains("persistence configuration"));
+
+    let enabled = persistence_command(&t, &["on"]).run().unwrap();
+    assert_output_ok(&enabled);
+    let global_scope = String::from_utf8(enabled.stdout)
+        .unwrap()
+        .lines()
+        .find_map(|line| line.strip_prefix("scope: "))
+        .map(PathBuf::from)
+        .unwrap();
+    let output = run();
+    assert_eq!(output.status.code(), Some(23), "{}", stderr_of(&output));
+    assert!(
+        fs::read_dir(&global_scope)
+            .unwrap()
+            .flatten()
+            .all(|entry| !entry.file_name().to_string_lossy().ends_with(".json")),
+        "remote-coordinator handoff recorded inactive local endpoints"
+    );
+    assert_output_ok(&persistence_command(&t, &["off"]).run().unwrap());
+}
+
+#[test]
+fn ephemeral_persistence_refuses_openssh_expanding_runtime_paths() {
+    let t = Tmp::new();
+    let runtime = t.path("runtime-${HOME}");
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["persist", "on", "--ephemeral"])
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", &runtime)
+        .run()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(stderr_of(&output).contains("OpenSSH expansion syntax"));
+    assert!(!runtime.exists(), "unsafe runtime path was created");
+}
+
+#[test]
 fn durable_and_ephemeral_policies_reach_implicit_ssh_connections() {
     let t = Tmp::new();
     fs::create_dir(t.path("runtime")).unwrap();

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -9724,75 +9724,333 @@ fn mappings_md_drop_specials_example_works_verbatim() {
     assert!(!t.path("dst/pipe").exists());
 }
 
-#[test]
-fn reuse_connection_flag_surface() {
-    let t = Tmp::new();
-    write(&t.path("src/a.txt"), b"a");
-    // Conflicts with an explicit remote shell on the rsync surface.
-    let out = syq(&[
-        "-a",
-        "--reuse-connection",
-        "-e",
-        "ssh -p 2222",
-        &t.s("src/"),
-        &t.s("dst"),
-    ]);
-    assert!(!out.status.success());
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    assert!(stderr.contains("--rsh"), "{stderr}");
-    // syq map never connects; the flag is refused there.
-    let out = syq_map_in(&t.path(""), &["--src-src", "src", "--reuse-connection"]);
-    assert!(!out.status.success());
-    assert!(String::from_utf8_lossy(&out.stderr).contains("only available on syq cp"));
-    // Local copies accept it as a no-op on both surfaces.
-    let out = syq_cp_in(
-        &t.path(""),
-        &[
-            "--src-src",
-            "src",
-            "--into",
-            "out",
-            "--reuse-connection",
-            "-q",
-        ],
-        None,
-    );
-    assert!(
-        out.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    assert_eq!(read(&t.path("out/a.txt")), b"a");
-    let out = syq(&["-a", "--reuse-connection", &t.s("src/"), &t.s("out2")]);
-    assert!(out.status.success());
+fn persistence_command(t: &Tmp, args: &[&str]) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+    command
+        .arg("persist")
+        .args(args)
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"));
+    command
+}
+
+fn ephemeral_scope(t: &Tmp) -> PathBuf {
+    let output = persistence_command(t, &["on", "--ephemeral"])
+        .run()
+        .expect("create ephemeral persistence scope");
+    assert_output_ok(&output);
+    let path = output.stdout.strip_suffix(b"\n").unwrap();
+    PathBuf::from(std::ffi::OsString::from_vec(path.to_vec()))
 }
 
 #[test]
-fn reuse_connection_refused_for_direct_remote_to_remote() {
-    let out = syq(&["-a", "--reuse-connection", "hostA:src/", "hostB:dst/"]);
-    assert!(!out.status.success());
-    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    assert!(
-        stderr.contains("direct remote-to-remote"),
-        "stderr: {stderr}"
+fn persistence_policy_and_ephemeral_scopes_have_separate_lifecycles() {
+    let t = Tmp::new();
+    fs::create_dir(t.path("runtime")).unwrap();
+
+    let status = persistence_command(&t, &["status"]).run().unwrap();
+    assert_output_ok(&status);
+    assert!(String::from_utf8_lossy(&status.stdout).contains("is off"));
+
+    let enabled = persistence_command(&t, &["on"]).run().unwrap();
+    assert_output_ok(&enabled);
+    let global_scope = String::from_utf8(enabled.stdout)
+        .unwrap()
+        .lines()
+        .find_map(|line| line.strip_prefix("scope: "))
+        .map(PathBuf::from)
+        .expect("global scope path");
+    assert!(global_scope.is_dir());
+
+    let scope = ephemeral_scope(&t);
+    assert!(scope.is_dir());
+    assert_ne!(scope, global_scope);
+    assert_eq!(
+        fs::metadata(&scope).unwrap().permissions().mode() & 0o777,
+        0o700
     );
 
-    let out = native_syq(&[
-        "cp",
-        "--reuse-connection",
-        "--from",
-        "hostA",
-        "--src-src",
-        "src",
-        "--to",
-        "hostB",
-        "--run-at",
-        "target",
-        "--into",
-        "dst",
-    ]);
+    write(&t.path("src/a.txt"), b"a");
+    let copy = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--pscope"])
+        .arg(&scope)
+        .args(["--src-src", &t.s("src"), "--into", &t.s("out"), "-q"])
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"))
+        .run()
+        .unwrap();
+    assert_output_ok(&copy);
+    assert_eq!(read(&t.path("out/a.txt")), b"a");
+
+    let scoped_status = persistence_command(&t, &["status", "--pscope", scope.to_str().unwrap()])
+        .run()
+        .unwrap();
+    assert_output_ok(&scoped_status);
+    assert!(String::from_utf8_lossy(&scoped_status.stdout).contains("connections: 0"));
+
+    let closed = persistence_command(&t, &["off", "--pscope", scope.to_str().unwrap()])
+        .run()
+        .unwrap();
+    assert_output_ok(&closed);
+    assert!(!scope.exists());
+    assert!(global_scope.exists(), "ephemeral off changed global scope");
+
+    let disabled = persistence_command(&t, &["off"]).run().unwrap();
+    assert_output_ok(&disabled);
+    assert!(!global_scope.exists());
+    let status = persistence_command(&t, &["status"]).run().unwrap();
+    assert_output_ok(&status);
+    assert!(String::from_utf8_lossy(&status.stdout).contains("is off"));
+}
+
+#[test]
+fn absent_user_config_environment_keeps_ordinary_commands_nonpersistent() {
+    let t = Tmp::new();
+    write(&t.path("src"), b"no home required");
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--src"])
+        .arg(t.path("src"))
+        .args(["--as"])
+        .arg(t.path("dst"))
+        .arg("-q")
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("XDG_RUNTIME_DIR")
+        .env_remove("HOME")
+        .run()
+        .unwrap();
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("dst")), b"no home required");
+}
+
+#[test]
+fn durable_and_ephemeral_policies_reach_implicit_ssh_connections() {
+    let t = Tmp::new();
+    fs::create_dir(t.path("runtime")).unwrap();
+    let ssh = fake_ssh(&t);
+    write(&t.path("src"), b"persistent");
+
+    let enabled = persistence_command(&t, &["on"]).run().unwrap();
+    assert_output_ok(&enabled);
+    let global_scope = String::from_utf8(enabled.stdout)
+        .unwrap()
+        .lines()
+        .find_map(|line| line.strip_prefix("scope: "))
+        .unwrap()
+        .to_owned();
+    let mut copy = Command::new(env!("CARGO_BIN_EXE_syq"));
+    copy.args(["cp", "--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args(["--no-tcp", "-j", "1"])
+        .arg(t.path("src"))
+        .args(["--to", "backup.example:2222", "--as"])
+        .arg(t.path("global-dst"))
+        .arg("-q")
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"))
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", ssh.parent().unwrap().to_string_lossy()),
+        );
+    let output = copy.run().unwrap();
+    assert_output_ok(&output);
+    let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    assert!(log.contains("ControlMaster=auto"), "{log}");
+    assert!(log.contains("ControlPersist=300"), "{log}");
+    assert!(
+        log.contains(&format!("ControlPath={global_scope}/cm-")),
+        "{log}"
+    );
+    let status = persistence_command(&t, &["status"]).run().unwrap();
+    assert_output_ok(&status);
+    assert!(String::from_utf8_lossy(&status.stdout).contains("backup.example:2222"));
+
+    // Stand in for the OpenSSH master at the recorded socket and verify that
+    // `persist off` asks that exact endpoint to exit before removing the scope.
+    let record = fs::read_dir(&global_scope)
+        .unwrap()
+        .flatten()
+        .find(|entry| entry.file_name().to_string_lossy().ends_with(".json"))
+        .expect("endpoint record");
+    let socket_name = record
+        .file_name()
+        .to_string_lossy()
+        .strip_suffix(".json")
+        .unwrap()
+        .to_owned();
+    let socket_path = Path::new(&global_scope).join(socket_name);
+    let _master = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
+    let close_ssh = t.path("close-bin/ssh");
+    executable(
+        &close_ssh,
+        br#"#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_CLOSE_LOG"
+exit 0
+"#,
+    );
+    let mut off = persistence_command(&t, &["off"]);
+    off.env(
+        "PATH",
+        format!(
+            "{}:/usr/bin:/bin",
+            close_ssh.parent().unwrap().to_string_lossy()
+        ),
+    )
+    .env("FAKE_CLOSE_LOG", t.path("close.log"));
+    assert_output_ok(&off.run().unwrap());
+    let close_log = fs::read_to_string(t.path("close.log")).unwrap();
+    assert!(close_log.contains("-O exit"), "{close_log}");
+    assert!(close_log.contains("-p 2222"), "{close_log}");
+    assert!(close_log.ends_with("-- backup.example\n"), "{close_log}");
+    assert!(!Path::new(&global_scope).exists());
+
+    let scope = ephemeral_scope(&t);
+    fs::write(t.path("rsh.log"), b"").unwrap();
+    let mut scoped_copy = Command::new(env!("CARGO_BIN_EXE_syq"));
+    scoped_copy
+        .args(["cp", "--pscope"])
+        .arg(&scope)
+        .args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
+        .args(["--no-tcp", "-j", "1"])
+        .arg(t.path("src"))
+        .args(["--to", "backup.example:2222", "--as"])
+        .arg(t.path("scoped-dst"))
+        .arg("-q")
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"))
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", ssh.parent().unwrap().to_string_lossy()),
+        );
+    let output = scoped_copy.run().unwrap();
+    assert_output_ok(&output);
+    let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    assert!(
+        log.contains(&format!("ControlPath={}/cm-", scope.display())),
+        "{log}"
+    );
+    assert_output_ok(
+        &persistence_command(&t, &["off", "--pscope", scope.to_str().unwrap()])
+            .run()
+            .unwrap(),
+    );
+}
+
+#[test]
+fn pscope_is_shared_by_transfer_surfaces_and_refuses_unrelated_directories() {
+    let t = Tmp::new();
+    fs::create_dir(t.path("runtime")).unwrap();
+    let scope = ephemeral_scope(&t);
+    write(&t.path("src/a"), b"a");
+
+    let compat = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["rsync", "-a", "--pscope"])
+        .arg(&scope)
+        .args([&t.s("src/"), &t.s("compat"), "--no-progress"])
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"))
+        .run()
+        .unwrap();
+    assert_output_ok(&compat);
+    assert_eq!(read(&t.path("compat/a")), b"a");
+
+    write(&t.path("remove-me"), b"gone");
+    let removal = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["rm", "--pscope"])
+        .arg(&scope)
+        .args(["--src", "remove-me", "-q"])
+        .current_dir(&t.0)
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"))
+        .run()
+        .unwrap();
+    assert_output_ok(&removal);
+    assert!(!t.path("remove-me").exists());
+
+    let map = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["map", "--pscope"])
+        .arg(&scope)
+        .args(["--src", &t.s("src/a")])
+        .run()
+        .unwrap();
+    assert!(!map.status.success());
+    assert!(
+        stderr_of(&map).contains("unexpected argument '--pscope'"),
+        "{}",
+        stderr_of(&map)
+    );
+
+    let victim = t.path("victim");
+    fs::create_dir(&victim).unwrap();
+    fs::set_permissions(&victim, fs::Permissions::from_mode(0o755)).unwrap();
+    let attack = t.path("not-a-scope");
+    std::os::unix::fs::symlink(&victim, &attack).unwrap();
+    let refused = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--pscope"])
+        .arg(&attack)
+        .args(["--src", &t.s("src/a"), "--as", &t.s("no-copy"), "-q"])
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"))
+        .run()
+        .unwrap();
+    assert!(!refused.status.success());
+    assert_eq!(
+        fs::metadata(&victim).unwrap().permissions().mode() & 0o777,
+        0o755
+    );
+}
+
+#[test]
+fn explicit_pscope_is_refused_for_remote_coordinators() {
+    let t = Tmp::new();
+    fs::create_dir(t.path("runtime")).unwrap();
+    let scope = ephemeral_scope(&t);
+    let scope = scope.to_str().unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "rsync",
+            "-a",
+            "--pscope",
+            scope,
+            "hostA:src/",
+            "hostB:dst/",
+            "--no-progress",
+        ])
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"))
+        .run()
+        .unwrap();
     assert!(!out.status.success());
-    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr_of(&out).contains("direct remote-to-remote"));
+
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--pscope",
+            scope,
+            "--from",
+            "hostA",
+            "--src-src",
+            "src",
+            "--to",
+            "hostB",
+            "--run-at",
+            "target",
+            "--into",
+            "dst",
+            "-q",
+        ])
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"))
+        .run()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = stderr_of(&out);
     assert!(stderr.contains("remote transfer coordinator"), "{stderr}");
     assert!(stderr.contains("--run-at local"), "{stderr}");
 }


### PR DESCRIPTION
## Summary

- replace the per-command `--reuse-connection` switch with durable `syq persist on`, `status`, and `off` lifecycle commands
- add isolated script-owned scopes from `syq persist on --ephemeral`, selected by `--pscope` on `cp`, `rm`, and `rsync`
- securely manage per-user scope directories, atomically record endpoints for parallel commands, report connection state, and close live OpenSSH masters on shutdown
- resolve persistence lazily only for eligible implicit local SSH edges, and hand remote-coordinator transfers off before constructing local endpoints
- pass control paths byte-exactly as `-S` arguments, escape OpenSSH percent expansion, and reject `${...}` or leading-`~` expansion forms
- document the interface, security boundary, topology constraints, and scripting pattern

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (266 unit, 295 local integration, 9 update tests)

The integration coverage verifies OpenSSH control arguments and shutdown targeting with fake SSH processes and a live Unix-socket stand-in. A real remote sshd or hardware-token authentication flow was not exercised.