### PR TITLE
Prototype exact descriptor handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,12 @@ jobs:
           cargo test --locked
           rooted::tests::operator_resolver_selects_a_last_component_symlink_without_following_it
           -- --exact
+      - name: Exercise macOS cross-process descriptor handoff
+        if: needs.scope.outputs.native == 'true'
+        run: >-
+          cargo test --locked
+          descriptor_broker::tests::independent_process_receives_exact_registered_descriptor
+          -- --exact
       - if: needs.scope.outputs.native == 'true'
         run: scripts/test-installer.sh
       - if: needs.scope.outputs.native == 'true'

--- a/src/agent_broker.rs
+++ b/src/agent_broker.rs
@@ -7,23 +7,28 @@
 //! userauth request binds each signature to the destination host key and login
 //! user.
 
+use crate::private_broker::{
+    ConnectionRegistry, PrivateBroker, PrivateBrokerConfig, TrackedStream,
+};
 use anyhow::{anyhow, bail, Context, Result};
 use signature::{Signer, Verifier};
 use ssh_agent_lib::proto::extension::{MessageExtension, SessionBind};
 use ssh_agent_lib::proto::{Extension, Identity, PublicCredential, Request, Response, SignRequest};
 use ssh_agent_lib::ssh_encoding::{Decode, Encode};
 use ssh_agent_lib::ssh_key::{public::KeyData, Algorithm, PrivateKey, PublicKey};
-use std::collections::{HashMap, HashSet};
 use std::ffi::{CStr, OsString};
 use std::fs;
 use std::io::{self, Read, Write};
-use std::net::Shutdown;
-use std::os::unix::fs::{FileTypeExt, PermissionsExt};
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::fs::FileTypeExt;
+#[cfg(test)]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(test)]
+use std::os::unix::net::UnixListener;
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
+#[cfg(test)]
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -37,44 +42,6 @@ const MAX_SSH_CONFIG_BYTES: usize = 1024 * 1024;
 const SSH_AGENT_FAILURE: &[u8] = &[5];
 const SSH_AGENT_SUCCESS: &[u8] = &[6];
 const SSH_AGENT_EXTENSION_FAILURE: &[u8] = &[28];
-
-static SIGNAL_CLEANUP_PATHS: OnceLock<Arc<Mutex<HashSet<PathBuf>>>> = OnceLock::new();
-static SIGNAL_CLEANUP_THREAD: OnceLock<()> = OnceLock::new();
-
-fn register_signal_cleanup(path: &Path) -> Result<()> {
-    let paths = SIGNAL_CLEANUP_PATHS
-        .get_or_init(|| Arc::new(Mutex::new(HashSet::new())))
-        .clone();
-    if SIGNAL_CLEANUP_THREAD.get().is_none() {
-        let mut signals = signal_hook::iterator::Signals::new([
-            signal_hook::consts::SIGINT,
-            signal_hook::consts::SIGTERM,
-        ])
-        .context("register constrained-agent signal cleanup")?;
-        let cleanup_paths = paths.clone();
-        thread::Builder::new()
-            .name("syq-agent-signal-cleanup".into())
-            .spawn(move || {
-                if let Some(signal) = signals.forever().next() {
-                    let paths: Vec<_> = cleanup_paths.lock().unwrap().iter().cloned().collect();
-                    for path in paths {
-                        let _ = std::fs::remove_dir_all(path);
-                    }
-                    let _ = signal_hook::low_level::emulate_default_handler(signal);
-                }
-            })
-            .context("start constrained-agent signal cleanup")?;
-        let _ = SIGNAL_CLEANUP_THREAD.set(());
-    }
-    paths.lock().unwrap().insert(path.to_path_buf());
-    Ok(())
-}
-
-fn unregister_signal_cleanup(path: &Path) {
-    if let Some(paths) = SIGNAL_CLEANUP_PATHS.get() {
-        paths.lock().unwrap().remove(path);
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct HostPolicy {
@@ -778,18 +745,14 @@ fn parse_known_host_output(
 /// listener and workers, and removes the private socket directory.
 pub struct ConstrainedAgentBroker {
     ambient_socket: PathBuf,
-    socket_path: PathBuf,
-    shutdown: Arc<AtomicBool>,
-    connections: Arc<ConnectionRegistry>,
-    listener_thread: Option<JoinHandle<()>>,
-    _socket_dir: tempfile::TempDir,
+    broker: PrivateBroker,
 }
 
 impl std::fmt::Debug for ConstrainedAgentBroker {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("ConstrainedAgentBroker")
-            .field("socket_path", &self.socket_path)
+            .field("socket_path", &self.broker.socket_path())
             .finish_non_exhaustive()
     }
 }
@@ -889,56 +852,31 @@ impl ConstrainedAgentBroker {
                 ambient_socket.display()
             );
         }
-        let socket_dir = tempfile::Builder::new()
-            .prefix("syq-agent-")
-            .tempdir()
-            .context("create private constrained-agent directory")?;
-        let socket_path = socket_dir.path().join("agent.sock");
-        validate_openssh_option_path(&socket_path, "temporary constrained-agent path")?;
-        let listener = UnixListener::bind(&socket_path)
-            .with_context(|| format!("bind constrained agent at {}", socket_path.display()))?;
-        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))?;
-        listener.set_nonblocking(true)?;
-        register_signal_cleanup(socket_dir.path())?;
-
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let connections = Arc::new(ConnectionRegistry::default());
-        let thread_shutdown = Arc::clone(&shutdown);
-        let thread_connections = Arc::clone(&connections);
         let backend = Arc::new(backend);
         let policy = Arc::new(policy);
-        let listener_thread = thread::Builder::new()
-            .name("syq-agent-listener".into())
-            .spawn(move || {
-                accept_connections(
-                    listener,
-                    backend,
-                    policy,
-                    max_connections,
-                    thread_shutdown,
-                    thread_connections,
-                )
-            });
-        let listener_thread = match listener_thread {
-            Ok(thread) => thread,
-            Err(error) => {
-                unregister_signal_cleanup(socket_dir.path());
-                return Err(error).context("start constrained-agent listener");
-            }
-        };
+        let broker = PrivateBroker::start(
+            PrivateBrokerConfig {
+                directory_prefix: "syq-agent-",
+                socket_name: "agent.sock",
+                listener_thread: "syq-agent-listener",
+                client_thread: "syq-agent-client",
+                max_connections,
+                io_timeout: BROKER_IO_TIMEOUT,
+            },
+            move |stream, connections| {
+                let _ = serve_client(stream, &backend, &policy, connections);
+            },
+        )?;
+        validate_openssh_option_path(broker.socket_path(), "temporary constrained-agent path")?;
 
         Ok(Self {
             ambient_socket,
-            socket_path,
-            shutdown,
-            connections,
-            listener_thread: Some(listener_thread),
-            _socket_dir: socket_dir,
+            broker,
         })
     }
 
     pub fn socket_path(&self) -> &Path {
-        &self.socket_path
+        self.broker.socket_path()
     }
 
     pub fn ambient_socket(&self) -> &Path {
@@ -960,146 +898,6 @@ fn validate_openssh_option_path(path: &Path, label: &str) -> Result<()> {
         bail!("{label} contains characters that are unsafe in an OpenSSH command-line option");
     }
     Ok(())
-}
-
-impl Drop for ConstrainedAgentBroker {
-    fn drop(&mut self) {
-        self.shutdown.store(true, Ordering::Release);
-        self.connections.shutdown_all();
-        // Wake accept immediately instead of waiting for the nonblocking poll.
-        let _ = UnixStream::connect(&self.socket_path);
-        if let Some(listener) = self.listener_thread.take() {
-            let _ = listener.join();
-        }
-        unregister_signal_cleanup(self._socket_dir.path());
-    }
-}
-
-fn accept_connections(
-    listener: UnixListener,
-    backend: Arc<SigningBackend>,
-    policy: Arc<BrokerPolicy>,
-    max_connections: usize,
-    shutdown: Arc<AtomicBool>,
-    connections: Arc<ConnectionRegistry>,
-) {
-    let mut workers: Vec<JoinHandle<()>> = Vec::new();
-    while !shutdown.load(Ordering::Acquire) {
-        reap_workers(&mut workers);
-        match listener.accept() {
-            Ok((stream, _)) => {
-                if workers.len() >= max_connections {
-                    let _ = stream.shutdown(Shutdown::Both);
-                    continue;
-                }
-                let Ok(stream) = connections.track(stream) else {
-                    continue;
-                };
-                let worker_backend = Arc::clone(&backend);
-                let worker_policy = Arc::clone(&policy);
-                let worker_connections = Arc::clone(&connections);
-                match thread::Builder::new()
-                    .name("syq-agent-client".into())
-                    .spawn(move || {
-                        let _ = serve_client(
-                            stream,
-                            &worker_backend,
-                            &worker_policy,
-                            worker_connections,
-                        );
-                    }) {
-                    Ok(worker) => workers.push(worker),
-                    Err(_) => continue,
-                }
-            }
-            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                thread::sleep(Duration::from_millis(5));
-            }
-            Err(_) => break,
-        }
-    }
-    connections.shutdown_all();
-    for worker in workers {
-        let _ = worker.join();
-    }
-}
-
-fn reap_workers(workers: &mut Vec<JoinHandle<()>>) {
-    let mut index = 0;
-    while index < workers.len() {
-        if workers[index].is_finished() {
-            let worker = workers.swap_remove(index);
-            let _ = worker.join();
-        } else {
-            index += 1;
-        }
-    }
-}
-
-#[derive(Default)]
-struct ConnectionRegistry {
-    next_id: AtomicU64,
-    streams: Mutex<HashMap<u64, UnixStream>>,
-}
-
-impl ConnectionRegistry {
-    fn track(self: &Arc<Self>, stream: UnixStream) -> io::Result<TrackedStream> {
-        stream.set_read_timeout(Some(BROKER_IO_TIMEOUT))?;
-        stream.set_write_timeout(Some(BROKER_IO_TIMEOUT))?;
-        let registered = stream.try_clone()?;
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        self.streams
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(id, registered);
-        Ok(TrackedStream {
-            stream,
-            id,
-            registry: Arc::clone(self),
-        })
-    }
-
-    fn shutdown_all(&self) {
-        let streams = self
-            .streams
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        for stream in streams.values() {
-            let _ = stream.shutdown(Shutdown::Both);
-        }
-    }
-}
-
-struct TrackedStream {
-    stream: UnixStream,
-    id: u64,
-    registry: Arc<ConnectionRegistry>,
-}
-
-impl Drop for TrackedStream {
-    fn drop(&mut self) {
-        self.registry
-            .streams
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .remove(&self.id);
-    }
-}
-
-impl Read for TrackedStream {
-    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
-        self.stream.read(buffer)
-    }
-}
-
-impl Write for TrackedStream {
-    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
-        self.stream.write(buffer)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.stream.flush()
-    }
 }
 
 #[derive(Default)]
@@ -2628,26 +2426,12 @@ mod tests {
             clients.push(client);
         }
         let deadline = Instant::now() + Duration::from_secs(2);
-        while broker
-            .connections
-            .streams
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .len()
-            < TEST_BROKER_CONNECTIONS
+        while broker.broker.active_connections() < TEST_BROKER_CONNECTIONS
             && Instant::now() < deadline
         {
             thread::sleep(Duration::from_millis(5));
         }
-        assert_eq!(
-            broker
-                .connections
-                .streams
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .len(),
-            TEST_BROKER_CONNECTIONS
-        );
+        assert_eq!(broker.broker.active_connections(), TEST_BROKER_CONNECTIONS);
         let mut excess = UnixStream::connect(&path).unwrap();
         excess
             .set_read_timeout(Some(Duration::from_secs(1)))
@@ -2668,16 +2452,10 @@ mod tests {
     #[test]
     fn tracked_broker_connections_have_bounded_io() {
         let (stream, _peer) = UnixStream::pair().unwrap();
-        let registry = Arc::new(ConnectionRegistry::default());
+        let registry = Arc::new(ConnectionRegistry::new(BROKER_IO_TIMEOUT));
         let tracked = registry.track(stream).unwrap();
-        assert_eq!(
-            tracked.stream.read_timeout().unwrap(),
-            Some(BROKER_IO_TIMEOUT)
-        );
-        assert_eq!(
-            tracked.stream.write_timeout().unwrap(),
-            Some(BROKER_IO_TIMEOUT)
-        );
+        assert_eq!(tracked.read_timeout().unwrap(), Some(BROKER_IO_TIMEOUT));
+        assert_eq!(tracked.write_timeout().unwrap(), Some(BROKER_IO_TIMEOUT));
     }
 
     #[test]

--- a/src/descriptor_broker.rs
+++ b/src/descriptor_broker.rs
@@ -1,0 +1,581 @@
+//! Session-scoped directory registration and exact cross-process handoff.
+//!
+//! A control process owns the registry and keeps every registered directory
+//! open. Threads in that process clone roots directly; independent workers use
+//! a private, secret-authenticated Unix socket and receive the same open file
+//! description with `SCM_RIGHTS`. No worker reopens an operator pathname.
+
+use crate::private_broker::{PrivateBroker, PrivateBrokerConfig, TrackedStream};
+use anyhow::{anyhow, bail, Context, Result};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::mem::{size_of, zeroed};
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+const CLAIM_MAGIC: &[u8; 8] = b"SYQFD001";
+const SECRET_LEN: usize = 32;
+const CLAIM_LEN: usize = CLAIM_MAGIC.len() + SECRET_LEN + size_of::<u64>();
+const RESPONSE_OK: u8 = 0;
+const RESPONSE_REJECTED: u8 = 1;
+const RESPONSE_INTERNAL: u8 = 2;
+const BROKER_IO_TIMEOUT: Duration = Duration::from_secs(10);
+const FD_CONTROL_LEN: usize =
+    unsafe { libc::CMSG_SPACE(size_of::<RawFd>() as libc::c_uint) as usize };
+
+#[repr(C)]
+union FdControl {
+    _align: libc::cmsghdr,
+    bytes: [u8; FD_CONTROL_LEN],
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct RegisteredRootId(u64);
+
+struct RegisteredRoot {
+    directory: File,
+}
+
+struct RegistryState {
+    next_id: u64,
+    roots: HashMap<RegisteredRootId, RegisteredRoot>,
+}
+
+#[derive(Clone)]
+pub(crate) struct RegisteredRootRegistry {
+    state: Arc<Mutex<RegistryState>>,
+    max_roots: usize,
+}
+
+impl RegisteredRootRegistry {
+    fn new(max_roots: usize) -> Result<Self> {
+        if max_roots == 0 {
+            bail!("descriptor session needs at least one root slot");
+        }
+        Ok(Self {
+            state: Arc::new(Mutex::new(RegistryState {
+                next_id: 1,
+                roots: HashMap::new(),
+            })),
+            max_roots,
+        })
+    }
+
+    pub(crate) fn register(&self, directory: File) -> Result<RegisteredRootId> {
+        let metadata = directory
+            .metadata()
+            .context("inspect directory registered with descriptor session")?;
+        if !metadata.is_dir() {
+            bail!("only directories may be registered as session roots");
+        }
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.roots.len() >= self.max_roots {
+            bail!(
+                "descriptor session root limit ({}) exceeded; reduce distinct roots or raise the session limit",
+                self.max_roots
+            );
+        }
+        let id = RegisteredRootId(state.next_id);
+        state.next_id = state
+            .next_id
+            .checked_add(1)
+            .context("descriptor session exhausted root identifiers")?;
+        state.roots.insert(id, RegisteredRoot { directory });
+        Ok(id)
+    }
+
+    /// Used by local workers and TCP workers hosted by the control process.
+    pub(crate) fn acquire(&self, id: RegisteredRootId) -> Result<File> {
+        self.acquire_optional(id)?
+            .with_context(|| format!("unknown descriptor session root {}", id.0))
+    }
+
+    fn acquire_optional(&self, id: RegisteredRootId) -> Result<Option<File>> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .roots
+            .get(&id)
+            .map(|root| root.directory.try_clone())
+            .transpose()
+            .context("duplicate registered session root")
+    }
+
+    fn contains(&self, id: RegisteredRootId) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .roots
+            .contains_key(&id)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct DescriptorTicket {
+    socket_path: PathBuf,
+    secret: [u8; SECRET_LEN],
+    root_id: RegisteredRootId,
+}
+
+impl std::fmt::Debug for DescriptorTicket {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DescriptorTicket")
+            .field("socket_path", &self.socket_path)
+            .field("root_id", &self.root_id)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Owns the endpoint session's roots and its independent-worker handoff
+/// broker. Dropping it closes the broker before releasing the registered roots.
+pub(crate) struct DescriptorSession {
+    broker: PrivateBroker,
+    registry: RegisteredRootRegistry,
+    secret: [u8; SECRET_LEN],
+}
+
+impl DescriptorSession {
+    pub(crate) fn start(max_roots: usize, max_connections: usize) -> Result<Self> {
+        let registry = RegisteredRootRegistry::new(max_roots)?;
+        let secret: [u8; SECRET_LEN] = crate::crypto::random_bytes(SECRET_LEN)
+            .try_into()
+            .map_err(|_| anyhow!("generated descriptor broker secret has the wrong length"))?;
+        let server_registry = registry.clone();
+        let server_secret = secret;
+        let broker = PrivateBroker::start(
+            PrivateBrokerConfig {
+                directory_prefix: "syq-fd-",
+                socket_name: "broker.sock",
+                listener_thread: "syq-fd-listener",
+                client_thread: "syq-fd-client",
+                max_connections,
+                io_timeout: BROKER_IO_TIMEOUT,
+            },
+            move |mut stream, _connections| {
+                let _ = serve_claim(&mut stream, &server_registry, &server_secret);
+            },
+        )?;
+        Ok(Self {
+            broker,
+            registry,
+            secret,
+        })
+    }
+
+    pub(crate) fn registry(&self) -> RegisteredRootRegistry {
+        self.registry.clone()
+    }
+
+    pub(crate) fn register(&self, directory: File) -> Result<RegisteredRootId> {
+        self.registry.register(directory)
+    }
+
+    pub(crate) fn ticket(&self, root_id: RegisteredRootId) -> Result<DescriptorTicket> {
+        if !self.registry.contains(root_id) {
+            bail!("unknown descriptor session root {}", root_id.0);
+        }
+        Ok(DescriptorTicket {
+            socket_path: self.broker.socket_path().to_path_buf(),
+            secret: self.secret,
+            root_id,
+        })
+    }
+}
+
+/// Claim a registered root from an independent process. The returned
+/// descriptor refers to the exact registered object even if its original
+/// pathname has been renamed or replaced.
+pub(crate) fn claim_descriptor(ticket: &DescriptorTicket) -> Result<File> {
+    let mut stream = UnixStream::connect(&ticket.socket_path).with_context(|| {
+        format!(
+            "connect to descriptor broker {}",
+            ticket.socket_path.display()
+        )
+    })?;
+    stream.set_read_timeout(Some(BROKER_IO_TIMEOUT))?;
+    stream.set_write_timeout(Some(BROKER_IO_TIMEOUT))?;
+    let mut claim = [0u8; CLAIM_LEN];
+    claim[..CLAIM_MAGIC.len()].copy_from_slice(CLAIM_MAGIC);
+    let secret_start = CLAIM_MAGIC.len();
+    claim[secret_start..secret_start + SECRET_LEN].copy_from_slice(&ticket.secret);
+    claim[secret_start + SECRET_LEN..].copy_from_slice(&ticket.root_id.0.to_be_bytes());
+    stream.write_all(&claim)?;
+
+    let (status, descriptor) = receive_descriptor(stream.as_raw_fd())?;
+    match (status, descriptor) {
+        (RESPONSE_OK, Some(descriptor)) => Ok(descriptor),
+        (RESPONSE_OK, None) => bail!("descriptor broker returned success without a descriptor"),
+        (RESPONSE_REJECTED, None) => bail!("descriptor broker rejected the session root claim"),
+        (RESPONSE_INTERNAL, None) => {
+            bail!("descriptor broker could not duplicate the session root")
+        }
+        (_, Some(_)) => bail!("descriptor broker attached a descriptor to an error response"),
+        (status, None) => bail!("descriptor broker returned unknown status {status}"),
+    }
+}
+
+fn serve_claim(
+    stream: &mut TrackedStream,
+    registry: &RegisteredRootRegistry,
+    secret: &[u8; SECRET_LEN],
+) -> Result<()> {
+    let mut claim = [0u8; CLAIM_LEN];
+    stream.read_exact(&mut claim)?;
+    let secret_start = CLAIM_MAGIC.len();
+    let authenticated = claim[..secret_start] == *CLAIM_MAGIC
+        && claim[secret_start..secret_start + SECRET_LEN] == *secret;
+    if !authenticated {
+        stream.write_all(&[RESPONSE_REJECTED])?;
+        return Ok(());
+    }
+    let root_id = RegisteredRootId(u64::from_be_bytes(
+        claim[secret_start + SECRET_LEN..]
+            .try_into()
+            .expect("claim root identifier has a fixed length"),
+    ));
+    match registry.acquire_optional(root_id) {
+        Ok(Some(directory)) => send_descriptor(stream.as_raw_fd(), directory.as_raw_fd())?,
+        Ok(None) => stream.write_all(&[RESPONSE_REJECTED])?,
+        Err(_) => stream.write_all(&[RESPONSE_INTERNAL])?,
+    }
+    Ok(())
+}
+
+fn send_descriptor(socket: RawFd, descriptor: RawFd) -> io::Result<()> {
+    let mut status = [RESPONSE_OK];
+    let mut iovec = libc::iovec {
+        iov_base: status.as_mut_ptr().cast(),
+        iov_len: status.len(),
+    };
+    let mut control = FdControl {
+        bytes: [0; FD_CONTROL_LEN],
+    };
+    let mut message: libc::msghdr = unsafe { zeroed() };
+    message.msg_iov = &mut iovec;
+    message.msg_iovlen = 1;
+    message.msg_control = unsafe { control.bytes.as_mut_ptr().cast() };
+    message.msg_controllen = FD_CONTROL_LEN as _;
+    unsafe {
+        let header = libc::CMSG_FIRSTHDR(&message);
+        if header.is_null() {
+            return Err(io::Error::other("SCM_RIGHTS control buffer is too small"));
+        }
+        (*header).cmsg_level = libc::SOL_SOCKET;
+        (*header).cmsg_type = libc::SCM_RIGHTS;
+        (*header).cmsg_len = libc::CMSG_LEN(size_of::<RawFd>() as libc::c_uint) as _;
+        std::ptr::write_unaligned(libc::CMSG_DATA(header).cast::<RawFd>(), descriptor);
+    }
+    loop {
+        let sent = unsafe { libc::sendmsg(socket, &message, 0) };
+        if sent == 1 {
+            return Ok(());
+        }
+        if sent >= 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "descriptor broker sent an incomplete response",
+            ));
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+fn receive_descriptor(socket: RawFd) -> io::Result<(u8, Option<File>)> {
+    let mut status = [0u8];
+    let mut iovec = libc::iovec {
+        iov_base: status.as_mut_ptr().cast(),
+        iov_len: status.len(),
+    };
+    let mut control = FdControl {
+        bytes: [0; FD_CONTROL_LEN],
+    };
+    let mut message: libc::msghdr = unsafe { zeroed() };
+    message.msg_iov = &mut iovec;
+    message.msg_iovlen = 1;
+    message.msg_control = unsafe { control.bytes.as_mut_ptr().cast() };
+    message.msg_controllen = FD_CONTROL_LEN as _;
+    #[cfg(target_os = "linux")]
+    let flags = libc::MSG_CMSG_CLOEXEC;
+    // Darwin does not expose an atomic close-on-exec receive flag. The future
+    // worker protocol must therefore claim its roots during single-threaded
+    // initialization, before it can spawn children, and acknowledge startup
+    // only after this function has applied FD_CLOEXEC.
+    #[cfg(not(target_os = "linux"))]
+    let flags = 0;
+    loop {
+        let received = unsafe { libc::recvmsg(socket, &mut message, flags) };
+        if received == 1 {
+            break;
+        }
+        if received == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "descriptor broker closed without a response",
+            ));
+        }
+        if received > 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "descriptor broker returned an oversized response",
+            ));
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+
+    let mut descriptors = Vec::new();
+    let mut malformed = message.msg_flags & libc::MSG_CTRUNC != 0;
+    unsafe {
+        let mut header = libc::CMSG_FIRSTHDR(&message);
+        while !header.is_null() {
+            let header_len = libc::CMSG_LEN(0) as usize;
+            let control_len = (*header).cmsg_len as usize;
+            if (*header).cmsg_level == libc::SOL_SOCKET
+                && (*header).cmsg_type == libc::SCM_RIGHTS
+                && control_len >= header_len
+            {
+                let data_len = control_len - header_len;
+                malformed |= data_len == 0 || !data_len.is_multiple_of(size_of::<RawFd>());
+                for index in 0..data_len / size_of::<RawFd>() {
+                    let raw = std::ptr::read_unaligned(
+                        libc::CMSG_DATA(header).cast::<RawFd>().add(index),
+                    );
+                    let file = File::from_raw_fd(raw);
+                    set_close_on_exec(&file)?;
+                    descriptors.push(file);
+                }
+            } else {
+                malformed = true;
+            }
+            header = libc::CMSG_NXTHDR(&message, header);
+        }
+    }
+    if malformed || descriptors.len() > 1 {
+        drop(descriptors);
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "descriptor broker returned malformed ancillary data",
+        ));
+    }
+    Ok((status[0], descriptors.pop()))
+}
+
+fn set_close_on_exec(file: &File) -> io::Result<()> {
+    let flags = loop {
+        let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+        if flags >= 0 {
+            break flags;
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    };
+    loop {
+        if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, flags | libc::FD_CLOEXEC) } == 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::os::unix::fs::MetadataExt;
+    use std::process::Command;
+
+    const CHILD_ENV: &str = "SYQ_TEST_DESCRIPTOR_BROKER_CHILD";
+    const CHILD_TEST: &str =
+        "descriptor_broker::tests::independent_process_receives_exact_registered_descriptor";
+
+    fn read_at(directory: &File, name: &CStr) -> Vec<u8> {
+        let descriptor = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        assert!(
+            descriptor >= 0,
+            "openat failed: {}",
+            io::Error::last_os_error()
+        );
+        let mut file = unsafe { File::from_raw_fd(descriptor) };
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).unwrap();
+        bytes
+    }
+
+    fn ticket_from_environment() -> DescriptorTicket {
+        let socket_path =
+            PathBuf::from(std::env::var_os("SYQ_TEST_DESCRIPTOR_BROKER_SOCKET").unwrap());
+        let secret_bytes = hex_decode(&std::env::var("SYQ_TEST_DESCRIPTOR_BROKER_SECRET").unwrap());
+        DescriptorTicket {
+            socket_path,
+            secret: secret_bytes.try_into().unwrap(),
+            root_id: RegisteredRootId(
+                std::env::var("SYQ_TEST_DESCRIPTOR_BROKER_ROOT")
+                    .unwrap()
+                    .parse()
+                    .unwrap(),
+            ),
+        }
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    fn hex_decode(value: &str) -> Vec<u8> {
+        value
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|digits| u8::from_str_radix(std::str::from_utf8(digits).unwrap(), 16).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn shared_process_workers_clone_the_registered_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let selected = temp.path().join("selected");
+        std::fs::create_dir(&selected).unwrap();
+        std::fs::write(selected.join("marker"), b"original").unwrap();
+        let original = File::open(&selected).unwrap();
+        let identity = original.metadata().unwrap();
+        let session = DescriptorSession::start(4, 4).unwrap();
+        let root = session.register(original).unwrap();
+        let registry = session.registry();
+
+        std::fs::rename(&selected, temp.path().join("moved")).unwrap();
+        std::fs::create_dir(&selected).unwrap();
+        std::fs::write(selected.join("marker"), b"replacement").unwrap();
+
+        let local_registry = registry.clone();
+        let local = std::thread::spawn(move || local_registry.acquire(root).unwrap());
+        let tcp = std::thread::spawn(move || registry.acquire(root).unwrap());
+        for directory in [local.join().unwrap(), tcp.join().unwrap()] {
+            let metadata = directory.metadata().unwrap();
+            assert_eq!(
+                (metadata.dev(), metadata.ino()),
+                (identity.dev(), identity.ino())
+            );
+            assert_eq!(read_at(&directory, c"marker"), b"original");
+        }
+    }
+
+    #[test]
+    fn independent_process_receives_exact_registered_descriptor() {
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let ticket = ticket_from_environment();
+            let directory = claim_descriptor(&ticket).unwrap();
+            let metadata = directory.metadata().unwrap();
+            let expected_dev: u64 = std::env::var("SYQ_TEST_DESCRIPTOR_BROKER_DEV")
+                .unwrap()
+                .parse()
+                .unwrap();
+            let expected_ino: u64 = std::env::var("SYQ_TEST_DESCRIPTOR_BROKER_INO")
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert_eq!(
+                (metadata.dev(), metadata.ino()),
+                (expected_dev, expected_ino)
+            );
+            assert_eq!(read_at(&directory, c"marker"), b"original");
+            assert_ne!(
+                unsafe { libc::fcntl(directory.as_raw_fd(), libc::F_GETFD) } & libc::FD_CLOEXEC,
+                0
+            );
+            return;
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let selected = temp.path().join("selected");
+        std::fs::create_dir(&selected).unwrap();
+        std::fs::write(selected.join("marker"), b"original").unwrap();
+        let original = File::open(&selected).unwrap();
+        let identity = original.metadata().unwrap();
+        let session = DescriptorSession::start(4, 4).unwrap();
+        let root = session.register(original).unwrap();
+        let ticket = session.ticket(root).unwrap();
+
+        std::fs::rename(&selected, temp.path().join("moved")).unwrap();
+        std::fs::create_dir(&selected).unwrap();
+        std::fs::write(selected.join("marker"), b"replacement").unwrap();
+
+        let status = Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", CHILD_TEST, "--nocapture"])
+            .env(CHILD_ENV, "1")
+            .env("SYQ_TEST_DESCRIPTOR_BROKER_SOCKET", &ticket.socket_path)
+            .env("SYQ_TEST_DESCRIPTOR_BROKER_SECRET", hex(&ticket.secret))
+            .env("SYQ_TEST_DESCRIPTOR_BROKER_ROOT", root.0.to_string())
+            .env("SYQ_TEST_DESCRIPTOR_BROKER_DEV", identity.dev().to_string())
+            .env("SYQ_TEST_DESCRIPTOR_BROKER_INO", identity.ino().to_string())
+            .status()
+            .unwrap();
+        assert!(status.success(), "descriptor handoff subprocess failed");
+    }
+
+    #[test]
+    fn broker_rejects_bad_secrets_and_unknown_roots() {
+        let temp = tempfile::tempdir().unwrap();
+        let session = DescriptorSession::start(2, 2).unwrap();
+        let root = session.register(File::open(temp.path()).unwrap()).unwrap();
+
+        let mut bad_secret = session.ticket(root).unwrap();
+        bad_secret.secret[0] ^= 1;
+        assert!(claim_descriptor(&bad_secret)
+            .unwrap_err()
+            .to_string()
+            .contains("rejected"));
+
+        let mut unknown = session.ticket(root).unwrap();
+        unknown.root_id = RegisteredRootId(root.0 + 1);
+        assert!(claim_descriptor(&unknown)
+            .unwrap_err()
+            .to_string()
+            .contains("rejected"));
+    }
+
+    #[test]
+    fn registration_requires_explicit_root_reuse_and_enforces_the_limit() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("first");
+        std::fs::create_dir(&first).unwrap();
+        let session = DescriptorSession::start(1, 1).unwrap();
+        let first_id = session.register(File::open(&first).unwrap()).unwrap();
+        assert!(session.registry().acquire(first_id).is_ok());
+        let error = session.register(File::open(&first).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("root limit (1) exceeded"));
+    }
+
+    #[test]
+    fn ticket_debug_output_does_not_expose_the_secret() {
+        let temp = tempfile::tempdir().unwrap();
+        let session = DescriptorSession::start(1, 1).unwrap();
+        let root = session.register(File::open(temp.path()).unwrap()).unwrap();
+        let ticket = session.ticket(root).unwrap();
+        let debug = format!("{ticket:?}");
+        assert!(debug.contains("root_id"));
+        assert!(!debug.contains(&hex(&ticket.secret)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ mod cli;
 mod conn;
 mod crypto;
 mod delegation;
+#[allow(dead_code)]
+mod descriptor_broker;
 mod direct;
 pub mod enrollment;
 mod fsops;
@@ -12,6 +14,7 @@ mod janky_cat;
 mod native_map;
 mod native_rm;
 mod persistence;
+mod private_broker;
 mod progress;
 mod proto;
 mod receipt;

--- a/src/private_broker.rs
+++ b/src/private_broker.rs
@@ -1,0 +1,366 @@
+//! Shared lifecycle for private, bounded Unix-socket brokers.
+//!
+//! The socket lives in a mode-0700 temporary directory and is itself mode
+//! 0600. Dropping the broker closes active clients, joins its listener and
+//! client threads, and removes the directory. Signal cleanup removes private
+//! broker directories before restoring the signal's default action.
+
+use anyhow::{bail, Context, Result};
+use std::collections::{HashMap, HashSet};
+use std::io::{self, Read, Write};
+use std::net::Shutdown;
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+static SIGNAL_CLEANUP_PATHS: OnceLock<Arc<Mutex<HashSet<PathBuf>>>> = OnceLock::new();
+static SIGNAL_CLEANUP_THREAD: OnceLock<io::Result<()>> = OnceLock::new();
+
+fn register_signal_cleanup(path: &Path) -> Result<()> {
+    let paths = SIGNAL_CLEANUP_PATHS
+        .get_or_init(|| Arc::new(Mutex::new(HashSet::new())))
+        .clone();
+    let result = SIGNAL_CLEANUP_THREAD.get_or_init(|| {
+        let mut signals = signal_hook::iterator::Signals::new([
+            signal_hook::consts::SIGINT,
+            signal_hook::consts::SIGTERM,
+        ])?;
+        let cleanup_paths = Arc::clone(&paths);
+        thread::Builder::new()
+            .name("syq-broker-signal-cleanup".into())
+            .spawn(move || {
+                if let Some(signal) = signals.forever().next() {
+                    let paths: Vec<_> = cleanup_paths
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .iter()
+                        .cloned()
+                        .collect();
+                    for path in paths {
+                        let _ = std::fs::remove_dir_all(path);
+                    }
+                    let _ = signal_hook::low_level::emulate_default_handler(signal);
+                }
+            })?;
+        Ok(())
+    });
+    if let Err(error) = result {
+        return Err(io::Error::new(error.kind(), error.to_string()))
+            .context("register private broker signal cleanup");
+    }
+    paths
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(path.to_path_buf());
+    Ok(())
+}
+
+fn unregister_signal_cleanup(path: &Path) {
+    if let Some(paths) = SIGNAL_CLEANUP_PATHS.get() {
+        paths
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(path);
+    }
+}
+
+pub(crate) struct PrivateBrokerConfig<'a> {
+    pub(crate) directory_prefix: &'a str,
+    pub(crate) socket_name: &'a str,
+    pub(crate) listener_thread: &'a str,
+    pub(crate) client_thread: &'a str,
+    pub(crate) max_connections: usize,
+    pub(crate) io_timeout: Duration,
+}
+
+/// A running private Unix-socket broker.
+pub(crate) struct PrivateBroker {
+    socket_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+    connections: Arc<ConnectionRegistry>,
+    listener_thread: Option<JoinHandle<()>>,
+    socket_dir: tempfile::TempDir,
+}
+
+impl PrivateBroker {
+    pub(crate) fn start<F>(config: PrivateBrokerConfig<'_>, handler: F) -> Result<Self>
+    where
+        F: Fn(TrackedStream, Arc<ConnectionRegistry>) + Send + Sync + 'static,
+    {
+        if config.max_connections == 0 {
+            bail!("private broker needs at least one connection slot");
+        }
+        let socket_dir = tempfile::Builder::new()
+            .prefix(config.directory_prefix)
+            .tempdir()
+            .context("create private broker directory")?;
+        std::fs::set_permissions(socket_dir.path(), std::fs::Permissions::from_mode(0o700))?;
+        let socket_path = socket_dir.path().join(config.socket_name);
+        let listener = UnixListener::bind(&socket_path)
+            .with_context(|| format!("bind private broker at {}", socket_path.display()))?;
+        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))?;
+        listener.set_nonblocking(true)?;
+        register_signal_cleanup(socket_dir.path())?;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let connections = Arc::new(ConnectionRegistry::new(config.io_timeout));
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread_connections = Arc::clone(&connections);
+        let handler = Arc::new(handler);
+        let max_connections = config.max_connections;
+        let client_thread = config.client_thread.to_owned();
+        let listener_thread = thread::Builder::new()
+            .name(config.listener_thread.to_owned())
+            .spawn(move || {
+                accept_connections(
+                    listener,
+                    max_connections,
+                    &client_thread,
+                    thread_shutdown,
+                    thread_connections,
+                    handler,
+                )
+            });
+        let listener_thread = match listener_thread {
+            Ok(thread) => thread,
+            Err(error) => {
+                unregister_signal_cleanup(socket_dir.path());
+                return Err(error).context("start private broker listener");
+            }
+        };
+
+        Ok(Self {
+            socket_path,
+            shutdown,
+            connections,
+            listener_thread: Some(listener_thread),
+            socket_dir,
+        })
+    }
+
+    pub(crate) fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_connections(&self) -> usize {
+        self.connections.active()
+    }
+}
+
+impl std::fmt::Debug for PrivateBroker {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PrivateBroker")
+            .field("socket_path", &self.socket_path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for PrivateBroker {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        self.connections.shutdown_all();
+        // Wake accept immediately instead of waiting for the nonblocking poll.
+        let _ = UnixStream::connect(&self.socket_path);
+        if let Some(listener) = self.listener_thread.take() {
+            let _ = listener.join();
+        }
+        unregister_signal_cleanup(self.socket_dir.path());
+    }
+}
+
+fn accept_connections<F>(
+    listener: UnixListener,
+    max_connections: usize,
+    client_thread: &str,
+    shutdown: Arc<AtomicBool>,
+    connections: Arc<ConnectionRegistry>,
+    handler: Arc<F>,
+) where
+    F: Fn(TrackedStream, Arc<ConnectionRegistry>) + Send + Sync + 'static,
+{
+    let mut workers: Vec<JoinHandle<()>> = Vec::new();
+    while !shutdown.load(Ordering::Acquire) {
+        reap_workers(&mut workers);
+        match listener.accept() {
+            Ok((stream, _)) => {
+                if workers.len() >= max_connections {
+                    let _ = stream.shutdown(Shutdown::Both);
+                    continue;
+                }
+                let Ok(stream) = connections.track(stream) else {
+                    continue;
+                };
+                let worker_handler = Arc::clone(&handler);
+                let worker_connections = Arc::clone(&connections);
+                if let Ok(worker) = thread::Builder::new()
+                    .name(client_thread.to_owned())
+                    .spawn(move || worker_handler(stream, worker_connections))
+                {
+                    workers.push(worker);
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(5));
+            }
+            Err(_) => break,
+        }
+    }
+    connections.shutdown_all();
+    for worker in workers {
+        let _ = worker.join();
+    }
+}
+
+fn reap_workers(workers: &mut Vec<JoinHandle<()>>) {
+    let mut index = 0;
+    while index < workers.len() {
+        if workers[index].is_finished() {
+            let worker = workers.swap_remove(index);
+            let _ = worker.join();
+        } else {
+            index += 1;
+        }
+    }
+}
+
+pub(crate) struct ConnectionRegistry {
+    next_id: AtomicU64,
+    streams: Mutex<HashMap<u64, UnixStream>>,
+    io_timeout: Duration,
+}
+
+impl ConnectionRegistry {
+    pub(crate) fn new(io_timeout: Duration) -> Self {
+        Self {
+            next_id: AtomicU64::new(0),
+            streams: Mutex::new(HashMap::new()),
+            io_timeout,
+        }
+    }
+
+    pub(crate) fn track(self: &Arc<Self>, stream: UnixStream) -> io::Result<TrackedStream> {
+        stream.set_read_timeout(Some(self.io_timeout))?;
+        stream.set_write_timeout(Some(self.io_timeout))?;
+        let registered = stream.try_clone()?;
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.streams
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(id, registered);
+        Ok(TrackedStream {
+            stream,
+            id,
+            registry: Arc::clone(self),
+        })
+    }
+
+    fn shutdown_all(&self) {
+        let streams = self
+            .streams
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for stream in streams.values() {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+    }
+
+    #[cfg(test)]
+    fn active(&self) -> usize {
+        self.streams
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
+    }
+}
+
+pub(crate) struct TrackedStream {
+    stream: UnixStream,
+    id: u64,
+    registry: Arc<ConnectionRegistry>,
+}
+
+impl TrackedStream {
+    #[cfg(test)]
+    pub(crate) fn read_timeout(&self) -> io::Result<Option<Duration>> {
+        self.stream.read_timeout()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn write_timeout(&self) -> io::Result<Option<Duration>> {
+        self.stream.write_timeout()
+    }
+}
+
+impl AsRawFd for TrackedStream {
+    fn as_raw_fd(&self) -> RawFd {
+        self.stream.as_raw_fd()
+    }
+}
+
+impl Drop for TrackedStream {
+    fn drop(&mut self) {
+        self.registry
+            .streams
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.id);
+    }
+}
+
+impl Read for TrackedStream {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        self.stream.read(buffer)
+    }
+}
+
+impl Write for TrackedStream {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.stream.write(buffer)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stream.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn broker_uses_private_modes_and_removes_its_directory() {
+        let broker = PrivateBroker::start(
+            PrivateBrokerConfig {
+                directory_prefix: "syq-private-broker-test-",
+                socket_name: "broker.sock",
+                listener_thread: "syq-private-test-listener",
+                client_thread: "syq-private-test-client",
+                max_connections: 1,
+                io_timeout: Duration::from_secs(1),
+            },
+            |_, _| {},
+        )
+        .unwrap();
+        let socket = broker.socket_path().to_path_buf();
+        let directory = socket.parent().unwrap().to_path_buf();
+
+        assert_eq!(
+            std::fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(&socket).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+
+        drop(broker);
+        assert!(!directory.exists());
+    }
+}


### PR DESCRIPTION
## Summary

- factor the constrained-agent Unix-socket lifecycle into a reusable private broker
- add a session-scoped registry for explicit directory capabilities
- clone held descriptors for local/in-process TCP workers and transfer exact descriptors to independent processes with authenticated `SCM_RIGHTS`
- test rename/replacement resistance, rejected claims, resource bounds, secret redaction, private socket modes, and cleanup
- exercise the subprocess handoff on macOS CI

## Design result

The prototype selects exact descriptor handoff over pathname reopen for independent SSH workers. Root IDs name explicit registered capabilities; the registry does not infer equivalence from `(device, inode)`, which may hide distinct mount contexts. Linux receives with `MSG_CMSG_CLOEXEC`. Since Darwin has no equivalent atomic receive flag, future macOS workers must claim roots during single-threaded initialization before spawning children, then acknowledge readiness only after `FD_CLOEXEC` is set.

This PR does not yet change copy behavior, add worker-registration protocol fields, or claim ordinary-copy path confinement. It establishes and tests the primitive needed for that next slice.

## Verification

At rebased head `c11c027`:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (267 unit, 282 integration, 7 updater tests)
- `scripts/check-workflows.sh`