### PR TITLE
Implement encrypted receiver receipt streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+ "cpufeatures 0.3.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher 0.5.2",
+ "poly1305",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +567,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -791,12 +815,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "hpke"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5130e119706b4d8c2180da6126f7e60b6c38c2d340d539219f57051f0a7af7"
+dependencies = [
+ "aead",
+ "chacha20poly1305",
+ "getrandom 0.4.3",
+ "hkdf",
+ "hybrid-array",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -1086,6 +1146,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.1",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,7 +1299,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -1660,6 +1730,7 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "flate2",
  "getrandom 0.4.3",
+ "hpke",
  "ignore",
  "jwalk",
  "libc",
@@ -1678,6 +1749,7 @@ dependencies = [
  "ssh-key",
  "tempfile",
  "ureq",
+ "zeroize",
  "zstd",
 ]
 
@@ -1921,6 +1993,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +2027,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ shell-words = "1"
 serde_bytes = "0.11"
 aes-gcm = "0.11"
 getrandom = "0.4"
+hpke = { version = "0.14", default-features = false, features = ["alloc", "getrandom", "chacha", "x25519"] }
+zeroize = "1"
 serde_json = "1"
 serde_json_canonicalizer = "0.3"
 base64 = { version = "0.23", default-features = false, features = ["std"] }

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -317,9 +317,10 @@ jq -cs 'if (.[-1].type? // "") != "result"
 
 The jq program first checks the stream's terminal record: a results
 file without one is from a run that did not finish (a crash, a kill),
-and a terminal status other than `success` or `partial` (an aborted
-run, say) means queued entries were never settled — in both cases
-entries may have no records at all, so a retry manifest built from
+and a terminal status other than `success` or `partial` (an `aborted`
+incomplete receipt or a `refused` run) means queued entries were never
+settled or their receipt records may be missing. In both cases, entries
+may have no records at all, so a retry manifest built from
 what is there would look complete while it is not. With the
 terminal record present, the filter is what an exit code cannot
 express: which entries failed, and whether a retry could help.

--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -284,8 +284,14 @@ the terminal aggregates, and metadata-only updates are not yet
 reported per operation. A missing terminal record means the run did
 not finish.
 
-The results writer lives with the transfer coordinator. For a direct
-remote-to-remote copy, use `--results -` to stream its NDJSON back over the
+Normally the results writer lives with the transfer coordinator. For an
+attached direct remote-to-remote copy through a command-restricted receiver,
+however, `--results -` is written by the invoking machine only after it has
+verified and decrypted hostB's receipt. Those records have
+`"provenance":"receiver_attested"`, omit unauthenticated source claims, and
+add a `receiver_final_state` record for every path the transfer could have
+changed; `scope` identifies the signed mutation scope and `dst` is relative to
+it. Other direct remote coordinators stream their NDJSON back over the
 coordinator connection. A named results file is accepted only when the
 coordinator is local, including `--run-at local`; this avoids interpreting a
 local-looking pathname on a remote host. `--results` cannot be combined with

--- a/README.md
+++ b/README.md
@@ -346,13 +346,17 @@ policy. On a direct remote-to-remote copy through that receiver, `cp` also
 accepts the receiver ceilings
 `--max-entries N`, `--max-total-bytes SIZE`, and `--max-runtime DURATION`
 (`s`, `m`, or `h`; at most 23h), and `--receipt hashed`, which asks the
-receiver to record a BLAKE3 digest of every file it publishes in its signed
-receipt. They are signed into the grant and enforced or honored by hostB, and
-are refused anywhere else because nothing would act on them.
+receiver to record a closure-time BLAKE3 digest for every regular file whose
+path the transfer could have changed. They are signed into the grant and
+enforced or honored by hostB, and are refused anywhere else because nothing
+would act on them.
 `cp` additionally accepts `--mapping` and `--results`
-(see [MAPPINGS.md](MAPPINGS.md)). For a direct remote-to-remote copy,
-`--results -` streams the remote coordinator's NDJSON back to the invoking
-terminal. A named results file requires `--run-at local`; direct remote
+(see [MAPPINGS.md](MAPPINGS.md)). For an attached direct remote-to-remote copy
+through a command-restricted receiver, `--results -` is derived locally from
+the verified receipt and marks its records `"provenance":"receiver_attested"`;
+it includes receiver operation outcomes and closure-time final states. Other
+remote coordinators stream their own NDJSON back to the invoking terminal. A
+named results file requires `--run-at local`; direct remote
 coordinators reject it rather than creating a surprising remote file.
 `--results` is also rejected with `--detach`, because its stream would no
 longer remain attached. Neither `--mapping` nor `--results` can be combined
@@ -658,23 +662,51 @@ whether a requested mutation could have survived the signed filter traversal. Ho
 escape those checks or independently authenticate to hostB with the enrollment
 key.
 
-HostA also cannot misreport what landed. Every command-restricted transfer
-ends with hostB issuing a signed receipt: the files it published with their
-sizes (and BLAKE3 digests with `--receipt hashed`), in-place files from the
-moment their bytes change and marked complete only once their final step ran,
-what it deleted, the hashes
-it computed for `--verify-only` and `--hash`, how many requests it refused, and
-its entry and byte totals, bound to the enrollment and the one-time request ID
-and signed with a key only hostB holds. HostA relays the receipt as one line
-of its output; the local machine verifies it against the public key recorded
-at enrollment and fails the transfer if the receipt is missing, does not
-verify, names a different grant, records refused requests, or lists an
-incomplete in-place file while hostA reported success. `-v` prints the verified
-totals. The receipt is hostB's view of hostB: it says nothing about what hostA
-omitted or invented. The boundary runs between the two hosts, not inside hostB: the receiver
-runs as the enrolled account and remembers what it created by pathname, so a
-local writer who can already modify the destination tree is outside its
-guarantee, exactly as for the ordinary engine.
+HostA also cannot forge a clean account of what hostB's restricted receiver
+did. Every attached command-restricted transfer ends with a v2 receipt. Its
+canonical stream records one outcome for every receiver-visible logical
+pathname mutation: one file lifecycle, each directory/symlink/special or
+metadata operation, and each individual `--prune` unlink or rmdir. Failed and
+abandoned operations and bounded refusal records remain visible. After closing
+the grant and waiting for admitted requests to settle, hostB records the final
+type, size, symlink target, applicable metadata, and optional BLAKE3 digest of
+every path an admitted mutation could have changed. Paths are raw bytes
+relative to numbered signed mutation scopes, never ambient absolute hostB
+paths.
+
+The small signed terminal binds the complete signed grant, enrollment and
+one-time request IDs, stream digest/count/size, policy, summary, and clean or
+non-clean status. HostB then encrypts the stream and signed terminal to a fresh
+per-transfer X25519 recipient key using HPKE (X25519/HKDF-SHA-256/
+ChaCha20-Poly1305). HostA relays bounded opaque frames. The invoking machine
+spools them outside the heap, decrypts them, and checks HPKE authentication,
+the enrolled Ed25519 signature, grant binding, sequence, complete stream
+commitment, summary, and terminal status before printing trusted results.
+Missing, altered, reordered, replayed, or suppressed frames cannot become a
+valid clean receipt; suppression remains a denial of service. `-v` prints the
+verified totals. Enrollments made by an older syq must be refreshed with
+`syq enrollment add` first (eligible ordinary copies can do this
+automatically). The initial signed policy caps the stream at 4,000,000 records
+and 512 MiB of plaintext. Reaching either cap closes further mutation authority
+and produces an explicit non-clean terminal instead of a truncated clean
+receipt. Encryption does not pad or conceal frame count, ciphertext length, or
+timing.
+
+This is hostB's closure-time account, not a transaction or a source manifest.
+It does not prove that hostA supplied every intended path or the intended
+bytes, roll back a failed transfer, inventory source scans, blocks, syscalls,
+or descendants of one logical recursive operation, protect a compromised
+hostB or receipt key, protect against a hostB-local writer already authorized
+to modify the tree, or make the observed state immutable after issuance.
+Diagnostic text is bounded context rather than a stable interface; structured
+codes and dispositions are authoritative. An authenticated expected manifest
+is required for source completeness and byte authenticity.
+
+Restricted `--detach` deliberately has a weaker boundary until durable local
+job state exists. The launcher prints a security warning even under `-q` and
+reports only that the job started. HostB's signed v2 stream is plaintext in
+hostA's detached log, so hostA can read or suppress it, and `--follow` displays
+but does not locally authenticate completion.
 
 The command-restricted path requires encrypted TCP data connections. Ordered
 filter rules and `--delete-excluded` are included in the signed grant: the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -728,7 +728,7 @@ struct NativeCopyOperationalArgs {
     /// Command-restricted receiver ceiling: the signed grant expires DURATION after it is issued, e.g. 30m or 2h (direct remote-to-remote only; at most 23h)
     #[arg(long, value_name = "DURATION")]
     max_runtime: Option<String>,
-    /// Receipt detail from the command-restricted receiver: sizes of published files (default) or also a BLAKE3 digest of each (direct remote-to-remote only)
+    /// Receiver receipt detail: final sizes (default) or also final BLAKE3 file digests (direct remote-to-remote only)
     #[arg(long, value_name = "MODE", value_enum)]
     receipt: Option<ReceiptMode>,
 }
@@ -770,7 +770,7 @@ struct NativeRemoteArgs {
         conflicts_with = "no_tcp"
     )]
     tcp_congestion: Option<String>,
-    /// Run a remote-to-remote transfer detached at its coordinator
+    /// Run at the remote coordinator and return after launch; restricted receipts remain plaintext in its log and are not locally verified
     #[arg(long)]
     detach: bool,
     /// Give a remote coordinator no forwarded agent; it must own credentials for the peer

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -52,7 +52,8 @@ use std::time::{Duration, Instant};
 
 pub(crate) const SSHSIG_NAMESPACE: &str = "syq-grant@greaber.github";
 const WIRE_MAGIC: &[u8; 8] = b"SYQGRNT\0";
-const WIRE_VERSION: u16 = 1;
+const WIRE_VERSION_V1: u16 = 1;
+const WIRE_VERSION: u16 = 2;
 const WIRE_HEADER_LEN: usize = WIRE_MAGIC.len() + 2 + 4 + 4;
 const MAX_GRANT_BYTES: usize = 32 * 1024;
 const MAX_SIGNATURE_BYTES: usize = 16 * 1024;
@@ -414,6 +415,16 @@ impl ReceiptPolicy {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct GrantBodyV2 {
+    grant: Grant,
+    max_file_data_bytes_per_second: u64,
+    filters: FilterPolicy,
+    root_existence: RootExistence,
+    receipt: ReceiptPolicy,
+    receipt_v2: crate::receipt_v2::ReceiptPolicyV2,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct SignedGrantEnvelope {
     pub grant: Grant,
@@ -421,6 +432,7 @@ pub(crate) struct SignedGrantEnvelope {
     pub filters: FilterPolicy,
     pub root_existence: RootExistence,
     pub receipt: ReceiptPolicy,
+    pub receipt_v2: Option<crate::receipt_v2::ReceiptPolicyV2>,
     /// Canonical OpenSSH armored SSHSIG bytes.
     pub signature: Vec<u8>,
 }
@@ -434,6 +446,7 @@ impl SignedGrantEnvelope {
             filters: FilterPolicy::default(),
             root_existence: RootExistence::Any,
             receipt: ReceiptPolicy::default(),
+            receipt_v2: None,
             signature,
         }
     }
@@ -441,12 +454,19 @@ impl SignedGrantEnvelope {
     pub(crate) fn encode(&self) -> Result<Vec<u8>> {
         self.grant.validate_static()?;
         validate_canonical_sshsig(&self.signature)?;
+        let wire_version = if self.receipt_v2.is_some() {
+            WIRE_VERSION
+        } else {
+            WIRE_VERSION_V1
+        };
         let body = canonical_body_bytes(
+            wire_version,
             &self.grant,
             self.max_file_data_bytes_per_second,
             &self.filters,
             self.root_existence,
             self.receipt,
+            self.receipt_v2.as_ref(),
         )?;
         if body.len() > MAX_GRANT_BYTES {
             bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
@@ -456,7 +476,7 @@ impl SignedGrantEnvelope {
         }
         let mut out = Vec::with_capacity(WIRE_HEADER_LEN + body.len() + self.signature.len());
         out.extend_from_slice(WIRE_MAGIC);
-        out.extend_from_slice(&WIRE_VERSION.to_be_bytes());
+        out.extend_from_slice(&wire_version.to_be_bytes());
         out.extend_from_slice(&(body.len() as u32).to_be_bytes());
         out.extend_from_slice(&(self.signature.len() as u32).to_be_bytes());
         out.extend_from_slice(&body);
@@ -472,7 +492,7 @@ impl SignedGrantEnvelope {
             bail!("not a SYQ signed grant envelope");
         }
         let version = u16::from_be_bytes(bytes[8..10].try_into().expect("fixed header"));
-        if version != WIRE_VERSION {
+        if !matches!(version, WIRE_VERSION_V1 | WIRE_VERSION) {
             bail!("unsupported signed grant envelope version {version}");
         }
         let grant_len =
@@ -493,27 +513,60 @@ impl SignedGrantEnvelope {
             bail!("signed grant envelope length is noncanonical");
         }
         let body_bytes = &bytes[WIRE_HEADER_LEN..WIRE_HEADER_LEN + grant_len];
-        let body: GrantBody = postcard::from_bytes(body_bytes).context("decode signed grant")?;
+        let (grant, max_file_data_bytes_per_second, filters, root_existence, receipt, receipt_v2) =
+            match version {
+                WIRE_VERSION_V1 => {
+                    let body: GrantBody =
+                        postcard::from_bytes(body_bytes).context("decode signed grant")?;
+                    (
+                        body.grant,
+                        body.max_file_data_bytes_per_second,
+                        body.filters,
+                        body.root_existence,
+                        body.receipt,
+                        None,
+                    )
+                }
+                WIRE_VERSION => {
+                    let body: GrantBodyV2 =
+                        postcard::from_bytes(body_bytes).context("decode signed grant")?;
+                    (
+                        body.grant,
+                        body.max_file_data_bytes_per_second,
+                        body.filters,
+                        body.root_existence,
+                        body.receipt,
+                        Some(body.receipt_v2),
+                    )
+                }
+                _ => unreachable!(),
+            };
         if canonical_body_bytes(
-            &body.grant,
-            body.max_file_data_bytes_per_second,
-            &body.filters,
-            body.root_existence,
-            body.receipt,
+            version,
+            &grant,
+            max_file_data_bytes_per_second,
+            &filters,
+            root_existence,
+            receipt,
+            receipt_v2.as_ref(),
         )? != body_bytes
         {
             bail!("signed grant uses a noncanonical encoding");
         }
-        body.grant.validate_static()?;
-        body.filters.validate(&body.grant)?;
+        grant.validate_static()?;
+        filters.validate(&grant)?;
+        if let Some(receipt) = &receipt_v2 {
+            receipt.validate()?;
+        }
         let signature = bytes[WIRE_HEADER_LEN + grant_len..].to_vec();
         validate_canonical_sshsig(&signature)?;
         Ok(Self {
-            grant: body.grant,
-            max_file_data_bytes_per_second: body.max_file_data_bytes_per_second,
-            filters: body.filters,
-            root_existence: body.root_existence,
-            receipt: body.receipt,
+            grant,
+            max_file_data_bytes_per_second,
+            filters,
+            root_existence,
+            receipt,
+            receipt_v2,
             signature,
         })
     }
@@ -525,6 +578,7 @@ impl SignedGrantEnvelope {
             &self.filters,
             self.root_existence,
             self.receipt,
+            self.receipt_v2.as_ref(),
         )
     }
 }
@@ -539,6 +593,7 @@ pub(crate) fn sign_grant(
         mut filters,
         root_existence,
         receipt,
+        receipt_v2,
     } = constraints;
     if private_key.is_encrypted() {
         bail!("cannot sign a grant with an encrypted transport key");
@@ -558,6 +613,7 @@ pub(crate) fn sign_grant(
         &filters,
         root_existence,
         receipt,
+        receipt_v2.as_ref(),
     )?;
     let signature = private_key
         .sign(SSHSIG_NAMESPACE, HashAlg::Sha256, &payload)
@@ -571,6 +627,7 @@ pub(crate) fn sign_grant(
         filters,
         root_existence,
         receipt,
+        receipt_v2,
         signature,
     }
     .encode()
@@ -584,6 +641,7 @@ fn signing_payload_default(grant: &Grant, max_file_data_bytes_per_second: u64) -
         &FilterPolicy::default(),
         RootExistence::Any,
         ReceiptPolicy::default(),
+        None,
     )
 }
 
@@ -593,43 +651,83 @@ fn signing_payload(
     filters: &FilterPolicy,
     root_existence: RootExistence,
     receipt: ReceiptPolicy,
+    receipt_v2: Option<&crate::receipt_v2::ReceiptPolicyV2>,
 ) -> Result<Vec<u8>> {
     grant.validate_static()?;
     filters.validate(grant)?;
+    let wire_version = if receipt_v2.is_some() {
+        WIRE_VERSION
+    } else {
+        WIRE_VERSION_V1
+    };
     let body = canonical_body_bytes(
+        wire_version,
         grant,
         max_file_data_bytes_per_second,
         filters,
         root_existence,
         receipt,
+        receipt_v2,
     )?;
     if body.len() > MAX_GRANT_BYTES {
         bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
     }
     let mut out = Vec::with_capacity(WIRE_MAGIC.len() + 2 + 4 + body.len());
     out.extend_from_slice(WIRE_MAGIC);
-    out.extend_from_slice(&WIRE_VERSION.to_be_bytes());
+    out.extend_from_slice(&wire_version.to_be_bytes());
     out.extend_from_slice(&(body.len() as u32).to_be_bytes());
     out.extend_from_slice(&body);
     Ok(out)
 }
 
 fn canonical_body_bytes(
+    wire_version: u16,
     grant: &Grant,
     max_file_data_bytes_per_second: u64,
     filters: &FilterPolicy,
     root_existence: RootExistence,
     receipt: ReceiptPolicy,
+    receipt_v2: Option<&crate::receipt_v2::ReceiptPolicyV2>,
 ) -> Result<Vec<u8>> {
     receipt.validate()?;
-    postcard::to_stdvec(&GrantBody {
-        grant: grant.clone(),
-        max_file_data_bytes_per_second,
-        filters: filters.clone(),
-        root_existence,
-        receipt,
-    })
-    .context("encode canonical signed grant")
+    if let Some(receipt) = receipt_v2 {
+        receipt.validate()?;
+    }
+    if receipt.required && receipt_v2.is_some() {
+        bail!("a grant cannot carry both v1 and v2 receipt policies");
+    }
+    match wire_version {
+        WIRE_VERSION_V1 => {
+            if receipt_v2.is_some() {
+                bail!("version-one grants cannot carry a v2 receipt policy");
+            }
+            postcard::to_stdvec(&GrantBody {
+                grant: grant.clone(),
+                max_file_data_bytes_per_second,
+                filters: filters.clone(),
+                root_existence,
+                receipt,
+            })
+            .context("encode canonical signed grant")
+        }
+        WIRE_VERSION => {
+            if receipt != ReceiptPolicy::default() {
+                bail!("version-two grants cannot carry a legacy receipt policy");
+            }
+            postcard::to_stdvec(&GrantBodyV2 {
+                grant: grant.clone(),
+                max_file_data_bytes_per_second,
+                filters: filters.clone(),
+                root_existence,
+                receipt,
+                receipt_v2: receipt_v2
+                    .context("version-two grant requires a v2 receipt policy")?
+                    .clone(),
+            })
+            .context("encode canonical signed grant")
+        }
+        _ => bail!("unsupported signed grant envelope version {wire_version}"),
+    }
 }
 
 fn validate_identity(name: &str, value: &str, maximum: usize, slash_allowed: bool) -> Result<()> {
@@ -1042,6 +1140,8 @@ pub(crate) struct VerifiedGrant {
     filters: FilterPolicy,
     root_existence: RootExistence,
     receipt: ReceiptPolicy,
+    receipt_v2: Option<crate::receipt_v2::ReceiptPolicyV2>,
+    grant_digest: [u8; 32],
     execution_deadline: Instant,
 }
 
@@ -1052,6 +1152,7 @@ pub(crate) struct GrantConstraints {
     pub filters: FilterPolicy,
     pub root_existence: RootExistence,
     pub receipt: ReceiptPolicy,
+    pub receipt_v2: Option<crate::receipt_v2::ReceiptPolicyV2>,
 }
 
 impl VerifiedGrant {
@@ -1060,7 +1161,7 @@ impl VerifiedGrant {
         self.execution_deadline
     }
 
-    pub(crate) fn into_parts(self) -> (Grant, GrantConstraints, Instant) {
+    pub(crate) fn into_parts(self) -> (Grant, GrantConstraints, [u8; 32], Instant) {
         (
             self.grant,
             GrantConstraints {
@@ -1068,7 +1169,9 @@ impl VerifiedGrant {
                 filters: self.filters,
                 root_existence: self.root_existence,
                 receipt: self.receipt,
+                receipt_v2: self.receipt_v2,
             },
+            self.grant_digest,
             self.execution_deadline,
         )
     }
@@ -1083,15 +1186,16 @@ pub(crate) fn verify_and_claim(
     let envelope = SignedGrantEnvelope::decode(encoded)?;
     context.validate_at(&envelope.grant, Instant::now())?;
     let payload = envelope.signing_payload()?;
-    let digest: [u8; 32] = Sha256::digest(&payload).into();
-    replay.reject_if_claimed(envelope.grant.request_id, digest)?;
+    let replay_digest: [u8; 32] = Sha256::digest(&payload).into();
+    let grant_digest = grant_transcript_digest(&payload);
+    replay.reject_if_claimed(envelope.grant.request_id, replay_digest)?;
     policy.verify(
         replay,
         context.expected_signer,
         &envelope.signature,
         &payload,
     )?;
-    replay.claim_after_lock(envelope.grant.request_id, digest, || {
+    replay.claim_after_lock(envelope.grant.request_id, replay_digest, || {
         context.validate_at(&envelope.grant, Instant::now())
     })?;
     let verified_at = Instant::now();
@@ -1108,8 +1212,23 @@ pub(crate) fn verify_and_claim(
         filters: envelope.filters,
         root_existence: envelope.root_existence,
         receipt: envelope.receipt,
+        receipt_v2: envelope.receipt_v2,
+        grant_digest,
         execution_deadline,
     })
+}
+
+pub(crate) fn signed_grant_digest(encoded: &[u8]) -> Result<[u8; 32]> {
+    let envelope = SignedGrantEnvelope::decode(encoded)?;
+    Ok(grant_transcript_digest(&envelope.signing_payload()?))
+}
+
+fn grant_transcript_digest(payload: &[u8]) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"syq-grant-transcript-v1@greaber.github\0");
+    hasher.update(&(payload.len() as u64).to_be_bytes());
+    hasher.update(payload);
+    *hasher.finalize().as_bytes()
 }
 
 fn execution_deadline(
@@ -2165,16 +2284,18 @@ mod tests {
         signature: &[u8],
     ) -> Vec<u8> {
         let grant = canonical_body_bytes(
+            WIRE_VERSION_V1,
             grant,
             max_file_data_bytes_per_second,
             &FilterPolicy::default(),
             RootExistence::Any,
             ReceiptPolicy::default(),
+            None,
         )
         .expect("encode test grant");
         let mut out = Vec::new();
         out.extend_from_slice(WIRE_MAGIC);
-        out.extend_from_slice(&WIRE_VERSION.to_be_bytes());
+        out.extend_from_slice(&WIRE_VERSION_V1.to_be_bytes());
         out.extend_from_slice(&(grant.len() as u32).to_be_bytes());
         out.extend_from_slice(&(signature.len() as u32).to_be_bytes());
         out.extend_from_slice(&grant);
@@ -2331,6 +2452,10 @@ mod tests {
         )
         .unwrap();
         let decoded = SignedGrantEnvelope::decode(&receipted).unwrap();
+        assert_eq!(
+            u16::from_be_bytes(receipted[8..10].try_into().unwrap()),
+            WIRE_VERSION_V1
+        );
         assert_eq!(decoded.receipt, policy);
         let verified = verify_and_claim(
             &receipted,
@@ -2352,6 +2477,45 @@ mod tests {
             &private,
         )
         .is_err());
+
+        // Grant v2 binds the complete receipt delivery policy, including the
+        // per-transfer HPKE recipient key, into the signed grant transcript.
+        let policy_v2 = crate::receipt_v2::ReceiptPolicyV2 {
+            required: true,
+            hashed: true,
+            max_records: 32,
+            max_plaintext_bytes: 64 * 1024,
+            delivery: crate::receipt_v2::ReceiptDeliveryV2::AttachedEncrypted {
+                suite: crate::receipt_v2::HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+                recipient_public_key: [4; 32],
+            },
+        };
+        let receipted_v2 = sign_grant(
+            fixture_grant(53),
+            GrantConstraints {
+                receipt_v2: Some(policy_v2.clone()),
+                ..GrantConstraints::default()
+            },
+            &private,
+        )
+        .unwrap();
+        let decoded = SignedGrantEnvelope::decode(&receipted_v2).unwrap();
+        assert_eq!(
+            u16::from_be_bytes(receipted_v2[8..10].try_into().unwrap()),
+            WIRE_VERSION
+        );
+        assert_eq!(decoded.receipt_v2, Some(policy_v2.clone()));
+        let expected_digest = signed_grant_digest(&receipted_v2).unwrap();
+        let verified = verify_and_claim(
+            &receipted_v2,
+            &context(SIGNER, TARGET, NOW, 0),
+            &fixture.policy(),
+            &fixture.replay("in-process-receipt-v2-signature-replay"),
+        )
+        .expect("OpenSSH must accept the signed receipt v2 policy");
+        let (_, extensions, digest, _) = verified.into_parts();
+        assert_eq!(extensions.receipt_v2, Some(policy_v2));
+        assert_eq!(digest, expected_digest);
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -6,42 +6,134 @@ use crate::delegation::RequestId;
 use crate::enrollment::EnrollmentId;
 use anyhow::{bail, Context, Result};
 use base64::Engine as _;
-use std::io::{BufRead, IsTerminal};
+use std::io::{BufRead, IsTerminal, Read, Seek, Write};
 use std::process::{Command, Stdio};
 
 /// What the invoking machine expects hostB's receipt to say about itself.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct ReceiptExpectation {
     public_key: String,
     enrollment_id: EnrollmentId,
     request_id: RequestId,
+    recipient_secret: Option<crate::receipt_v2::RecipientSecret>,
+    policy: Option<crate::receipt_v2::ReceiptPolicyV2>,
+    grant_digest: Option<[u8; 32]>,
 }
 
 /// The receipt envelope is bounded at 64 MiB; allow for base64 and slack.
 const MAX_RECEIPT_LINE_BYTES: usize = 96 * 1024 * 1024;
+const MAX_RECEIPT_V2_LINE_BYTES: usize = 192 * 1024;
+const MAX_RECEIPT_V2_CAPTURE_BYTES: u64 = 640 * 1024 * 1024;
+
+enum CapturedReceipt {
+    V1(Vec<u8>),
+    V2(CapturedReceiptV2),
+}
+
+struct CapturedReceiptV2 {
+    file: std::fs::File,
+    frames: u64,
+    bytes: u64,
+    ended: bool,
+}
+
+impl CapturedReceiptV2 {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            file: tempfile::tempfile().context("create encrypted receipt spool")?,
+            frames: 0,
+            bytes: 0,
+            ended: false,
+        })
+    }
+
+    fn push(&mut self, encoded: &[u8]) -> Result<()> {
+        if self.ended {
+            bail!("the relayed receipt contains a frame after its terminal frame");
+        }
+        let terminal = crate::receipt_v2::transport_frame_is_end(encoded)?;
+        let length = u32::try_from(encoded.len()).context("receipt frame length exceeds u32")?;
+        let added = 4u64 + u64::from(length);
+        self.bytes = self
+            .bytes
+            .checked_add(added)
+            .context("receipt capture byte count overflow")?;
+        if self.bytes > MAX_RECEIPT_V2_CAPTURE_BYTES {
+            bail!("the relayed receipt exceeds its local capture limit");
+        }
+        self.file.write_all(&length.to_be_bytes())?;
+        self.file.write_all(encoded)?;
+        self.frames += 1;
+        self.ended = terminal;
+        Ok(())
+    }
+
+    fn frames(&mut self) -> Result<CapturedFrames<'_>> {
+        self.file.flush()?;
+        self.file.seek(std::io::SeekFrom::Start(0))?;
+        Ok(CapturedFrames {
+            file: &mut self.file,
+            remaining: self.frames,
+        })
+    }
+}
+
+struct CapturedFrames<'a> {
+    file: &'a mut std::fs::File,
+    remaining: u64,
+}
+
+impl Iterator for CapturedFrames<'_> {
+    type Item = Result<Vec<u8>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        self.remaining -= 1;
+        Some((|| {
+            let mut length = [0u8; 4];
+            self.file.read_exact(&mut length)?;
+            let mut encoded = vec![0u8; u32::from_be_bytes(length) as usize];
+            self.file.read_exact(&mut encoded)?;
+            Ok(encoded)
+        })())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ReceiptLineKind {
+    V1,
+    V2,
+}
 
 /// Pass the orchestrator's stdout through byte for byte, keeping only the
-/// receipt line to ourselves. Used only when a receipt is expected; other
-/// transfers inherit stdout untouched. Returns the last receipt payload.
-fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<Vec<u8>>> {
+/// receipt marker lines to ourselves. Used only when a receipt is expected;
+/// other transfers inherit stdout untouched. V2 frames are decoded one line
+/// at a time and spooled rather than accumulated in memory.
+fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<CapturedReceipt>> {
     relay_stdout_bounded(stdout, MAX_RECEIPT_LINE_BYTES)
 }
 
 /// Streams every ordinary line straight through without holding more than
 /// one buffer of it, so a hostile orchestrator cannot make this machine
 /// buffer an arbitrarily long line; only a receipt line is collected, up to
-/// `limit` bytes.
-fn relay_stdout_bounded(stdout: impl std::io::Read, limit: usize) -> Result<Option<Vec<u8>>> {
-    use std::io::Write;
-    let prefix = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes();
+/// its protocol-specific limit.
+fn relay_stdout_bounded(
+    stdout: impl std::io::Read,
+    legacy_limit: usize,
+) -> Result<Option<CapturedReceipt>> {
+    let v1_prefix = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes();
+    let v2_prefix = crate::receipt_v2::RECEIPT_LINE_PREFIX.as_bytes();
+    let decision_len = v1_prefix.len().max(v2_prefix.len());
     let mut reader = std::io::BufReader::with_capacity(64 * 1024, stdout);
     let mut out = std::io::stdout().lock();
     let mut receipt = None;
     // The first bytes of the current line, held only until the prefix
     // decision; then either the receipt payload being collected or nothing.
-    let mut head: Vec<u8> = Vec::with_capacity(prefix.len());
+    let mut head: Vec<u8> = Vec::with_capacity(decision_len);
     let mut decided = false;
-    let mut capturing: Option<Vec<u8>> = None;
+    let mut capturing: Option<(ReceiptLineKind, Vec<u8>)> = None;
     let finish_capture = |payload: &mut Vec<u8>| {
         while payload
             .last()
@@ -68,31 +160,36 @@ fn relay_stdout_bounded(stdout: impl std::io::Read, limit: usize) -> Result<Opti
             consumed += segment.len();
             if !decided {
                 head.extend_from_slice(segment);
-                if head.len() >= prefix.len() || ends_line {
+                if head.len() >= decision_len || ends_line {
                     decided = true;
-                    if head.starts_with(prefix) {
-                        capturing = Some(head[prefix.len()..].to_vec());
+                    if head.starts_with(v2_prefix) {
+                        capturing = Some((ReceiptLineKind::V2, head[v2_prefix.len()..].to_vec()));
+                    } else if head.starts_with(v1_prefix) {
+                        capturing = Some((ReceiptLineKind::V1, head[v1_prefix.len()..].to_vec()));
                     } else {
                         out.write_all(&head)
                             .context("relay remote orchestrator output")?;
                     }
                     head.clear();
                 }
-            } else if let Some(payload) = capturing.as_mut() {
+            } else if let Some((_, payload)) = capturing.as_mut() {
                 payload.extend_from_slice(segment);
             } else {
                 out.write_all(segment)
                     .context("relay remote orchestrator output")?;
             }
-            if let Some(payload) = capturing.as_mut() {
+            if let Some((kind, payload)) = capturing.as_mut() {
+                let limit = match kind {
+                    ReceiptLineKind::V1 => legacy_limit,
+                    ReceiptLineKind::V2 => MAX_RECEIPT_V2_LINE_BYTES,
+                };
                 if payload.len() > limit {
                     bail!("the relayed receipt line exceeds {limit} bytes");
                 }
             }
             if ends_line {
-                if let Some(payload) = capturing.as_mut() {
-                    receipt = Some(finish_capture(payload));
-                    capturing = None;
+                if let Some((kind, mut payload)) = capturing.take() {
+                    store_receipt_line(&mut receipt, kind, finish_capture(&mut payload))?;
                 } else {
                     out.flush().context("relay remote orchestrator output")?;
                 }
@@ -103,18 +200,48 @@ fn relay_stdout_bounded(stdout: impl std::io::Read, limit: usize) -> Result<Opti
     }
     // Output that ended without a newline.
     if !head.is_empty() {
-        if head.starts_with(prefix) {
-            capturing = Some(head[prefix.len()..].to_vec());
+        if head.starts_with(v2_prefix) {
+            capturing = Some((ReceiptLineKind::V2, head[v2_prefix.len()..].to_vec()));
+        } else if head.starts_with(v1_prefix) {
+            capturing = Some((ReceiptLineKind::V1, head[v1_prefix.len()..].to_vec()));
         } else {
             out.write_all(&head)
                 .context("relay remote orchestrator output")?;
         }
     }
-    if let Some(payload) = capturing.as_mut() {
-        receipt = Some(finish_capture(payload));
+    if let Some((kind, mut payload)) = capturing.take() {
+        store_receipt_line(&mut receipt, kind, finish_capture(&mut payload))?;
     }
     out.flush().context("relay remote orchestrator output")?;
     Ok(receipt)
+}
+
+fn store_receipt_line(
+    captured: &mut Option<CapturedReceipt>,
+    kind: ReceiptLineKind,
+    payload: Vec<u8>,
+) -> Result<()> {
+    match kind {
+        ReceiptLineKind::V1 => {
+            if captured.is_some() {
+                bail!("the remote orchestrator relayed more than one legacy receipt line");
+            }
+            *captured = Some(CapturedReceipt::V1(payload));
+        }
+        ReceiptLineKind::V2 => {
+            let encoded = base64::engine::general_purpose::STANDARD_NO_PAD
+                .decode(payload.trim_ascii())
+                .context("decode a receipt v2 frame relayed from the source host")?;
+            if captured.is_none() {
+                *captured = Some(CapturedReceipt::V2(CapturedReceiptV2::new()?));
+            }
+            let Some(CapturedReceipt::V2(receipt)) = captured.as_mut() else {
+                bail!("the remote orchestrator mixed receipt protocol versions");
+            };
+            receipt.push(&encoded)?;
+        }
+    }
+    Ok(())
 }
 
 /// Verify hostB's receipt against the grant this machine signed. A missing,
@@ -122,16 +249,31 @@ fn relay_stdout_bounded(stdout: impl std::io::Read, limit: usize) -> Result<Opti
 /// what the source-side orchestrator reported.
 fn settle_receipt(
     expectation: &ReceiptExpectation,
-    payload: Option<&[u8]>,
+    captured: Option<&mut CapturedReceipt>,
     src_host: &str,
     dst_host: &str,
-    orchestrator_succeeded: bool,
+    orchestrator_exit_code: i32,
+    emit_results: bool,
     verbose: bool,
 ) -> Result<()> {
-    let Some(payload) = payload else {
+    let Some(captured) = captured else {
         bail!(
             "the command-restricted receiver on {dst_host} issued no receipt through {src_host}; what landed cannot be verified"
         );
+    };
+    if expectation.policy.is_some() {
+        return settle_receipt_v2(
+            expectation,
+            captured,
+            src_host,
+            dst_host,
+            orchestrator_exit_code,
+            emit_results,
+            verbose,
+        );
+    }
+    let CapturedReceipt::V1(payload) = captured else {
+        bail!("the receiver on {dst_host} returned a receipt protocol version that does not match the signed grant");
     };
     let envelope = base64::engine::general_purpose::STANDARD_NO_PAD
         .decode(payload.trim_ascii())
@@ -161,7 +303,7 @@ fn settle_receipt(
             "{} in-place file(s) on {dst_host} were written but never completed",
             receipt.incomplete_count
         );
-        if orchestrator_succeeded {
+        if orchestrator_exit_code == 0 {
             bail!("{message}, yet {src_host} reported success");
         }
         eprintln!("syq: warning: {message}");
@@ -174,6 +316,147 @@ fn settle_receipt(
             receipt.deleted_count,
             receipt.observed_count,
             receipt.entries
+        );
+    }
+    Ok(())
+}
+
+fn settle_receipt_v2(
+    expectation: &ReceiptExpectation,
+    captured: &mut CapturedReceipt,
+    src_host: &str,
+    dst_host: &str,
+    orchestrator_exit_code: i32,
+    emit_results: bool,
+    verbose: bool,
+) -> Result<()> {
+    let CapturedReceipt::V2(captured) = captured else {
+        bail!("the receiver on {dst_host} returned a legacy receipt for a v2 grant");
+    };
+    if !captured.ended {
+        bail!("the receipt relayed through {src_host} has no terminal frame");
+    }
+    let secret = expectation
+        .recipient_secret
+        .as_ref()
+        .context("the local HPKE receipt key is unavailable")?;
+    let policy = expectation
+        .policy
+        .as_ref()
+        .context("the signed receipt policy is unavailable")?;
+    if !matches!(
+        policy.delivery,
+        crate::receipt_v2::ReceiptDeliveryV2::AttachedEncrypted { .. }
+    ) {
+        bail!("an attached transfer has a detached receipt policy");
+    }
+    let grant_digest = expectation
+        .grant_digest
+        .context("the signed grant digest is unavailable")?;
+    let frames = captured.frames()?;
+    let mut receipt = crate::receipt_v2::open_attached_frames(
+        frames,
+        secret,
+        &expectation.public_key,
+        expectation.enrollment_id,
+        expectation.request_id,
+        grant_digest,
+        policy,
+    )
+    .with_context(|| format!("decrypt and verify the receipt from {dst_host}"))?;
+
+    let mut first_problem = None;
+    receipt.for_each_record(|record| {
+        if first_problem.is_none() {
+            first_problem = match record {
+                crate::receipt_v2::RecordV2::Operation(record)
+                    if !matches!(
+                        record.disposition,
+                        crate::receipt_v2::OperationDispositionV2::Applied
+                            | crate::receipt_v2::OperationDispositionV2::Observed
+                    ) =>
+                {
+                    Some(format!(
+                        "{:?} {:?} for scope {} path {:?}{}",
+                        record.action,
+                        record.disposition,
+                        record.scope,
+                        String::from_utf8_lossy(&record.path),
+                        record
+                            .diagnostic
+                            .as_deref()
+                            .map(|message| format!(": {message}"))
+                            .unwrap_or_default()
+                    ))
+                }
+                crate::receipt_v2::RecordV2::Refusal(record) => Some(format!(
+                    "receiver refusal{}",
+                    record
+                        .diagnostic
+                        .as_deref()
+                        .map(|message| format!(": {message}"))
+                        .unwrap_or_default()
+                )),
+                crate::receipt_v2::RecordV2::FinalState(record)
+                    if matches!(
+                        record.object,
+                        crate::receipt_v2::FinalObjectV2::ObservationFailed { .. }
+                            | crate::receipt_v2::FinalObjectV2::Present {
+                                observation_error: Some(_),
+                                ..
+                            }
+                    ) =>
+                {
+                    Some(format!(
+                        "final-state observation failed for scope {} path {:?}",
+                        record.scope,
+                        String::from_utf8_lossy(&record.path)
+                    ))
+                }
+                _ => None,
+            };
+        }
+        Ok(())
+    })?;
+
+    let terminal = receipt.terminal.clone();
+    if emit_results {
+        crate::receipt_v2::write_automation_results(
+            &mut receipt,
+            &mut std::io::stdout().lock(),
+            orchestrator_exit_code,
+        )
+        .context("write receiver-attested --results stream")?;
+    }
+    if terminal.summary.refusals > 0 {
+        bail!(
+            "the receiver on {dst_host} refused {} request(s) from {src_host}; first: {}",
+            terminal.summary.refusals,
+            first_problem.as_deref().unwrap_or("(no detail recorded)")
+        );
+    }
+    if terminal.status != crate::receipt_v2::ReceiptStatusV2::Clean {
+        let message = format!(
+            "the receiver on {dst_host} issued a {:?} receipt{}",
+            terminal.status,
+            first_problem
+                .as_deref()
+                .map(|problem| format!("; first: {problem}"))
+                .unwrap_or_default()
+        );
+        if orchestrator_exit_code == 0 {
+            bail!("{message}, yet {src_host} reported success");
+        }
+        eprintln!("syq: warning: {message}");
+    }
+    if verbose {
+        eprintln!(
+            "syq: encrypted receipt from {dst_host} verified: {} operations, {} final states, {} files published ({}), {} deletions",
+            terminal.summary.operations,
+            terminal.summary.final_states,
+            terminal.summary.published_files,
+            crate::progress::human(terminal.summary.published_bytes),
+            terminal.summary.deletions
         );
     }
     Ok(())
@@ -515,6 +798,9 @@ fn run_remote(
                 public_key: prepared.receipt_public_key.clone(),
                 enrollment_id: prepared.enrollment_id,
                 request_id: prepared.request_id,
+                recipient_secret: prepared.receipt_recipient_secret,
+                policy: Some(prepared.receipt_policy),
+                grant_digest: Some(prepared.grant_digest),
             });
             if !args.quiet {
                 eprintln!(
@@ -632,7 +918,7 @@ fn run_remote(
     if let Some(n) = args.max_delete {
         remote.push(format!("--max-delete={n}"));
     }
-    if args.native_results.is_some() {
+    if args.native_results.is_some() && receipt_expectation.is_none() {
         // run_remote accepts only stdout above. The outer SSH process inherits
         // stdout, so the NDJSON stream and its terminal record reach the
         // original caller without assigning surprising remote path semantics.
@@ -810,6 +1096,11 @@ fn run_remote(
         );
     }
     if args.detach {
+        if receipt_expectation.is_some() {
+            eprintln!(
+                "syq: warning: detached restricted transfer reports only that the job started; its final signed receipt will be plaintext in hostA's log, visible to hostA, and will not be verified on this machine"
+            );
+        }
         let run = || {
             let mut cmd = make_command();
             cmd.stdin(Stdio::null())
@@ -890,10 +1181,11 @@ fn run_remote(
     if let Some(expectation) = &receipt_expectation {
         settle_receipt(
             expectation,
-            receipt_payload.as_deref(),
+            receipt_payload.as_mut(),
             &coordinator_host,
             peer.host.as_deref().unwrap_or("the peer endpoint"),
-            code == 0,
+            code,
+            args.native_results.is_some(),
             args.verbose > 0,
         )?;
     }
@@ -1081,6 +1373,9 @@ mod tests {
             public_key: key.public_key().to_openssh().unwrap(),
             enrollment_id,
             request_id,
+            recipient_secret: None,
+            policy: None,
+            grant_digest: None,
         };
         let mut ledger = crate::receipt::Ledger::default();
         ledger.published.insert(
@@ -1099,12 +1394,15 @@ mod tests {
                 .encode(crate::receipt::sign(&receipt, &key).unwrap())
         };
         let settle = |expectation: &ReceiptExpectation, payload: Option<&str>| {
+            let mut captured =
+                payload.map(|payload| CapturedReceipt::V1(payload.as_bytes().to_vec()));
             settle_receipt(
                 expectation,
-                payload.map(str::as_bytes),
+                captured.as_mut(),
                 "host-a",
                 "host-b",
-                true,
+                0,
+                false,
                 false,
             )
         };
@@ -1137,11 +1435,13 @@ mod tests {
         );
         let partial = encode(&partial, request_id);
         assert!(settle(&expectation, Some(&partial)).is_err());
+        let mut captured = CapturedReceipt::V1(partial.as_bytes().to_vec());
         settle_receipt(
             &expectation,
-            Some(partial.as_bytes()),
+            Some(&mut captured),
             "host-a",
             "host-b",
+            23,
             false,
             false,
         )
@@ -1155,7 +1455,11 @@ mod tests {
         .unwrap();
         let mismatched = ReceiptExpectation {
             public_key: stranger.public_key().to_openssh().unwrap(),
-            ..expectation.clone()
+            enrollment_id,
+            request_id,
+            recipient_secret: None,
+            policy: None,
+            grant_digest: None,
         };
         assert!(settle(&mismatched, Some(&good)).is_err());
 
@@ -1165,11 +1469,12 @@ mod tests {
         output.extend_from_slice(crate::receipt::RECEIPT_LINE_PREFIX.as_bytes());
         output.extend_from_slice(good.as_bytes());
         output.extend_from_slice(b"\r\n");
-        assert_eq!(
-            relay_stdout(output.as_slice()).unwrap().as_deref(),
-            Some(good.as_bytes())
-        );
-        assert_eq!(relay_stdout(b"plain\n".as_slice()).unwrap(), None);
+        let relayed = relay_stdout(output.as_slice()).unwrap().unwrap();
+        let CapturedReceipt::V1(relayed) = relayed else {
+            panic!("expected a legacy receipt");
+        };
+        assert_eq!(relayed, good.as_bytes());
+        assert!(relay_stdout(b"plain\n".as_slice()).unwrap().is_none());
 
         // Ordinary lines stream through however long they are, a receipt
         // line without a trailing newline still counts, and an oversized
@@ -1178,16 +1483,50 @@ mod tests {
         long.push(b'\n');
         long.extend_from_slice(crate::receipt::RECEIPT_LINE_PREFIX.as_bytes());
         long.extend_from_slice(good.as_bytes());
-        assert_eq!(
-            relay_stdout_bounded(long.as_slice(), 4096)
-                .unwrap()
-                .as_deref(),
-            Some(good.as_bytes())
-        );
+        let relayed = relay_stdout_bounded(long.as_slice(), 4096)
+            .unwrap()
+            .unwrap();
+        let CapturedReceipt::V1(relayed) = relayed else {
+            panic!("expected a legacy receipt");
+        };
+        assert_eq!(relayed, good.as_bytes());
         let mut oversized = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes().to_vec();
         oversized.extend(std::iter::repeat_n(b'A', 5000));
         oversized.push(b'\n');
         assert!(relay_stdout_bounded(oversized.as_slice(), 4096).is_err());
+
+        // V2 marker lines are decoded and spooled as separate bounded frames,
+        // not accumulated into one receipt allocation.
+        let frames = [
+            crate::receipt_v2::TransportFrameV2::Start {
+                mode: crate::receipt_v2::TransportModeV2::DetachedSignedPlaintext,
+                encapsulated_key: Vec::new(),
+            },
+            crate::receipt_v2::TransportFrameV2::Chunk {
+                sequence: 0,
+                payload: b"stream".to_vec(),
+            },
+            crate::receipt_v2::TransportFrameV2::End {
+                sequence: 1,
+                payload: b"terminal".to_vec(),
+            },
+        ]
+        .map(|frame| crate::receipt_v2::encode_transport_frame(&frame).unwrap());
+        let mut output = Vec::new();
+        for frame in &frames {
+            output.extend_from_slice(crate::receipt_v2::RECEIPT_LINE_PREFIX.as_bytes());
+            output.extend_from_slice(
+                base64::engine::general_purpose::STANDARD_NO_PAD
+                    .encode(frame)
+                    .as_bytes(),
+            );
+            output.push(b'\n');
+        }
+        let Some(CapturedReceipt::V2(mut captured)) = relay_stdout(&output[..]).unwrap() else {
+            panic!("expected captured receipt v2 frames");
+        };
+        let captured: Vec<Vec<u8>> = captured.frames().unwrap().map(Result::unwrap).collect();
+        assert_eq!(captured, frames);
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -20,6 +20,45 @@ struct ReceiptExpectation {
     grant_digest: Option<[u8; 32]>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ReceiptSettlementOutcome {
+    results_status: &'static str,
+    exit_code: i32,
+    rejects_receipt: bool,
+}
+
+fn receipt_settlement_outcome(
+    receipt_status: crate::receipt_v2::ReceiptStatusV2,
+    refusals: u64,
+    orchestrator_exit_code: i32,
+) -> ReceiptSettlementOutcome {
+    let rejects_receipt = refusals > 0
+        || (receipt_status != crate::receipt_v2::ReceiptStatusV2::Clean
+            && orchestrator_exit_code == 0);
+    let exit_code = if rejects_receipt {
+        1
+    } else {
+        orchestrator_exit_code
+    };
+    let results_status = if receipt_status == crate::receipt_v2::ReceiptStatusV2::Incomplete {
+        // An incomplete receipt stream can omit operations. Never describe it
+        // as safe input for a per-entry retry, even when the coordinator also
+        // reported a conventional partial-transfer exit.
+        "aborted"
+    } else if refusals > 0 || orchestrator_exit_code == 25 {
+        "refused"
+    } else if exit_code == 0 {
+        "success"
+    } else {
+        "partial"
+    };
+    ReceiptSettlementOutcome {
+        results_status,
+        exit_code,
+        rejects_receipt,
+    }
+}
+
 /// The receipt envelope is bounded at 64 MiB; allow for base64 and slack.
 const MAX_RECEIPT_LINE_BYTES: usize = 96 * 1024 * 1024;
 const MAX_RECEIPT_V2_LINE_BYTES: usize = 192 * 1024;
@@ -420,20 +459,43 @@ fn settle_receipt_v2(
     })?;
 
     let terminal = receipt.terminal.clone();
+    let outcome = receipt_settlement_outcome(
+        terminal.status,
+        terminal.summary.refusals,
+        orchestrator_exit_code,
+    );
+    let settlement_error = if terminal.summary.refusals > 0 {
+        Some(format!(
+            "the receiver on {dst_host} refused {} request(s) from {src_host}; first: {}",
+            terminal.summary.refusals,
+            first_problem.as_deref().unwrap_or("(no detail recorded)")
+        ))
+    } else if terminal.status != crate::receipt_v2::ReceiptStatusV2::Clean
+        && orchestrator_exit_code == 0
+    {
+        Some(format!(
+            "the receiver on {dst_host} issued a {:?} receipt{}, yet {src_host} reported success",
+            terminal.status,
+            first_problem
+                .as_deref()
+                .map(|problem| format!("; first: {problem}"))
+                .unwrap_or_default()
+        ))
+    } else {
+        None
+    };
+    debug_assert_eq!(outcome.rejects_receipt, settlement_error.is_some());
     if emit_results {
         crate::receipt_v2::write_automation_results(
             &mut receipt,
             &mut std::io::stdout().lock(),
-            orchestrator_exit_code,
+            outcome.results_status,
+            outcome.exit_code,
         )
         .context("write receiver-attested --results stream")?;
     }
-    if terminal.summary.refusals > 0 {
-        bail!(
-            "the receiver on {dst_host} refused {} request(s) from {src_host}; first: {}",
-            terminal.summary.refusals,
-            first_problem.as_deref().unwrap_or("(no detail recorded)")
-        );
+    if let Some(message) = settlement_error {
+        bail!(message);
     }
     if terminal.status != crate::receipt_v2::ReceiptStatusV2::Clean {
         let message = format!(
@@ -444,9 +506,6 @@ fn settle_receipt_v2(
                 .map(|problem| format!("; first: {problem}"))
                 .unwrap_or_default()
         );
-        if orchestrator_exit_code == 0 {
-            bail!("{message}, yet {src_host} reported success");
-        }
         eprintln!("syq: warning: {message}");
     }
     if verbose {
@@ -1361,6 +1420,28 @@ mod tests {
         assert_eq!(broker_connection_limit(None, 8).unwrap(), 65);
         assert_eq!(broker_connection_limit(Some(128), 128).unwrap(), 129);
         assert!(broker_connection_limit(Some(usize::MAX), usize::MAX).is_err());
+    }
+
+    #[test]
+    fn receipt_settlement_preserves_terminal_outcomes() {
+        use crate::receipt_v2::ReceiptStatusV2::{Clean, Failed, Incomplete};
+
+        let cases = [
+            (Clean, 0, 0, "success", 0, false),
+            (Clean, 0, 23, "partial", 23, false),
+            (Clean, 0, 25, "refused", 25, false),
+            (Failed, 0, 0, "partial", 1, true),
+            (Failed, 1, 23, "refused", 1, true),
+            (Incomplete, 0, 0, "aborted", 1, true),
+            (Incomplete, 0, 23, "aborted", 23, false),
+            (Incomplete, 1, 23, "aborted", 1, true),
+        ];
+        for (receipt_status, refusals, coordinator, status, exit_code, rejects) in cases {
+            let outcome = receipt_settlement_outcome(receipt_status, refusals, coordinator);
+            assert_eq!(outcome.results_status, status);
+            assert_eq!(outcome.exit_code, exit_code);
+            assert_eq!(outcome.rejects_receipt, rejects);
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod persistence;
 mod progress;
 mod proto;
 mod receipt;
+mod receipt_v2;
 mod remote_helper;
 mod restricted;
 mod results;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -532,6 +532,9 @@ pub enum Response {
     TransportStats(Option<TcpSocketStats>),
     /// A signed receipt envelope (see receipt.rs).
     Receipt(#[serde(with = "serde_bytes")] Vec<u8>),
+    /// One bounded frame of a receipt v2 stream. The final frame is marked
+    /// inside the canonical frame encoding.
+    ReceiptV2(#[serde(with = "serde_bytes")] Vec<u8>),
     Ok,
     Err(String),
 }
@@ -629,6 +632,7 @@ impl SizeHint for Response {
                     + 32
             }
             Response::Hashes(v) | Response::HeldHashes { hashes: v, .. } => v.len() * 32 + 24,
+            Response::Receipt(v) | Response::ReceiptV2(v) => v.len() + 16,
             _ => 256,
         }
     }

--- a/src/receipt_v2.rs
+++ b/src/receipt_v2.rs
@@ -714,7 +714,8 @@ impl VerifiedReceiptV2 {
 pub(crate) fn write_automation_results(
     receipt: &mut VerifiedReceiptV2,
     out: &mut dyn Write,
-    orchestrator_exit_code: i32,
+    results_status: &'static str,
+    exit_code: i32,
 ) -> Result<()> {
     fn write_record(
         out: &mut dyn Write,
@@ -869,13 +870,6 @@ pub(crate) fn write_automation_results(
     })?;
 
     let terminal = &receipt.terminal;
-    let effective_exit_code = if terminal.status == ReceiptStatusV2::Clean {
-        orchestrator_exit_code
-    } else if orchestrator_exit_code == 0 {
-        1
-    } else {
-        orchestrator_exit_code
-    };
     let errors = terminal
         .summary
         .failed
@@ -888,9 +882,9 @@ pub(crate) fn write_automation_results(
         serde_json::json!({
             "type": "result",
             "provenance": "receiver_attested",
-            "status": if effective_exit_code == 0 { "success" } else { "partial" },
+            "status": results_status,
             "receipt_status": receipt_status_name(terminal.status),
-            "exit_code": effective_exit_code,
+            "exit_code": exit_code,
             "files_transferred": terminal.summary.published_files,
             "directories_ensured": directories_ensured,
             "symlinks_created": symlinks_created,
@@ -1509,7 +1503,7 @@ mod tests {
         assert_eq!(records.len(), 2);
 
         let mut automation = Vec::new();
-        write_automation_results(&mut verified, &mut automation, 0).unwrap();
+        write_automation_results(&mut verified, &mut automation, "refused", 25).unwrap();
         let records: Vec<serde_json::Value> = String::from_utf8(automation)
             .unwrap()
             .lines()
@@ -1522,7 +1516,10 @@ mod tests {
             records[2]["object"]["digest"]["value"],
             "0909090909090909090909090909090909090909090909090909090909090909"
         );
-        assert_eq!(records.last().unwrap()["receipt_status"], "clean");
+        let result = records.last().unwrap();
+        assert_eq!(result["status"], "refused");
+        assert_eq!(result["receipt_status"], "clean");
+        assert_eq!(result["exit_code"], 25);
 
         let mut missing = frames;
         missing.remove(1);

--- a/src/receipt_v2.rs
+++ b/src/receipt_v2.rs
@@ -1,0 +1,1695 @@
+//! Receipt v2: a complete receiver-authored record stream, a small signed
+//! terminal commitment, and optional HPKE delivery to the invoking machine.
+//!
+//! The stream records logical pathname operations and closure-time state. It
+//! deliberately does not attest source completeness, block writes, syscalls,
+//! or hostB-local writers. An authenticated expected manifest is a separate
+//! future layer.
+
+use crate::delegation::RequestId;
+use crate::enrollment::EnrollmentId;
+use crate::proto::Kind;
+use anyhow::{anyhow, bail, Context, Result};
+use hpke::{
+    aead::ChaCha20Poly1305, kdf::HkdfSha256, kem::X25519HkdfSha256, setup_receiver, setup_sender,
+    Deserializable, Kem as _, OpModeR, OpModeS, Serializable,
+};
+use serde::{Deserialize, Serialize};
+use ssh_key::{HashAlg, LineEnding, PrivateKey, PublicKey, SshSig};
+use std::collections::BTreeSet;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+use zeroize::Zeroize;
+
+type Kem = X25519HkdfSha256;
+type Kdf = HkdfSha256;
+type Aead = ChaCha20Poly1305;
+
+pub(crate) const RECEIPT_NAMESPACE: &str = "syq-receipt-v2@greaber.github";
+pub(crate) const RECEIPT_LINE_PREFIX: &str = "syq-receipt-v2:";
+const TERMINAL_MAGIC: &[u8; 8] = b"SYQRCV2\0";
+const TERMINAL_VERSION: u16 = 2;
+const FRAME_MAGIC: &[u8; 8] = b"SYQRFV2\0";
+const FRAME_VERSION: u16 = 2;
+const HEADER_LEN: usize = 8 + 2 + 4;
+const TERMINAL_HEADER_LEN: usize = 8 + 2 + 4 + 4;
+const MAX_TERMINAL_BYTES: usize = 64 * 1024;
+const MAX_SIGNATURE_BYTES: usize = 16 * 1024;
+const MAX_FRAME_BODY_BYTES: usize = 96 * 1024;
+pub(crate) const PLAINTEXT_CHUNK_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_DIAGNOSTIC_BYTES: usize = 1024;
+pub(crate) const DEFAULT_MAX_RECORDS: u64 = 4_000_000;
+pub(crate) const DEFAULT_MAX_PLAINTEXT_BYTES: u64 = 512 * 1024 * 1024;
+const STREAM_RECORD_HEADER_BYTES: usize = 4;
+const HPKE_TAG_BYTES: usize = 16;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum HpkeSuiteV1 {
+    X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ReceiptDeliveryV2 {
+    AttachedEncrypted {
+        suite: HpkeSuiteV1,
+        recipient_public_key: [u8; 32],
+    },
+    DetachedSignedPlaintext,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ReceiptPolicyV2 {
+    pub required: bool,
+    pub hashed: bool,
+    pub max_records: u64,
+    pub max_plaintext_bytes: u64,
+    pub delivery: ReceiptDeliveryV2,
+}
+
+impl ReceiptPolicyV2 {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if !self.required {
+            bail!("receipt v2 policy must require a receipt");
+        }
+        if self.max_records == 0 || self.max_records > DEFAULT_MAX_RECORDS {
+            bail!("receipt record limit is outside the supported range");
+        }
+        if self.max_plaintext_bytes == 0 || self.max_plaintext_bytes > DEFAULT_MAX_PLAINTEXT_BYTES {
+            bail!("receipt byte limit is outside the supported range");
+        }
+        match &self.delivery {
+            ReceiptDeliveryV2::AttachedEncrypted {
+                recipient_public_key,
+                ..
+            } if recipient_public_key.iter().all(|byte| *byte == 0) => {
+                bail!("receipt recipient public key must be nonzero")
+            }
+            ReceiptDeliveryV2::AttachedEncrypted { .. }
+            | ReceiptDeliveryV2::DetachedSignedPlaintext => Ok(()),
+        }
+    }
+}
+
+pub(crate) struct RecipientSecret([u8; 32]);
+
+impl std::fmt::Debug for RecipientSecret {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("RecipientSecret([REDACTED])")
+    }
+}
+
+impl Drop for RecipientSecret {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+pub(crate) fn generate_recipient() -> Result<(RecipientSecret, [u8; 32])> {
+    let (private, public) = Kem::gen_keypair();
+    let private: [u8; 32] = private
+        .to_bytes()
+        .as_slice()
+        .try_into()
+        .context("HPKE generated an unexpected private-key length")?;
+    let public: [u8; 32] = public
+        .to_bytes()
+        .as_slice()
+        .try_into()
+        .context("HPKE generated an unexpected public-key length")?;
+    Ok((RecipientSecret(private), public))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum OperationActionV2 {
+    PublishFile { size: u64, inplace: bool },
+    EnsureDirectory,
+    CreateSymlink,
+    CreateSpecial { kind: Kind },
+    SetMetadata { flags: u8 },
+    DeleteFile,
+    DeleteDirectory,
+    ObserveFileHash,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum OperationDispositionV2 {
+    Applied,
+    Failed,
+    Incomplete,
+    Observed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum OutcomeCodeV2 {
+    None,
+    ExecutionFailed,
+    AuthorizationRefused,
+    FileLifecycleIncomplete,
+    ObservationFailed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct OperationRecordV2 {
+    pub sequence: u64,
+    pub scope: u32,
+    pub path: Vec<u8>,
+    pub action: OperationActionV2,
+    pub disposition: OperationDispositionV2,
+    pub code: OutcomeCodeV2,
+    pub diagnostic: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct RefusalRecordV2 {
+    pub sequence: u64,
+    pub code: OutcomeCodeV2,
+    pub diagnostic: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ObjectMetadataV2 {
+    pub mode: u32,
+    pub uid: u32,
+    pub gid: u32,
+    pub mtime: i64,
+    pub mtime_nsec: u32,
+    pub rdev: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum FinalObjectV2 {
+    Absent,
+    Present {
+        kind: Kind,
+        size: u64,
+        digest: Option<[u8; 32]>,
+        symlink_target: Option<Vec<u8>>,
+        metadata: ObjectMetadataV2,
+        observation_error: Option<String>,
+    },
+    ObservationFailed {
+        code: OutcomeCodeV2,
+        diagnostic: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct FinalStateRecordV2 {
+    pub sequence: u64,
+    pub scope: u32,
+    pub path: Vec<u8>,
+    pub object: FinalObjectV2,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum RecordV2 {
+    Operation(OperationRecordV2),
+    Refusal(RefusalRecordV2),
+    FinalState(FinalStateRecordV2),
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ReceiptSummaryV2 {
+    pub operations: u64,
+    pub applied: u64,
+    pub failed: u64,
+    pub incomplete: u64,
+    pub refusals: u64,
+    pub final_states: u64,
+    pub observation_failures: u64,
+    pub published_files: u64,
+    pub published_bytes: u64,
+    pub deletions: u64,
+    pub observed_hashes: u64,
+    pub entries_touched: u64,
+    pub transferred_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ReceiptStatusV2 {
+    Clean,
+    Failed,
+    Incomplete,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum RecordingFailureV2 {
+    LimitExceeded,
+    StorageFailed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ManifestStatusV2 {
+    NotProvided,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum ReceiptSchemaV2 {
+    LogicalMutationsAndFinalStateV2,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum DigestAlgorithmV2 {
+    Blake3,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TerminalReceiptV2 {
+    pub schema: ReceiptSchemaV2,
+    pub enrollment_id: EnrollmentId,
+    pub request_id: RequestId,
+    pub grant_digest: [u8; 32],
+    pub issued_at: i64,
+    pub status: ReceiptStatusV2,
+    pub authority_closed: bool,
+    pub in_flight: u64,
+    pub stream_digest: [u8; 32],
+    pub stream_digest_algorithm: DigestAlgorithmV2,
+    pub content_digest_algorithm: Option<DigestAlgorithmV2>,
+    pub record_count: u64,
+    pub plaintext_bytes: u64,
+    pub summary: ReceiptSummaryV2,
+    pub policy: ReceiptPolicyV2,
+    pub recording_failure: Option<RecordingFailureV2>,
+    pub expected_manifest_digest: Option<[u8; 32]>,
+    pub manifest_status: ManifestStatusV2,
+}
+
+/// Append-only canonical receipt stream. The anonymous temporary file keeps
+/// receipt size off the heap; its signed policy bounds both records and bytes.
+pub(crate) struct StreamWriterV2 {
+    file: File,
+    hasher: blake3::Hasher,
+    record_count: u64,
+    plaintext_bytes: u64,
+    summary: ReceiptSummaryV2,
+    max_records: u64,
+    max_plaintext_bytes: u64,
+    recording_failure: Option<RecordingFailureV2>,
+}
+
+pub(crate) struct ReceiptClosureV2<'a> {
+    pub enrollment_id: EnrollmentId,
+    pub request_id: RequestId,
+    pub grant_digest: [u8; 32],
+    pub issued_at: i64,
+    pub policy: ReceiptPolicyV2,
+    pub entries_touched: u64,
+    pub transferred_bytes: u64,
+    pub signing_key: &'a PrivateKey,
+}
+
+impl std::fmt::Debug for StreamWriterV2 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("StreamWriterV2")
+            .field("record_count", &self.record_count)
+            .field("plaintext_bytes", &self.plaintext_bytes)
+            .field("summary", &self.summary)
+            .field("recording_failure", &self.recording_failure)
+            .finish()
+    }
+}
+
+impl StreamWriterV2 {
+    pub(crate) fn new(policy: &ReceiptPolicyV2) -> Result<Self> {
+        policy.validate()?;
+        Ok(Self {
+            file: tempfile::tempfile().context("create receiver receipt spool")?,
+            hasher: blake3::Hasher::new(),
+            record_count: 0,
+            plaintext_bytes: 0,
+            summary: ReceiptSummaryV2::default(),
+            max_records: policy.max_records,
+            max_plaintext_bytes: policy.max_plaintext_bytes,
+            recording_failure: None,
+        })
+    }
+
+    pub(crate) fn is_failed(&self) -> bool {
+        self.recording_failure.is_some()
+    }
+
+    pub(crate) fn next_sequence(&self) -> u64 {
+        self.record_count
+    }
+
+    pub(crate) fn mark_recording_failure(&mut self) {
+        self.recording_failure
+            .get_or_insert(RecordingFailureV2::StorageFailed);
+    }
+
+    pub(crate) fn append(&mut self, record: &RecordV2) {
+        if self.recording_failure.is_some() {
+            return;
+        }
+        if record_sequence(record) != self.record_count {
+            self.recording_failure = Some(RecordingFailureV2::StorageFailed);
+            return;
+        }
+        let body = match postcard::to_stdvec(record) {
+            Ok(body) => body,
+            Err(_) => {
+                self.recording_failure = Some(RecordingFailureV2::StorageFailed);
+                return;
+            }
+        };
+        let framed_len = match STREAM_RECORD_HEADER_BYTES.checked_add(body.len()) {
+            Some(length) => length,
+            None => {
+                self.recording_failure = Some(RecordingFailureV2::LimitExceeded);
+                return;
+            }
+        };
+        let new_bytes = match self.plaintext_bytes.checked_add(framed_len as u64) {
+            Some(bytes) => bytes,
+            None => {
+                self.recording_failure = Some(RecordingFailureV2::LimitExceeded);
+                return;
+            }
+        };
+        if self.record_count >= self.max_records || new_bytes > self.max_plaintext_bytes {
+            self.recording_failure = Some(RecordingFailureV2::LimitExceeded);
+            return;
+        }
+        let length = match u32::try_from(body.len()) {
+            Ok(length) => length.to_be_bytes(),
+            Err(_) => {
+                self.recording_failure = Some(RecordingFailureV2::LimitExceeded);
+                return;
+            }
+        };
+        if self
+            .file
+            .write_all(&length)
+            .and_then(|()| self.file.write_all(&body))
+            .is_err()
+        {
+            self.recording_failure = Some(RecordingFailureV2::StorageFailed);
+            return;
+        }
+        self.hasher.update(&length);
+        self.hasher.update(&body);
+        self.record_count += 1;
+        self.plaintext_bytes = new_bytes;
+        summarize(record, &mut self.summary);
+    }
+
+    pub(crate) fn finish(mut self, closure: ReceiptClosureV2<'_>) -> Result<IssuedReceiptV2> {
+        let ReceiptClosureV2 {
+            enrollment_id,
+            request_id,
+            grant_digest,
+            issued_at,
+            policy,
+            entries_touched,
+            transferred_bytes,
+            signing_key,
+        } = closure;
+        self.file.flush().context("flush receiver receipt spool")?;
+        self.file
+            .seek(SeekFrom::Start(0))
+            .context("rewind receiver receipt spool")?;
+        self.summary.entries_touched = entries_touched;
+        self.summary.transferred_bytes = transferred_bytes;
+        let status = if self.recording_failure.is_some() || self.summary.observation_failures > 0 {
+            ReceiptStatusV2::Incomplete
+        } else if self.summary.failed > 0
+            || self.summary.incomplete > 0
+            || self.summary.refusals > 0
+        {
+            ReceiptStatusV2::Failed
+        } else {
+            ReceiptStatusV2::Clean
+        };
+        let terminal = TerminalReceiptV2 {
+            schema: ReceiptSchemaV2::LogicalMutationsAndFinalStateV2,
+            enrollment_id,
+            request_id,
+            grant_digest,
+            issued_at,
+            status,
+            authority_closed: true,
+            in_flight: 0,
+            stream_digest: *self.hasher.finalize().as_bytes(),
+            stream_digest_algorithm: DigestAlgorithmV2::Blake3,
+            content_digest_algorithm: policy.hashed.then_some(DigestAlgorithmV2::Blake3),
+            record_count: self.record_count,
+            plaintext_bytes: self.plaintext_bytes,
+            summary: self.summary,
+            policy: policy.clone(),
+            recording_failure: self.recording_failure,
+            expected_manifest_digest: None,
+            manifest_status: ManifestStatusV2::NotProvided,
+        };
+        Ok(IssuedReceiptV2 {
+            stream: self.file,
+            stream_len: self.plaintext_bytes,
+            signed_terminal: sign_terminal(&terminal, signing_key)?,
+            enrollment_id,
+            request_id,
+            grant_digest,
+            delivery: policy.delivery,
+        })
+    }
+}
+
+fn record_sequence(record: &RecordV2) -> u64 {
+    match record {
+        RecordV2::Operation(record) => record.sequence,
+        RecordV2::Refusal(record) => record.sequence,
+        RecordV2::FinalState(record) => record.sequence,
+    }
+}
+
+fn summarize(record: &RecordV2, summary: &mut ReceiptSummaryV2) {
+    match record {
+        RecordV2::Operation(record) => {
+            summary.operations += 1;
+            match record.disposition {
+                OperationDispositionV2::Applied | OperationDispositionV2::Observed => {
+                    summary.applied += 1
+                }
+                OperationDispositionV2::Failed => summary.failed += 1,
+                OperationDispositionV2::Incomplete => summary.incomplete += 1,
+            }
+            match record.action {
+                OperationActionV2::PublishFile { size, .. }
+                    if record.disposition == OperationDispositionV2::Applied =>
+                {
+                    summary.published_files += 1;
+                    summary.published_bytes = summary.published_bytes.saturating_add(size);
+                }
+                OperationActionV2::DeleteFile | OperationActionV2::DeleteDirectory
+                    if record.disposition == OperationDispositionV2::Applied =>
+                {
+                    summary.deletions += 1;
+                }
+                OperationActionV2::ObserveFileHash
+                    if record.disposition == OperationDispositionV2::Observed =>
+                {
+                    summary.observed_hashes += 1;
+                }
+                _ => {}
+            }
+        }
+        RecordV2::Refusal(_) => summary.refusals += 1,
+        RecordV2::FinalState(record) => {
+            summary.final_states += 1;
+            if matches!(
+                record.object,
+                FinalObjectV2::ObservationFailed { .. }
+                    | FinalObjectV2::Present {
+                        observation_error: Some(_),
+                        ..
+                    }
+            ) {
+                summary.observation_failures += 1;
+            }
+        }
+    }
+}
+
+pub(crate) struct IssuedReceiptV2 {
+    stream: File,
+    stream_len: u64,
+    signed_terminal: Vec<u8>,
+    enrollment_id: EnrollmentId,
+    request_id: RequestId,
+    grant_digest: [u8; 32],
+    delivery: ReceiptDeliveryV2,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum TransportModeV2 {
+    AttachedEncrypted,
+    DetachedSignedPlaintext,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum TransportFrameV2 {
+    Start {
+        mode: TransportModeV2,
+        encapsulated_key: Vec<u8>,
+    },
+    Chunk {
+        sequence: u64,
+        payload: Vec<u8>,
+    },
+    End {
+        sequence: u64,
+        payload: Vec<u8>,
+    },
+}
+
+pub(crate) fn emit_transport_frames(
+    mut issued: IssuedReceiptV2,
+    mut emit: impl FnMut(Vec<u8>) -> Result<()>,
+) -> Result<()> {
+    let info = hpke_info(issued.enrollment_id, issued.request_id, issued.grant_digest)?;
+    match issued.delivery {
+        ReceiptDeliveryV2::AttachedEncrypted {
+            suite: HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+            recipient_public_key,
+        } => {
+            let public = <Kem as hpke::Kem>::PublicKey::from_bytes(&recipient_public_key)
+                .map_err(|_| anyhow!("invalid HPKE recipient public key in signed grant"))?;
+            let (encapsulated, mut sender) =
+                setup_sender::<Aead, Kdf, Kem>(&OpModeS::Base, &public, &info)
+                    .map_err(|_| anyhow!("set up HPKE receipt sender"))?;
+            emit(encode_transport_frame(&TransportFrameV2::Start {
+                mode: TransportModeV2::AttachedEncrypted,
+                encapsulated_key: encapsulated.to_bytes().as_slice().to_vec(),
+            })?)?;
+            let mut sequence = 0u64;
+            let mut buffer = vec![0u8; PLAINTEXT_CHUNK_BYTES];
+            let mut remaining = issued.stream_len;
+            while remaining > 0 {
+                let wanted = usize::try_from(remaining.min(PLAINTEXT_CHUNK_BYTES as u64))
+                    .expect("bounded receipt chunk");
+                issued
+                    .stream
+                    .read_exact(&mut buffer[..wanted])
+                    .context("read receiver receipt spool")?;
+                let payload = sender
+                    .seal(&buffer[..wanted], &frame_aad(sequence, false))
+                    .map_err(|_| anyhow!("encrypt receipt stream frame"))?;
+                emit(encode_transport_frame(&TransportFrameV2::Chunk {
+                    sequence,
+                    payload,
+                })?)?;
+                sequence += 1;
+                remaining -= wanted as u64;
+            }
+            let payload = sender
+                .seal(&issued.signed_terminal, &frame_aad(sequence, true))
+                .map_err(|_| anyhow!("encrypt receipt terminal frame"))?;
+            emit(encode_transport_frame(&TransportFrameV2::End {
+                sequence,
+                payload,
+            })?)?;
+        }
+        ReceiptDeliveryV2::DetachedSignedPlaintext => {
+            emit(encode_transport_frame(&TransportFrameV2::Start {
+                mode: TransportModeV2::DetachedSignedPlaintext,
+                encapsulated_key: Vec::new(),
+            })?)?;
+            let mut sequence = 0u64;
+            let mut buffer = vec![0u8; PLAINTEXT_CHUNK_BYTES];
+            let mut remaining = issued.stream_len;
+            while remaining > 0 {
+                let wanted = usize::try_from(remaining.min(PLAINTEXT_CHUNK_BYTES as u64))
+                    .expect("bounded receipt chunk");
+                issued
+                    .stream
+                    .read_exact(&mut buffer[..wanted])
+                    .context("read receiver receipt spool")?;
+                emit(encode_transport_frame(&TransportFrameV2::Chunk {
+                    sequence,
+                    payload: buffer[..wanted].to_vec(),
+                })?)?;
+                sequence += 1;
+                remaining -= wanted as u64;
+            }
+            emit(encode_transport_frame(&TransportFrameV2::End {
+                sequence,
+                payload: issued.signed_terminal,
+            })?)?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn encode_transport_frame(frame: &TransportFrameV2) -> Result<Vec<u8>> {
+    let body = postcard::to_stdvec(frame).context("encode receipt transport frame")?;
+    if body.len() > MAX_FRAME_BODY_BYTES {
+        bail!("receipt transport frame exceeds size limit");
+    }
+    let mut encoded = Vec::with_capacity(HEADER_LEN + body.len());
+    encoded.extend_from_slice(FRAME_MAGIC);
+    encoded.extend_from_slice(&FRAME_VERSION.to_be_bytes());
+    encoded.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    encoded.extend_from_slice(&body);
+    Ok(encoded)
+}
+
+pub(crate) fn decode_transport_frame(encoded: &[u8]) -> Result<TransportFrameV2> {
+    if encoded.len() < HEADER_LEN || &encoded[..8] != FRAME_MAGIC {
+        bail!("not a receipt v2 transport frame");
+    }
+    let version = u16::from_be_bytes(encoded[8..10].try_into().expect("fixed header"));
+    if version != FRAME_VERSION {
+        bail!("unsupported receipt transport version {version}");
+    }
+    let body_len = u32::from_be_bytes(encoded[10..14].try_into().expect("fixed header")) as usize;
+    if body_len == 0 || body_len > MAX_FRAME_BODY_BYTES || encoded.len() != HEADER_LEN + body_len {
+        bail!("receipt transport frame length is noncanonical");
+    }
+    let body = &encoded[HEADER_LEN..];
+    let frame: TransportFrameV2 =
+        postcard::from_bytes(body).context("decode receipt transport frame")?;
+    if postcard::to_stdvec(&frame)? != body {
+        bail!("receipt transport frame uses a noncanonical encoding");
+    }
+    match &frame {
+        TransportFrameV2::Start {
+            mode: TransportModeV2::AttachedEncrypted,
+            encapsulated_key,
+        } if encapsulated_key.len() != 32 => bail!("invalid HPKE encapsulated-key length"),
+        TransportFrameV2::Start {
+            mode: TransportModeV2::DetachedSignedPlaintext,
+            encapsulated_key,
+        } if !encapsulated_key.is_empty() => {
+            bail!("plaintext receipt start frame carries an encapsulated key")
+        }
+        TransportFrameV2::Chunk { payload, .. }
+            if payload.len() > PLAINTEXT_CHUNK_BYTES + HPKE_TAG_BYTES =>
+        {
+            bail!("receipt chunk payload exceeds size limit")
+        }
+        TransportFrameV2::End { payload, .. }
+            if payload.len()
+                > MAX_TERMINAL_BYTES
+                    + MAX_SIGNATURE_BYTES
+                    + TERMINAL_HEADER_LEN
+                    + HPKE_TAG_BYTES =>
+        {
+            bail!("receipt terminal payload exceeds size limit")
+        }
+        _ => {}
+    }
+    Ok(frame)
+}
+
+pub(crate) fn transport_frame_is_end(encoded: &[u8]) -> Result<bool> {
+    Ok(matches!(
+        decode_transport_frame(encoded)?,
+        TransportFrameV2::End { .. }
+    ))
+}
+
+pub(crate) struct VerifiedReceiptV2 {
+    pub terminal: TerminalReceiptV2,
+    stream: File,
+}
+
+impl VerifiedReceiptV2 {
+    pub(crate) fn for_each_record(
+        &mut self,
+        mut visit: impl FnMut(RecordV2) -> Result<()>,
+    ) -> Result<()> {
+        self.stream.seek(SeekFrom::Start(0))?;
+        for _ in 0..self.terminal.record_count {
+            let record = read_record(&mut self.stream)?;
+            visit(record)?;
+        }
+        Ok(())
+    }
+}
+
+/// Publish the already-verified receiver account as the version-0 automation
+/// stream. These records deliberately identify their provenance: unlike the
+/// coordinator's ordinary `--results`, every fact here came from the signed
+/// receipt. Scope-relative paths are not expanded into ambient hostB paths.
+pub(crate) fn write_automation_results(
+    receipt: &mut VerifiedReceiptV2,
+    out: &mut dyn Write,
+    orchestrator_exit_code: i32,
+) -> Result<()> {
+    fn write_record(
+        out: &mut dyn Write,
+        seq: &mut u64,
+        mut value: serde_json::Value,
+    ) -> Result<()> {
+        let object = value
+            .as_object_mut()
+            .expect("automation record is an object");
+        object.insert("schema".into(), crate::results::SCHEMA.into());
+        object.insert(
+            "schema_version".into(),
+            crate::results::SCHEMA_VERSION.into(),
+        );
+        object.insert("seq".into(), (*seq).into());
+        *seq += 1;
+        serde_json::to_writer(&mut *out, &value)?;
+        out.write_all(b"\n")?;
+        Ok(())
+    }
+
+    let mut seq = 0;
+    write_record(
+        out,
+        &mut seq,
+        serde_json::json!({
+            "type": "run",
+            "syq_version": env!("CARGO_PKG_VERSION"),
+            "mode": "cp",
+            "mapping": false,
+            "provenance": "receiver_attested",
+        }),
+    )?;
+    let mut directories_ensured = 0u64;
+    let mut symlinks_created = 0u64;
+    let mut specials_created = 0u64;
+    receipt.for_each_record(|record| {
+        let value = match record {
+            RecordV2::Operation(record) => {
+                let (action, kind, bytes) = match record.action {
+                    OperationActionV2::PublishFile { size, .. } => {
+                        ("transfer_file", "file", Some(size))
+                    }
+                    OperationActionV2::EnsureDirectory => {
+                        if record.disposition == OperationDispositionV2::Applied {
+                            directories_ensured += 1;
+                        }
+                        ("create_directory", "directory", None)
+                    }
+                    OperationActionV2::CreateSymlink => {
+                        if record.disposition == OperationDispositionV2::Applied {
+                            symlinks_created += 1;
+                        }
+                        ("create_symlink", "symlink", None)
+                    }
+                    OperationActionV2::CreateSpecial { .. } => {
+                        if record.disposition == OperationDispositionV2::Applied {
+                            specials_created += 1;
+                        }
+                        ("create_special", "special", None)
+                    }
+                    OperationActionV2::SetMetadata { .. } => ("set_metadata", "object", None),
+                    OperationActionV2::DeleteFile => ("delete_file", "object", None),
+                    OperationActionV2::DeleteDirectory => ("delete_directory", "directory", None),
+                    OperationActionV2::ObserveFileHash => ("observe_hash", "file", None),
+                };
+                let mut value = serde_json::json!({
+                    "type": "operation_result",
+                    "provenance": "receiver_attested",
+                    "action": action,
+                    "kind": kind,
+                    "scope": record.scope,
+                    "dst": tagged_path(&record.path),
+                    "disposition": disposition_name(record.disposition),
+                    "code": outcome_name(record.code),
+                });
+                let object = value
+                    .as_object_mut()
+                    .expect("operation record is an object");
+                if let Some(bytes) = bytes {
+                    object.insert("bytes".into(), bytes.into());
+                }
+                if let Some(message) = record.diagnostic {
+                    object.insert("message".into(), message.into());
+                }
+                value
+            }
+            RecordV2::Refusal(record) => serde_json::json!({
+                "type": "error",
+                "provenance": "receiver_attested",
+                "code": outcome_name(record.code),
+                "message": record.diagnostic,
+            }),
+            RecordV2::FinalState(record) => {
+                let object = match record.object {
+                    FinalObjectV2::Absent => serde_json::json!({"state": "absent"}),
+                    FinalObjectV2::ObservationFailed { code, diagnostic } => serde_json::json!({
+                        "state": "observation_failed",
+                        "code": outcome_name(code),
+                        "message": diagnostic,
+                    }),
+                    FinalObjectV2::Present {
+                        kind,
+                        size,
+                        digest,
+                        symlink_target,
+                        metadata,
+                        observation_error,
+                    } => {
+                        let mut object = serde_json::json!({
+                            "state": "present",
+                            "kind": kind_name(kind),
+                            "size": size,
+                            "metadata": {
+                                "mode": metadata.mode,
+                                "uid": metadata.uid,
+                                "gid": metadata.gid,
+                                "mtime": metadata.mtime,
+                                "mtime_nsec": metadata.mtime_nsec,
+                                "rdev": metadata.rdev,
+                            },
+                        });
+                        let fields = object.as_object_mut().expect("final object is an object");
+                        if let Some(digest) = digest {
+                            fields.insert(
+                                "digest".into(),
+                                serde_json::json!({
+                                    "algorithm": "blake3",
+                                    "value": encode_hex(&digest),
+                                }),
+                            );
+                        }
+                        if let Some(target) = symlink_target {
+                            fields.insert("symlink_target".into(), tagged_path(&target));
+                        }
+                        if let Some(error) = observation_error {
+                            fields.insert("observation_error".into(), error.into());
+                        }
+                        object
+                    }
+                };
+                serde_json::json!({
+                    "type": "receiver_final_state",
+                    "provenance": "receiver_attested",
+                    "scope": record.scope,
+                    "dst": tagged_path(&record.path),
+                    "object": object,
+                })
+            }
+        };
+        write_record(out, &mut seq, value)
+    })?;
+
+    let terminal = &receipt.terminal;
+    let effective_exit_code = if terminal.status == ReceiptStatusV2::Clean {
+        orchestrator_exit_code
+    } else if orchestrator_exit_code == 0 {
+        1
+    } else {
+        orchestrator_exit_code
+    };
+    let errors = terminal
+        .summary
+        .failed
+        .saturating_add(terminal.summary.incomplete)
+        .saturating_add(terminal.summary.refusals)
+        .saturating_add(terminal.summary.observation_failures);
+    write_record(
+        out,
+        &mut seq,
+        serde_json::json!({
+            "type": "result",
+            "provenance": "receiver_attested",
+            "status": if effective_exit_code == 0 { "success" } else { "partial" },
+            "receipt_status": receipt_status_name(terminal.status),
+            "exit_code": effective_exit_code,
+            "files_transferred": terminal.summary.published_files,
+            "directories_ensured": directories_ensured,
+            "symlinks_created": symlinks_created,
+            "specials_created": specials_created,
+            "errors": errors,
+            "bytes_transferred": terminal.summary.transferred_bytes,
+            "operations": terminal.summary.operations,
+            "final_states": terminal.summary.final_states,
+            "deletions": terminal.summary.deletions,
+            "receipt_records": terminal.record_count,
+        }),
+    )?;
+    out.flush()?;
+    Ok(())
+}
+
+fn tagged_path(path: &[u8]) -> serde_json::Value {
+    use base64::Engine as _;
+    match std::str::from_utf8(path) {
+        Ok(value) => serde_json::json!({"encoding": "utf-8", "value": value}),
+        Err(_) => serde_json::json!({
+            "encoding": "base64",
+            "value": base64::engine::general_purpose::STANDARD.encode(path),
+        }),
+    }
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut encoded, "{byte:02x}").expect("write to String");
+    }
+    encoded
+}
+
+fn disposition_name(disposition: OperationDispositionV2) -> &'static str {
+    match disposition {
+        OperationDispositionV2::Applied => "succeeded",
+        OperationDispositionV2::Failed => "failed",
+        OperationDispositionV2::Incomplete => "incomplete",
+        OperationDispositionV2::Observed => "observed",
+    }
+}
+
+fn outcome_name(code: OutcomeCodeV2) -> &'static str {
+    match code {
+        OutcomeCodeV2::None => "none",
+        OutcomeCodeV2::ExecutionFailed => "execution_failed",
+        OutcomeCodeV2::AuthorizationRefused => "authorization_refused",
+        OutcomeCodeV2::FileLifecycleIncomplete => "file_lifecycle_incomplete",
+        OutcomeCodeV2::ObservationFailed => "observation_failed",
+    }
+}
+
+fn receipt_status_name(status: ReceiptStatusV2) -> &'static str {
+    match status {
+        ReceiptStatusV2::Clean => "clean",
+        ReceiptStatusV2::Failed => "failed",
+        ReceiptStatusV2::Incomplete => "incomplete",
+    }
+}
+
+fn kind_name(kind: Kind) -> &'static str {
+    match kind {
+        Kind::Dir => "directory",
+        Kind::File => "file",
+        Kind::Symlink => "symlink",
+        Kind::Fifo => "fifo",
+        Kind::Socket => "socket",
+        Kind::CharDev => "character_device",
+        Kind::BlockDev => "block_device",
+        Kind::Other => "other",
+    }
+}
+
+/// Decrypt and verify an attached receipt whose encoded transport frames have
+/// been captured in order. Decrypted bytes remain in an anonymous temporary
+/// file until the terminal signature and stream commitment have verified.
+pub(crate) fn open_attached_frames<I>(
+    frames: I,
+    recipient_secret: &RecipientSecret,
+    receipt_public_key: &str,
+    expected_enrollment_id: EnrollmentId,
+    expected_request_id: RequestId,
+    expected_grant_digest: [u8; 32],
+    expected_policy: &ReceiptPolicyV2,
+) -> Result<VerifiedReceiptV2>
+where
+    I: IntoIterator<Item = Result<Vec<u8>>>,
+{
+    let mut frames = frames.into_iter();
+    let first = frames
+        .next()
+        .context("receipt stream has no start frame")??;
+    let encapsulated_key = match decode_transport_frame(&first)? {
+        TransportFrameV2::Start {
+            mode: TransportModeV2::AttachedEncrypted,
+            encapsulated_key,
+        } => encapsulated_key,
+        TransportFrameV2::Start {
+            mode: TransportModeV2::DetachedSignedPlaintext,
+            ..
+        } => bail!("attached transfer received a detached plaintext receipt"),
+        _ => bail!("receipt stream does not begin with a start frame"),
+    };
+    let private = <Kem as hpke::Kem>::PrivateKey::from_bytes(&recipient_secret.0)
+        .map_err(|_| anyhow!("invalid local HPKE receipt private key"))?;
+    let encapsulated = <Kem as hpke::Kem>::EncappedKey::from_bytes(&encapsulated_key)
+        .map_err(|_| anyhow!("invalid HPKE receipt encapsulated key"))?;
+    let info = hpke_info(
+        expected_enrollment_id,
+        expected_request_id,
+        expected_grant_digest,
+    )?;
+    let mut receiver =
+        setup_receiver::<Aead, Kdf, Kem>(&OpModeR::Base, &private, &encapsulated, &info)
+            .map_err(|_| anyhow!("set up HPKE receipt receiver"))?;
+    let mut stream = tempfile::tempfile().context("create local decrypted receipt spool")?;
+    let mut sequence = 0u64;
+    let signed_terminal = loop {
+        let encoded = frames
+            .next()
+            .context("receipt stream has no terminal frame")??;
+        match decode_transport_frame(&encoded)? {
+            TransportFrameV2::Chunk {
+                sequence: observed,
+                payload,
+            } => {
+                if observed != sequence {
+                    bail!("receipt frame sequence is not contiguous");
+                }
+                let plaintext = receiver
+                    .open(&payload, &frame_aad(sequence, false))
+                    .map_err(|_| anyhow!("receipt stream frame failed authentication"))?;
+                stream
+                    .write_all(&plaintext)
+                    .context("write local decrypted receipt spool")?;
+                sequence += 1;
+            }
+            TransportFrameV2::End {
+                sequence: observed,
+                payload,
+            } => {
+                if observed != sequence {
+                    bail!("receipt terminal sequence is not contiguous");
+                }
+                let terminal = receiver
+                    .open(&payload, &frame_aad(sequence, true))
+                    .map_err(|_| anyhow!("receipt terminal frame failed authentication"))?;
+                break terminal;
+            }
+            TransportFrameV2::Start { .. } => bail!("receipt stream contains a second start frame"),
+        }
+    };
+    if frames.next().is_some() {
+        bail!("receipt stream contains data after its terminal frame");
+    }
+    stream
+        .flush()
+        .context("flush local decrypted receipt spool")?;
+    let terminal = verify_terminal(&signed_terminal, receipt_public_key)?;
+    if terminal.enrollment_id != expected_enrollment_id
+        || terminal.request_id != expected_request_id
+        || terminal.grant_digest != expected_grant_digest
+    {
+        bail!("receipt names a different signed grant");
+    }
+    if &terminal.policy != expected_policy {
+        bail!("receipt policy does not match the signed grant");
+    }
+    verify_stream(&mut stream, &terminal)?;
+    Ok(VerifiedReceiptV2 { terminal, stream })
+}
+
+fn verify_stream(stream: &mut File, terminal: &TerminalReceiptV2) -> Result<()> {
+    if terminal.schema != ReceiptSchemaV2::LogicalMutationsAndFinalStateV2
+        || terminal.stream_digest_algorithm != DigestAlgorithmV2::Blake3
+        || terminal.content_digest_algorithm
+            != terminal.policy.hashed.then_some(DigestAlgorithmV2::Blake3)
+    {
+        bail!("receipt schema or digest algorithms are inconsistent with its policy");
+    }
+    if terminal.record_count > terminal.policy.max_records
+        || terminal.plaintext_bytes > terminal.policy.max_plaintext_bytes
+    {
+        bail!("receipt stream exceeds its signed policy limit");
+    }
+    if terminal.expected_manifest_digest.is_some()
+        || terminal.manifest_status != ManifestStatusV2::NotProvided
+    {
+        bail!("receipt uses an expected-manifest result not supported by this version");
+    }
+    let length = stream
+        .metadata()
+        .context("inspect decrypted receipt spool")?
+        .len();
+    if length != terminal.plaintext_bytes {
+        bail!("receipt plaintext byte count does not match its stream");
+    }
+    stream.seek(SeekFrom::Start(0))?;
+    let mut hasher = blake3::Hasher::new();
+    let mut summary = ReceiptSummaryV2::default();
+    let mut final_locations = BTreeSet::new();
+    for expected_sequence in 0..terminal.record_count {
+        let mut length = [0u8; STREAM_RECORD_HEADER_BYTES];
+        stream
+            .read_exact(&mut length)
+            .context("receipt stream ended before its signed record count")?;
+        let body_len = u32::from_be_bytes(length) as usize;
+        if body_len == 0 || body_len > MAX_FRAME_BODY_BYTES {
+            bail!("receipt record length is outside the supported range");
+        }
+        let mut body = vec![0u8; body_len];
+        stream
+            .read_exact(&mut body)
+            .context("receipt record is truncated")?;
+        let record: RecordV2 = postcard::from_bytes(&body).context("decode receipt record")?;
+        if postcard::to_stdvec(&record)? != body {
+            bail!("receipt record uses a noncanonical encoding");
+        }
+        if record_sequence(&record) != expected_sequence {
+            bail!("receipt record sequence is not contiguous");
+        }
+        validate_record(&record, &terminal.policy)?;
+        if let RecordV2::FinalState(record) = &record {
+            if !final_locations.insert((record.scope, record.path.clone())) {
+                bail!("receipt repeats a final-state location");
+            }
+        }
+        hasher.update(&length);
+        hasher.update(&body);
+        summarize(&record, &mut summary);
+    }
+    let mut trailing = [0u8; 1];
+    if stream.read(&mut trailing)? != 0 {
+        bail!("receipt stream has data after its signed record count");
+    }
+    summary.entries_touched = terminal.summary.entries_touched;
+    summary.transferred_bytes = terminal.summary.transferred_bytes;
+    if terminal.recording_failure.is_none()
+        && final_locations.len() as u64 != terminal.summary.entries_touched
+    {
+        bail!("receipt final-state coverage does not match its touched-path count");
+    }
+    if *hasher.finalize().as_bytes() != terminal.stream_digest {
+        bail!("receipt stream does not match its signed digest");
+    }
+    if summary != terminal.summary {
+        bail!("receipt summary does not match its record stream");
+    }
+    if !terminal.authority_closed || terminal.in_flight != 0 {
+        bail!("receipt was issued before receiver authority closed");
+    }
+    let expected_status =
+        if terminal.recording_failure.is_some() || summary.observation_failures > 0 {
+            ReceiptStatusV2::Incomplete
+        } else if summary.failed > 0 || summary.incomplete > 0 || summary.refusals > 0 {
+            ReceiptStatusV2::Failed
+        } else {
+            ReceiptStatusV2::Clean
+        };
+    if terminal.status != expected_status {
+        bail!("receipt status is inconsistent with its records");
+    }
+    stream.seek(SeekFrom::Start(0))?;
+    Ok(())
+}
+
+fn validate_record(record: &RecordV2, policy: &ReceiptPolicyV2) -> Result<()> {
+    let valid_relative_path = |path: &[u8]| {
+        !path.starts_with(b"/")
+            && !path.contains(&0)
+            && (path.is_empty()
+                || path
+                    .split(|byte| *byte == b'/')
+                    .all(|part| !part.is_empty() && part != b"." && part != b".."))
+    };
+    let valid_diagnostic = |diagnostic: &Option<String>| {
+        diagnostic
+            .as_ref()
+            .is_none_or(|message| message.len() <= MAX_DIAGNOSTIC_BYTES + '…'.len_utf8())
+    };
+    match record {
+        RecordV2::Operation(record) => {
+            if !valid_relative_path(&record.path) || !valid_diagnostic(&record.diagnostic) {
+                bail!("receipt operation has an invalid path or diagnostic");
+            }
+            let expected_code = match record.disposition {
+                OperationDispositionV2::Applied | OperationDispositionV2::Observed => {
+                    OutcomeCodeV2::None
+                }
+                OperationDispositionV2::Failed => OutcomeCodeV2::ExecutionFailed,
+                OperationDispositionV2::Incomplete => OutcomeCodeV2::FileLifecycleIncomplete,
+            };
+            if record.code != expected_code
+                || (record.disposition == OperationDispositionV2::Observed
+                    && record.action != OperationActionV2::ObserveFileHash)
+                || (record.action == OperationActionV2::ObserveFileHash
+                    && matches!(record.disposition, OperationDispositionV2::Applied))
+                || (matches!(
+                    record.disposition,
+                    OperationDispositionV2::Applied | OperationDispositionV2::Observed
+                ) && record.diagnostic.is_some())
+            {
+                bail!("receipt operation code, disposition, and diagnostic are inconsistent");
+            }
+        }
+        RecordV2::Refusal(record) => {
+            if record.code != OutcomeCodeV2::AuthorizationRefused
+                || !valid_diagnostic(&record.diagnostic)
+            {
+                bail!("receipt refusal is inconsistent");
+            }
+        }
+        RecordV2::FinalState(record) => {
+            if !valid_relative_path(&record.path) {
+                bail!("receipt final state has an invalid relative path");
+            }
+            match &record.object {
+                FinalObjectV2::Absent => {}
+                FinalObjectV2::ObservationFailed { code, diagnostic } => {
+                    if *code != OutcomeCodeV2::ObservationFailed || !valid_diagnostic(diagnostic) {
+                        bail!("receipt final-state failure is inconsistent");
+                    }
+                }
+                FinalObjectV2::Present {
+                    kind,
+                    digest,
+                    symlink_target,
+                    observation_error,
+                    ..
+                } => {
+                    if !valid_diagnostic(observation_error)
+                        || (*kind != Kind::File && digest.is_some())
+                        || (*kind == Kind::File
+                            && policy.hashed
+                            && observation_error.is_none()
+                            && digest.is_none())
+                        || (!policy.hashed && digest.is_some())
+                        || (*kind != Kind::Symlink && symlink_target.is_some())
+                        || (*kind == Kind::Symlink
+                            && observation_error.is_none()
+                            && symlink_target.is_none())
+                    {
+                        bail!("receipt final object is inconsistent with its kind or policy");
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn read_record(stream: &mut File) -> Result<RecordV2> {
+    let mut length = [0u8; STREAM_RECORD_HEADER_BYTES];
+    stream.read_exact(&mut length)?;
+    let body_len = u32::from_be_bytes(length) as usize;
+    if body_len == 0 || body_len > MAX_FRAME_BODY_BYTES {
+        bail!("receipt record length is outside the supported range");
+    }
+    let mut body = vec![0u8; body_len];
+    stream.read_exact(&mut body)?;
+    let record: RecordV2 = postcard::from_bytes(&body)?;
+    if postcard::to_stdvec(&record)? != body {
+        bail!("receipt record uses a noncanonical encoding");
+    }
+    Ok(record)
+}
+
+fn sign_terminal(receipt: &TerminalReceiptV2, private_key: &PrivateKey) -> Result<Vec<u8>> {
+    if private_key.is_encrypted() {
+        bail!("cannot sign a receipt with an encrypted key");
+    }
+    let body = postcard::to_stdvec(receipt).context("encode receipt terminal")?;
+    if body.len() > MAX_TERMINAL_BYTES {
+        bail!("receipt terminal exceeds size limit");
+    }
+    let payload = terminal_signing_payload(&body);
+    let signature = private_key
+        .sign(RECEIPT_NAMESPACE, HashAlg::Sha256, &payload)
+        .context("sign receipt terminal")?
+        .to_pem(LineEnding::LF)
+        .context("encode receipt terminal signature")?
+        .into_bytes();
+    if signature.len() > MAX_SIGNATURE_BYTES {
+        bail!("receipt terminal signature exceeds size limit");
+    }
+    let mut encoded = Vec::with_capacity(TERMINAL_HEADER_LEN + body.len() + signature.len());
+    encoded.extend_from_slice(TERMINAL_MAGIC);
+    encoded.extend_from_slice(&TERMINAL_VERSION.to_be_bytes());
+    encoded.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    encoded.extend_from_slice(&(signature.len() as u32).to_be_bytes());
+    encoded.extend_from_slice(&body);
+    encoded.extend_from_slice(&signature);
+    Ok(encoded)
+}
+
+fn verify_terminal(encoded: &[u8], public_key: &str) -> Result<TerminalReceiptV2> {
+    if encoded.len() < TERMINAL_HEADER_LEN || &encoded[..8] != TERMINAL_MAGIC {
+        bail!("not a receipt v2 terminal envelope");
+    }
+    let version = u16::from_be_bytes(encoded[8..10].try_into().expect("fixed header"));
+    if version != TERMINAL_VERSION {
+        bail!("unsupported receipt terminal version {version}");
+    }
+    let body_len = u32::from_be_bytes(encoded[10..14].try_into().expect("fixed header")) as usize;
+    let signature_len =
+        u32::from_be_bytes(encoded[14..18].try_into().expect("fixed header")) as usize;
+    if body_len == 0 || body_len > MAX_TERMINAL_BYTES {
+        bail!("receipt terminal length is outside the supported range");
+    }
+    if signature_len == 0 || signature_len > MAX_SIGNATURE_BYTES {
+        bail!("receipt terminal signature length is outside the supported range");
+    }
+    let expected = TERMINAL_HEADER_LEN
+        .checked_add(body_len)
+        .and_then(|length| length.checked_add(signature_len))
+        .context("receipt terminal length overflow")?;
+    if encoded.len() != expected {
+        bail!("receipt terminal envelope length is noncanonical");
+    }
+    let body = &encoded[TERMINAL_HEADER_LEN..TERMINAL_HEADER_LEN + body_len];
+    let signature = std::str::from_utf8(&encoded[TERMINAL_HEADER_LEN + body_len..])
+        .context("receipt terminal signature is not text")?;
+    let signature = SshSig::from_pem(signature).context("parse receipt terminal signature")?;
+    let public_key =
+        PublicKey::from_openssh(public_key).context("parse enrollment receipt public key")?;
+    public_key
+        .verify(
+            RECEIPT_NAMESPACE,
+            &terminal_signing_payload(body),
+            &signature,
+        )
+        .context("receipt terminal signature does not verify")?;
+    let receipt: TerminalReceiptV2 =
+        postcard::from_bytes(body).context("decode receipt terminal")?;
+    if postcard::to_stdvec(&receipt)? != body {
+        bail!("receipt terminal uses a noncanonical encoding");
+    }
+    receipt.policy.validate()?;
+    Ok(receipt)
+}
+
+fn terminal_signing_payload(body: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(8 + 2 + 4 + body.len());
+    payload.extend_from_slice(TERMINAL_MAGIC);
+    payload.extend_from_slice(&TERMINAL_VERSION.to_be_bytes());
+    payload.extend_from_slice(&(body.len() as u32).to_be_bytes());
+    payload.extend_from_slice(body);
+    payload
+}
+
+fn hpke_info(
+    enrollment_id: EnrollmentId,
+    request_id: RequestId,
+    grant_digest: [u8; 32],
+) -> Result<Vec<u8>> {
+    postcard::to_stdvec(&(
+        "syq-receipt-v2-hpke@greaber.github",
+        enrollment_id,
+        request_id,
+        grant_digest,
+    ))
+    .context("encode receipt HPKE context")
+}
+
+fn frame_aad(sequence: u64, terminal: bool) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(32);
+    aad.extend_from_slice(b"syq-receipt-v2-frame\0");
+    aad.extend_from_slice(&sequence.to_be_bytes());
+    aad.push(u8::from(terminal));
+    aad
+}
+
+pub(crate) fn bounded_diagnostic(error: &str) -> Option<String> {
+    bounded_format(format_args!("{error}"))
+}
+
+pub(crate) fn bounded_format(arguments: std::fmt::Arguments<'_>) -> Option<String> {
+    struct BoundedWriter {
+        text: String,
+        truncated: bool,
+    }
+
+    impl std::fmt::Write for BoundedWriter {
+        fn write_str(&mut self, value: &str) -> std::fmt::Result {
+            let remaining = MAX_DIAGNOSTIC_BYTES.saturating_sub(self.text.len());
+            if value.len() <= remaining {
+                self.text.push_str(value);
+            } else {
+                let mut end = remaining.min(value.len());
+                while !value.is_char_boundary(end) {
+                    end -= 1;
+                }
+                self.text.push_str(&value[..end]);
+                self.truncated = true;
+            }
+            Ok(())
+        }
+    }
+
+    let mut writer = BoundedWriter {
+        text: String::new(),
+        truncated: false,
+    };
+    std::fmt::write(&mut writer, arguments).expect("bounded String formatting cannot fail");
+    if writer.text.is_empty() {
+        return None;
+    }
+    if writer.truncated {
+        writer.text.push('…');
+    }
+    Some(writer.text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(seed: u8) -> PrivateKey {
+        let keypair = ssh_key::private::Ed25519Keypair::from_seed(&[seed; 32]);
+        PrivateKey::new(keypair.into(), "syq-receipt-v2-test").unwrap()
+    }
+
+    fn policy(public: [u8; 32]) -> ReceiptPolicyV2 {
+        ReceiptPolicyV2 {
+            required: true,
+            hashed: true,
+            max_records: 32,
+            max_plaintext_bytes: 64 * 1024,
+            delivery: ReceiptDeliveryV2::AttachedEncrypted {
+                suite: HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+                recipient_public_key: public,
+            },
+        }
+    }
+
+    #[test]
+    fn encrypted_stream_round_trips_and_binds_all_frames() {
+        let (secret, public) = generate_recipient().unwrap();
+        let policy = policy(public);
+        let enrollment_id = EnrollmentId::random();
+        let request_id = RequestId::fresh(1_900_000_000).unwrap();
+        let grant_digest = [7; 32];
+        let signing_key = key(3);
+        let mut stream = StreamWriterV2::new(&policy).unwrap();
+        stream.append(&RecordV2::Operation(OperationRecordV2 {
+            sequence: stream.next_sequence(),
+            scope: 0,
+            path: b"artifact".to_vec(),
+            action: OperationActionV2::PublishFile {
+                size: 3,
+                inplace: false,
+            },
+            disposition: OperationDispositionV2::Applied,
+            code: OutcomeCodeV2::None,
+            diagnostic: None,
+        }));
+        stream.append(&RecordV2::FinalState(FinalStateRecordV2 {
+            sequence: stream.next_sequence(),
+            scope: 0,
+            path: b"artifact".to_vec(),
+            object: FinalObjectV2::Present {
+                kind: Kind::File,
+                size: 3,
+                digest: Some([9; 32]),
+                symlink_target: None,
+                metadata: ObjectMetadataV2 {
+                    mode: 0o100644,
+                    uid: 1000,
+                    gid: 1000,
+                    mtime: 5,
+                    mtime_nsec: 6,
+                    rdev: 0,
+                },
+                observation_error: None,
+            },
+        }));
+        let issued = stream
+            .finish(ReceiptClosureV2 {
+                enrollment_id,
+                request_id,
+                grant_digest,
+                issued_at: 1_900_000_001,
+                policy: policy.clone(),
+                entries_touched: 1,
+                transferred_bytes: 3,
+                signing_key: &signing_key,
+            })
+            .unwrap();
+        let mut frames = Vec::new();
+        emit_transport_frames(issued, |frame| {
+            frames.push(frame);
+            Ok(())
+        })
+        .unwrap();
+        let mut verified = open_attached_frames(
+            frames.clone().into_iter().map(Ok),
+            &secret,
+            &signing_key.public_key().to_openssh().unwrap(),
+            enrollment_id,
+            request_id,
+            grant_digest,
+            &policy,
+        )
+        .unwrap();
+        assert_eq!(verified.terminal.status, ReceiptStatusV2::Clean);
+        let mut records = Vec::new();
+        verified
+            .for_each_record(|record| {
+                records.push(record);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(records.len(), 2);
+
+        let mut automation = Vec::new();
+        write_automation_results(&mut verified, &mut automation, 0).unwrap();
+        let records: Vec<serde_json::Value> = String::from_utf8(automation)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(records[0]["provenance"], "receiver_attested");
+        assert_eq!(records[1]["type"], "operation_result");
+        assert_eq!(records[2]["type"], "receiver_final_state");
+        assert_eq!(
+            records[2]["object"]["digest"]["value"],
+            "0909090909090909090909090909090909090909090909090909090909090909"
+        );
+        assert_eq!(records.last().unwrap()["receipt_status"], "clean");
+
+        let mut missing = frames;
+        missing.remove(1);
+        assert!(open_attached_frames(
+            missing.into_iter().map(Ok),
+            &secret,
+            &signing_key.public_key().to_openssh().unwrap(),
+            enrollment_id,
+            request_id,
+            grant_digest,
+            &policy,
+        )
+        .is_err());
+
+        let issued = {
+            let mut stream = StreamWriterV2::new(&policy).unwrap();
+            stream.append(&RecordV2::Operation(OperationRecordV2 {
+                sequence: 0,
+                scope: 0,
+                path: b"artifact".to_vec(),
+                action: OperationActionV2::EnsureDirectory,
+                disposition: OperationDispositionV2::Applied,
+                code: OutcomeCodeV2::None,
+                diagnostic: None,
+            }));
+            stream
+                .finish(ReceiptClosureV2 {
+                    enrollment_id,
+                    request_id,
+                    grant_digest,
+                    issued_at: 1_900_000_001,
+                    policy: policy.clone(),
+                    entries_touched: 1,
+                    transferred_bytes: 0,
+                    signing_key: &signing_key,
+                })
+                .unwrap()
+        };
+        let mut tampered = Vec::new();
+        emit_transport_frames(issued, |frame| {
+            tampered.push(frame);
+            Ok(())
+        })
+        .unwrap();
+        let mut chunk = decode_transport_frame(&tampered[1]).unwrap();
+        let TransportFrameV2::Chunk { payload, .. } = &mut chunk else {
+            panic!("expected encrypted stream chunk");
+        };
+        payload[0] ^= 1;
+        tampered[1] = encode_transport_frame(&chunk).unwrap();
+        assert!(open_attached_frames(
+            tampered.into_iter().map(Ok),
+            &secret,
+            &signing_key.public_key().to_openssh().unwrap(),
+            enrollment_id,
+            request_id,
+            grant_digest,
+            &policy,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn detached_delivery_is_a_signed_plaintext_stream() {
+        let policy = ReceiptPolicyV2 {
+            required: true,
+            hashed: false,
+            max_records: 8,
+            max_plaintext_bytes: 4096,
+            delivery: ReceiptDeliveryV2::DetachedSignedPlaintext,
+        };
+        let enrollment_id = EnrollmentId::random();
+        let request_id = RequestId::fresh(1_900_000_000).unwrap();
+        let signing_key = key(8);
+        let mut stream = StreamWriterV2::new(&policy).unwrap();
+        stream.append(&RecordV2::Operation(OperationRecordV2 {
+            sequence: 0,
+            scope: 1,
+            path: b"plain".to_vec(),
+            action: OperationActionV2::EnsureDirectory,
+            disposition: OperationDispositionV2::Applied,
+            code: OutcomeCodeV2::None,
+            diagnostic: None,
+        }));
+        stream.append(&RecordV2::FinalState(FinalStateRecordV2 {
+            sequence: 1,
+            scope: 1,
+            path: b"plain".to_vec(),
+            object: FinalObjectV2::Absent,
+        }));
+        let issued = stream
+            .finish(ReceiptClosureV2 {
+                enrollment_id,
+                request_id,
+                grant_digest: [8; 32],
+                issued_at: 1_900_000_001,
+                policy,
+                entries_touched: 1,
+                transferred_bytes: 0,
+                signing_key: &signing_key,
+            })
+            .unwrap();
+        let mut frames = Vec::new();
+        emit_transport_frames(issued, |frame| {
+            frames.push(decode_transport_frame(&frame)?);
+            Ok(())
+        })
+        .unwrap();
+        assert!(matches!(
+            frames[0],
+            TransportFrameV2::Start {
+                mode: TransportModeV2::DetachedSignedPlaintext,
+                ref encapsulated_key,
+            } if encapsulated_key.is_empty()
+        ));
+        let TransportFrameV2::Chunk { payload, .. } = &frames[1] else {
+            panic!("expected plaintext receipt chunk");
+        };
+        let mut spool = tempfile::tempfile().unwrap();
+        spool.write_all(payload).unwrap();
+        let TransportFrameV2::End { payload, .. } = &frames[2] else {
+            panic!("expected signed terminal frame");
+        };
+        let terminal =
+            verify_terminal(payload, &signing_key.public_key().to_openssh().unwrap()).unwrap();
+        verify_stream(&mut spool, &terminal).unwrap();
+    }
+
+    #[test]
+    fn limits_fail_closed_without_truncating_into_success() {
+        let (_, public) = generate_recipient().unwrap();
+        let mut policy = policy(public);
+        policy.max_records = 1;
+        let mut stream = StreamWriterV2::new(&policy).unwrap();
+        for path in [b"a".as_slice(), b"b".as_slice()] {
+            stream.append(&RecordV2::Operation(OperationRecordV2 {
+                sequence: stream.next_sequence(),
+                scope: 0,
+                path: path.to_vec(),
+                action: OperationActionV2::EnsureDirectory,
+                disposition: OperationDispositionV2::Applied,
+                code: OutcomeCodeV2::None,
+                diagnostic: None,
+            }));
+        }
+        assert!(stream.is_failed());
+        let signing_key = key(4);
+        let terminal = stream
+            .finish(ReceiptClosureV2 {
+                enrollment_id: EnrollmentId::random(),
+                request_id: RequestId::fresh(1_900_000_000).unwrap(),
+                grant_digest: [1; 32],
+                issued_at: 1_900_000_001,
+                policy,
+                entries_touched: 2,
+                transferred_bytes: 0,
+                signing_key: &signing_key,
+            })
+            .unwrap();
+        assert_eq!(terminal.stream_len, 13);
+    }
+
+    #[test]
+    fn diagnostics_are_bounded_on_utf8_boundaries() {
+        let text = "é".repeat(MAX_DIAGNOSTIC_BYTES);
+        let bounded = bounded_diagnostic(&text).unwrap();
+        assert!(bounded.len() <= MAX_DIAGNOSTIC_BYTES + '…'.len_utf8());
+        assert!(bounded.ends_with('…'));
+    }
+}

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -17,7 +17,7 @@ use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use ssh_key::private::Ed25519Keypair;
 use ssh_key::{LineEnding, PrivateKey};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
@@ -34,7 +34,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 // Advance this generation whenever an installed receiver or its signed grant
 // protocol becomes incompatible. Local metadata from another generation is
 // ignored, so the next eligible copy installs a fresh receiver enrollment.
-const CONFIG_VERSION: u16 = 2;
+const CONFIG_VERSION: u16 = 3;
 const MAX_STATE_FILE: usize = 256 * 1024;
 const MAX_AUTHORIZED_KEYS: usize = 16 * 1024 * 1024;
 const DEFAULT_MAX_ENTRIES: u64 = 100_000_000;
@@ -124,6 +124,25 @@ pub(crate) struct PreparedTransfer {
     pub(crate) request_id: RequestId,
     /// Verifier for the receipt hostB will issue.
     pub(crate) receipt_public_key: String,
+    /// Attached transfers keep this ephemeral HPKE key only until settlement.
+    pub(crate) receipt_recipient_secret: Option<crate::receipt_v2::RecipientSecret>,
+    pub(crate) receipt_policy: crate::receipt_v2::ReceiptPolicyV2,
+    pub(crate) grant_digest: [u8; 32],
+}
+
+pub(crate) enum IssuedReceipt {
+    V1(Vec<u8>),
+    V2(crate::receipt_v2::IssuedReceiptV2),
+}
+
+#[cfg(test)]
+impl IssuedReceipt {
+    fn into_v1(self) -> Vec<u8> {
+        match self {
+            Self::V1(envelope) => envelope,
+            Self::V2(_) => panic!("test expected a legacy receipt"),
+        }
+    }
 }
 
 struct AuthorityState {
@@ -150,6 +169,11 @@ struct AuthorityState {
     tcp_listener_started: bool,
     /// What hostB will attest to in its receipt.
     ledger: crate::receipt::Ledger,
+    /// V2 records live in an anonymous spool; only mutation-relevant paths
+    /// enter `touched_v2`, never paths merely returned by a destination scan.
+    ledger_v2: Option<crate::receipt_v2::StreamWriterV2>,
+    touched_v2: BTreeSet<Vec<u8>>,
+    file_lifecycles_v2: HashMap<(Vec<u8>, proto::PartialId), FileLifecycleV2>,
     /// Requests authorized for execution whose outcome has not been settled
     /// yet, across every connection. The receipt waits for zero.
     in_flight: u64,
@@ -286,6 +310,8 @@ pub(crate) struct RestrictedAuthority {
     enrollment_id: EnrollmentId,
     request_id: RequestId,
     receipt_policy: ReceiptPolicy,
+    receipt_policy_v2: Option<crate::receipt_v2::ReceiptPolicyV2>,
+    grant_digest: [u8; 32],
     receipt_key: PrivateKey,
     file_data_limit: Option<crate::bwlimit::BandwidthLimit>,
     receiver_umask: u32,
@@ -301,6 +327,7 @@ impl RestrictedAuthority {
         config: &ReceiverEnrollment,
         grant: Grant,
         extensions: GrantConstraints,
+        grant_digest: [u8; 32],
         receipt_key: PrivateKey,
         deadline: Instant,
     ) -> Result<Self> {
@@ -309,6 +336,7 @@ impl RestrictedAuthority {
             filters,
             root_existence,
             receipt: receipt_policy,
+            receipt_v2: receipt_policy_v2,
         } = extensions;
         let enrollment_id = grant.enrollment_id;
         let request_id = grant.request_id;
@@ -353,6 +381,10 @@ impl RestrictedAuthority {
         let receiver_umask = read_process_umask();
         let file_data_limit = (max_file_data_bytes_per_second > 0)
             .then(|| crate::bwlimit::BandwidthLimit::new(max_file_data_bytes_per_second));
+        let ledger_v2 = receipt_policy_v2
+            .as_ref()
+            .map(crate::receipt_v2::StreamWriterV2::new)
+            .transpose()?;
         let authority = Self {
             guard: ContainerGuard {
                 root: config.root.as_bytes().to_vec(),
@@ -368,6 +400,8 @@ impl RestrictedAuthority {
             enrollment_id,
             request_id,
             receipt_policy,
+            receipt_policy_v2,
+            grant_digest,
             receipt_key,
             file_data_limit,
             receiver_umask,
@@ -386,6 +420,9 @@ impl RestrictedAuthority {
                 live_connections: 0,
                 tcp_listener_started: false,
                 ledger: crate::receipt::Ledger::default(),
+                ledger_v2,
+                touched_v2: BTreeSet::new(),
+                file_lifecycles_v2: HashMap::new(),
                 in_flight: 0,
                 receipt_closing: false,
                 receipt_issued: false,
@@ -396,7 +433,7 @@ impl RestrictedAuthority {
     }
 
     /// Sign hostB's account of this grant and close it to further mutation.
-    pub(crate) fn issue_receipt(&self) -> Result<Vec<u8>> {
+    pub(crate) fn issue_receipt(&self) -> Result<IssuedReceipt> {
         let key = &self.receipt_key;
         // Close the grant first, then wait for every request already
         // authorized on any connection to execute and settle, so the receipt
@@ -420,6 +457,119 @@ impl RestrictedAuthority {
             state = self.settled.wait_timeout(state, remaining).unwrap().0;
         }
         state.receipt_issued = true;
+        if let Some(policy) = self.receipt_policy_v2.clone() {
+            let mut stream = state
+                .ledger_v2
+                .take()
+                .context("receiver receipt v2 spool is unavailable")?;
+            let lifecycles = std::mem::take(&mut state.file_lifecycles_v2);
+            let touched = std::mem::take(&mut state.touched_v2);
+            let entries_touched = touched.len() as u64;
+            let transferred_bytes = state.transferred_bytes;
+            drop(state);
+
+            for ((path, _), lifecycle) in lifecycles {
+                if lifecycle.recorded {
+                    continue;
+                }
+                self.append_operation_to_stream_v2(
+                    &mut stream,
+                    &path,
+                    crate::receipt_v2::OperationActionV2::PublishFile {
+                        size: lifecycle.size,
+                        inplace: lifecycle.inplace,
+                    },
+                    if lifecycle.last_error.is_some() {
+                        crate::receipt_v2::OperationDispositionV2::Failed
+                    } else {
+                        crate::receipt_v2::OperationDispositionV2::Incomplete
+                    },
+                    lifecycle.last_error.as_deref().or(Some(
+                        "file lifecycle ended without a successful finalization",
+                    )),
+                );
+            }
+
+            for path in touched {
+                let object = match self.observe_final(&path) {
+                    Ok(None) => crate::receipt_v2::FinalObjectV2::Absent,
+                    Ok(Some(metadata)) => {
+                        let kind = kind_from_mode(metadata.mode);
+                        let mut observation_error = None;
+                        let digest = if kind == proto::Kind::File && policy.hashed {
+                            match self.digest_published(&path) {
+                                Ok(digest) => Some(digest),
+                                Err(error) => {
+                                    observation_error = crate::receipt_v2::bounded_format(
+                                        format_args!("hash final file: {error:#}"),
+                                    );
+                                    None
+                                }
+                            }
+                        } else {
+                            None
+                        };
+                        let symlink_target = if kind == proto::Kind::Symlink {
+                            match self.read_published_link(&path) {
+                                Ok(target) => Some(target),
+                                Err(error) => {
+                                    observation_error = crate::receipt_v2::bounded_format(
+                                        format_args!("read final symlink: {error:#}"),
+                                    );
+                                    None
+                                }
+                            }
+                        } else {
+                            None
+                        };
+                        crate::receipt_v2::FinalObjectV2::Present {
+                            kind,
+                            size: metadata.len,
+                            digest,
+                            symlink_target,
+                            metadata: crate::receipt_v2::ObjectMetadataV2 {
+                                mode: metadata.mode,
+                                uid: metadata.uid,
+                                gid: metadata.gid,
+                                mtime: metadata.mtime,
+                                mtime_nsec: metadata.mtime_nsec,
+                                rdev: metadata.rdev,
+                            },
+                            observation_error,
+                        }
+                    }
+                    Err(error) => crate::receipt_v2::FinalObjectV2::ObservationFailed {
+                        code: crate::receipt_v2::OutcomeCodeV2::ObservationFailed,
+                        diagnostic: crate::receipt_v2::bounded_format(format_args!("{error:#}")),
+                    },
+                };
+                let Some((scope, relative)) = self.receipt_location(&path) else {
+                    stream.mark_recording_failure();
+                    continue;
+                };
+                let sequence = stream.next_sequence();
+                stream.append(&crate::receipt_v2::RecordV2::FinalState(
+                    crate::receipt_v2::FinalStateRecordV2 {
+                        sequence,
+                        scope,
+                        path: relative,
+                        object,
+                    },
+                ));
+            }
+            return Ok(IssuedReceipt::V2(stream.finish(
+                crate::receipt_v2::ReceiptClosureV2 {
+                    enrollment_id: self.enrollment_id,
+                    request_id: self.request_id,
+                    grant_digest: self.grant_digest,
+                    issued_at: now()?,
+                    policy,
+                    entries_touched,
+                    transferred_bytes,
+                    signing_key: key,
+                },
+            )?));
+        }
         if let Some(first) = state.ledger.hash_failures.first() {
             bail!(
                 "{} published file(s) could not be hashed for the receipt; first: {first}",
@@ -463,7 +613,7 @@ impl RestrictedAuthority {
             state.transferred_bytes,
         )?;
         drop(state);
-        crate::receipt::sign(&receipt, key)
+        Ok(IssuedReceipt::V1(crate::receipt::sign(&receipt, key)?))
     }
 
     /// Metadata of a touched path in the final tree, with a missing path or
@@ -502,6 +652,22 @@ impl RestrictedAuthority {
         let mut hasher = blake3::Hasher::new();
         std::io::copy(&mut file, &mut hasher)?;
         Ok(*hasher.finalize().as_bytes())
+    }
+
+    fn read_published_link(&self, path: &[u8]) -> Result<Vec<u8>> {
+        let root_path = Path::new(OsStr::from_bytes(&self.guard.root));
+        let relative = Path::new(OsStr::from_bytes(path))
+            .strip_prefix(root_path)
+            .context("published path is outside the enrolled root")?;
+        let relative = RelativePath::new(relative.as_os_str().as_bytes())?;
+        let root = Root::open_verified(
+            root_path,
+            RootIdentity {
+                dev: self.guard.dev,
+                ino: self.guard.ino,
+            },
+        )?;
+        root.read_link(&relative)
     }
 
     /// Check the signed placement-root precondition once, against the
@@ -749,6 +915,13 @@ impl RestrictedAuthority {
         if state.receipt_issued || state.receipt_closing {
             bail!("the signed grant is closed: its receipt has been issued");
         }
+        if state
+            .ledger_v2
+            .as_ref()
+            .is_some_and(crate::receipt_v2::StreamWriterV2::is_failed)
+        {
+            bail!("the signed grant is closed because receipt recording failed");
+        }
         drop(state);
         Self::validate_request_path(path)?;
         if !self
@@ -774,6 +947,75 @@ impl RestrictedAuthority {
         self.state.lock().unwrap().created.contains(path)
     }
 
+    fn receipt_location(&self, path: &[u8]) -> Option<(u32, Vec<u8>)> {
+        self.copy
+            .mutation_scopes
+            .iter()
+            .enumerate()
+            .filter(|(_, scope)| Self::scope_allows(scope, path))
+            .max_by_key(|(index, scope)| (scope.path.len(), std::cmp::Reverse(*index)))
+            .and_then(|(index, scope)| {
+                let relative = if path == scope.path {
+                    Vec::new()
+                } else {
+                    path.get(scope.path.len() + 1..)?.to_vec()
+                };
+                Some((u32::try_from(index).ok()?, relative))
+            })
+    }
+
+    fn append_operation_v2(
+        &self,
+        state: &mut AuthorityState,
+        path: &[u8],
+        action: crate::receipt_v2::OperationActionV2,
+        disposition: crate::receipt_v2::OperationDispositionV2,
+        error: Option<&str>,
+    ) {
+        let Some(stream) = state.ledger_v2.as_mut() else {
+            return;
+        };
+        self.append_operation_to_stream_v2(stream, path, action, disposition, error);
+    }
+
+    fn append_operation_to_stream_v2(
+        &self,
+        stream: &mut crate::receipt_v2::StreamWriterV2,
+        path: &[u8],
+        action: crate::receipt_v2::OperationActionV2,
+        disposition: crate::receipt_v2::OperationDispositionV2,
+        error: Option<&str>,
+    ) {
+        let Some((scope, relative)) = self.receipt_location(path) else {
+            stream.mark_recording_failure();
+            return;
+        };
+        let sequence = stream.next_sequence();
+        let code = match disposition {
+            crate::receipt_v2::OperationDispositionV2::Failed => {
+                crate::receipt_v2::OutcomeCodeV2::ExecutionFailed
+            }
+            crate::receipt_v2::OperationDispositionV2::Incomplete => {
+                crate::receipt_v2::OutcomeCodeV2::FileLifecycleIncomplete
+            }
+            crate::receipt_v2::OperationDispositionV2::Applied
+            | crate::receipt_v2::OperationDispositionV2::Observed => {
+                crate::receipt_v2::OutcomeCodeV2::None
+            }
+        };
+        stream.append(&crate::receipt_v2::RecordV2::Operation(
+            crate::receipt_v2::OperationRecordV2 {
+                sequence,
+                scope,
+                path: relative,
+                action,
+                disposition,
+                code,
+                diagnostic: error.and_then(crate::receipt_v2::bounded_diagnostic),
+            },
+        ));
+    }
+
     /// Confirm or forget the provisional creations of an executed request.
     /// Only a confirmed creation becomes this grant's own; a failed one is
     /// dropped so the path cannot later be replaced as if it were.
@@ -782,16 +1024,22 @@ impl RestrictedAuthority {
         let Settlement {
             creations,
             outcomes,
+            touched_v2,
             tracked,
         } = settlement;
-        if creations.is_empty() && outcomes.is_empty() && !tracked {
+        if creations.is_empty() && outcomes.is_empty() && touched_v2.is_empty() && !tracked {
             return;
         }
-        let failed = |index: usize| match response {
-            proto::Response::Err(_) => true,
-            proto::Response::Applied(results) => results.get(index).is_some_and(Option::is_some),
-            _ => false,
+        let outcome_error = |index: usize| -> Option<&str> {
+            match response {
+                proto::Response::Err(error) => Some(error.as_str()),
+                proto::Response::Applied(results) => {
+                    results.get(index).and_then(|error| error.as_deref())
+                }
+                _ => None,
+            }
         };
+        let failed = |index: usize| outcome_error(index).is_some();
         // Hash completed publications for a hashed receipt now, before the
         // orchestrator's deferred directory modes can make them unreadable,
         // and before taking the state lock.
@@ -823,6 +1071,7 @@ impl RestrictedAuthority {
                 state.created.insert(creation.path);
             }
         }
+        state.touched_v2.extend(touched_v2);
         for (outcome, digest) in outcomes {
             match outcome {
                 // Both dispositions are kept; the receipt decides between
@@ -858,7 +1107,101 @@ impl RestrictedAuthority {
                 }
                 PendingOutcome::Observe { path } => {
                     if let proto::Response::FileHash { size, hash } = response {
-                        state.ledger.observed.insert(path, (*size, *hash));
+                        state.ledger.observed.insert(path.clone(), (*size, *hash));
+                        self.append_operation_v2(
+                            &mut state,
+                            &path,
+                            crate::receipt_v2::OperationActionV2::ObserveFileHash,
+                            crate::receipt_v2::OperationDispositionV2::Observed,
+                            None,
+                        );
+                    } else {
+                        self.append_operation_v2(
+                            &mut state,
+                            &path,
+                            crate::receipt_v2::OperationActionV2::ObserveFileHash,
+                            crate::receipt_v2::OperationDispositionV2::Failed,
+                            outcome_error(0).or(Some("receiver returned no file hash")),
+                        );
+                    }
+                }
+                PendingOutcome::LogicalV2 {
+                    index,
+                    path,
+                    action,
+                } => {
+                    let error = outcome_error(index);
+                    self.append_operation_v2(
+                        &mut state,
+                        &path,
+                        action,
+                        if error.is_some() {
+                            crate::receipt_v2::OperationDispositionV2::Failed
+                        } else {
+                            crate::receipt_v2::OperationDispositionV2::Applied
+                        },
+                        error,
+                    );
+                }
+                PendingOutcome::FileStageV2 {
+                    index,
+                    path,
+                    partial_id,
+                    size,
+                    inplace,
+                    stage,
+                } => {
+                    if state.ledger_v2.is_none() {
+                        continue;
+                    }
+                    let error = outcome_error(index);
+                    let mut inconsistent = false;
+                    let emit_complete = {
+                        let lifecycle = state
+                            .file_lifecycles_v2
+                            .entry((path.clone(), partial_id))
+                            .or_insert(FileLifecycleV2 {
+                                size,
+                                inplace,
+                                recorded: false,
+                                last_error: None,
+                            });
+                        if lifecycle.size != size || lifecycle.inplace != inplace {
+                            inconsistent = true;
+                        }
+                        if matches!(stage, FileStageV2::Prepare | FileStageV2::Write)
+                            && lifecycle.recorded
+                        {
+                            lifecycle.recorded = false;
+                            lifecycle.last_error = None;
+                        }
+                        if let Some(error) = error {
+                            lifecycle.last_error = crate::receipt_v2::bounded_diagnostic(error);
+                            if stage == FileStageV2::Finalize {
+                                lifecycle.recorded = false;
+                            }
+                            false
+                        } else if stage == FileStageV2::Finalize && !lifecycle.recorded {
+                            lifecycle.recorded = true;
+                            lifecycle.last_error = None;
+                            true
+                        } else {
+                            false
+                        }
+                    };
+                    if inconsistent {
+                        if let Some(stream) = state.ledger_v2.as_mut() {
+                            stream.mark_recording_failure();
+                        }
+                    }
+                    if emit_complete {
+                        self.append_operation_v2(
+                            &mut state,
+                            &path,
+                            crate::receipt_v2::OperationActionV2::PublishFile { size, inplace },
+                            crate::receipt_v2::OperationDispositionV2::Applied,
+                            None,
+                        );
                     }
                 }
                 PendingOutcome::Publish { .. } | PendingOutcome::Delete { .. } => {}
@@ -1452,6 +1795,7 @@ impl RestrictedAuthority {
         index: usize,
         pending: &mut Vec<PendingCreation>,
         outcomes: &mut Vec<PendingOutcome>,
+        touched_v2: &mut Vec<Vec<u8>>,
     ) -> Result<()> {
         let path = match &*operation {
             Op::Mkdir { path, .. }
@@ -1479,6 +1823,12 @@ impl RestrictedAuthority {
                     index,
                     path: path.clone(),
                 });
+                outcomes.push(PendingOutcome::LogicalV2 {
+                    index,
+                    path: path.clone(),
+                    action: crate::receipt_v2::OperationActionV2::DeleteDirectory,
+                });
+                touched_v2.push(path.clone());
                 return Ok(());
             }
             Op::Unlink { path } => {
@@ -1488,6 +1838,12 @@ impl RestrictedAuthority {
                     index,
                     path: path.clone(),
                 });
+                outcomes.push(PendingOutcome::LogicalV2 {
+                    index,
+                    path: path.clone(),
+                    action: crate::receipt_v2::OperationActionV2::DeleteFile,
+                });
+                touched_v2.push(path.clone());
                 return Ok(());
             }
         };
@@ -1510,17 +1866,33 @@ impl RestrictedAuthority {
                     self.remember_receiver_creation(path, true)?;
                     *mode = 0o700;
                 }
+                outcomes.push(PendingOutcome::LogicalV2 {
+                    index,
+                    path: path.clone(),
+                    action: crate::receipt_v2::OperationActionV2::EnsureDirectory,
+                });
+                touched_v2.push(path.clone());
                 Ok(())
             }
             Op::Symlink {
                 path, condition, ..
-            } => self.constrain_creation(path, condition, false, index, pending),
+            } => {
+                self.constrain_creation(path, condition, false, index, pending)?;
+                outcomes.push(PendingOutcome::LogicalV2 {
+                    index,
+                    path: path.clone(),
+                    action: crate::receipt_v2::OperationActionV2::CreateSymlink,
+                });
+                touched_v2.push(path.clone());
+                Ok(())
+            }
             Op::Mknod {
                 path,
                 mode,
                 condition,
                 ..
             } => {
+                let kind = kind_from_mode(*mode);
                 self.constrain_creation(path, condition, false, index, pending)?;
                 if !self.copy.options.preserve_permissions {
                     self.remember_receiver_creation(path, false)?;
@@ -1530,6 +1902,12 @@ impl RestrictedAuthority {
                     let file_type = *mode & libc::S_IFMT as u32;
                     *mode = file_type | 0o600;
                 }
+                outcomes.push(PendingOutcome::LogicalV2 {
+                    index,
+                    path: path.clone(),
+                    action: crate::receipt_v2::OperationActionV2::CreateSpecial { kind },
+                });
+                touched_v2.push(path.clone());
                 Ok(())
             }
             Op::SetMeta {
@@ -1545,7 +1923,14 @@ impl RestrictedAuthority {
                     flags,
                     condition,
                     ReceiverModeTarget::AnyExisting,
-                )
+                )?;
+                outcomes.push(PendingOutcome::LogicalV2 {
+                    index,
+                    path: path.clone(),
+                    action: crate::receipt_v2::OperationActionV2::SetMetadata { flags: *flags },
+                });
+                touched_v2.push(path.clone());
+                Ok(())
             }
             Op::SetFileMetaIfSame {
                 path,
@@ -1560,7 +1945,14 @@ impl RestrictedAuthority {
                     flags,
                     condition,
                     ReceiverModeTarget::RegularFile,
-                )
+                )?;
+                outcomes.push(PendingOutcome::LogicalV2 {
+                    index,
+                    path: path.clone(),
+                    action: crate::receipt_v2::OperationActionV2::SetMetadata { flags: *flags },
+                });
+                touched_v2.push(path.clone());
+                Ok(())
             }
             Op::Remove { .. } | Op::Rmdir { .. } | Op::Unlink { .. } => Ok(()),
         }
@@ -1572,6 +1964,7 @@ impl RestrictedAuthority {
     pub(crate) fn authorize(&self, request: &mut Request, over_ssh: bool) -> Result<Settlement> {
         let mut pending = Vec::new();
         let mut outcomes = Vec::new();
+        let mut touched_v2 = Vec::new();
         // Requests the server executes and then settles; the receipt waits
         // for all of them. The others are answered inline without settling.
         let tracked = !matches!(
@@ -1593,12 +1986,26 @@ impl RestrictedAuthority {
             if state.receipt_issued || state.receipt_closing {
                 bail!("the signed grant is closed: its receipt has been issued");
             }
+            if state
+                .ledger_v2
+                .as_ref()
+                .is_some_and(crate::receipt_v2::StreamWriterV2::is_failed)
+            {
+                bail!("the signed grant is closed because receipt recording failed");
+            }
             state.in_flight += 1;
         }
-        match self.authorize_inner(request, over_ssh, &mut pending, &mut outcomes) {
+        match self.authorize_inner(
+            request,
+            over_ssh,
+            &mut pending,
+            &mut outcomes,
+            &mut touched_v2,
+        ) {
             Ok(()) => Ok(Settlement {
                 creations: pending,
                 outcomes,
+                touched_v2,
                 tracked,
             }),
             Err(error) => {
@@ -1610,7 +2017,21 @@ impl RestrictedAuthority {
                     state.in_flight = state.in_flight.saturating_sub(1);
                     self.settled.notify_all();
                 }
-                state.ledger.record_refusal(&format!("{error:#}"));
+                if self.receipt_policy.required {
+                    state.ledger.record_refusal(&format!("{error:#}"));
+                }
+                if let Some(stream) = state.ledger_v2.as_mut() {
+                    let sequence = stream.next_sequence();
+                    stream.append(&crate::receipt_v2::RecordV2::Refusal(
+                        crate::receipt_v2::RefusalRecordV2 {
+                            sequence,
+                            code: crate::receipt_v2::OutcomeCodeV2::AuthorizationRefused,
+                            diagnostic: crate::receipt_v2::bounded_format(format_args!(
+                                "{error:#}"
+                            )),
+                        },
+                    ));
+                }
                 Err(error)
             }
         }
@@ -1622,6 +2043,7 @@ impl RestrictedAuthority {
         over_ssh: bool,
         pending: &mut Vec<PendingCreation>,
         outcomes: &mut Vec<PendingOutcome>,
+        touched_v2: &mut Vec<Vec<u8>>,
     ) -> Result<()> {
         self.check_deadline()?;
         match request {
@@ -1716,7 +2138,7 @@ impl RestrictedAuthority {
             }
             Request::Apply { ops, guard } => {
                 for (index, operation) in ops.iter_mut().enumerate() {
-                    self.authorize_op(operation, index, pending, outcomes)?;
+                    self.authorize_op(operation, index, pending, outcomes, touched_v2)?;
                 }
                 *guard = Some(self.guard.clone());
             }
@@ -1767,6 +2189,14 @@ impl RestrictedAuthority {
                 self.check_mutation_path(path, false)?;
                 self.constrain_update(path, false, None, pending)?;
                 self.reserve_bytes(path, *partial_id, *len)?;
+                outcomes.push(PendingOutcome::FileStageV2 {
+                    index: 0,
+                    path: path.clone(),
+                    partial_id: *partial_id,
+                    size: *len,
+                    inplace: false,
+                    stage: FileStageV2::Prepare,
+                });
                 *guard = Some(self.guard.clone());
             }
             Request::FinishBasis {
@@ -1786,6 +2216,12 @@ impl RestrictedAuthority {
                     condition,
                     ReceiverModeTarget::RegularFile,
                 )?;
+                outcomes.push(PendingOutcome::LogicalV2 {
+                    index: 0,
+                    path: path.clone(),
+                    action: crate::receipt_v2::OperationActionV2::SetMetadata { flags: *flags },
+                });
+                touched_v2.push(path.clone());
                 *guard = Some(self.guard.clone());
             }
             Request::Prepare {
@@ -1805,6 +2241,14 @@ impl RestrictedAuthority {
                 self.check_mutation_path(path, false)?;
                 self.constrain_prepare(path)?;
                 self.reserve_bytes(path, *partial_id, *size)?;
+                outcomes.push(PendingOutcome::FileStageV2 {
+                    index: 0,
+                    path: path.clone(),
+                    partial_id: *partial_id,
+                    size: *size,
+                    inplace: *inplace,
+                    stage: FileStageV2::Prepare,
+                });
                 if *inplace {
                     // In-place preparation resizes the final file itself:
                     // the receipt must know even if no final step follows.
@@ -1814,6 +2258,7 @@ impl RestrictedAuthority {
                         size: *size,
                         complete: false,
                     });
+                    touched_v2.push(path.clone());
                 }
                 *guard = Some(self.guard.clone());
             }
@@ -1843,7 +2288,16 @@ impl RestrictedAuthority {
                         size: declared,
                         complete: false,
                     });
+                    touched_v2.push(path.clone());
                 }
+                outcomes.push(PendingOutcome::FileStageV2 {
+                    index: 0,
+                    path: path.clone(),
+                    partial_id: *partial_id,
+                    size: declared,
+                    inplace: *inplace,
+                    stage: FileStageV2::Write,
+                });
                 self.charge_bytes(path, *off, data.len())?;
                 *guard = Some(self.guard.clone());
             }
@@ -1869,6 +2323,15 @@ impl RestrictedAuthority {
                     size: self.declared_size(path, *partial_id)?,
                     complete: true,
                 });
+                outcomes.push(PendingOutcome::FileStageV2 {
+                    index: 0,
+                    path: path.clone(),
+                    partial_id: *partial_id,
+                    size: self.declared_size(path, *partial_id)?,
+                    inplace: *inplace,
+                    stage: FileStageV2::Finalize,
+                });
+                touched_v2.push(path.clone());
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -1901,6 +2364,15 @@ impl RestrictedAuthority {
                         size: put.data.len() as u64,
                         complete: true,
                     });
+                    outcomes.push(PendingOutcome::LogicalV2 {
+                        index,
+                        path: put.path.clone(),
+                        action: crate::receipt_v2::OperationActionV2::PublishFile {
+                            size: put.data.len() as u64,
+                            inplace: false,
+                        },
+                    });
+                    touched_v2.push(put.path.clone());
                     self.constrain_receiver_mode(
                         &put.path,
                         &mut put.meta,
@@ -1941,8 +2413,46 @@ impl RestrictedAuthority {
 pub(crate) struct Settlement {
     creations: Vec<PendingCreation>,
     outcomes: Vec<PendingOutcome>,
+    /// Final destination paths this admitted request could have changed.
+    touched_v2: Vec<Vec<u8>>,
     /// The request counts as in flight until settled.
     tracked: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FileStageV2 {
+    Prepare,
+    Write,
+    Finalize,
+}
+
+fn kind_from_mode(mode: u32) -> proto::Kind {
+    #[cfg(target_os = "linux")]
+    let kind = mode & libc::S_IFMT;
+    #[cfg(not(target_os = "linux"))]
+    let kind = mode & libc::S_IFMT as u32;
+    #[cfg(target_os = "linux")]
+    let value = |value: libc::mode_t| value;
+    #[cfg(not(target_os = "linux"))]
+    let value = |value: libc::mode_t| value as u32;
+    match kind {
+        kind if kind == value(libc::S_IFDIR) => proto::Kind::Dir,
+        kind if kind == value(libc::S_IFREG) => proto::Kind::File,
+        kind if kind == value(libc::S_IFLNK) => proto::Kind::Symlink,
+        kind if kind == value(libc::S_IFIFO) => proto::Kind::Fifo,
+        kind if kind == value(libc::S_IFSOCK) => proto::Kind::Socket,
+        kind if kind == value(libc::S_IFCHR) => proto::Kind::CharDev,
+        kind if kind == value(libc::S_IFBLK) => proto::Kind::BlockDev,
+        _ => proto::Kind::Other,
+    }
+}
+
+#[derive(Debug)]
+struct FileLifecycleV2 {
+    size: u64,
+    inplace: bool,
+    recorded: bool,
+    last_error: Option<String>,
 }
 
 /// One receipt-relevant effect of a request, confirmed by `settle`.
@@ -1962,6 +2472,19 @@ enum PendingOutcome {
     },
     Observe {
         path: Vec<u8>,
+    },
+    LogicalV2 {
+        index: usize,
+        path: Vec<u8>,
+        action: crate::receipt_v2::OperationActionV2,
+    },
+    FileStageV2 {
+        index: usize,
+        path: Vec<u8>,
+        partial_id: proto::PartialId,
+        size: u64,
+        inplace: bool,
+        stage: FileStageV2,
     },
 }
 
@@ -3221,6 +3744,28 @@ pub(crate) fn prepare_transfer(
         &canonical_destination,
     )?;
     let request_id = grant.request_id;
+    let (receipt_recipient_secret, receipt_delivery) = if args.detach {
+        (
+            None,
+            crate::receipt_v2::ReceiptDeliveryV2::DetachedSignedPlaintext,
+        )
+    } else {
+        let (secret, public) = crate::receipt_v2::generate_recipient()?;
+        (
+            Some(secret),
+            crate::receipt_v2::ReceiptDeliveryV2::AttachedEncrypted {
+                suite: crate::receipt_v2::HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+                recipient_public_key: public,
+            },
+        )
+    };
+    let receipt_policy = crate::receipt_v2::ReceiptPolicyV2 {
+        required: true,
+        hashed: args.receipt_hashed,
+        max_records: crate::receipt_v2::DEFAULT_MAX_RECORDS,
+        max_plaintext_bytes: crate::receipt_v2::DEFAULT_MAX_PLAINTEXT_BYTES,
+        delivery: receipt_delivery,
+    };
     let grant = delegation::sign_grant(
         grant,
         GrantConstraints {
@@ -3235,17 +3780,19 @@ pub(crate) fn prepare_transfer(
                 delete_excluded: args.delete_excluded,
             },
             root_existence: root_existence_for(args.target_existence),
-            receipt: ReceiptPolicy {
-                required: true,
-                hashed: args.receipt_hashed,
-            },
+            receipt: ReceiptPolicy::default(),
+            receipt_v2: Some(receipt_policy.clone()),
         },
         &private_key,
     )?;
+    let grant_digest = delegation::signed_grant_digest(&grant)?;
     Ok(PreparedTransfer {
         private_key,
         request_id,
         receipt_public_key,
+        receipt_recipient_secret,
+        receipt_policy,
+        grant_digest,
         canonical_destination,
         grant: base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(grant),
         enrollment_id: metadata.id,
@@ -3293,12 +3840,13 @@ pub(crate) fn run_receiver(enrollment: &str) -> Result<()> {
         revocation_file: None,
     };
     let verified = delegation::verify_and_claim(&envelope, &context, &policy, &replay)?;
-    let (grant, extensions, deadline) = verified.into_parts();
+    let (grant, extensions, grant_digest, deadline) = verified.into_parts();
     let receipt_key = load_receipt_key(replay_path.parent().context("receiver state directory")?)?;
     let authority = std::sync::Arc::new(RestrictedAuthority::new(
         &config,
         grant,
         extensions,
+        grant_digest,
         receipt_key,
         deadline,
     )?);
@@ -3578,6 +4126,7 @@ mod tests {
             placement,
             root_existence,
             None,
+            None,
         )
     }
 
@@ -3593,7 +4142,11 @@ mod tests {
         placement: DestinationPlacement,
         root_existence: RootExistence,
         receipt: Option<(PrivateKey, bool)>,
+        receipt_v2: Option<(PrivateKey, crate::receipt_v2::ReceiptPolicyV2)>,
     ) -> Result<RestrictedAuthority> {
+        if receipt.is_some() && receipt_v2.is_some() {
+            bail!("test authority cannot enable both receipt versions");
+        }
         let opened = Root::open(root).unwrap();
         let identity = opened.identity();
         let id = EnrollmentId::random();
@@ -3659,15 +4212,18 @@ mod tests {
                 },
             }),
         };
-        let (receipt_key, receipt_policy) = match receipt {
-            Some((key, hashed)) => (
+        let (receipt_key, receipt_policy, receipt_policy_v2) = match (receipt, receipt_v2) {
+            (Some((key, hashed)), None) => (
                 key,
                 ReceiptPolicy {
                     required: true,
                     hashed,
                 },
+                None,
             ),
-            None => (generate_receipt_key(id)?, ReceiptPolicy::default()),
+            (None, Some((key, policy))) => (key, ReceiptPolicy::default(), Some(policy)),
+            (None, None) => (generate_receipt_key(id)?, ReceiptPolicy::default(), None),
+            (Some(_), Some(_)) => bail!("test authority cannot enable both receipt versions"),
         };
         RestrictedAuthority::new(
             &config,
@@ -3677,7 +4233,9 @@ mod tests {
                 filters,
                 root_existence,
                 receipt: receipt_policy,
+                receipt_v2: receipt_policy_v2,
             },
+            [0; 32],
             receipt_key,
             Instant::now() + std::time::Duration::from_secs(60),
         )
@@ -4708,6 +5266,7 @@ mod tests {
             DestinationPlacement::ExactPath,
             RootExistence::Any,
             Some((key, hashed)),
+            None,
         )
         .unwrap();
         // Waiting for in-flight requests is bounded by the grant deadline;
@@ -4742,6 +5301,7 @@ mod tests {
             DestinationPlacement::ExactPath,
             RootExistence::Any,
             Some((key, true)),
+            None,
         )
         .unwrap();
         let put = |path: &Path| proto::SmallPut {
@@ -4799,7 +5359,7 @@ mod tests {
         let mut outside = prepare_request(&root.join("elsewhere"));
         assert!(authority.authorize(&mut outside, false).is_err());
 
-        let envelope = authority.issue_receipt().unwrap();
+        let envelope = authority.issue_receipt().unwrap().into_v1();
         let receipt = crate::receipt::verify(&envelope, &public).unwrap();
         assert_eq!(receipt.enrollment_id, authority.enrollment_id);
         assert_eq!(receipt.request_id, authority.request_id);
@@ -4889,12 +5449,148 @@ mod tests {
             let settlement = racing.authorize(&mut delete, false).unwrap();
             racing.settle(settlement, &proto::Response::Applied(vec![None]));
         }
-        let envelope = racing.issue_receipt().unwrap();
+        let envelope = racing.issue_receipt().unwrap().into_v1();
         let receipt = crate::receipt::verify(&envelope, &racing_public(&racing)).unwrap();
         assert_eq!(receipt.deleted, vec![path_bytes(&vanished)]);
         assert_eq!(receipt.published.len(), 1);
         assert_eq!(receipt.published[0].path, path_bytes(&returned));
         assert_eq!(receipt.published[0].size, 4);
+    }
+
+    #[test]
+    fn receipt_v2_records_each_outcome_and_closure_state_then_encrypts_it() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let target = root.join("target");
+        let copied_name = vec![b'c', b'o', b'p', 0xff];
+        let copied = target.join(OsString::from_vec(copied_name.clone()));
+        let failed = target.join("failed");
+        let removed = target.join("removed");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(&removed, b"old").unwrap();
+
+        let receipt_key = generate_receipt_key(EnrollmentId::random()).unwrap();
+        let receipt_public = receipt_key.public_key().to_openssh().unwrap();
+        let (recipient_secret, recipient_public_key) =
+            crate::receipt_v2::generate_recipient().unwrap();
+        let policy = crate::receipt_v2::ReceiptPolicyV2 {
+            required: true,
+            hashed: true,
+            max_records: 64,
+            max_plaintext_bytes: 1 << 20,
+            delivery: crate::receipt_v2::ReceiptDeliveryV2::AttachedEncrypted {
+                suite: crate::receipt_v2::HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+                recipient_public_key,
+            },
+        };
+        let authority = test_authority_with_receipt(
+            &root,
+            DeletionPolicy::DeleteDestinationOnly,
+            1024,
+            0,
+            FilterPolicy::default(),
+            PublicationPolicy::AtomicStaged,
+            ExistingDestinationPolicy::Replace,
+            DestinationPlacement::ExactPath,
+            RootExistence::Any,
+            None,
+            Some((receipt_key, policy.clone())),
+        )
+        .unwrap();
+        let put = |path: &Path| proto::SmallPut {
+            path: path_bytes(path),
+            partial_id: [7; 16],
+            data: b"new".to_vec(),
+            hash: crate::fsops::content_digest(b"new"),
+            meta: plain_meta(),
+            flags: 0,
+            condition: proto::TargetCondition::Any,
+            guard: None,
+        };
+        let mut batch = Request::PutSmallBatch(vec![put(&copied), put(&failed)]);
+        let settlement = authority.authorize(&mut batch, false).unwrap();
+        fs::write(&copied, b"new").unwrap();
+        authority.settle(
+            settlement,
+            &proto::Response::Applied(vec![None, Some("executor rejected it".into())]),
+        );
+        let mut delete = apply(Op::Unlink {
+            path: path_bytes(&removed),
+        });
+        let settlement = authority.authorize(&mut delete, false).unwrap();
+        fs::remove_file(&removed).unwrap();
+        authority.settle(settlement, &proto::Response::Applied(vec![None]));
+        assert!(authority
+            .authorize(&mut prepare_request(&root.join("outside")), false)
+            .is_err());
+
+        let issued = match authority.issue_receipt().unwrap() {
+            IssuedReceipt::V2(receipt) => receipt,
+            IssuedReceipt::V1(_) => panic!("expected receipt v2"),
+        };
+        let mut frames = Vec::new();
+        crate::receipt_v2::emit_transport_frames(issued, |frame| {
+            frames.push(Ok(frame));
+            Ok(())
+        })
+        .unwrap();
+        let mut verified = crate::receipt_v2::open_attached_frames(
+            frames,
+            &recipient_secret,
+            &receipt_public,
+            authority.enrollment_id,
+            authority.request_id,
+            [0; 32],
+            &policy,
+        )
+        .unwrap();
+        assert_eq!(
+            verified.terminal.status,
+            crate::receipt_v2::ReceiptStatusV2::Failed
+        );
+        assert_eq!(verified.terminal.summary.operations, 3);
+        assert_eq!(verified.terminal.summary.refusals, 1);
+        assert_eq!(verified.terminal.summary.final_states, 3);
+        assert_eq!(verified.terminal.summary.published_files, 1);
+        assert_eq!(verified.terminal.summary.deletions, 1);
+
+        let mut records = Vec::new();
+        verified
+            .for_each_record(|record| {
+                records.push(record);
+                Ok(())
+            })
+            .unwrap();
+        assert!(records.iter().any(|record| matches!(
+            record,
+            crate::receipt_v2::RecordV2::Operation(operation)
+                if operation.path == copied_name
+                    && operation.disposition == crate::receipt_v2::OperationDispositionV2::Applied
+        )));
+        assert!(records.iter().any(|record| matches!(
+            record,
+            crate::receipt_v2::RecordV2::Operation(operation)
+                if operation.path == b"failed"
+                    && operation.disposition == crate::receipt_v2::OperationDispositionV2::Failed
+        )));
+        assert!(records.iter().any(|record| matches!(
+            record,
+            crate::receipt_v2::RecordV2::FinalState(state)
+                if state.path == copied_name
+                    && matches!(
+                        state.object,
+                        crate::receipt_v2::FinalObjectV2::Present {
+                            digest: Some(digest),
+                            ..
+                        } if digest == *blake3::hash(b"new").as_bytes()
+                    )
+        )));
+        assert!(records.iter().any(|record| matches!(
+            record,
+            crate::receipt_v2::RecordV2::FinalState(state)
+                if state.path == b"removed"
+                    && state.object == crate::receipt_v2::FinalObjectV2::Absent
+        )));
     }
 
     #[test]
@@ -4917,6 +5613,7 @@ mod tests {
             DestinationPlacement::ExactPath,
             RootExistence::Any,
             Some((key, false)),
+            None,
         )
         .unwrap();
         let mut prepare = Request::Prepare {
@@ -4944,7 +5641,7 @@ mod tests {
         authority.settle(settlement, &proto::Response::Ok);
 
         // Without a final step the receipt still lists the file, incomplete.
-        let envelope = authority.issue_receipt().unwrap();
+        let envelope = authority.issue_receipt().unwrap().into_v1();
         let receipt = crate::receipt::verify(&envelope, &public).unwrap();
         assert_eq!(receipt.published_count, 1);
         assert_eq!(receipt.incomplete_count, 1);
@@ -4966,6 +5663,7 @@ mod tests {
             DestinationPlacement::ExactPath,
             RootExistence::Any,
             Some((key, false)),
+            None,
         )
         .unwrap();
         let mut prepare = Request::Prepare {
@@ -4989,7 +5687,8 @@ mod tests {
         };
         let settlement = finished.authorize(&mut finalize, false).unwrap();
         finished.settle(settlement, &proto::Response::Ok);
-        let receipt = crate::receipt::verify(&finished.issue_receipt().unwrap(), &public).unwrap();
+        let receipt =
+            crate::receipt::verify(&finished.issue_receipt().unwrap().into_v1(), &public).unwrap();
         assert_eq!(receipt.published_count, 1);
         assert_eq!(receipt.incomplete_count, 0);
         assert!(receipt.published[0].complete);

--- a/src/results.rs
+++ b/src/results.rs
@@ -10,6 +10,11 @@
 //! record for every counted error; exactly one terminal `result`. Unchanged
 //! and excluded entries are aggregated in the terminal record only, and
 //! metadata-only updates are not yet reported per operation.
+//!
+//! Attached direct copies through a command-restricted receiver are the one
+//! exception: receipt_v2 emits their stream locally after verification, marks
+//! its provenance, omits source-side claims hostB cannot authenticate, and
+//! includes closure-time final-state records.
 
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};

--- a/src/server.rs
+++ b/src/server.rs
@@ -336,7 +336,15 @@ fn serve<R: Read + Send + 'static, W: Write>(
             }
             Request::Receipt => match &authority {
                 Some(authority) => match authority.issue_receipt() {
-                    Ok(envelope) => w.write_msg(&Response::Receipt(envelope))?,
+                    Ok(crate::restricted::IssuedReceipt::V1(envelope)) => {
+                        w.write_msg(&Response::Receipt(envelope))?
+                    }
+                    Ok(crate::restricted::IssuedReceipt::V2(receipt)) => {
+                        crate::receipt_v2::emit_transport_frames(receipt, |frame| {
+                            w.write_msg(&Response::ReceiptV2(frame))?;
+                            Ok(())
+                        })?;
+                    }
                     Err(error) => w.write_msg(&Response::Err(format!("{error:#}")))?,
                 },
                 None => w.write_msg(&Response::Err(

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -2073,20 +2073,55 @@ pub fn run(args: Args) -> Result<i32> {
     drop(st);
 
     // With a command-restricted receiver, ask for its signed receipt now that
-    // every mutation is settled, and hand it to the invoking machine as one
-    // marked line. That machine verifies it; this orchestrator's own report
-    // is not trusted for what landed.
+    // every mutation is settled, and hand its bounded frames to the invoking
+    // machine as marked lines. That machine verifies it; this orchestrator's
+    // own report is not trusted for what landed.
     if args.restricted_grant.is_some() {
         use base64::Engine as _;
-        match dst_ctl.call(Request::Receipt) {
-            Ok(Response::Receipt(envelope)) => println!(
-                "{}{}",
-                crate::receipt::RECEIPT_LINE_PREFIX,
-                base64::engine::general_purpose::STANDARD_NO_PAD.encode(envelope)
-            ),
-            Ok(Response::Err(error)) => progress.error(&format!("syq: receipt: {error}")),
-            Ok(other) => progress.error(&format!("syq: receipt: unexpected response {other:?}")),
-            Err(error) => progress.error(&format!("syq: receipt: {error:#}")),
+        if let Err(error) = dst_ctl.send(Request::Receipt) {
+            progress.error(&format!("syq: receipt: {error:#}"));
+        } else {
+            loop {
+                match dst_ctl.recv() {
+                    Ok(Response::Receipt(envelope)) => {
+                        println!(
+                            "{}{}",
+                            crate::receipt::RECEIPT_LINE_PREFIX,
+                            base64::engine::general_purpose::STANDARD_NO_PAD.encode(envelope)
+                        );
+                        break;
+                    }
+                    Ok(Response::ReceiptV2(frame)) => {
+                        let terminal = match crate::receipt_v2::transport_frame_is_end(&frame) {
+                            Ok(terminal) => terminal,
+                            Err(error) => {
+                                progress.error(&format!("syq: receipt: {error:#}"));
+                                break;
+                            }
+                        };
+                        println!(
+                            "{}{}",
+                            crate::receipt_v2::RECEIPT_LINE_PREFIX,
+                            base64::engine::general_purpose::STANDARD_NO_PAD.encode(frame)
+                        );
+                        if terminal {
+                            break;
+                        }
+                    }
+                    Ok(Response::Err(error)) => {
+                        progress.error(&format!("syq: receipt: {error}"));
+                        break;
+                    }
+                    Ok(other) => {
+                        progress.error(&format!("syq: receipt: unexpected response {other:?}"));
+                        break;
+                    }
+                    Err(error) => {
+                        progress.error(&format!("syq: receipt: {error:#}"));
+                        break;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- add grant wire v2 while retaining current wire-v1 decoding; v2 binds the complete receipt policy, fresh X25519 recipient key, delivery mode, limits, and exact grant transcript
- record one canonical outcome per receiver-visible logical pathname mutation, plus a closure-time final-state record for every path an admitted mutation could have changed
- sign a bounded terminal commitment and encrypt attached receipt frames with HPKE X25519/HKDF-SHA-256/ChaCha20-Poly1305; spool both receiver and local streams outside the heap
- fail closed on missing, altered, reordered, replayed, incomplete, or over-limit receipts; receipt failure closes further mutation authority and can never become a truncated clean result
- preserve restricted detach with an unconditional warning and signed plaintext receipt in the coordinator log; it reports launch only and makes no locally verified completion claim
- derive attached `--results -` locally from the verified receipt and mark every emitted record `receiver_attested`
- advance the installed receiver generation so older enrollments are refreshed before wire-v2 use

## Security boundary

A clean receipt authenticates hostB receiver operations and its closure-time observations. It does not prove source completeness or intended source bytes without a future expected manifest. It is not a transaction or rollback mechanism, does not attest blocks/syscalls/scans or recursive descendant inventories, and does not protect against compromised hostB, its receipt key, authorized hostB-local co-writers, or changes after issuance. Diagnostics are bounded context; structured codes and dispositions are the contract. HPKE does not hide frame count, ciphertext length, or timing.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (266 unit, 282 local integration, 7 update)

Not run: a live two-host command-restricted transfer. The protocol, receiver settlement, framing, encryption, tampering, limits, detached delivery, non-UTF-8 paths, and local relay/verification paths are covered by tests.