### PR TITLE
Unify operator path resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,12 @@ jobs:
           persist-credentials: false
       - if: needs.scope.outputs.native == 'true'
         run: cargo check --locked --all-targets
+      - name: Exercise macOS symlink descriptor pinning
+        if: needs.scope.outputs.native == 'true'
+        run: >-
+          cargo test --locked
+          rooted::tests::operator_resolver_selects_a_last_component_symlink_without_following_it
+          -- --exact
       - if: needs.scope.outputs.native == 'true'
         run: scripts/test-installer.sh
       - if: needs.scope.outputs.native == 'true'

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -2,7 +2,10 @@
 //! by `syq --server` for remote endpoints, so both sides behave identically.
 
 use crate::proto::*;
-use crate::rooted::{RelativePath, Root, RootIdentity, RootMetadata};
+use crate::rooted::{
+    OperatorFinalComponent, OperatorResolver, PinnedPath, RelativePath, Root, RootIdentity,
+    RootMetadata,
+};
 use anyhow::{anyhow, bail, Context, Result};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, VecDeque};
@@ -216,88 +219,37 @@ fn select_operator_directory(
     if raw.contains(&0) {
         bail!("destination path contains NUL");
     }
-
-    let absolute = raw.starts_with(b"/");
-    let mut directory = open_operator_directory_start(absolute)?;
-    let mut remaining: VecDeque<Vec<u8>> = raw
-        .split(|byte| *byte == b'/')
-        .filter(|component| !component.is_empty())
-        .map(<[u8]>::to_vec)
-        .collect();
-    let mut symlink_hops = 0usize;
-
-    while let Some(component) = remaining.pop_front() {
-        if component == b"." {
-            continue;
+    let mut hops = Vec::new();
+    match OperatorResolver::resolve_process(
+        raw,
+        symlink_policy,
+        OperatorFinalComponent::Directory,
+        allow_missing,
+        &mut hops,
+    )? {
+        PinnedPath::Directory(directory) => {
+            let (directory, _) = directory.into_parts();
+            let selection = OperatorDirectorySelection {
+                path: path_bytes(&path),
+                directory,
+                missing: VecDeque::new(),
+            };
+            let anchor = selection.anchor()?;
+            Ok((selection, Some(anchor)))
         }
-        if component == b".." {
-            directory = open_operator_directory_at(&directory, b"..")?;
-            continue;
-        }
-
-        let metadata = match operator_lstat_at(&directory, &component) {
-            Ok(metadata) => metadata,
-            Err(error) if error.kind() == io::ErrorKind::NotFound && allow_missing => {
-                remaining.push_front(component);
-                let selection = OperatorDirectorySelection {
+        PinnedPath::Missing(missing) => {
+            let (directory, missing) = missing.into_parts();
+            Ok((
+                OperatorDirectorySelection {
                     path: path_bytes(&path),
                     directory,
-                    missing: remaining,
-                };
-                return Ok((selection, None));
-            }
-            Err(error) => return Err(error.into()),
-        };
-        if metadata.st_mode & libc::S_IFMT == libc::S_IFLNK {
-            let euid = unsafe { libc::geteuid() };
-            match symlink_policy {
-                OperatorSymlinkPolicy::Refuse => bail!(
-                    "refusing symlink component {:?}; pass --follow to resolve symlinks",
-                    OsStr::from_bytes(&component)
-                ),
-                OperatorSymlinkPolicy::TrustedOwner
-                    if !operator_symlink_owner_is_trusted(metadata.st_uid, euid) =>
-                {
-                    bail!(
-                        "refusing symlink component {:?} owned by uid {}; expected uid 0 or receiver uid {}",
-                        OsStr::from_bytes(&component),
-                        metadata.st_uid,
-                        euid
-                    );
-                }
-                OperatorSymlinkPolicy::TrustedOwner | OperatorSymlinkPolicy::FollowAll => {}
-            }
-            symlink_hops += 1;
-            if symlink_hops > 40 {
-                bail!("too many symlink levels in destination path");
-            }
-            let target = operator_readlink_at(&directory, &component)?;
-            if target.starts_with(b"/") {
-                directory = open_operator_directory_start(true)?;
-            }
-            let mut expanded: VecDeque<Vec<u8>> = target
-                .split(|byte| *byte == b'/')
-                .filter(|part| !part.is_empty())
-                .map(<[u8]>::to_vec)
-                .collect();
-            expanded.append(&mut remaining);
-            remaining = expanded;
-            continue;
+                    missing,
+                },
+                None,
+            ))
         }
-
-        if metadata.st_mode & libc::S_IFMT != libc::S_IFDIR {
-            return Err(io::Error::from_raw_os_error(libc::ENOTDIR).into());
-        }
-        directory = open_operator_directory_at(&directory, &component)?;
+        PinnedPath::Leaf(_) => bail!("destination path is not a directory"),
     }
-
-    let selection = OperatorDirectorySelection {
-        path: path_bytes(&path),
-        directory,
-        missing: VecDeque::new(),
-    };
-    let anchor = selection.anchor()?;
-    Ok((selection, Some(anchor)))
 }
 
 /// Check the current spelling of an operator-supplied local path without
@@ -319,56 +271,30 @@ pub(crate) fn check_operator_path_no_symlinks(
     if raw.contains(&0) {
         bail!("operator path contains NUL");
     }
-
-    let mut directory = open_operator_directory_start(raw.starts_with(b"/"))?;
-    let mut remaining: VecDeque<Vec<u8>> = raw
-        .split(|byte| *byte == b'/')
-        .filter(|component| !component.is_empty())
-        .map(<[u8]>::to_vec)
-        .collect();
-    while let Some(component) = remaining.pop_front() {
-        if component == b"." {
-            continue;
-        }
-        if component == b".." {
-            directory = open_operator_directory_at(&directory, b"..")?;
-            continue;
-        }
-
-        let final_component = remaining.is_empty();
-        let metadata = match operator_lstat_at(&directory, &component) {
-            Ok(metadata) => metadata,
-            Err(error)
-                if final_component
-                    && allow_missing_final
-                    && error.kind() == io::ErrorKind::NotFound =>
-            {
-                return Ok(());
+    let mut hops = Vec::new();
+    match OperatorResolver::resolve_process(
+        raw,
+        OperatorSymlinkPolicy::Refuse,
+        OperatorFinalComponent::Entry {
+            follow_symlink: false,
+        },
+        allow_missing_final,
+        &mut hops,
+    )? {
+        PinnedPath::Directory(_) => Ok(()),
+        PinnedPath::Leaf(leaf) if !leaf.metadata().is_symlink() || allow_final_symlink => Ok(()),
+        PinnedPath::Leaf(_) => bail!(
+            "operator path encounters a last-component symlink; pass --follow to resolve symlinks"
+        ),
+        PinnedPath::Missing(missing) => {
+            let (_, components) = missing.into_parts();
+            if components.len() == 1 {
+                Ok(())
+            } else {
+                Err(io::Error::from_raw_os_error(libc::ENOENT).into())
             }
-            Err(error) => return Err(error.into()),
-        };
-        if metadata.st_mode & libc::S_IFMT == libc::S_IFLNK {
-            if final_component && allow_final_symlink {
-                return Ok(());
-            }
-            bail!(
-                "operator path encounters symlink component {:?}; pass --follow to resolve symlinks",
-                OsStr::from_bytes(&component)
-            );
         }
-        if final_component {
-            return Ok(());
-        }
-        if metadata.st_mode & libc::S_IFMT != libc::S_IFDIR {
-            return Err(io::Error::from_raw_os_error(libc::ENOTDIR).into());
-        }
-        directory = open_operator_directory_at(&directory, &component)?;
     }
-    Ok(())
-}
-
-fn operator_symlink_owner_is_trusted(owner: u32, euid: u32) -> bool {
-    owner == 0 || owner == euid
 }
 
 fn operator_directory_flags() -> libc::c_int {
@@ -448,38 +374,6 @@ fn operator_lstat_at(parent: &File, component: &[u8]) -> io::Result<libc::stat> 
         if error.kind() != io::ErrorKind::Interrupted {
             return Err(error);
         }
-    }
-}
-
-fn operator_readlink_at(parent: &File, component: &[u8]) -> io::Result<Vec<u8>> {
-    let component = CString::new(component).expect("path component was checked for NUL");
-    let mut capacity = 256usize;
-    loop {
-        let mut target = Vec::<u8>::with_capacity(capacity);
-        let length = unsafe {
-            libc::readlinkat(
-                parent.as_raw_fd(),
-                component.as_ptr(),
-                target.as_mut_ptr().cast(),
-                capacity,
-            )
-        };
-        if length < 0 {
-            let error = io::Error::last_os_error();
-            if error.kind() == io::ErrorKind::Interrupted {
-                continue;
-            }
-            return Err(error);
-        }
-        let length = length as usize;
-        if length < capacity {
-            unsafe { target.set_len(length) };
-            return Ok(target);
-        }
-        capacity = capacity
-            .checked_mul(2)
-            .filter(|next| *next <= libc::PATH_MAX as usize * 2)
-            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENAMETOOLONG))?;
     }
 }
 
@@ -4095,14 +3989,6 @@ mod tests {
             .contains("appeared after the new-target precondition"));
 
         fs::remove_dir_all(&dir).unwrap();
-    }
-
-    #[test]
-    fn operator_symlink_trust_is_root_or_receiver_ownership() {
-        assert!(operator_symlink_owner_is_trusted(0, 1000));
-        assert!(operator_symlink_owner_is_trusted(1000, 1000));
-        assert!(!operator_symlink_owner_is_trusted(1001, 1000));
-        assert!(!operator_symlink_owner_is_trusted(1000, 0));
     }
 
     #[test]

--- a/src/native_rm.rs
+++ b/src/native_rm.rs
@@ -8,20 +8,23 @@
 //! selected symlink and symlinks encountered below a selected directory are
 //! unlinked as entries; neither is followed.
 
-use crate::proto::{NativeRemoveKind, NativeRemoveOutcome, NativeRemoveSelection, PathBytes};
+use crate::proto::{
+    NativeRemoveKind, NativeRemoveOutcome, NativeRemoveSelection, OperatorSymlinkPolicy, PathBytes,
+};
+use crate::rooted::{
+    OperatorFinalComponent, OperatorResolver, OperatorSymlinkHop, PinnedLeaf as RootedPinnedLeaf,
+    PinnedPath, RootMetadata,
+};
 use anyhow::{bail, Context, Result};
-use std::collections::VecDeque;
 use std::ffi::CString;
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-use std::path::Path;
+use std::os::unix::fs::MetadataExt;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, Instant};
 
-const SYMLINK_LIMIT: usize = 40;
 const EVENT_BATCH: usize = 200;
 const EVENT_POLL: Duration = Duration::from_millis(100);
 const EVENT_FLUSH: Duration = Duration::from_millis(100);
@@ -97,18 +100,27 @@ enum ResolvedSelection {
     Directory(PinnedDirectory),
 }
 
-struct Cursor {
-    directory: File,
-    anchor: Option<PinnedName>,
-}
-
 struct Resolver {
-    base: File,
-    confined: bool,
+    resolver: OperatorResolver,
     follow: bool,
 }
 
 impl Resolver {
+    fn new(base: &File, confined: bool, follow: bool) -> Result<Self> {
+        Ok(Self {
+            resolver: OperatorResolver::beneath(
+                base,
+                confined,
+                if follow {
+                    OperatorSymlinkPolicy::FollowAll
+                } else {
+                    OperatorSymlinkPolicy::Refuse
+                },
+            )?,
+            follow,
+        })
+    }
+
     fn resolve(
         &self,
         selection: &NativeRemoveSelection,
@@ -116,21 +128,59 @@ impl Resolver {
     ) -> Result<ResolvedSelection> {
         validate_selector(&selection.path)?;
         let label = selection.path.clone();
-        let mut components = path_components(&selection.path);
-        let initial = Cursor {
-            directory: self.base.try_clone().context("duplicate removal base")?,
-            anchor: None,
-        };
-        let mut stack = vec![initial];
-        let mut symlinks = 0usize;
+        let mut hops = Vec::new();
+        let resolved = self.resolver.resolve(
+            &selection.path,
+            OperatorFinalComponent::Entry {
+                follow_symlink: self.follow,
+            },
+            true,
+            &mut hops,
+        );
+        append_selector_hops(&selection.path, &hops, traces);
+        let resolved = resolved.with_context(|| {
+            format!(
+                "resolve selector {:?}",
+                String::from_utf8_lossy(&selection.path)
+            )
+        })?;
 
-        loop {
-            let Some(component) = components.pop_front() else {
-                let current = stack.last().expect("resolver stack is nonempty");
-                let identity = identity_from_file(&current.directory)?;
+        match resolved {
+            PinnedPath::Missing(_) => {
+                traces.push(format!(
+                    "selector {:?} is absent",
+                    String::from_utf8_lossy(&label)
+                ));
+                Ok(ResolvedSelection::Missing)
+            }
+            PinnedPath::Leaf(leaf) => {
+                let identity = identity_from_root(leaf.metadata());
+                require_kind(selection.kind, identity, &label)?;
+                traces.push(format!(
+                    "selector {:?} resolved to {} {}:{}",
+                    String::from_utf8_lossy(&label),
+                    if identity.is_symlink() {
+                        "symlink"
+                    } else {
+                        "non-directory"
+                    },
+                    identity.dev,
+                    identity.ino
+                ));
+                let (name, object) = pinned_name_from_root(leaf);
+                Ok(ResolvedSelection::Leaf(PinnedLeaf {
+                    name,
+                    _object: object,
+                    label,
+                }))
+            }
+            PinnedPath::Directory(directory) => {
+                let identity = identity_from_root(directory.metadata());
                 require_kind(selection.kind, identity, &label)?;
                 let remove_root = selection.kind != NativeRemoveKind::Contents;
-                if remove_root && current.anchor.is_none() {
+                let (directory, name) = directory.into_parts();
+                let name = name.map(|name| pinned_name_from_root(name).0);
+                if remove_root && name.is_none() {
                     bail!(
                         "selector {:?} resolves to a directory without a removable name; select its contents explicitly instead",
                         String::from_utf8_lossy(&label)
@@ -142,195 +192,45 @@ impl Resolver {
                     identity.dev,
                     identity.ino
                 ));
-                return Ok(ResolvedSelection::Directory(PinnedDirectory {
-                    directory: current
-                        .directory
-                        .try_clone()
-                        .context("pin selected directory")?,
-                    name: current.anchor.as_ref().map(duplicate_name).transpose()?,
+                Ok(ResolvedSelection::Directory(PinnedDirectory {
+                    directory,
+                    name,
                     label,
                     remove_root,
-                }));
-            };
-
-            if component == b"." {
-                continue;
+                }))
             }
-            if component == b".." {
-                if stack.len() > 1 {
-                    stack.pop();
-                } else if self.confined {
-                    bail!(
-                        "selector {:?} follows a symlink outside --root",
-                        String::from_utf8_lossy(&selection.path)
-                    );
-                } else {
-                    let parent = open_directory_at(&stack[0].directory, b"..")
-                        .context("resolve symlink target parent")?;
-                    stack[0] = Cursor {
-                        directory: parent,
-                        anchor: None,
-                    };
-                }
-                continue;
-            }
-
-            let current = stack.last().expect("resolver stack is nonempty");
-            let identity = match metadata_at(current.directory.as_raw_fd(), &component) {
-                Ok(identity) => identity,
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                    traces.push(format!(
-                        "selector {:?} is absent",
-                        String::from_utf8_lossy(&label)
-                    ));
-                    return Ok(ResolvedSelection::Missing);
-                }
-                Err(error) => {
-                    return Err(error).with_context(|| {
-                        format!(
-                            "resolve selector {:?}",
-                            String::from_utf8_lossy(&selection.path)
-                        )
-                    });
-                }
-            };
-
-            let final_component = components.is_empty();
-            if identity.is_symlink() {
-                if !self.follow {
-                    if !final_component {
-                        bail!(
-                            "selector {:?} encounters symlink component {:?}; pass --follow to resolve symlinks",
-                            String::from_utf8_lossy(&selection.path),
-                            String::from_utf8_lossy(&component)
-                        );
-                    }
-                    require_kind(selection.kind, identity, &label)?;
-                    traces.push(format!(
-                        "selector {:?} resolved to symlink {}:{}",
-                        String::from_utf8_lossy(&label),
-                        identity.dev,
-                        identity.ino
-                    ));
-                    return Ok(ResolvedSelection::Leaf(PinnedLeaf {
-                        name: PinnedName {
-                            parent: PinnedParent::File(
-                                current
-                                    .directory
-                                    .try_clone()
-                                    .context("pin selected symlink parent")?,
-                            ),
-                            name: component_cstring(&component)?,
-                            identity,
-                        },
-                        // Linux can hold an O_PATH descriptor for a symlink,
-                        // but macOS has no corresponding portable open mode.
-                        // The pinned parent/name plus identity check is the
-                        // same mechanism used for symlinks found in a tree.
-                        _object: None,
-                        label,
-                    }));
-                }
-                symlinks += 1;
-                if symlinks > SYMLINK_LIMIT {
-                    bail!(
-                        "too many symlinks while resolving selector {:?}",
-                        String::from_utf8_lossy(&selection.path)
-                    );
-                }
-                let target = read_link_at(current.directory.as_raw_fd(), &component)?;
-                traces.push(format!(
-                    "selector {:?}: symlink {:?} -> {:?}",
-                    String::from_utf8_lossy(&selection.path),
-                    String::from_utf8_lossy(&component),
-                    String::from_utf8_lossy(&target)
-                ));
-                if target.starts_with(b"/") {
-                    if self.confined {
-                        bail!(
-                            "selector {:?} has an absolute symlink target outside --root",
-                            String::from_utf8_lossy(&selection.path)
-                        );
-                    }
-                    stack = vec![Cursor {
-                        directory: open_start(true)?,
-                        anchor: None,
-                    }];
-                }
-                let mut target_components = path_components(&target);
-                target_components.append(&mut components);
-                components = target_components;
-                continue;
-            }
-
-            if identity.is_dir() {
-                let directory = open_directory_at(&current.directory, &component)
-                    .with_context(|| format!("open directory component {:?}", bytes(&component)))?;
-                require_same_identity(identity, identity_from_file(&directory)?, "directory")?;
-                let anchor = PinnedName {
-                    parent: PinnedParent::File(
-                        current
-                            .directory
-                            .try_clone()
-                            .context("pin selected directory parent")?,
-                    ),
-                    name: component_cstring(&component)?,
-                    identity,
-                };
-                if final_component {
-                    require_kind(selection.kind, identity, &label)?;
-                    traces.push(format!(
-                        "selector {:?} resolved to directory {}:{}",
-                        String::from_utf8_lossy(&label),
-                        identity.dev,
-                        identity.ino
-                    ));
-                    return Ok(ResolvedSelection::Directory(PinnedDirectory {
-                        directory,
-                        name: Some(anchor),
-                        label,
-                        remove_root: selection.kind != NativeRemoveKind::Contents,
-                    }));
-                }
-                stack.push(Cursor {
-                    directory,
-                    anchor: Some(anchor),
-                });
-                continue;
-            }
-
-            if !final_component {
-                bail!(
-                    "non-directory component {:?} in selector {:?}",
-                    String::from_utf8_lossy(&component),
-                    String::from_utf8_lossy(&selection.path)
-                );
-            }
-            require_kind(selection.kind, identity, &label)?;
-            let object = open_metadata_at(current.directory.as_raw_fd(), &component)
-                .with_context(|| format!("pin selector {:?}", bytes(&label)))?;
-            require_same_identity(identity, identity_from_file(&object)?, "object")?;
-            traces.push(format!(
-                "selector {:?} resolved to non-directory {}:{}",
-                String::from_utf8_lossy(&label),
-                identity.dev,
-                identity.ino
-            ));
-            return Ok(ResolvedSelection::Leaf(PinnedLeaf {
-                name: PinnedName {
-                    parent: PinnedParent::File(
-                        current
-                            .directory
-                            .try_clone()
-                            .context("pin selected object parent")?,
-                    ),
-                    name: component_cstring(&component)?,
-                    identity,
-                },
-                _object: Some(object),
-                label,
-            }));
         }
+    }
+}
+
+fn append_selector_hops(path: &[u8], hops: &[OperatorSymlinkHop], traces: &mut Vec<String>) {
+    for hop in hops {
+        traces.push(format!(
+            "selector {:?}: symlink {:?} -> {:?}",
+            String::from_utf8_lossy(path),
+            String::from_utf8_lossy(&hop.component),
+            String::from_utf8_lossy(&hop.target)
+        ));
+    }
+}
+
+fn pinned_name_from_root(leaf: RootedPinnedLeaf) -> (PinnedName, Option<File>) {
+    let (parent, name, metadata, object) = leaf.into_parts();
+    (
+        PinnedName {
+            parent: PinnedParent::File(parent),
+            name,
+            identity: identity_from_root(metadata),
+        },
+        object,
+    )
+}
+
+fn identity_from_root(metadata: RootMetadata) -> Identity {
+    Identity {
+        dev: metadata.dev,
+        ino: metadata.ino,
+        file_type: metadata.file_type(),
     }
 }
 
@@ -404,7 +304,7 @@ fn open_base(
         ));
         return Ok((directory, false));
     }
-    let directory = open_start(false)?;
+    let directory = resolve_base_path(b".", false, "endpoint working directory", traces)?;
     let identity = identity_from_file(&directory)?;
     traces.push(format!(
         "endpoint working directory pinned as {}:{}",
@@ -425,80 +325,31 @@ fn resolve_base_path(
     if path.contains(&0) {
         bail!("{option} contains NUL");
     }
-    let mut components = path_components(path);
-    let mut stack = vec![Cursor {
-        directory: open_start(path.starts_with(b"/"))?,
-        anchor: None,
-    }];
-    let mut symlinks = 0usize;
-    while let Some(component) = components.pop_front() {
-        if component == b"." {
-            continue;
-        }
-        if component == b".." {
-            if stack.len() > 1 {
-                stack.pop();
-            } else {
-                let parent = open_directory_at(&stack[0].directory, b"..")
-                    .with_context(|| format!("resolve {option} parent"))?;
-                stack[0] = Cursor {
-                    directory: parent,
-                    anchor: None,
-                };
-            }
-            continue;
-        }
-        let current = stack.last().expect("base resolver stack is nonempty");
-        let identity = metadata_at(current.directory.as_raw_fd(), &component)
-            .with_context(|| format!("resolve {option} {:?}", bytes(path)))?;
-        if identity.is_symlink() {
-            if !follow {
-                bail!(
-                    "{option} {:?} encounters symlink component {:?}; pass --follow to resolve symlinks",
-                    String::from_utf8_lossy(path),
-                    String::from_utf8_lossy(&component)
-                );
-            }
-            symlinks += 1;
-            if symlinks > SYMLINK_LIMIT {
-                bail!(
-                    "too many symlinks while resolving {option} {:?}",
-                    bytes(path)
-                );
-            }
-            let target = read_link_at(current.directory.as_raw_fd(), &component)?;
-            traces.push(format!(
-                "{option} {:?}: symlink {:?} -> {:?}",
-                String::from_utf8_lossy(path),
-                String::from_utf8_lossy(&component),
-                String::from_utf8_lossy(&target)
-            ));
-            if target.starts_with(b"/") {
-                stack = vec![Cursor {
-                    directory: open_start(true)?,
-                    anchor: None,
-                }];
-            }
-            let mut target_components = path_components(&target);
-            target_components.append(&mut components);
-            components = target_components;
-            continue;
-        }
-        if !identity.is_dir() {
-            bail!("{option} {:?} is not a directory", bytes(path));
-        }
-        let directory = open_directory_at(&current.directory, &component)
-            .with_context(|| format!("open {option} component {:?}", bytes(&component)))?;
-        require_same_identity(identity, identity_from_file(&directory)?, "base directory")?;
-        stack.push(Cursor {
-            directory,
-            anchor: None,
-        });
+    let mut hops = Vec::new();
+    let selected = OperatorResolver::resolve_process(
+        path,
+        if follow {
+            OperatorSymlinkPolicy::FollowAll
+        } else {
+            OperatorSymlinkPolicy::Refuse
+        },
+        OperatorFinalComponent::Directory,
+        false,
+        &mut hops,
+    );
+    for hop in &hops {
+        traces.push(format!(
+            "{option} {:?}: symlink {:?} -> {:?}",
+            String::from_utf8_lossy(path),
+            String::from_utf8_lossy(&hop.component),
+            String::from_utf8_lossy(&hop.target)
+        ));
     }
-    stack
-        .pop()
-        .map(|cursor| cursor.directory)
-        .context("base path did not resolve to a directory")
+    let selected = selected.with_context(|| format!("resolve {option} {:?}", bytes(path)))?;
+    let PinnedPath::Directory(directory) = selected else {
+        bail!("{option} {:?} is not a directory", bytes(path));
+    };
+    Ok(directory.into_parts().0)
 }
 
 struct DirectoryJob {
@@ -603,11 +454,7 @@ pub(crate) fn remove(
 ) -> Result<()> {
     let mut traces = Vec::new();
     let (base, confined) = open_base(cwd, root, follow_symlinks, &mut traces)?;
-    let resolver = Resolver {
-        base,
-        confined,
-        follow: follow_symlinks,
-    };
+    let resolver = Resolver::new(&base, confined, follow_symlinks)?;
 
     // This phase is deliberately complete before the worker pool starts: a
     // later selector can never acquire a new meaning because an earlier one
@@ -929,26 +776,6 @@ fn remove_pinned(name: &PinnedName, directory: bool) -> Result<()> {
         .context("remove pinned object")
 }
 
-fn duplicate_name(name: &PinnedName) -> Result<PinnedName> {
-    Ok(PinnedName {
-        parent: match &name.parent {
-            PinnedParent::File(file) => {
-                PinnedParent::File(file.try_clone().context("duplicate pinned parent")?)
-            }
-            PinnedParent::Directory(job) => PinnedParent::Directory(job.clone()),
-        },
-        name: name.name.clone(),
-        identity: name.identity,
-    })
-}
-
-fn path_components(path: &[u8]) -> VecDeque<Vec<u8>> {
-    path.split(|byte| *byte == b'/')
-        .filter(|component| !component.is_empty())
-        .map(<[u8]>::to_vec)
-        .collect()
-}
-
 fn join_label(parent: &[u8], child: &[u8]) -> PathBytes {
     let mut path = parent.to_vec();
     if !path.is_empty() && !path.ends_with(b"/") {
@@ -960,15 +787,6 @@ fn join_label(parent: &[u8], child: &[u8]) -> PathBytes {
 
 fn bytes(path: &[u8]) -> String {
     String::from_utf8_lossy(path).into_owned()
-}
-
-fn open_start(root: bool) -> Result<File> {
-    let path = if root { Path::new("/") } else { Path::new(".") };
-    OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOCTTY | libc::O_CLOEXEC)
-        .open(path)
-        .with_context(|| format!("open removal base {}", path.display()))
 }
 
 fn component_cstring(component: &[u8]) -> Result<CString> {
@@ -988,19 +806,6 @@ fn open_directory_at(parent: &File, component: &[u8]) -> io::Result<File> {
             | libc::O_NOCTTY
             | libc::O_CLOEXEC,
     )
-}
-
-fn open_metadata_at(parent: RawFd, component: &[u8]) -> io::Result<File> {
-    let component = CString::new(component)
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path component contains NUL"))?;
-    #[cfg(target_os = "linux")]
-    let flags = libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC;
-    #[cfg(target_os = "macos")]
-    let flags = libc::O_EVTONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    let flags =
-        libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_NOCTTY | libc::O_CLOEXEC;
-    open_at(parent, &component, flags)
 }
 
 fn open_at(parent: RawFd, name: &CString, flags: libc::c_int) -> io::Result<File> {
@@ -1083,38 +888,6 @@ fn require_same_identity(expected: Identity, actual: Identity, what: &str) -> Re
         );
     }
     Ok(())
-}
-
-fn read_link_at(parent: RawFd, component: &[u8]) -> Result<Vec<u8>> {
-    let component = component_cstring(component)?;
-    let mut buffer = vec![0u8; 256];
-    loop {
-        let read = loop {
-            let result = unsafe {
-                libc::readlinkat(
-                    parent,
-                    component.as_ptr(),
-                    buffer.as_mut_ptr().cast(),
-                    buffer.len(),
-                )
-            };
-            if result >= 0 {
-                break result as usize;
-            }
-            let error = io::Error::last_os_error();
-            if error.kind() != io::ErrorKind::Interrupted {
-                return Err(error).context("read selector symlink");
-            }
-        };
-        if read < buffer.len() {
-            buffer.truncate(read);
-            return Ok(buffer);
-        }
-        if buffer.len() >= 1024 * 1024 {
-            bail!("symlink target exceeds size limit");
-        }
-        buffer.resize(buffer.len() * 2, 0);
-    }
 }
 
 struct DirectoryStream(*mut libc::DIR);
@@ -1218,9 +991,9 @@ fn get_errno() -> libc::c_int {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::fs::{self, OpenOptions};
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::symlink;
+    use std::os::unix::fs::{symlink, OpenOptionsExt};
 
     fn selector(path: &[u8], kind: NativeRemoveKind) -> NativeRemoveSelection {
         NativeRemoveSelection {

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -23,7 +23,9 @@
 //! descriptor-based traversal, an already-open descendant remains the selected
 //! object if another process subsequently renames it.
 
+use crate::proto::OperatorSymlinkPolicy;
 use anyhow::{bail, Context, Result};
+use std::collections::VecDeque;
 use std::ffi::CString;
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -63,7 +65,7 @@ pub(crate) struct RootIdentity {
     pub(crate) ino: u64,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RootMetadata {
     pub(crate) dev: u64,
     pub(crate) ino: u64,
@@ -77,6 +79,350 @@ pub(crate) struct RootMetadata {
     pub(crate) uid: u32,
     pub(crate) gid: u32,
     pub(crate) rdev: u64,
+}
+
+/// Whether resolution needs to traverse the last component as a directory or
+/// select it as a named entry. Selecting an entry may independently request
+/// that a last-component symlink be followed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OperatorFinalComponent {
+    Directory,
+    Entry { follow_symlink: bool },
+}
+
+/// One symlink hop taken while resolving an operator path. Callers use this
+/// only for diagnostics; authority is carried by the returned descriptors.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OperatorSymlinkHop {
+    pub(crate) component: Vec<u8>,
+    pub(crate) target: Vec<u8>,
+}
+
+/// An existing named entry selected relative to its retained parent. `object`
+/// pins a non-directory object where the platform can open it without
+/// following; a selected symlink may have only its parent, name, and observed
+/// identity. Directories are pinned separately by `PinnedDirectory`.
+pub(crate) struct PinnedLeaf {
+    parent: File,
+    name: CString,
+    metadata: RootMetadata,
+    object: Option<File>,
+}
+
+impl PinnedLeaf {
+    fn try_clone(&self) -> Result<Self> {
+        Ok(Self {
+            parent: self.parent.try_clone().context("duplicate pinned parent")?,
+            name: self.name.clone(),
+            metadata: self.metadata,
+            object: self
+                .object
+                .as_ref()
+                .map(|object| object.try_clone())
+                .transpose()
+                .context("duplicate pinned object")?,
+        })
+    }
+
+    pub(crate) fn metadata(&self) -> RootMetadata {
+        self.metadata
+    }
+
+    pub(crate) fn into_parts(self) -> (File, CString, RootMetadata, Option<File>) {
+        (self.parent, self.name, self.metadata, self.object)
+    }
+}
+
+/// An existing selected directory. `entry` retains the parent/name used to
+/// select it when the directory itself may later need to be renamed or
+/// removed; it is absent when resolution ends at the resolver's base.
+pub(crate) struct PinnedDirectory {
+    directory: File,
+    entry: Option<PinnedLeaf>,
+    metadata: RootMetadata,
+}
+
+impl PinnedDirectory {
+    pub(crate) fn metadata(&self) -> RootMetadata {
+        self.metadata
+    }
+
+    pub(crate) fn into_parts(self) -> (File, Option<PinnedLeaf>) {
+        (self.directory, self.entry)
+    }
+}
+
+/// The nearest retained existing directory and the unresolved suffix beneath
+/// it. Creation remains a caller policy; this type supplies only authority.
+pub(crate) struct PinnedMissing {
+    directory: File,
+    components: VecDeque<Vec<u8>>,
+}
+
+impl PinnedMissing {
+    pub(crate) fn into_parts(self) -> (File, VecDeque<Vec<u8>>) {
+        (self.directory, self.components)
+    }
+}
+
+pub(crate) enum PinnedPath {
+    Missing(PinnedMissing),
+    Leaf(PinnedLeaf),
+    Directory(PinnedDirectory),
+}
+
+struct OperatorCursor {
+    directory: File,
+    entry: Option<PinnedLeaf>,
+}
+
+/// Descriptor-retaining component resolver for paths supplied directly by an
+/// operator. Descendant transfer paths use `RelativePath` and `Root` instead.
+pub(crate) struct OperatorResolver {
+    base: File,
+    confined: bool,
+    relative_input: bool,
+    symlink_policy: OperatorSymlinkPolicy,
+}
+
+impl OperatorResolver {
+    /// Begin at the process root or cwd. Absolute symlink targets may restart
+    /// at `/` because this form is not confined beneath a caller-provided base.
+    pub(crate) fn resolve_process(
+        path: &[u8],
+        symlink_policy: OperatorSymlinkPolicy,
+        final_component: OperatorFinalComponent,
+        allow_missing: bool,
+        hops: &mut Vec<OperatorSymlinkHop>,
+    ) -> Result<PinnedPath> {
+        Self {
+            base: open_operator_start(path.starts_with(b"/"))?,
+            confined: false,
+            relative_input: false,
+            symlink_policy,
+        }
+        .resolve(path, final_component, allow_missing, hops)
+    }
+
+    /// Begin at an already-open directory. The supplied path must be relative;
+    /// a confined resolver also refuses `..` and symlink targets that would
+    /// escape that directory.
+    pub(crate) fn beneath(
+        base: &File,
+        confined: bool,
+        symlink_policy: OperatorSymlinkPolicy,
+    ) -> Result<Self> {
+        Ok(Self {
+            base: base.try_clone().context("duplicate operator path base")?,
+            confined,
+            relative_input: true,
+            symlink_policy,
+        })
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        path: &[u8],
+        final_component: OperatorFinalComponent,
+        allow_missing: bool,
+        hops: &mut Vec<OperatorSymlinkHop>,
+    ) -> Result<PinnedPath> {
+        if path.contains(&0) {
+            bail!("operator path contains NUL");
+        }
+        if self.relative_input && path.starts_with(b"/") {
+            bail!("path beneath an opened operator base must be relative");
+        }
+        let mut components = operator_components(path);
+        let mut stack = vec![OperatorCursor {
+            directory: self
+                .base
+                .try_clone()
+                .context("duplicate operator path base")?,
+            entry: None,
+        }];
+        let mut symlink_count = 0usize;
+
+        loop {
+            let Some(component) = components.pop_front() else {
+                let current = stack.last().expect("operator resolver stack is nonempty");
+                let metadata = root_metadata_from_std(&current.directory.metadata()?)?;
+                return Ok(PinnedPath::Directory(PinnedDirectory {
+                    directory: current
+                        .directory
+                        .try_clone()
+                        .context("pin selected directory")?,
+                    entry: current
+                        .entry
+                        .as_ref()
+                        .map(PinnedLeaf::try_clone)
+                        .transpose()?,
+                    metadata,
+                }));
+            };
+
+            if component == b"." {
+                continue;
+            }
+            if component == b".." {
+                if stack.len() > 1 {
+                    stack.pop();
+                } else if self.confined {
+                    bail!("operator path resolves outside its confined root");
+                } else {
+                    stack[0] = OperatorCursor {
+                        directory: open_operator_directory_at(&stack[0].directory, b"..")
+                            .context("resolve operator path parent")?,
+                        entry: None,
+                    };
+                }
+                continue;
+            }
+
+            let current = stack.last().expect("operator resolver stack is nonempty");
+            let name = operator_component_cstring(&component)?;
+            let metadata = match metadata_at(current.directory.as_raw_fd(), &name) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == io::ErrorKind::NotFound && allow_missing => {
+                    components.push_front(component);
+                    return Ok(PinnedPath::Missing(PinnedMissing {
+                        directory: current
+                            .directory
+                            .try_clone()
+                            .context("pin nearest existing directory")?,
+                        components,
+                    }));
+                }
+                Err(error) => return Err(error).context("inspect operator path component"),
+            };
+            let final_name = components.is_empty();
+            let follow_symlink = !final_name
+                || matches!(final_component, OperatorFinalComponent::Directory)
+                || matches!(
+                    final_component,
+                    OperatorFinalComponent::Entry {
+                        follow_symlink: true
+                    }
+                );
+
+            if metadata.is_symlink() {
+                if !follow_symlink {
+                    let object = open_operator_symlink_at(current.directory.as_raw_fd(), &name)?;
+                    if let Some(object) = &object {
+                        require_operator_identity(
+                            metadata,
+                            root_metadata_from_std(&object.metadata()?)?,
+                            "operator symlink",
+                        )?;
+                    }
+                    return Ok(PinnedPath::Leaf(PinnedLeaf {
+                        parent: current
+                            .directory
+                            .try_clone()
+                            .context("pin selected symlink parent")?,
+                        name,
+                        metadata,
+                        object,
+                    }));
+                }
+                self.authorize_symlink(metadata, &component)?;
+                symlink_count += 1;
+                if symlink_count > 40 {
+                    bail!("too many symlink levels in operator path");
+                }
+                let target = operator_read_link_at(current.directory.as_raw_fd(), &name)?;
+                hops.push(OperatorSymlinkHop {
+                    component,
+                    target: target.clone(),
+                });
+                if target.starts_with(b"/") {
+                    if self.confined {
+                        bail!("operator path has an absolute symlink target outside its root");
+                    }
+                    stack = vec![OperatorCursor {
+                        directory: open_operator_start(true)?,
+                        entry: None,
+                    }];
+                }
+                let mut target_components = operator_components(&target);
+                target_components.append(&mut components);
+                components = target_components;
+                continue;
+            }
+
+            if metadata.is_dir() {
+                let directory = open_operator_directory_at(&current.directory, &component)
+                    .context("open operator directory component")?;
+                require_operator_identity(
+                    metadata,
+                    root_metadata_from_std(&directory.metadata()?)?,
+                    "operator directory",
+                )?;
+                let entry = PinnedLeaf {
+                    parent: current
+                        .directory
+                        .try_clone()
+                        .context("pin selected directory parent")?,
+                    name,
+                    metadata,
+                    object: None,
+                };
+                if final_name {
+                    return Ok(PinnedPath::Directory(PinnedDirectory {
+                        directory,
+                        entry: Some(entry),
+                        metadata,
+                    }));
+                }
+                stack.push(OperatorCursor {
+                    directory,
+                    entry: Some(entry),
+                });
+                continue;
+            }
+
+            if !final_name || matches!(final_component, OperatorFinalComponent::Directory) {
+                return Err(io::Error::from_raw_os_error(libc::ENOTDIR).into());
+            }
+            let object = open_operator_metadata_at(current.directory.as_raw_fd(), &name)
+                .context("pin operator path leaf")?;
+            require_operator_identity(
+                metadata,
+                root_metadata_from_std(&object.metadata()?)?,
+                "operator leaf",
+            )?;
+            return Ok(PinnedPath::Leaf(PinnedLeaf {
+                parent: current
+                    .directory
+                    .try_clone()
+                    .context("pin selected object parent")?,
+                name,
+                metadata,
+                object: Some(object),
+            }));
+        }
+    }
+
+    fn authorize_symlink(&self, metadata: RootMetadata, component: &[u8]) -> Result<()> {
+        let euid = unsafe { libc::geteuid() };
+        match self.symlink_policy {
+            OperatorSymlinkPolicy::Refuse => bail!(
+                "refusing symlink component {:?} in operator path; pass --follow to resolve symlinks",
+                String::from_utf8_lossy(component)
+            ),
+            OperatorSymlinkPolicy::TrustedOwner
+                if !operator_symlink_owner_is_trusted(metadata.uid, euid) =>
+            {
+                bail!(
+                    "refusing symlink component {:?} owned by uid {}; expected uid 0 or receiver uid {}",
+                    String::from_utf8_lossy(component),
+                    metadata.uid,
+                    euid
+                )
+            }
+            OperatorSymlinkPolicy::TrustedOwner | OperatorSymlinkPolicy::FollowAll => Ok(()),
+        }
+    }
 }
 
 impl RootMetadata {
@@ -428,19 +774,6 @@ impl Root {
         .with_context(|| format!("create confined node {}", path.label()))
     }
 
-    pub(crate) fn chmod(&self, path: &RelativePath, mode: u32) -> Result<()> {
-        let parent = self.resolve_parent(path)?;
-        retry_zero(|| unsafe {
-            libc::fchmodat(
-                parent.directory.as_raw_fd(),
-                parent.leaf.as_ptr(),
-                (mode & 0o7777) as libc::mode_t,
-                0,
-            )
-        })
-        .with_context(|| format!("chmod confined path {}", path.label()))
-    }
-
     pub(crate) fn chown(
         &self,
         path: &RelativePath,
@@ -734,6 +1067,133 @@ struct ResolvedParent {
 
 fn component_cstring(component: &[u8]) -> CString {
     CString::new(component).expect("RelativePath already rejected NUL")
+}
+
+fn operator_components(path: &[u8]) -> VecDeque<Vec<u8>> {
+    path.split(|byte| *byte == b'/')
+        .filter(|component| !component.is_empty())
+        .map(<[u8]>::to_vec)
+        .collect()
+}
+
+fn operator_component_cstring(component: &[u8]) -> Result<CString> {
+    CString::new(component).context("operator path component contains NUL")
+}
+
+fn operator_directory_flags() -> libc::c_int {
+    #[cfg(target_os = "linux")]
+    {
+        libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
+    }
+}
+
+fn open_operator_start(absolute: bool) -> Result<File> {
+    let name = CString::new(if absolute { "/" } else { "." })
+        .expect("fixed operator start contains no NUL");
+    open_operator_directory_fd(libc::AT_FDCWD, &name)
+}
+
+fn open_operator_directory_at(parent: &File, component: &[u8]) -> Result<File> {
+    let component = operator_component_cstring(component)?;
+    open_operator_directory_fd(parent.as_raw_fd(), &component)
+}
+
+fn open_operator_directory_fd(parent: RawFd, component: &CString) -> Result<File> {
+    let directory = open_at(parent, component, operator_directory_flags(), 0)?;
+    if !directory.metadata()?.is_dir() {
+        bail!("operator path component is not a directory");
+    }
+    Ok(directory)
+}
+
+fn open_operator_metadata_at(parent: RawFd, name: &CString) -> io::Result<File> {
+    #[cfg(target_os = "linux")]
+    let flags =
+        libc::O_PATH | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_NOCTTY | libc::O_CLOEXEC;
+    #[cfg(target_os = "macos")]
+    let flags =
+        libc::O_EVTONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_NOCTTY | libc::O_CLOEXEC;
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    let flags =
+        libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_NOCTTY | libc::O_CLOEXEC;
+    open_at(parent, name, flags, 0)
+}
+
+fn open_operator_symlink_at(parent: RawFd, name: &CString) -> Result<Option<File>> {
+    #[cfg(target_os = "linux")]
+    {
+        open_at(
+            parent,
+            name,
+            libc::O_PATH | libc::O_NOFOLLOW | libc::O_NOCTTY | libc::O_CLOEXEC,
+            0,
+        )
+        .map(Some)
+        .context("pin operator symlink")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        open_at(
+            parent,
+            name,
+            libc::O_SYMLINK | libc::O_NONBLOCK | libc::O_NOCTTY | libc::O_CLOEXEC,
+            0,
+        )
+        .map(Some)
+        .context("pin operator symlink")
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = (parent, name);
+        Ok(None)
+    }
+}
+
+fn operator_read_link_at(parent: RawFd, name: &CString) -> Result<Vec<u8>> {
+    let mut capacity = 256usize;
+    loop {
+        let mut target = Vec::<u8>::with_capacity(capacity);
+        let length = unsafe {
+            libc::readlinkat(parent, name.as_ptr(), target.as_mut_ptr().cast(), capacity)
+        };
+        if length < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error).context("read operator symlink");
+        }
+        let length = length as usize;
+        if length < capacity {
+            unsafe { target.set_len(length) };
+            return Ok(target);
+        }
+        capacity = capacity
+            .checked_mul(2)
+            .filter(|next| *next <= libc::PATH_MAX as usize * 2)
+            .context("operator symlink target is too long")?;
+    }
+}
+
+fn require_operator_identity(
+    expected: RootMetadata,
+    actual: RootMetadata,
+    label: &str,
+) -> Result<()> {
+    if (actual.dev, actual.ino, actual.file_type())
+        != (expected.dev, expected.ino, expected.file_type())
+    {
+        bail!("{label} changed identity during resolution");
+    }
+    Ok(())
+}
+
+fn operator_symlink_owner_is_trusted(owner: u32, euid: u32) -> bool {
+    owner == 0 || owner == euid
 }
 
 fn open_directory_at(parent: &File, component: &[u8]) -> io::Result<File> {
@@ -1047,6 +1507,211 @@ mod tests {
 
     fn relative(path: &[u8]) -> RelativePath {
         RelativePath::new(path).unwrap()
+    }
+
+    fn operator_path(path: &Path) -> Vec<u8> {
+        path.as_os_str().as_bytes().to_vec()
+    }
+
+    #[test]
+    fn operator_resolver_selects_a_last_component_symlink_without_following_it() {
+        let tree = TestDir::new("operator-leaf-link");
+        let outside = tree.path().join("outside");
+        fs::write(&outside, b"outside").unwrap();
+        let selected = tree.path().join("selected");
+        symlink(&outside, &selected).unwrap();
+        let original = fs::symlink_metadata(&selected).unwrap();
+
+        let mut hops = Vec::new();
+        let result = OperatorResolver::resolve_process(
+            &operator_path(&selected),
+            OperatorSymlinkPolicy::Refuse,
+            OperatorFinalComponent::Entry {
+                follow_symlink: false,
+            },
+            false,
+            &mut hops,
+        )
+        .unwrap();
+        let PinnedPath::Leaf(leaf) = result else {
+            panic!("last-component symlink was not selected as a leaf");
+        };
+        assert!(leaf.metadata().is_symlink());
+        let (_, name, _, object) = leaf.into_parts();
+        assert_eq!(name.as_bytes(), b"selected");
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            let object = object.expect("supported platform should pin the symlink object");
+            fs::rename(&selected, tree.path().join("moved")).unwrap();
+            symlink("replacement", &selected).unwrap();
+            let pinned = object.metadata().unwrap();
+            let replacement = fs::symlink_metadata(&selected).unwrap();
+            assert_eq!(
+                (pinned.dev(), pinned.ino()),
+                (original.dev(), original.ino())
+            );
+            assert_ne!(
+                (pinned.dev(), pinned.ino()),
+                (replacement.dev(), replacement.ino())
+            );
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        assert!(object.is_none());
+        assert!(hops.is_empty());
+        assert_eq!(fs::read(&outside).unwrap(), b"outside");
+    }
+
+    #[test]
+    fn operator_resolver_follows_only_components_requested_by_the_caller() {
+        let tree = TestDir::new("operator-follow");
+        let real = tree.path().join("real");
+        fs::create_dir(&real).unwrap();
+        let outside = tree.path().join("outside");
+        fs::write(&outside, b"outside").unwrap();
+        symlink("real", tree.path().join("container")).unwrap();
+        symlink(&outside, real.join("leaf")).unwrap();
+        let selected = tree.path().join("container/leaf");
+
+        let mut hops = Vec::new();
+        assert!(OperatorResolver::resolve_process(
+            &operator_path(&selected),
+            OperatorSymlinkPolicy::Refuse,
+            OperatorFinalComponent::Entry {
+                follow_symlink: false,
+            },
+            false,
+            &mut hops,
+        )
+        .is_err());
+
+        let result = OperatorResolver::resolve_process(
+            &operator_path(&selected),
+            OperatorSymlinkPolicy::FollowAll,
+            OperatorFinalComponent::Entry {
+                follow_symlink: false,
+            },
+            false,
+            &mut hops,
+        )
+        .unwrap();
+        let PinnedPath::Leaf(leaf) = result else {
+            panic!("last-component symlink was unexpectedly followed");
+        };
+        assert!(leaf.metadata().is_symlink());
+        assert_eq!(hops.len(), 1);
+        assert_eq!(hops[0].component, b"container");
+        assert_eq!(hops[0].target, b"real");
+    }
+
+    #[test]
+    fn operator_resolver_reports_the_missing_suffix_from_a_retained_parent() {
+        let tree = TestDir::new("operator-missing");
+        let base = File::open(tree.path()).unwrap();
+        let resolver =
+            OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::Refuse).unwrap();
+        let mut hops = Vec::new();
+        let result = resolver
+            .resolve(
+                b"new/nested",
+                OperatorFinalComponent::Directory,
+                true,
+                &mut hops,
+            )
+            .unwrap();
+        let PinnedPath::Missing(missing) = result else {
+            panic!("missing suffix was not returned");
+        };
+        let (directory, components) = missing.into_parts();
+        let metadata = directory.metadata().unwrap();
+        let expected = fs::metadata(tree.path()).unwrap();
+        assert_eq!(
+            (metadata.dev(), metadata.ino()),
+            (expected.dev(), expected.ino())
+        );
+        assert_eq!(
+            components,
+            VecDeque::from([b"new".to_vec(), b"nested".to_vec()])
+        );
+        assert!(hops.is_empty());
+    }
+
+    #[test]
+    fn operator_symlink_trust_is_root_or_receiver_ownership() {
+        assert!(operator_symlink_owner_is_trusted(0, 1000));
+        assert!(operator_symlink_owner_is_trusted(1000, 1000));
+        assert!(!operator_symlink_owner_is_trusted(1001, 1000));
+        assert!(!operator_symlink_owner_is_trusted(1000, 0));
+    }
+
+    #[test]
+    fn confined_operator_resolver_rejects_relative_and_absolute_link_escapes() {
+        let tree = TestDir::new("operator-confined");
+        let base_path = tree.path().join("base");
+        let outside = tree.path().join("outside");
+        fs::create_dir(&base_path).unwrap();
+        fs::create_dir(&outside).unwrap();
+        symlink("../outside", base_path.join("relative")).unwrap();
+        symlink(&outside, base_path.join("absolute")).unwrap();
+        let base = File::open(&base_path).unwrap();
+        let resolver =
+            OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::FollowAll).unwrap();
+
+        let mut hops = Vec::new();
+        assert!(resolver
+            .resolve(
+                b"/absolute-input",
+                OperatorFinalComponent::Directory,
+                false,
+                &mut hops,
+            )
+            .is_err());
+
+        for selected in [&b"relative"[..], &b"absolute"[..]] {
+            let mut hops = Vec::new();
+            assert!(resolver
+                .resolve(
+                    selected,
+                    OperatorFinalComponent::Directory,
+                    false,
+                    &mut hops,
+                )
+                .is_err());
+        }
+    }
+
+    #[test]
+    fn selected_operator_directory_remains_pinned_after_rename() {
+        let tree = TestDir::new("operator-directory-pin");
+        let selected = tree.path().join("selected");
+        fs::create_dir(&selected).unwrap();
+        let original = fs::metadata(&selected).unwrap();
+        let mut hops = Vec::new();
+        let result = OperatorResolver::resolve_process(
+            &operator_path(&selected),
+            OperatorSymlinkPolicy::Refuse,
+            OperatorFinalComponent::Directory,
+            false,
+            &mut hops,
+        )
+        .unwrap();
+        let PinnedPath::Directory(directory) = result else {
+            panic!("directory was not selected");
+        };
+
+        fs::rename(&selected, tree.path().join("moved")).unwrap();
+        fs::create_dir(&selected).unwrap();
+        let replacement = fs::metadata(&selected).unwrap();
+        let (directory, entry) = directory.into_parts();
+        let pinned = directory.metadata().unwrap();
+        assert_eq!(
+            (pinned.dev(), pinned.ino()),
+            (original.dev(), original.ino())
+        );
+        assert_ne!(
+            (pinned.dev(), pinned.ino()),
+            (replacement.dev(), replacement.ino())
+        );
+        assert!(entry.is_some());
     }
 
     #[test]

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -1509,10 +1509,6 @@ mod tests {
         RelativePath::new(path).unwrap()
     }
 
-    fn operator_path(path: &Path) -> Vec<u8> {
-        path.as_os_str().as_bytes().to_vec()
-    }
-
     #[test]
     fn operator_resolver_selects_a_last_component_symlink_without_following_it() {
         let tree = TestDir::new("operator-leaf-link");
@@ -1522,17 +1518,20 @@ mod tests {
         symlink(&outside, &selected).unwrap();
         let original = fs::symlink_metadata(&selected).unwrap();
 
+        let base = File::open(tree.path()).unwrap();
+        let resolver =
+            OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::Refuse).unwrap();
         let mut hops = Vec::new();
-        let result = OperatorResolver::resolve_process(
-            &operator_path(&selected),
-            OperatorSymlinkPolicy::Refuse,
-            OperatorFinalComponent::Entry {
-                follow_symlink: false,
-            },
-            false,
-            &mut hops,
-        )
-        .unwrap();
+        let result = resolver
+            .resolve(
+                b"selected",
+                OperatorFinalComponent::Entry {
+                    follow_symlink: false,
+                },
+                false,
+                &mut hops,
+            )
+            .unwrap();
         let PinnedPath::Leaf(leaf) = result else {
             panic!("last-component symlink was not selected as a leaf");
         };
@@ -1570,30 +1569,34 @@ mod tests {
         fs::write(&outside, b"outside").unwrap();
         symlink("real", tree.path().join("container")).unwrap();
         symlink(&outside, real.join("leaf")).unwrap();
-        let selected = tree.path().join("container/leaf");
+        let base = File::open(tree.path()).unwrap();
 
         let mut hops = Vec::new();
-        assert!(OperatorResolver::resolve_process(
-            &operator_path(&selected),
-            OperatorSymlinkPolicy::Refuse,
-            OperatorFinalComponent::Entry {
-                follow_symlink: false,
-            },
-            false,
-            &mut hops,
-        )
-        .is_err());
+        let refusing =
+            OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::Refuse).unwrap();
+        assert!(refusing
+            .resolve(
+                b"container/leaf",
+                OperatorFinalComponent::Entry {
+                    follow_symlink: false,
+                },
+                false,
+                &mut hops,
+            )
+            .is_err());
 
-        let result = OperatorResolver::resolve_process(
-            &operator_path(&selected),
-            OperatorSymlinkPolicy::FollowAll,
-            OperatorFinalComponent::Entry {
-                follow_symlink: false,
-            },
-            false,
-            &mut hops,
-        )
-        .unwrap();
+        let following =
+            OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::FollowAll).unwrap();
+        let result = following
+            .resolve(
+                b"container/leaf",
+                OperatorFinalComponent::Entry {
+                    follow_symlink: false,
+                },
+                false,
+                &mut hops,
+            )
+            .unwrap();
         let PinnedPath::Leaf(leaf) = result else {
             panic!("last-component symlink was unexpectedly followed");
         };
@@ -1685,15 +1688,18 @@ mod tests {
         let selected = tree.path().join("selected");
         fs::create_dir(&selected).unwrap();
         let original = fs::metadata(&selected).unwrap();
+        let base = File::open(tree.path()).unwrap();
+        let resolver =
+            OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::Refuse).unwrap();
         let mut hops = Vec::new();
-        let result = OperatorResolver::resolve_process(
-            &operator_path(&selected),
-            OperatorSymlinkPolicy::Refuse,
-            OperatorFinalComponent::Directory,
-            false,
-            &mut hops,
-        )
-        .unwrap();
+        let result = resolver
+            .resolve(
+                b"selected",
+                OperatorFinalComponent::Directory,
+                false,
+                &mut hops,
+            )
+            .unwrap();
         let PinnedPath::Directory(directory) = result else {
             panic!("directory was not selected");
         };

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -110,20 +110,6 @@ pub(crate) struct PinnedLeaf {
 }
 
 impl PinnedLeaf {
-    fn try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            parent: self.parent.try_clone().context("duplicate pinned parent")?,
-            name: self.name.clone(),
-            metadata: self.metadata,
-            object: self
-                .object
-                .as_ref()
-                .map(|object| object.try_clone())
-                .transpose()
-                .context("duplicate pinned object")?,
-        })
-    }
-
     pub(crate) fn metadata(&self) -> RootMetadata {
         self.metadata
     }
@@ -173,7 +159,14 @@ pub(crate) enum PinnedPath {
 
 struct OperatorCursor {
     directory: File,
-    entry: Option<PinnedLeaf>,
+    entry: Option<OperatorEntry>,
+}
+
+/// How the cursor's directory was selected. Intermediate cursors deliberately
+/// omit a parent descriptor; only the final capability retains one.
+struct OperatorEntry {
+    name: CString,
+    metadata: RootMetadata,
 }
 
 /// Descriptor-retaining component resolver for paths supplied directly by an
@@ -247,16 +240,30 @@ impl OperatorResolver {
             let Some(component) = components.pop_front() else {
                 let current = stack.last().expect("operator resolver stack is nonempty");
                 let metadata = root_metadata_from_std(&current.directory.metadata()?)?;
+                let entry = if let Some(entry) = &current.entry {
+                    let parent = &stack
+                        .iter()
+                        .rev()
+                        .nth(1)
+                        .expect("a selected entry has a parent cursor")
+                        .directory;
+                    Some(PinnedLeaf {
+                        parent: parent
+                            .try_clone()
+                            .context("pin selected directory parent")?,
+                        name: entry.name.clone(),
+                        metadata: entry.metadata,
+                        object: None,
+                    })
+                } else {
+                    None
+                };
                 return Ok(PinnedPath::Directory(PinnedDirectory {
                     directory: current
                         .directory
                         .try_clone()
                         .context("pin selected directory")?,
-                    entry: current
-                        .entry
-                        .as_ref()
-                        .map(PinnedLeaf::try_clone)
-                        .transpose()?,
+                    entry,
                     metadata,
                 }));
             };
@@ -358,25 +365,24 @@ impl OperatorResolver {
                     root_metadata_from_std(&directory.metadata()?)?,
                     "operator directory",
                 )?;
-                let entry = PinnedLeaf {
-                    parent: current
-                        .directory
-                        .try_clone()
-                        .context("pin selected directory parent")?,
-                    name,
-                    metadata,
-                    object: None,
-                };
                 if final_name {
                     return Ok(PinnedPath::Directory(PinnedDirectory {
                         directory,
-                        entry: Some(entry),
+                        entry: Some(PinnedLeaf {
+                            parent: current
+                                .directory
+                                .try_clone()
+                                .context("pin selected directory parent")?,
+                            name,
+                            metadata,
+                            object: None,
+                        }),
                         metadata,
                     }));
                 }
                 stack.push(OperatorCursor {
                     directory,
-                    entry: Some(entry),
+                    entry: Some(OperatorEntry { name, metadata }),
                 });
                 continue;
             }
@@ -1478,6 +1484,7 @@ mod tests {
     use std::os::unix::ffi::{OsStrExt, OsStringExt};
     use std::os::unix::fs::{symlink, PermissionsExt};
     use std::path::PathBuf;
+    use std::process::Command;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::Arc;
 
@@ -1694,7 +1701,7 @@ mod tests {
         let mut hops = Vec::new();
         let result = resolver
             .resolve(
-                b"selected",
+                b"selected/.",
                 OperatorFinalComponent::Directory,
                 false,
                 &mut hops,
@@ -1718,6 +1725,58 @@ mod tests {
             (replacement.dev(), replacement.ino())
         );
         assert!(entry.is_some());
+    }
+
+    #[test]
+    fn operator_resolver_handles_deep_path_with_low_fd_limit() {
+        const CHILD_ENV: &str = "SYQ_TEST_OPERATOR_RESOLVER_LOW_FD_CHILD";
+        const TEST_NAME: &str =
+            "rooted::tests::operator_resolver_handles_deep_path_with_low_fd_limit";
+
+        if std::env::var_os(CHILD_ENV).is_none() {
+            let status = Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", TEST_NAME, "--nocapture"])
+                .env(CHILD_ENV, "1")
+                .status()
+                .unwrap();
+            assert!(status.success(), "low-FD resolver subprocess failed");
+            return;
+        }
+
+        let tree = TestDir::new("operator-low-fd");
+        let path = (0..40)
+            .map(|index| format!("component-{index:02}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        fs::create_dir_all(tree.path().join(&path)).unwrap();
+        let base = File::open(tree.path()).unwrap();
+
+        let mut limits: libc::rlimit = unsafe { std::mem::zeroed() };
+        assert_eq!(
+            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) },
+            0
+        );
+        assert!(
+            limits.rlim_max >= 64,
+            "hard file-descriptor limit is below 64"
+        );
+        limits.rlim_cur = 64;
+        assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limits) }, 0);
+
+        let resolver =
+            OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::Refuse).unwrap();
+        let result = resolver
+            .resolve(
+                path.as_bytes(),
+                OperatorFinalComponent::Directory,
+                false,
+                &mut Vec::new(),
+            )
+            .unwrap();
+        let PinnedPath::Directory(directory) = result else {
+            panic!("deep directory was not selected");
+        };
+        assert!(directory.metadata().is_dir());
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- add one descriptor-retaining component resolver for process paths and paths beneath an opened base
- distinguish directory traversal from literal last-component selection and retain existing, leaf, or missing-parent capabilities
- migrate copy destination/control preflight and native rm base/selector walks to the shared resolver
- pin selected symlink objects on Linux and macOS and remove the unsafe unused Root chmod helper

Security boundary:
This is the shared selection foundation, not a claim of complete ordinary-copy containment. Scanner and worker descendant requests still need session root registration and descriptor handoff in follow-up work.

Verification:
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets (258 unit, 288 local integration, 9 updater tests)