### PR TITLE
Pin destination roots across worker sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,11 +829,12 @@ Identical to rsync:
 - An explicitly supplied destination root that is a symlink to a directory is
   that directory when the link is owned by root or by the receiver's effective
   uid (the link is kept, with or without a trailing slash). A foreign-owned
-  component is refused. Each receiving connection retains and verifies the
-  selected directory, so replacing the external destination spelling afterward
-  cannot redirect its writes. A symlink encountered below the destination root
-  is payload at that path: it is replaced rather than followed, even when it
-  points to a directory.
+  component is refused. The control connection registers the selected open
+  directory, and every worker receives that exact directory descriptor rather
+  than resolving the operator path again. Replacing the external destination
+  spelling afterward therefore cannot redirect its writes. A symlink
+  encountered below the destination root is payload at that path: it is
+  replaced rather than followed, even when it points to a directory.
 - Recognizable `.syq-part.<job-id>` paths in a source are copied as ordinary
   payload and produce one warning summary. Before transfer starts, SYQ rejects
   the exceptional case where a mapped payload path exactly equals a sidecar
@@ -1237,8 +1238,9 @@ data connections across all of them (multipath) — it keeps only paths within
 2x of the fastest, so it never drags a fast transfer down by mixing in a slow
 link. Every candidate still gets its complete bounded probe window, but those
 independent probes run while the control connection prepares the destination.
-Worker Hello and destination anchoring are likewise sent in one
-pipelined setup turn. Single-homed hosts and laptops use the one best path,
+An unrestricted destination worker claims its registered directory as part of
+its authenticated Hello, and the receiver acknowledges readiness only after
+that claim succeeds. Single-homed hosts and laptops use the one best path,
 unchanged. With ufw:
 
 ```sh

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -141,17 +141,6 @@ fn is_multiplexed_ssh_session_error(error: &anyhow::Error) -> bool {
         .any(|cause| cause.is::<MultiplexedSshSessionError>())
 }
 
-fn worker_initialization_response(response: Response) -> Result<()> {
-    match response {
-        Response::Ok => Ok(()),
-        Response::Err(error) => Err(WorkerInitializationError(error).into()),
-        other => Err(WorkerInitializationError(format!(
-            "unexpected worker initialization response {other:?}"
-        ))
-        .into()),
-    }
-}
-
 #[cfg(target_os = "linux")]
 fn tcp_congestion_control<S: AsRawFd>(socket: &S) -> std::io::Result<String> {
     // Linux currently caps names at TCP_CA_NAME_MAX (16 including NUL). Leave
@@ -1046,16 +1035,21 @@ impl RemoteSpec {
     /// queue behind workers. In managed mode the release helper is installed
     /// on first use if the remote lacks it.
     pub fn connect_with(&self, compress: bool, limited: bool) -> Result<RemoteConn> {
-        self.connect_with_request(compress, limited, None)
+        let role = if limited {
+            ConnectionRole::SourceWorker
+        } else {
+            ConnectionRole::Control
+        };
+        self.connect_with_role(compress, limited, role)
     }
 
-    fn connect_with_request(
+    fn connect_with_role(
         &self,
         compress: bool,
         limited: bool,
-        initial_request: Option<Request>,
+        role: ConnectionRole,
     ) -> Result<RemoteConn> {
-        let first = self.connect_retried(compress, limited, initial_request.clone());
+        let first = self.connect_retried(compress, limited, role.clone());
         let Err(first_error) = first else {
             return first;
         };
@@ -1064,7 +1058,7 @@ impl RemoteSpec {
         }
 
         self.install_helper()?;
-        self.connect_retried(compress, limited, initial_request)
+        self.connect_retried(compress, limited, role)
             .with_context(|| {
                 format!(
                     "could not start the {} helper installed on {}",
@@ -1078,14 +1072,14 @@ impl RemoteSpec {
         &self,
         compress: bool,
         limited: bool,
-        initial_request: Option<Request>,
+        role: ConnectionRole,
     ) -> Result<RemoteConn> {
         let mut delay = std::time::Duration::from_millis(200);
         let mut last = None;
         for attempt in 0..6 {
             let _slot = limited.then(connect_slot);
             let ssh_connection = self.ssh_connection(limited);
-            match self.connect_once(compress, ssh_connection, initial_request.clone()) {
+            match self.connect_once(compress, ssh_connection, role.clone()) {
                 Ok(c) => return Ok(c),
                 Err(e)
                     if ssh_connection == SshConnection::Worker
@@ -1152,7 +1146,7 @@ impl RemoteSpec {
         &self,
         compress: bool,
         ssh_connection: SshConnection,
-        initial_request: Option<Request>,
+        role: ConnectionRole,
     ) -> Result<RemoteConn> {
         let mut server_args = vec!["--server".into()];
         if let Some(grant) = &self.restricted_grant {
@@ -1198,7 +1192,7 @@ impl RemoteSpec {
             tcp_socket: None,
             multiplexed_ssh: ssh_connection == SshConnection::Worker,
         };
-        let conn = hello(conn, compress, Vec::new(), initial_request)?;
+        let conn = hello(conn, compress, Vec::new(), role)?;
         self.record_peer(&conn);
         Ok(conn)
     }
@@ -1417,7 +1411,7 @@ impl RemoteSpec {
         &self,
         info: &TcpInfo,
         compress: bool,
-        initial_request: Option<Request>,
+        role: ConnectionRole,
     ) -> Result<RemoteConn> {
         let n = info.addrs.len();
         let start = info.next.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % n;
@@ -1491,7 +1485,7 @@ impl RemoteSpec {
                 tcp_socket: Some(tcp_socket),
                 multiplexed_ssh: false,
             };
-            let conn = hello(conn, compress, info.token.clone(), initial_request.clone())?;
+            let conn = hello(conn, compress, info.token.clone(), role.clone())?;
             self.record_peer(&conn);
             return Ok(conn);
         }
@@ -1608,20 +1602,16 @@ fn hello(
     mut conn: RemoteConn,
     compress: bool,
     token: Vec<u8>,
-    initial_request: Option<Request>,
+    role: ConnectionRole,
 ) -> Result<RemoteConn> {
+    let destination_worker = matches!(role, ConnectionRole::DestinationWorker { .. });
     conn.send(Request::Hello {
         identity: crate::identity::build().to_string(),
         compress,
         debug: crate::transfer::debug(),
         token,
+        role,
     })?;
-    // Worker destination anchoring is independent of the Hello response. Put
-    // it on the wire immediately so the receiver can authenticate, anchor,
-    // and acknowledge within one WAN turn while preserving response order.
-    if let Some(request) = initial_request.as_ref() {
-        conn.send(request.clone())?;
-    }
     match conn.recv() {
         Ok(Response::HelloOk { identity, platform }) if identity == crate::identity::build() => {
             conn.peer = Some(PeerInfo { identity, platform });
@@ -1633,15 +1623,22 @@ fn hello(
                 crate::identity::build()
             )
         }
-        Ok(Response::Err(e)) => bail!("{}: {e}", conn.label),
+        Ok(Response::Err(error)) if destination_worker => {
+            return Err(WorkerInitializationError(format!("{}: {error}", conn.label)).into())
+        }
+        Ok(Response::Err(error)) => bail!("{}: {error}", conn.label),
+        Ok(other) if destination_worker => {
+            return Err(WorkerInitializationError(format!(
+                "{}: unexpected handshake response {other:?}",
+                conn.label
+            ))
+            .into())
+        }
         Ok(other) => bail!("{}: unexpected handshake response {other:?}", conn.label),
         Err(e) => {
             return Err(e)
                 .with_context(|| format!("could not start the remote syq on {}", conn.label))
         }
-    }
-    if initial_request.is_some() {
-        worker_initialization_response(conn.recv()?)?;
     }
     Ok(conn)
 }
@@ -2071,26 +2068,46 @@ impl Endpoint {
     }
 
     pub fn connect(&self, compress: bool) -> Result<Box<dyn Conn>> {
-        self.connect_with_request(compress, None)
+        self.connect_with_role(compress, ConnectionRole::SourceWorker)
     }
 
-    pub(crate) fn connect_with_request(
+    pub(crate) fn connect_with_destination(
         &self,
         compress: bool,
-        initial_request: Option<Request>,
+        destination: Option<DestinationRoot>,
     ) -> Result<Box<dyn Conn>> {
+        self.connect_with_role(compress, ConnectionRole::DestinationWorker { destination })
+    }
+
+    fn connect_with_role(&self, compress: bool, role: ConnectionRole) -> Result<Box<dyn Conn>> {
         match self {
             Endpoint::Local => {
                 let mut conn = LocalConn::new();
-                if let Some(request) = initial_request {
-                    worker_initialization_response(conn.call(request)?)?;
+                match role {
+                    ConnectionRole::DestinationWorker {
+                        destination: Some(destination),
+                    } => conn
+                        .ops
+                        .initialize_destination(&destination)
+                        .map_err(|error| {
+                            WorkerInitializationError(format!(
+                                "initialize local destination worker: {error:#}"
+                            ))
+                        })?,
+                    ConnectionRole::DestinationWorker { destination: None } => {
+                        return Err(WorkerInitializationError(
+                            "local destination worker requires a registered root".into(),
+                        )
+                        .into())
+                    }
+                    ConnectionRole::Control | ConnectionRole::SourceWorker => {}
                 }
                 Ok(Box::new(conn))
             }
             Endpoint::Remote(spec) => {
                 let info = spec.tcp.lock().unwrap().clone();
                 if let Some(info) = info.filter(|i| !i.failed) {
-                    match spec.connect_tcp(&info, compress, initial_request.clone()) {
+                    match spec.connect_tcp(&info, compress, role.clone()) {
                         Ok(c) => return Ok(Box::new(c)),
                         Err(e)
                             if is_tcp_congestion_error(&e)
@@ -2129,11 +2146,7 @@ impl Endpoint {
                         spec.label()
                     );
                 }
-                Ok(Box::new(spec.connect_with_request(
-                    compress,
-                    true,
-                    initial_request,
-                )?))
+                Ok(Box::new(spec.connect_with_role(compress, true, role)?))
             }
         }
     }
@@ -2254,7 +2267,7 @@ mod tests {
         };
 
         let error = spec
-            .connect_tcp(&info, false, None)
+            .connect_tcp(&info, false, ConnectionRole::SourceWorker)
             .err()
             .expect("unregistered congestion control should fail locally");
         let message = format!("{error:#}");
@@ -2275,14 +2288,22 @@ mod tests {
 
     #[test]
     fn rejected_worker_initialization_is_not_a_retryable_transport_error() {
-        let error = worker_initialization_response(Response::Err("destination changed".into()))
-            .unwrap_err();
+        let error: anyhow::Error = WorkerInitializationError("destination changed".into()).into();
         assert!(is_worker_initialization_error(&error));
         assert!(!is_tcp_congestion_error(&error));
     }
 
     #[test]
-    fn hello_sends_worker_initialization_before_waiting_for_its_response() {
+    fn hello_carries_destination_initialization_before_readiness() {
+        let temp = tempfile::tempdir().unwrap();
+        let descriptor_session = crate::descriptor_broker::DescriptorSessionSlot::default();
+        let ticket = descriptor_session
+            .register(std::fs::File::open(temp.path()).unwrap())
+            .unwrap();
+        let destination = DestinationRoot {
+            ticket,
+            request_prefix: b"destination".to_vec(),
+        };
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let address = listener.local_addr().unwrap();
         let server = std::thread::spawn(move || {
@@ -2291,14 +2312,18 @@ mod tests {
                 .set_read_timeout(Some(std::time::Duration::from_secs(1)))
                 .unwrap();
             let mut reader = FrameReader::new(socket.try_clone().unwrap());
-            assert!(matches!(
-                reader.read_msg::<Request>().unwrap(),
-                Request::Hello { .. }
-            ));
-            assert!(matches!(
-                reader.read_msg::<Request>().unwrap(),
-                Request::AnchorDestination { .. }
-            ));
+            let hello = reader.read_msg::<Request>().unwrap();
+            let Request::Hello {
+                role:
+                    ConnectionRole::DestinationWorker {
+                        destination: Some(destination),
+                    },
+                ..
+            } = hello
+            else {
+                panic!("destination initialization was not carried in Hello");
+            };
+            assert_eq!(destination.request_prefix, b"destination");
 
             let mut writer = FrameWriter::new(socket, false);
             writer
@@ -2307,7 +2332,6 @@ mod tests {
                     platform: crate::identity::platform(),
                 })
                 .unwrap();
-            writer.write_msg(&Response::Ok).unwrap();
         });
 
         let socket = TcpStream::connect(address).unwrap();
@@ -2327,18 +2351,15 @@ mod tests {
             conn,
             false,
             Vec::new(),
-            Some(Request::AnchorDestination {
-                path: Some(b"destination".to_vec()),
-                expected_dev: 1,
-                expected_ino: 2,
-                request_prefix: b"destination".to_vec(),
-                symlink_policy: OperatorSymlinkPolicy::TrustedOwner,
-            }),
+            ConnectionRole::DestinationWorker {
+                destination: Some(destination),
+            },
         )
         .unwrap();
         assert!(conn.peer.is_some());
         drop(conn);
         server.join().unwrap();
+        descriptor_session.close();
     }
 
     #[test]

--- a/src/descriptor_broker.rs
+++ b/src/descriptor_broker.rs
@@ -7,13 +7,17 @@
 
 use crate::private_broker::{PrivateBroker, PrivateBrokerConfig, TrackedStream};
 use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::mem::{size_of, zeroed};
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -24,6 +28,8 @@ const RESPONSE_OK: u8 = 0;
 const RESPONSE_REJECTED: u8 = 1;
 const RESPONSE_INTERNAL: u8 = 2;
 const BROKER_IO_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_MAX_ROOTS: usize = 256;
+const DEFAULT_MAX_CONNECTIONS: usize = 256;
 const FD_CONTROL_LEN: usize =
     unsafe { libc::CMSG_SPACE(size_of::<RawFd>() as libc::c_uint) as usize };
 
@@ -33,7 +39,7 @@ union FdControl {
     bytes: [u8; FD_CONTROL_LEN],
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub(crate) struct RegisteredRootId(u64);
 
 struct RegisteredRoot {
@@ -78,7 +84,7 @@ impl RegisteredRootRegistry {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if state.roots.len() >= self.max_roots {
             bail!(
-                "descriptor session root limit ({}) exceeded; reduce distinct roots or raise the session limit",
+                "descriptor session root limit ({}) exceeded; split the operation into fewer distinct roots",
                 self.max_roots
             );
         }
@@ -117,9 +123,10 @@ impl RegisteredRootRegistry {
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct DescriptorTicket {
-    socket_path: PathBuf,
+#[derive(Clone, Deserialize, Serialize)]
+pub struct DescriptorTicket {
+    #[serde(with = "serde_bytes")]
+    socket_path: Vec<u8>,
     secret: [u8; SECRET_LEN],
     root_id: RegisteredRootId,
 }
@@ -128,9 +135,15 @@ impl std::fmt::Debug for DescriptorTicket {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("DescriptorTicket")
-            .field("socket_path", &self.socket_path)
+            .field("socket_path", &self.socket_path())
             .field("root_id", &self.root_id)
             .finish_non_exhaustive()
+    }
+}
+
+impl DescriptorTicket {
+    fn socket_path(&self) -> PathBuf {
+        PathBuf::from(OsStr::from_bytes(&self.socket_path))
     }
 }
 
@@ -183,10 +196,98 @@ impl DescriptorSession {
             bail!("unknown descriptor session root {}", root_id.0);
         }
         Ok(DescriptorTicket {
-            socket_path: self.broker.socket_path().to_path_buf(),
+            socket_path: self.broker.socket_path().as_os_str().as_bytes().to_vec(),
             secret: self.secret,
             root_id,
         })
+    }
+
+    fn acquire(&self, ticket: &DescriptorTicket) -> Result<File> {
+        if ticket.secret != self.secret
+            || ticket.socket_path != self.broker.socket_path().as_os_str().as_bytes()
+        {
+            bail!("descriptor ticket does not belong to this endpoint session");
+        }
+        self.registry.acquire(ticket.root_id)
+    }
+}
+
+/// A process-local view of one endpoint session. The control connection
+/// creates the descriptor broker lazily when it registers a root. TCP workers
+/// share this slot and clone the root directly; a fresh independent-worker
+/// process has an empty slot and claims the same root over the broker socket.
+#[derive(Clone)]
+pub(crate) struct DescriptorSessionSlot {
+    session: Arc<Mutex<Option<DescriptorSession>>>,
+    closed: Arc<AtomicBool>,
+    max_roots: usize,
+    max_connections: usize,
+}
+
+impl Default for DescriptorSessionSlot {
+    fn default() -> Self {
+        Self {
+            session: Arc::new(Mutex::new(None)),
+            closed: Arc::new(AtomicBool::new(false)),
+            max_roots: DEFAULT_MAX_ROOTS,
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+        }
+    }
+}
+
+impl DescriptorSessionSlot {
+    pub(crate) fn register(&self, directory: File) -> Result<DescriptorTicket> {
+        if self.closed.load(Ordering::Acquire) {
+            bail!("descriptor session is closed");
+        }
+        let mut session = self
+            .session
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.closed.load(Ordering::Acquire) {
+            bail!("descriptor session is closed");
+        }
+        if session.is_none() {
+            *session = Some(DescriptorSession::start(
+                self.max_roots,
+                self.max_connections,
+            )?);
+        }
+        let session = session.as_ref().expect("descriptor session initialized");
+        let root_id = session.register(directory)?;
+        session.ticket(root_id)
+    }
+
+    pub(crate) fn acquire(&self, ticket: &DescriptorTicket) -> Result<File> {
+        let session = self
+            .session
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(session) = session.as_ref() {
+            return session.acquire(ticket);
+        }
+        drop(session);
+        if self.closed.load(Ordering::Acquire) {
+            bail!("descriptor session is closed");
+        }
+        claim_descriptor(ticket)
+    }
+
+    /// End the control session even if its detached TCP listener still holds
+    /// a clone of this slot. This synchronously stops the broker and releases
+    /// its private socket directory.
+    pub(crate) fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        let session = self
+            .session
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        drop(session);
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
     }
 }
 
@@ -194,12 +295,9 @@ impl DescriptorSession {
 /// descriptor refers to the exact registered object even if its original
 /// pathname has been renamed or replaced.
 pub(crate) fn claim_descriptor(ticket: &DescriptorTicket) -> Result<File> {
-    let mut stream = UnixStream::connect(&ticket.socket_path).with_context(|| {
-        format!(
-            "connect to descriptor broker {}",
-            ticket.socket_path.display()
-        )
-    })?;
+    let socket_path = ticket.socket_path();
+    let mut stream = UnixStream::connect(&socket_path)
+        .with_context(|| format!("connect to descriptor broker {}", socket_path.display()))?;
     stream.set_read_timeout(Some(BROKER_IO_TIMEOUT))?;
     stream.set_write_timeout(Some(BROKER_IO_TIMEOUT))?;
     let mut claim = [0u8; CLAIM_LEN];
@@ -426,8 +524,10 @@ mod tests {
     }
 
     fn ticket_from_environment() -> DescriptorTicket {
-        let socket_path =
-            PathBuf::from(std::env::var_os("SYQ_TEST_DESCRIPTOR_BROKER_SOCKET").unwrap());
+        let socket_path = std::env::var_os("SYQ_TEST_DESCRIPTOR_BROKER_SOCKET")
+            .unwrap()
+            .as_bytes()
+            .to_vec();
         let secret_bytes = hex_decode(&std::env::var("SYQ_TEST_DESCRIPTOR_BROKER_SECRET").unwrap());
         DescriptorTicket {
             socket_path,
@@ -461,17 +561,17 @@ mod tests {
         std::fs::write(selected.join("marker"), b"original").unwrap();
         let original = File::open(&selected).unwrap();
         let identity = original.metadata().unwrap();
-        let session = DescriptorSession::start(4, 4).unwrap();
-        let root = session.register(original).unwrap();
-        let registry = session.registry();
+        let session = DescriptorSessionSlot::default();
+        let ticket = session.register(original).unwrap();
 
         std::fs::rename(&selected, temp.path().join("moved")).unwrap();
         std::fs::create_dir(&selected).unwrap();
         std::fs::write(selected.join("marker"), b"replacement").unwrap();
 
-        let local_registry = registry.clone();
-        let local = std::thread::spawn(move || local_registry.acquire(root).unwrap());
-        let tcp = std::thread::spawn(move || registry.acquire(root).unwrap());
+        let local_session = session.clone();
+        let local_ticket = ticket.clone();
+        let local = std::thread::spawn(move || local_session.acquire(&local_ticket).unwrap());
+        let tcp = std::thread::spawn(move || session.acquire(&ticket).unwrap());
         for directory in [local.join().unwrap(), tcp.join().unwrap()] {
             let metadata = directory.metadata().unwrap();
             assert_eq!(
@@ -514,9 +614,8 @@ mod tests {
         std::fs::write(selected.join("marker"), b"original").unwrap();
         let original = File::open(&selected).unwrap();
         let identity = original.metadata().unwrap();
-        let session = DescriptorSession::start(4, 4).unwrap();
-        let root = session.register(original).unwrap();
-        let ticket = session.ticket(root).unwrap();
+        let session = DescriptorSessionSlot::default();
+        let ticket = session.register(original).unwrap();
 
         std::fs::rename(&selected, temp.path().join("moved")).unwrap();
         std::fs::create_dir(&selected).unwrap();
@@ -525,9 +624,12 @@ mod tests {
         let status = Command::new(std::env::current_exe().unwrap())
             .args(["--exact", CHILD_TEST, "--nocapture"])
             .env(CHILD_ENV, "1")
-            .env("SYQ_TEST_DESCRIPTOR_BROKER_SOCKET", &ticket.socket_path)
+            .env("SYQ_TEST_DESCRIPTOR_BROKER_SOCKET", ticket.socket_path())
             .env("SYQ_TEST_DESCRIPTOR_BROKER_SECRET", hex(&ticket.secret))
-            .env("SYQ_TEST_DESCRIPTOR_BROKER_ROOT", root.0.to_string())
+            .env(
+                "SYQ_TEST_DESCRIPTOR_BROKER_ROOT",
+                ticket.root_id.0.to_string(),
+            )
             .env("SYQ_TEST_DESCRIPTOR_BROKER_DEV", identity.dev().to_string())
             .env("SYQ_TEST_DESCRIPTOR_BROKER_INO", identity.ino().to_string())
             .status()
@@ -566,6 +668,34 @@ mod tests {
         assert!(session.registry().acquire(first_id).is_ok());
         let error = session.register(File::open(&first).unwrap()).unwrap_err();
         assert!(error.to_string().contains("root limit (1) exceeded"));
+    }
+
+    #[test]
+    fn populated_slot_rejects_another_sessions_ticket() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = DescriptorSessionSlot::default();
+        first.register(File::open(temp.path()).unwrap()).unwrap();
+        let second = DescriptorSessionSlot::default();
+        let foreign = second.register(File::open(temp.path()).unwrap()).unwrap();
+
+        let error = first.acquire(&foreign).unwrap_err();
+        assert!(error.to_string().contains("does not belong"));
+    }
+
+    #[test]
+    fn explicit_close_removes_broker_while_slot_clones_remain() {
+        let temp = tempfile::tempdir().unwrap();
+        let session = DescriptorSessionSlot::default();
+        let listener_clone = session.clone();
+        let ticket = session.register(File::open(temp.path()).unwrap()).unwrap();
+        let broker_directory = ticket.socket_path().parent().unwrap().to_path_buf();
+        assert!(broker_directory.exists());
+
+        session.close();
+
+        assert!(listener_clone.is_closed());
+        assert!(!broker_directory.exists());
+        assert!(listener_clone.acquire(&ticket).is_err());
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1,6 +1,7 @@
 //! Local filesystem operations. Used directly by the local endpoint and
 //! by `syq --server` for remote endpoints, so both sides behave identically.
 
+use crate::descriptor_broker::{DescriptorSessionSlot, DescriptorTicket};
 use crate::proto::*;
 use crate::rooted::{
     OperatorFinalComponent, OperatorResolver, PinnedPath, RelativePath, Root, RootIdentity,
@@ -306,11 +307,6 @@ fn operator_directory_flags() -> libc::c_int {
     {
         libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
     }
-}
-
-fn open_operator_directory_start(absolute: bool) -> Result<File> {
-    let component = if absolute { c"/" } else { c"." };
-    open_operator_directory_fd(libc::AT_FDCWD, component)
 }
 
 fn open_operator_directory_at(parent: &File, component: &[u8]) -> Result<File> {
@@ -730,6 +726,7 @@ pub struct FsOps {
     /// controller's decision to repair or accept that exact inode.
     held_basis: Option<HeldBasis>,
     operator_selection: Option<OperatorDirectorySelection>,
+    descriptor_session: DescriptorSessionSlot,
     destination_root: Option<File>,
     destination_prefix: Option<PathBytes>,
     initial_cwd: PathBuf,
@@ -770,11 +767,16 @@ impl Default for FsOps {
 
 impl FsOps {
     pub fn new() -> Self {
+        Self::with_descriptor_session(DescriptorSessionSlot::default())
+    }
+
+    pub(crate) fn with_descriptor_session(descriptor_session: DescriptorSessionSlot) -> Self {
         FsOps {
             fds: HashMap::new(),
             fd_order: Vec::new(),
             held_basis: None,
             operator_selection: None,
+            descriptor_session,
             destination_root: None,
             destination_prefix: None,
             initial_cwd: process_initial_cwd(),
@@ -805,49 +807,14 @@ impl FsOps {
 
     fn anchor_destination(
         &mut self,
-        path: Option<&[u8]>,
         expected_dev: u64,
         expected_ino: u64,
         request_prefix: &[u8],
-        symlink_policy: OperatorSymlinkPolicy,
-    ) -> Result<()> {
-        let selection = if let Some(path) = path {
-            match select_operator_directory(path, false, symlink_policy) {
-                Ok((selection, Some(anchor)))
-                    if (anchor.dev, anchor.ino) == (expected_dev, expected_ino) =>
-                {
-                    selection
-                }
-                result => {
-                    // TCP workers share the receiver process with the already
-                    // anchored control connection. If the external spelling
-                    // was replaced after selection, its cwd is still the exact
-                    // retained directory and is safe to reuse.
-                    let directory = open_operator_directory_start(false)?;
-                    let metadata = directory.metadata()?;
-                    if (metadata.dev(), metadata.ino()) != (expected_dev, expected_ino) {
-                        match result {
-                            Ok((_, Some(anchor))) => bail!(
-                                "destination root changed identity (expected {expected_dev}:{expected_ino}, found {}:{})",
-                                anchor.dev,
-                                anchor.ino
-                            ),
-                            Ok((_, None)) => bail!("destination root disappeared before worker setup"),
-                            Err(error) => return Err(error),
-                        }
-                    }
-                    OperatorDirectorySelection {
-                        path: path.to_vec(),
-                        directory,
-                        missing: VecDeque::new(),
-                    }
-                }
-            }
-        } else {
-            self.operator_selection
-                .take()
-                .context("destination directory was not checked on this connection")?
-        };
+    ) -> Result<DescriptorTicket> {
+        let selection = self
+            .operator_selection
+            .take()
+            .context("destination directory was not checked on this connection")?;
         if !selection.missing.is_empty() {
             bail!("destination directory has not been created");
         }
@@ -859,23 +826,12 @@ impl FsOps {
                 anchor.ino
             );
         }
-        loop {
-            if unsafe { libc::fchdir(selection.directory.as_raw_fd()) } == 0 {
-                break;
-            }
-            let error = io::Error::last_os_error();
-            if error.kind() != io::ErrorKind::Interrupted {
-                return Err(error).context("enter retained destination root");
-            }
-        }
-        self.fds.clear();
-        self.fd_order.clear();
-        self.held_basis.take();
-        self.destination_prefix = Some(request_prefix.to_vec());
-        self.destination_root = Some(selection.directory);
+        let ticket = self.descriptor_session.register(selection.directory)?;
+        let directory = self.descriptor_session.acquire(&ticket)?;
+        self.install_destination(directory, request_prefix)?;
 
         #[cfg(debug_assertions)]
-        if path.is_none() {
+        {
             if let Some(ready) = std::env::var_os("SYQ_TEST_DESTINATION_ANCHORED_FILE") {
                 fs::write(&ready, b"ready").with_context(|| {
                     format!(
@@ -890,6 +846,36 @@ impl FsOps {
                 }
             }
         }
+        Ok(ticket)
+    }
+
+    /// Install the exact control-session root delivered during worker
+    /// initialization. A same-process TCP worker clones it from the shared
+    /// registry; an independent worker claims it with SCM_RIGHTS.
+    pub(crate) fn initialize_destination(&mut self, destination: &DestinationRoot) -> Result<()> {
+        let directory = self.descriptor_session.acquire(&destination.ticket)?;
+        self.install_destination(directory, &destination.request_prefix)
+    }
+
+    fn install_destination(&mut self, directory: File, request_prefix: &[u8]) -> Result<()> {
+        // Destination operations are still pathname-based in this transitional
+        // slice, so enter the exact received descriptor as their base. The next
+        // stacked slice replaces those operations with descriptor-relative
+        // primitives and removes process-wide cwd dependence entirely.
+        loop {
+            if unsafe { libc::fchdir(directory.as_raw_fd()) } == 0 {
+                break;
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::Interrupted {
+                return Err(error).context("enter retained destination root");
+            }
+        }
+        self.fds.clear();
+        self.fd_order.clear();
+        self.held_basis.take();
+        self.destination_prefix = Some(request_prefix.to_vec());
+        self.destination_root = Some(directory);
         Ok(())
     }
 
@@ -3199,20 +3185,12 @@ impl FsOps {
                 .create_operator_directory(*mode, *require_absent)
                 .map(|anchor| Response::DirectorySelection(Some(anchor))),
             Request::AnchorDestination {
-                path,
                 expected_dev,
                 expected_ino,
                 request_prefix,
-                symlink_policy,
             } => self
-                .anchor_destination(
-                    path.as_deref(),
-                    *expected_dev,
-                    *expected_ino,
-                    request_prefix,
-                    *symlink_policy,
-                )
-                .map(|_| Response::Ok),
+                .anchor_destination(*expected_dev, *expected_ino, request_prefix)
+                .map(Response::DestinationRegistered),
             Request::PartialPaths {
                 paths,
                 partial_id,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -5,6 +5,7 @@
 //! flag bit 0 means the payload is zstd-compressed. Each writer decides
 //! independently whether to compress, readers always accept both.
 
+use crate::descriptor_broker::DescriptorTicket;
 use serde::{Deserialize, Serialize};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 
@@ -268,12 +269,34 @@ pub enum Op {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct DestinationRoot {
+    pub ticket: DescriptorTicket,
+    pub request_prefix: PathBytes,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum ConnectionRole {
+    /// The one connection allowed to create endpoint-session capabilities and
+    /// start its TCP data listener.
+    Control,
+    /// A data connection used only to read a source endpoint.
+    SourceWorker,
+    /// A data connection used to mutate a destination endpoint. Unrestricted
+    /// receivers require an exact registered root; restricted receivers derive
+    /// their confinement from the signed grant and reject a supplied ticket.
+    DestinationWorker {
+        destination: Option<DestinationRoot>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Request {
     Hello {
         identity: String,
         compress: bool,
         debug: bool,
         token: Vec<u8>,
+        role: ConnectionRole,
     },
     /// Ask the server to accept data connections over TCP (see crypto.rs).
     /// `key` is None for plaintext; `token` authenticates plaintext connections.
@@ -325,15 +348,12 @@ pub enum Request {
         /// it. Intermediate directories may still be shared safely.
         require_absent: bool,
     },
-    /// Retain and enter the selected destination directory for this
-    /// connection. The control connection reuses its checked descriptor;
-    /// independent workers securely reopen `path` and verify its identity.
+    /// Register the destination directory retained by the preceding operator
+    /// walk. Only the control connection may create this session capability.
     AnchorDestination {
-        path: Option<PathBytes>,
         expected_dev: u64,
         expected_ino: u64,
         request_prefix: PathBytes,
-        symlink_policy: OperatorSymlinkPolicy,
     },
     /// Compute the exact receiver-side sidecar names for collision preflight.
     PartialPaths {
@@ -502,6 +522,7 @@ pub enum Response {
     /// Absolute operator spelling plus device/inode of the securely opened
     /// directory, or None when an allowed missing suffix was reached.
     DirectorySelection(Option<DirectoryAnchor>),
+    DestinationRegistered(DescriptorTicket),
     PathResults(Vec<std::result::Result<PathBytes, String>>),
     BatchPlan {
         partial_paths: Vec<std::result::Result<PathBytes, String>>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,9 +2,10 @@
 //! TCP data connections (see `crypto.rs`) when the client asks for them.
 
 use crate::crypto::{Cipher, RecordReader, RecordWriter};
+use crate::descriptor_broker::DescriptorSessionSlot;
 use crate::fsops::{self, FsOps};
 use crate::proto::*;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::io::{self, ErrorKind, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
@@ -67,19 +68,13 @@ impl Drop for RequestReader {
     }
 }
 
-pub fn run() -> Result<()> {
-    serve(
-        io::stdin(),
-        io::stdout().lock(),
-        true,
-        None,
-        None,
-        None,
-        None,
-    )
+struct ServeSession {
+    authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
+    descriptor_session: DescriptorSessionSlot,
 }
 
-pub(crate) fn run_restricted(authority: Arc<crate::restricted::RestrictedAuthority>) -> Result<()> {
+pub fn run() -> Result<()> {
+    let descriptor_session = DescriptorSessionSlot::default();
     let result = serve(
         io::stdin(),
         io::stdout().lock(),
@@ -87,8 +82,30 @@ pub(crate) fn run_restricted(authority: Arc<crate::restricted::RestrictedAuthori
         None,
         None,
         None,
-        Some(Arc::clone(&authority)),
+        ServeSession {
+            authority: None,
+            descriptor_session: descriptor_session.clone(),
+        },
     );
+    descriptor_session.close();
+    result
+}
+
+pub(crate) fn run_restricted(authority: Arc<crate::restricted::RestrictedAuthority>) -> Result<()> {
+    let descriptor_session = DescriptorSessionSlot::default();
+    let result = serve(
+        io::stdin(),
+        io::stdout().lock(),
+        true,
+        None,
+        None,
+        None,
+        ServeSession {
+            authority: Some(Arc::clone(&authority)),
+            descriptor_session: descriptor_session.clone(),
+        },
+    );
+    descriptor_session.close();
     authority.close_control();
     result
 }
@@ -102,18 +119,24 @@ fn serve<R: Read + Send + 'static, W: Write>(
     expect_token: Option<Vec<u8>>,
     authed: Option<&std::sync::atomic::AtomicBool>,
     tcp_socket: Option<TcpStream>,
-    authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
+    session: ServeSession,
 ) -> Result<()> {
+    let ServeSession {
+        authority,
+        descriptor_session,
+    } = session;
     let mut r = FrameReader::new(r);
     let mut w = FrameWriter::new(w, false);
 
     let debug;
+    let role;
     match r.read_msg::<Request>()? {
         Request::Hello {
             identity,
             compress,
             debug: d,
             token,
+            role: requested_role,
         } => {
             debug = d;
             if let Some(t) = &expect_token {
@@ -137,21 +160,59 @@ fn serve<R: Read + Send + 'static, W: Write>(
             if let Some(authority) = &authority {
                 authority.validate_hello(compress)?;
             }
+            role = requested_role;
             w.compress = compress;
-            w.write_msg(&Response::HelloOk {
-                identity: expected_identity.to_string(),
-                platform: crate::identity::platform(),
-            })?;
         }
         _ => bail!("expected Hello"),
     }
+
+    if matches!(&role, ConnectionRole::Control) && !over_ssh {
+        w.write_msg(&Response::Err(
+            "control role is not allowed on a TCP data connection".into(),
+        ))?;
+        bail!("control role is not allowed on a TCP data connection");
+    }
+    let is_control = matches!(&role, ConnectionRole::Control);
+    let mut ops = FsOps::with_descriptor_session(descriptor_session.clone());
+    match &role {
+        ConnectionRole::DestinationWorker {
+            destination: Some(_),
+        } if authority.is_some() => {
+            w.write_msg(&Response::Err(
+                "a command-restricted destination derives its root from the signed grant".into(),
+            ))?;
+            bail!("command-restricted receiver rejected a supplied destination root");
+        }
+        ConnectionRole::DestinationWorker { destination: None } if authority.is_none() => {
+            w.write_msg(&Response::Err(
+                "unrestricted destination worker requires a registered root".into(),
+            ))?;
+            bail!("unrestricted destination worker has no registered root");
+        }
+        ConnectionRole::DestinationWorker {
+            destination: Some(destination),
+        } => {
+            if let Err(error) = ops.initialize_destination(destination) {
+                w.write_msg(&Response::Err(format!(
+                    "initialize destination worker: {error:#}"
+                )))?;
+                return Err(error).context("initialize destination worker");
+            }
+        }
+        ConnectionRole::Control
+        | ConnectionRole::SourceWorker
+        | ConnectionRole::DestinationWorker { destination: None } => {}
+    }
+    w.write_msg(&Response::HelloOk {
+        identity: crate::identity::build().to_string(),
+        platform: crate::identity::platform(),
+    })?;
 
     // Requests are parsed on a reader thread so incoming data keeps flowing
     // while a block is being hashed and written. TCP readers are shut down and
     // joined by the guard on every exit path.
     let reader = RequestReader::spawn(r, tcp_socket);
 
-    let mut ops = FsOps::new();
     let mut t = [0f64; 3];
     let (mut blocks, mut bytes) = (0u64, 0u64);
     loop {
@@ -163,6 +224,22 @@ fn serve<R: Read + Send + 'static, W: Write>(
             Err(_) => break,
         };
         t[0] += t0.elapsed().as_secs_f64();
+        if !is_control
+            && matches!(
+                &req,
+                Request::TcpListen { .. }
+                    | Request::NativeRemove { .. }
+                    | Request::CheckOperatorDirectory { .. }
+                    | Request::CreateOperatorDirectory { .. }
+                    | Request::AnchorDestination { .. }
+                    | Request::Receipt
+            )
+        {
+            w.write_msg(&Response::Err(
+                "request is allowed only on the control connection".into(),
+            ))?;
+            continue;
+        }
         let settlement = match &authority {
             Some(authority) => match authority.authorize(&mut req, over_ssh) {
                 Ok(settlement) => Some(settlement),
@@ -201,7 +278,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 port_hi,
                 congestion_control,
             } => {
-                if !over_ssh {
+                if !is_control {
                     w.write_msg(&Response::Err(
                         "TcpListen only allowed on the control connection".into(),
                     ))?;
@@ -216,6 +293,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
                     w.compress,
                     congestion_control.as_deref(),
                     authority.clone(),
+                    descriptor_session.clone(),
                 ) {
                     Ok((port, congestion_control)) => w.write_msg(&Response::TcpListening {
                         port,
@@ -446,6 +524,7 @@ fn tcp_listen(
     compress: bool,
     congestion_control: Option<&str>,
     authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
+    descriptor_session: DescriptorSessionSlot,
 ) -> Result<(u16, Option<String>)> {
     let mut listener = None;
     for port in lo..=hi.max(lo) {
@@ -473,22 +552,19 @@ fn tcp_listen(
         .as_ref()
         .map(|authority| u32::from(authority.maximum_connections()))
         .unwrap_or(256);
-    if authority.is_some() {
-        listener.set_nonblocking(true)?;
-    }
+    listener.set_nonblocking(true)?;
     std::thread::spawn(move || {
         loop {
-            if authority
-                .as_ref()
-                .is_some_and(|authority| !authority.control_is_open())
+            if descriptor_session.is_closed()
+                || authority
+                    .as_ref()
+                    .is_some_and(|authority| !authority.control_is_open())
             {
                 break;
             }
             let stream = match listener.accept() {
                 Ok((stream, _)) => stream,
-                Err(error)
-                    if authority.is_some() && error.kind() == std::io::ErrorKind::WouldBlock =>
-                {
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
                     std::thread::sleep(Duration::from_millis(25));
                     continue;
                 }
@@ -502,12 +578,13 @@ fn tcp_listen(
                 continue; // drop; stream closes
             }
             live.fetch_add(1, Relaxed);
-            let (key, token, live, seen, authority) = (
+            let (key, token, live, seen, authority, descriptor_session) = (
                 key.clone(),
                 token.clone(),
                 live.clone(),
                 seen.clone(),
                 authority.clone(),
+                descriptor_session.clone(),
             );
             std::thread::spawn(move || {
                 if let Err(e) = serve_tcp(
@@ -519,6 +596,7 @@ fn tcp_listen(
                     compress,
                     &seen,
                     authority.clone(),
+                    descriptor_session,
                 ) {
                     if debug {
                         eprintln!("syq server (tcp {id}): {e:#}");
@@ -541,6 +619,7 @@ fn serve_tcp(
     _compress: bool,
     seen: &std::sync::Mutex<std::collections::HashSet<u32>>,
     authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
+    descriptor_session: DescriptorSessionSlot,
 ) -> Result<()> {
     stream.set_nodelay(true)?;
     // Scanners and stray connections must not hold a thread forever.
@@ -594,7 +673,10 @@ fn serve_tcp(
         Some(token),
         Some(&authed),
         Some(stream.try_clone()?),
-        authority,
+        ServeSession {
+            authority,
+            descriptor_session,
+        },
     );
     if res.is_err() && !authed.load(std::sync::atomic::Ordering::SeqCst) {
         seen.lock().unwrap().remove(&conn_id);
@@ -698,7 +780,10 @@ mod tests {
                 None,
                 None,
                 Some(socket),
-                None,
+                ServeSession {
+                    authority: None,
+                    descriptor_session: DescriptorSessionSlot::default(),
+                },
             )
             .unwrap();
         });
@@ -712,6 +797,7 @@ mod tests {
                 compress: false,
                 debug: false,
                 token: Vec::new(),
+                role: ConnectionRole::SourceWorker,
             })
             .unwrap();
         assert!(matches!(
@@ -722,5 +808,57 @@ mod tests {
         server.join().unwrap();
         assert!(dropped.load(std::sync::atomic::Ordering::SeqCst));
         assert_eq!(Arc::strong_count(&dropped), 1);
+    }
+
+    #[test]
+    fn rejected_destination_ticket_is_not_acknowledged_as_ready() {
+        let selected = tempfile::tempdir().unwrap();
+        let owner = DescriptorSessionSlot::default();
+        let ticket = owner
+            .register(std::fs::File::open(selected.path()).unwrap())
+            .unwrap();
+        owner.close();
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            serve(
+                socket.try_clone().unwrap(),
+                socket,
+                false,
+                None,
+                None,
+                None,
+                ServeSession {
+                    authority: None,
+                    descriptor_session: DescriptorSessionSlot::default(),
+                },
+            )
+            .unwrap_err()
+        });
+
+        let socket = TcpStream::connect(address).unwrap();
+        let mut writer = FrameWriter::new(socket.try_clone().unwrap(), false);
+        let mut reader = FrameReader::new(socket);
+        writer
+            .write_msg(&Request::Hello {
+                identity: crate::identity::build().to_string(),
+                compress: false,
+                debug: false,
+                token: Vec::new(),
+                role: ConnectionRole::DestinationWorker {
+                    destination: Some(DestinationRoot {
+                        ticket,
+                        request_prefix: b"destination".to_vec(),
+                    }),
+                },
+            })
+            .unwrap();
+        assert!(matches!(
+            reader.read_msg::<Response>().unwrap(),
+            Response::Err(error) if error.contains("initialize destination worker")
+        ));
+        server.join().unwrap();
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -10,6 +10,7 @@ use crate::conn::{
 };
 use crate::fsops::{content_digest, is_partial_name, join};
 use crate::progress::{commas, human, Progress, WorkerStatus};
+use crate::proto::DestinationRoot as RegisteredDestinationRoot;
 use crate::proto::*;
 use crate::sched::{FileJob, Item, RangeHandle, Sched};
 use crate::tune::{self, Gate};
@@ -686,11 +687,9 @@ fn copy_identity(
 
 #[derive(Clone, Debug)]
 struct DestinationAnchor {
-    operator_path: PathBytes,
-    request_prefix: PathBytes,
+    destination: RegisteredDestinationRoot,
     dev: u64,
     ino: u64,
-    symlink_policy: OperatorSymlinkPolicy,
 }
 type DestinationAnchorSlot = std::sync::Arc<std::sync::OnceLock<DestinationAnchor>>;
 
@@ -1119,11 +1118,13 @@ pub fn run(args: Args) -> Result<i32> {
                     return Ok(());
                 }
                 let initial_destination = if destination_anchor_required {
-                    Some(worker_destination_request(
+                    Some(
                         destination_anchor
                             .get()
-                            .context("destination root was not anchored before workers started")?,
-                    ))
+                            .context("destination root was not anchored before workers started")?
+                            .destination
+                            .clone(),
+                    )
                 } else {
                     None
                 };
@@ -1137,7 +1138,8 @@ pub fn run(args: Args) -> Result<i32> {
                     let conns = src_ep.connect(compress).and_then(|src| {
                         Ok((
                             src,
-                            dst_ep.connect_with_request(compress, initial_destination.clone())?,
+                            dst_ep
+                                .connect_with_destination(compress, initial_destination.clone())?,
                         ))
                     });
                     let (src, dst) = match conns {
@@ -1656,12 +1658,8 @@ pub fn run(args: Args) -> Result<i32> {
             directory_selection = Some(create_operator_directory(&mut *dst_ctl, condition)?);
         }
         if let Some(selection) = directory_selection.take() {
-            let anchor = activate_control_destination(
-                &mut *dst_ctl,
-                selection,
-                request_prefix.clone(),
-                opts.operator_symlink_policy,
-            )?;
+            let anchor =
+                activate_control_destination(&mut *dst_ctl, selection, request_prefix.clone())?;
             if create_root {
                 mutation_root_condition = TargetCondition::Matches {
                     dev: anchor.dev,
@@ -2477,37 +2475,24 @@ fn activate_control_destination(
     conn: &mut dyn Conn,
     selection: DirectoryAnchor,
     request_prefix: PathBytes,
-    symlink_policy: OperatorSymlinkPolicy,
 ) -> Result<DestinationAnchor> {
-    let anchor = DestinationAnchor {
-        operator_path: selection.path,
-        request_prefix,
-        dev: selection.dev,
-        ino: selection.ino,
-        symlink_policy,
-    };
     match ok(
         conn.call(Request::AnchorDestination {
-            path: None,
-            expected_dev: anchor.dev,
-            expected_ino: anchor.ino,
-            request_prefix: anchor.request_prefix.clone(),
-            symlink_policy,
+            expected_dev: selection.dev,
+            expected_ino: selection.ino,
+            request_prefix: request_prefix.clone(),
         })?,
         "anchor destination root",
     )? {
-        Response::Ok => Ok(anchor),
+        Response::DestinationRegistered(ticket) => Ok(DestinationAnchor {
+            destination: RegisteredDestinationRoot {
+                ticket,
+                request_prefix,
+            },
+            dev: selection.dev,
+            ino: selection.ino,
+        }),
         other => bail!("unexpected response {other:?}"),
-    }
-}
-
-fn worker_destination_request(anchor: &DestinationAnchor) -> Request {
-    Request::AnchorDestination {
-        path: Some(anchor.operator_path.clone()),
-        expected_dev: anchor.dev,
-        expected_ino: anchor.ino,
-        request_prefix: anchor.request_prefix.clone(),
-        symlink_policy: anchor.symlink_policy,
     }
 }
 
@@ -3823,12 +3808,7 @@ impl Planner<'_> {
         if let Some((root, condition)) = self.create_root.take() {
             if self.use_operator_anchor {
                 let selection = create_operator_directory(self.dst, condition)?;
-                let anchor = activate_control_destination(
-                    self.dst,
-                    selection,
-                    root.clone(),
-                    self.opts.operator_symlink_policy,
-                )?;
+                let anchor = activate_control_destination(self.dst, selection, root.clone())?;
                 self.mutation_root_condition = TargetCondition::Matches {
                     dev: anchor.dev,
                     ino: anchor.ino,

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -6846,21 +6846,8 @@ fn destination_root_replacement_after_selection_cannot_redirect_worker() {
         std::os::unix::fs::symlink(t.path("outside"), t.path("dst")).unwrap();
 
         let output = child.wait_with_output().unwrap();
-        if no_tcp {
-            assert!(
-                !output.status.success(),
-                "a fresh worker reused a changed root"
-            );
-            assert!(
-                stderr_of(&output).contains("destination root changed identity"),
-                "{}",
-                stderr_of(&output)
-            );
-            assert!(!t.path("selected-and-moved/f").exists());
-        } else {
-            assert_output_ok(&output);
-            assert_eq!(read(&t.path("selected-and-moved/f")), b"payload");
-        }
+        assert_output_ok(&output);
+        assert_eq!(read(&t.path("selected-and-moved/f")), b"payload");
         assert!(!t.path("outside/f").exists());
         assert!(fs::symlink_metadata(t.path("dst"))
             .unwrap()


### PR DESCRIPTION
Summary:
- register the exact retained destination directory once on the control connection
- carry opaque session tickets inside explicit destination-worker Hello messages and claim before readiness
- clone descriptors for TCP workers and transfer them with SCM_RIGHTS to fresh worker processes
- enforce control/source/destination connection roles and reject peer-supplied roots on restricted receivers
- explicitly close descriptor sessions so detached TCP listeners cannot retain broker directories

Security boundary:
- removes destination operator-path re-resolution from worker startup
- destination operations still use a temporary fchdir adapter against the exact claimed descriptor; the next stacked work migrates those operation families to rooted primitives
- restricted receivers remain fail-closed under their signed guards but their existing guarded operation path is not changed in this PR

Verification:
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets (270 unit, 282 integration, 7 updater tests)
- adversarial destination rename/replacement test now succeeds against the pinned original through both TCP and fresh no-TCP worker processes