### PR TITLE
Root destination observation in retained descriptors

### DIFF
--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -19,7 +19,7 @@ use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 pub const PARTIAL_MARKER: &str = ".syq-part.";
 const FD_CACHE_MAX: usize = 16;
@@ -673,7 +673,14 @@ pub(crate) fn rooted_entry(
         _ => Kind::Other,
     };
     let link = if kind == Kind::Symlink {
-        Some(root.read_link(relative)?)
+        let target = root.read_link(relative)?;
+        let after = root.metadata(relative)?;
+        if (after.dev, after.ino, after.file_type())
+            != (metadata.dev, metadata.ino, metadata.file_type())
+        {
+            bail!("symlink changed while reading its target");
+        }
+        Some(target)
     } else {
         None
     };
@@ -727,7 +734,7 @@ pub struct FsOps {
     held_basis: Option<HeldBasis>,
     operator_selection: Option<OperatorDirectorySelection>,
     descriptor_session: DescriptorSessionSlot,
-    destination_root: Option<File>,
+    destination_root: Option<Arc<Root>>,
     destination_prefix: Option<PathBytes>,
     initial_cwd: PathBuf,
 }
@@ -858,12 +865,13 @@ impl FsOps {
     }
 
     fn install_destination(&mut self, directory: File, request_prefix: &[u8]) -> Result<()> {
+        let root = Arc::new(Root::from_directory(directory)?);
         // Destination operations are still pathname-based in this transitional
-        // slice, so enter the exact received descriptor as their base. The next
-        // stacked slice replaces those operations with descriptor-relative
-        // primitives and removes process-wide cwd dependence entirely.
+        // path for operation families not migrated to Root yet, so enter the
+        // exact received descriptor as their base. Stacked slices replace the
+        // remaining operations and then remove process-wide cwd dependence.
         loop {
-            if unsafe { libc::fchdir(directory.as_raw_fd()) } == 0 {
+            if unsafe { libc::fchdir(root.as_raw_fd()) } == 0 {
                 break;
             }
             let error = io::Error::last_os_error();
@@ -875,7 +883,7 @@ impl FsOps {
         self.fd_order.clear();
         self.held_basis.take();
         self.destination_prefix = Some(request_prefix.to_vec());
-        self.destination_root = Some(directory);
+        self.destination_root = Some(root);
         Ok(())
     }
 
@@ -926,16 +934,14 @@ impl FsOps {
             return partial_path(final_path, partial_id);
         }
         let relative = path_bytes(final_path);
+        let strict_relative = RelativePath::new(&relative)?;
         let logical = PathBuf::from(OsStr::from_bytes(&self.destination_full(&relative)));
-        let parent = if final_path
-            .parent()
-            .is_some_and(|parent| !parent.as_os_str().is_empty())
-        {
-            final_path.parent().unwrap()
-        } else {
-            Path::new(".")
-        };
-        let logical_partial = partial_path_with_name_max(&logical, partial_id, name_max(parent))?;
+        let component_limit = self
+            .destination_root
+            .as_ref()
+            .context("destination prefix has no retained root")?
+            .name_max_for_parent(&strict_relative)?;
+        let logical_partial = partial_path_with_name_max(&logical, partial_id, component_limit)?;
         Ok(PathBuf::from(OsStr::from_bytes(
             &self.destination_relative(logical_partial.as_os_str().as_bytes())?,
         )))
@@ -1173,6 +1179,16 @@ impl FsOps {
                 rooted_entry(&target.root, &target.relative, Vec::new(), metadata).ok()
             });
         }
+        if let Some(root) = self.destination_root.clone() {
+            if follow {
+                return vec![None; paths.len()];
+            }
+            return parallel_map(paths, |path| {
+                let relative = RelativePath::new(path).ok()?;
+                let metadata = root.metadata(&relative).ok()?;
+                rooted_entry(&root, &relative, Vec::new(), metadata).ok()
+            });
+        }
         parallel_map(paths, |p| {
             let full = resolve(p);
             let md = if follow {
@@ -1192,22 +1208,21 @@ impl FsOps {
     ) -> Vec<std::result::Result<PathBytes, String>> {
         parallel_map(paths, |path| {
             if let Some(guard) = guard {
-                guarded_target(path, guard).map_err(|error| format!("{error:#}"))?;
+                guarded_target(path, guard)?;
             }
             let requested = Path::new(OsStr::from_bytes(path));
             let resolved = if guard.is_some() {
                 partial_path_with_name_max(&resolve(path), partial_id, COMMON_NAME_MAX)
             } else {
                 self.partial_path(&resolve(path), partial_id)
-            };
-            resolved
-                .map(|resolved| {
-                    let name = resolved.file_name().expect("partial always has a name");
-                    let parent = requested.parent().unwrap_or_else(|| Path::new(""));
-                    path_bytes(&parent.join(name))
-                })
-                .map_err(|error| format!("{error:#}"))
+            }?;
+            let name = resolved.file_name().expect("partial always has a name");
+            let parent = requested.parent().unwrap_or_else(|| Path::new(""));
+            Ok(path_bytes(&parent.join(name)))
         })
+        .into_iter()
+        .map(|result: Result<PathBytes>| result.map_err(|error| format!("{error:#}")))
+        .collect()
     }
 
     /// Ops within a batch are independent (the planner orders batches so that
@@ -3121,12 +3136,13 @@ impl FsOps {
     }
 
     pub fn file_hash(&mut self, path: &[u8], guard: Option<&ContainerGuard>) -> Result<Response> {
-        let p = resolve(path);
         let mut f = if let Some(guard) = guard {
             let target = guarded_target(path, guard)?;
             target.root.open_regular_read(&target.relative)?
+        } else if let Some(root) = &self.destination_root {
+            root.open_regular_read(&RelativePath::new(path)?)?
         } else {
-            open_existing_regular(&p, false)?
+            open_existing_regular(&resolve(path), false)?
         };
         let mut h = blake3::Hasher::new();
         let mut buf = vec![0u8; 1 << 20];
@@ -4167,6 +4183,43 @@ mod tests {
         assert!(name.as_bytes().len() <= 143);
         assert!(name.to_str().is_some());
         assert!(is_partial_name(name));
+    }
+
+    #[test]
+    fn destination_observation_uses_the_adopted_root_not_its_old_name() {
+        let dir = test_dir();
+        let selected = dir.join("selected");
+        fs::create_dir_all(&selected).unwrap();
+        fs::write(selected.join("marker"), b"original").unwrap();
+        let root = Arc::new(Root::from_directory(File::open(&selected).unwrap()).unwrap());
+        let mut operations = FsOps::new();
+        operations.destination_root = Some(root);
+        operations.destination_prefix = Some(b"logical".to_vec());
+
+        fs::rename(&selected, dir.join("moved")).unwrap();
+        fs::create_dir(&selected).unwrap();
+        fs::write(selected.join("marker"), b"replacement").unwrap();
+
+        let stats = operations.stat_many(&[b"marker".to_vec()], false, None);
+        assert_eq!(stats[0].as_ref().unwrap().size, 8);
+        let Response::FileHash { size, hash } = operations.file_hash(b"marker", None).unwrap()
+        else {
+            panic!("unexpected hash response");
+        };
+        assert_eq!(size, 8);
+        assert_eq!(hash, content_digest(b"original"));
+
+        let partial =
+            operations.partial_paths(&[b"missing/deeper/marker".to_vec()], &[12; 16], None);
+        assert!(partial[0]
+            .as_ref()
+            .unwrap()
+            .starts_with(b"missing/deeper/.marker.syq-part."));
+        assert!(operations.partial_paths(&[b"../outside".to_vec()], &[12; 16], None)[0].is_err());
+        assert!(operations.file_hash(b"../outside", None).is_err());
+        assert!(operations.stat_many(&[b"../outside".to_vec()], false, None)[0].is_none());
+
+        fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -11,8 +11,9 @@
 //! descendant mutation and inspection; the unrestricted implementation remains
 //! separate. Existing roots, directory scans, regular-file I/O, leaf
 //! creation/replacement, metadata, and non-recursive unlink/rmdir are supported.
-//! Recursive removal and missing-root creation stay outside this layer. Roots
-//! and directory components must be openable with `O_RDONLY | O_DIRECTORY`.
+//! Recursive removal and missing-root creation stay outside this layer.
+//! Traversal uses search-only descriptors where the platform provides them;
+//! directory enumeration separately opens an independent readable descriptor.
 //!
 //! Linux currently uses the same component walk as other Unix platforms. An
 //! `openat2` fast path should be added only with tests proving that it has
@@ -29,7 +30,7 @@ use std::collections::VecDeque;
 use std::ffi::CString;
 use std::fs::{File, OpenOptions};
 use std::io;
-use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -522,11 +523,19 @@ impl Root {
             .custom_flags(libc::O_DIRECTORY | libc::O_NOCTTY | libc::O_CLOEXEC)
             .open(path)
             .with_context(|| format!("open confined root {}", path.display()))?;
+        Self::from_directory(directory)
+            .with_context(|| format!("validate confined root {}", path.display()))
+    }
+
+    /// Adopt an already-open directory as the authority boundary. This never
+    /// resolves a pathname and therefore preserves the selected object across
+    /// renames and namespace replacement.
+    pub(crate) fn from_directory(directory: File) -> Result<Self> {
         let metadata = directory
             .metadata()
-            .with_context(|| format!("stat confined root {}", path.display()))?;
+            .context("stat confined root descriptor")?;
         if !metadata.is_dir() {
-            bail!("confined root {} is not a directory", path.display());
+            bail!("confined root descriptor is not a directory");
         }
         Ok(Self {
             directory,
@@ -555,6 +564,10 @@ impl Root {
 
     pub(crate) fn identity(&self) -> RootIdentity {
         self.identity
+    }
+
+    pub(crate) fn as_raw_fd(&self) -> RawFd {
+        self.directory.as_raw_fd()
     }
 
     /// Open the root or a descendant directory without following any
@@ -688,11 +701,17 @@ impl Root {
     /// owns a duplicate descriptor and never reconstructs a pathname.
     pub(crate) fn read_directory(&self, path: &RelativePath) -> Result<Vec<Vec<u8>>> {
         let directory = self.open_directory(path)?;
-        let duplicated = retry_fd(|| unsafe { libc::dup(directory.as_raw_fd()) })?;
-        let stream = unsafe { libc::fdopendir(duplicated) };
+        // dup()/try_clone() would share the directory open-file-description
+        // offset. Reopen `.` so concurrent scans and retries each start with
+        // an independent readable stream, including when the authority is an
+        // O_PATH/O_SEARCH descriptor.
+        let readable = open_readable_directory_at(&directory, b".")
+            .with_context(|| format!("open readable confined directory {}", path.label()))?;
+        let descriptor = readable.into_raw_fd();
+        let stream = unsafe { libc::fdopendir(descriptor) };
         if stream.is_null() {
             let error = io::Error::last_os_error();
-            let _ = unsafe { libc::close(duplicated) };
+            let _ = unsafe { libc::close(descriptor) };
             return Err(error).context("open confined directory stream");
         }
         struct DirectoryStream(*mut libc::DIR);
@@ -720,6 +739,39 @@ impl Root {
             }
         }
         Ok(names)
+    }
+
+    /// Component limit for a sidecar beside `path`. Missing or non-directory
+    /// suffixes are walked back to the nearest existing real directory, never
+    /// through a symlink.
+    pub(crate) fn name_max_for_parent(&self, path: &RelativePath) -> Result<usize> {
+        let (parents, _) = path.leaf()?;
+        let mut components = parents.to_vec();
+        loop {
+            let candidate = RelativePath {
+                components: components.clone(),
+            };
+            match self.open_directory(&candidate) {
+                Ok(directory) => {
+                    set_errno(0);
+                    let limit =
+                        unsafe { libc::fpathconf(directory.as_raw_fd(), libc::_PC_NAME_MAX) };
+                    if limit > 0 {
+                        return Ok(limit as usize);
+                    }
+                    let errno = get_errno();
+                    if errno == 0 {
+                        return Ok(255);
+                    }
+                    return Err(io::Error::from_raw_os_error(errno))
+                        .context("query confined directory component limit");
+                }
+                Err(error) if missing_directory_suffix(&error) && !components.is_empty() => {
+                    components.pop();
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     pub(crate) fn read_link(&self, path: &RelativePath) -> Result<Vec<u8>> {
@@ -1203,6 +1255,21 @@ fn operator_symlink_owner_is_trusted(owner: u32, euid: u32) -> bool {
 }
 
 fn open_directory_at(parent: &File, component: &[u8]) -> io::Result<File> {
+    #[cfg(target_os = "linux")]
+    let access = libc::O_PATH;
+    #[cfg(target_os = "macos")]
+    let access = libc::O_SEARCH;
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    let access = libc::O_RDONLY;
+    open_at(
+        parent.as_raw_fd(),
+        &component_cstring(component),
+        access | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_NOCTTY | libc::O_CLOEXEC,
+        0,
+    )
+}
+
+fn open_readable_directory_at(parent: &File, component: &[u8]) -> io::Result<File> {
     open_at(
         parent.as_raw_fd(),
         &component_cstring(component),
@@ -1214,6 +1281,15 @@ fn open_directory_at(parent: &File, component: &[u8]) -> io::Result<File> {
             | libc::O_CLOEXEC,
         0,
     )
+}
+
+fn missing_directory_suffix(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<io::Error>()
+            .and_then(io::Error::raw_os_error)
+            .is_some_and(|errno| matches!(errno, libc::ENOENT | libc::ENOTDIR | libc::ELOOP))
+    })
 }
 
 fn open_at(parent: RawFd, name: &CString, flags: libc::c_int, mode: u32) -> io::Result<File> {
@@ -1255,19 +1331,6 @@ fn retry_zero(mut operation: impl FnMut() -> libc::c_int) -> io::Result<()> {
     loop {
         if operation() == 0 {
             return Ok(());
-        }
-        let error = io::Error::last_os_error();
-        if error.kind() != io::ErrorKind::Interrupted {
-            return Err(error);
-        }
-    }
-}
-
-fn retry_fd(mut operation: impl FnMut() -> libc::c_int) -> io::Result<libc::c_int> {
-    loop {
-        let descriptor = operation();
-        if descriptor >= 0 {
-            return Ok(descriptor);
         }
         let error = io::Error::last_os_error();
         if error.kind() != io::ErrorKind::Interrupted {
@@ -1849,6 +1912,61 @@ mod tests {
         old.read_to_end(&mut bytes).unwrap();
         assert_eq!(bytes, b"old");
         assert!(root.open_regular_read(&relative(b"new")).is_err());
+    }
+
+    #[test]
+    fn adopted_operator_descriptor_stays_stable_and_can_be_enumerated_repeatedly() {
+        let tree = TestDir::new("adopted-root");
+        let selected = tree.path().join("selected");
+        fs::create_dir(&selected).unwrap();
+        fs::write(selected.join("first"), b"first").unwrap();
+        fs::write(selected.join("second"), b"second").unwrap();
+        let pinned = OperatorResolver::resolve_process(
+            selected.as_os_str().as_bytes(),
+            OperatorSymlinkPolicy::Refuse,
+            OperatorFinalComponent::Directory,
+            false,
+            &mut Vec::new(),
+        )
+        .unwrap();
+        let PinnedPath::Directory(directory) = pinned else {
+            panic!("operator directory was not pinned");
+        };
+        let root = Root::from_directory(directory.into_parts().0).unwrap();
+
+        fs::rename(&selected, tree.path().join("moved")).unwrap();
+        fs::create_dir(&selected).unwrap();
+        fs::write(selected.join("replacement"), b"replacement").unwrap();
+
+        let mut first = root.read_directory(&relative(b"")).unwrap();
+        let mut second = root.read_directory(&relative(b"")).unwrap();
+        first.sort();
+        second.sort();
+        assert_eq!(first, [b"first".to_vec(), b"second".to_vec()]);
+        assert_eq!(second, first);
+        assert!(root.metadata(&relative(b"replacement")).is_err());
+    }
+
+    #[test]
+    fn descendant_traversal_needs_search_but_not_read_permission() {
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let tree = TestDir::new("search-only");
+        let child = tree.path().join("child");
+        fs::create_dir(&child).unwrap();
+        fs::write(child.join("file"), b"contents").unwrap();
+        let root = Root::open(tree.path()).unwrap();
+        fs::set_permissions(&child, fs::Permissions::from_mode(0o111)).unwrap();
+
+        let metadata = root.metadata(&relative(b"child/file")).unwrap();
+        assert!(metadata.is_file());
+        let mut file = root.open_regular_read(&relative(b"child/file")).unwrap();
+        let mut contents = Vec::new();
+        file.read_to_end(&mut contents).unwrap();
+        assert_eq!(contents, b"contents");
+
+        fs::set_permissions(&child, fs::Permissions::from_mode(0o700)).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #119.

This slice moves destination observation onto the descriptor received during worker initialization:

- adopts the already-open destination directory directly as a rooted authority, without resolving its pathname
- uses descriptor-relative StatMany and FileHash operations and descriptor-relative NAME_MAX queries for partial planning
- traverses directories with search-only descriptors where supported and opens independent readable streams for enumeration
- detects replacement while reading a symlink observation
- verifies that rename/replacement of the operator path cannot redirect observation

The destination apply, file-transfer state machine, and scanner/prune families still use the transitional exact-descriptor cwd established by #119. Those are the next stacked slices; this PR intentionally does not claim complete pathname-free containment.

Verification at 903b07b:

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets (273 unit, 282 integration, 7 updater)