### PR TITLE
Confine destination prune scans to retained roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,13 @@ containment guarantee for copy. Native `rm` retains the resolved directories
 and selected identities through mutation. Copy gives every destination worker
 the selected directory descriptor; destination observation, directory and
 special-file creation, metadata changes, and planned non-recursive deletion
-are relative to that descriptor. Destination scanning and regular-file
-transfer state, along with ordinary source walks and reads, have not all moved
-to descriptor-relative access yet. The default therefore rejects links present
-during preflight, while the remaining containment work must also prevent a
-concurrent rename or link substitution from redirecting those unmigrated
-operation families.
+are relative to that descriptor. Destination scanning, including the walk that
+plans `--delete`, is relative to it too and never follows descendant symlinks.
+Regular-file transfer state, along with ordinary source walks and reads, has
+not all moved to descriptor-relative access yet. The default therefore rejects
+links present during preflight, while the remaining containment work must also
+prevent a concurrent rename or link substitution from redirecting those
+unmigrated operation families.
 
 Placement is always explicit in this initial native surface:
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -393,6 +393,18 @@ impl Conn for LocalConn {
         ignored: &mut dyn FnMut(Vec<PathBytes>) -> Result<()>,
         warn: &mut dyn FnMut(String),
     ) -> Result<()> {
+        if let Some((destination_root, relative)) = self.ops.destination_scan_root(root)? {
+            return crate::scan::scan_descriptor(
+                destination_root,
+                &relative,
+                follow_root,
+                ignore,
+                report_ignored,
+                sink,
+                ignored,
+                warn,
+            );
+        }
         let root = self.ops.scan_root(root)?;
         crate::scan::scan(
             &fsops::resolve(&root),

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -684,7 +684,51 @@ pub(crate) fn rooted_entry(
     } else {
         None
     };
-    Ok(Entry {
+    Ok(entry_from_root_metadata(path, metadata, kind, link))
+}
+
+/// Build an entry relative to a directory already opened by a descriptor
+/// scanner. Symlink target reads and the confirming stat use that same parent
+/// descriptor, so neither operation has to rewalk a possibly renamed path.
+pub(crate) fn rooted_entry_in_directory(
+    root: &Root,
+    directory: &File,
+    name: &[u8],
+    path: PathBytes,
+    metadata: RootMetadata,
+) -> Result<Entry> {
+    let kind = match metadata.file_type() {
+        MODE_DIR => Kind::Dir,
+        MODE_FILE => Kind::File,
+        MODE_LINK => Kind::Symlink,
+        MODE_FIFO => Kind::Fifo,
+        MODE_SOCKET => Kind::Socket,
+        MODE_CHAR => Kind::CharDev,
+        MODE_BLOCK => Kind::BlockDev,
+        _ => Kind::Other,
+    };
+    let link = if kind == Kind::Symlink {
+        let target = root.read_link_in_directory(directory, name)?;
+        let after = root.metadata_in_directory(directory, name)?;
+        if (after.dev, after.ino, after.file_type())
+            != (metadata.dev, metadata.ino, metadata.file_type())
+        {
+            bail!("symlink changed while reading its target");
+        }
+        Some(target)
+    } else {
+        None
+    };
+    Ok(entry_from_root_metadata(path, metadata, kind, link))
+}
+
+fn entry_from_root_metadata(
+    path: PathBytes,
+    metadata: RootMetadata,
+    kind: Kind,
+    link: Option<PathBytes>,
+) -> Entry {
+    Entry {
         path,
         kind,
         size: if kind == Kind::File { metadata.len } else { 0 },
@@ -699,7 +743,7 @@ pub(crate) fn rooted_entry(
         ctime: metadata.ctime,
         ctime_nsec: metadata.ctime_nsec,
         link,
-    })
+    }
 }
 
 pub fn lstat_entry(rel: PathBytes, full: &Path) -> io::Result<Entry> {
@@ -1065,6 +1109,21 @@ impl FsOps {
 
     pub fn scan_root(&self, root: &[u8]) -> Result<PathBytes> {
         self.destination_relative(root)
+    }
+
+    /// Return the retained destination capability and a strict path beneath it
+    /// when this connection has adopted a destination root. Callers must use
+    /// this instead of resolving the rebased spelling through process cwd.
+    pub(crate) fn destination_scan_root(
+        &self,
+        requested: &[u8],
+    ) -> Result<Option<(Arc<Root>, PathBytes)>> {
+        let Some(root) = &self.destination_root else {
+            return Ok(None);
+        };
+        let relative = self.destination_relative(requested)?;
+        RelativePath::new(&relative)?;
+        Ok(Some((root.clone(), relative)))
     }
 
     fn rebase_response(&self, response: Response) -> Response {

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -581,6 +581,41 @@ impl Root {
         Ok(directory)
     }
 
+    /// Open a directory by its root-relative name and require that it is still
+    /// the entry previously observed by a caller such as the tree scanner.
+    pub(crate) fn open_directory_verified(
+        &self,
+        path: &RelativePath,
+        expected: RootMetadata,
+    ) -> Result<File> {
+        let directory = self.open_directory(path)?;
+        require_metadata_identity(
+            expected,
+            root_metadata_from_std(&directory.metadata()?)?,
+            "confined directory",
+        )?;
+        Ok(directory)
+    }
+
+    /// Open an observed child relative to an already-open parent. This lets a
+    /// bounded scanner carry authority forward without rewalking from the
+    /// root, while the identity check rejects a rename/replacement race.
+    pub(crate) fn open_child_directory_verified(
+        &self,
+        parent: &File,
+        name: &[u8],
+        expected: RootMetadata,
+    ) -> Result<File> {
+        directory_entry_cstring(name)?;
+        let directory = open_directory_at(parent, name).context("open confined child directory")?;
+        require_metadata_identity(
+            expected,
+            root_metadata_from_std(&directory.metadata()?)?,
+            "confined child directory",
+        )?;
+        Ok(directory)
+    }
+
     pub(crate) fn open_regular_read(&self, path: &RelativePath) -> Result<File> {
         self.open_regular(path, libc::O_RDONLY, false)
     }
@@ -737,6 +772,17 @@ impl Root {
             .with_context(|| format!("stat confined path {}", path.label()))
     }
 
+    /// Inspect a name relative to an already-open directory without following
+    /// a symlink in that name.
+    pub(crate) fn metadata_in_directory(
+        &self,
+        directory: &File,
+        name: &[u8],
+    ) -> Result<RootMetadata> {
+        let name = directory_entry_cstring(name)?;
+        metadata_at(directory.as_raw_fd(), &name).context("stat confined directory entry")
+    }
+
     pub(crate) fn metadata_optional(&self, path: &RelativePath) -> Result<Option<RootMetadata>> {
         if path.is_empty() {
             return self.metadata(path).map(Some);
@@ -755,12 +801,20 @@ impl Root {
     /// owns a duplicate descriptor and never reconstructs a pathname.
     pub(crate) fn read_directory(&self, path: &RelativePath) -> Result<Vec<Vec<u8>>> {
         let directory = self.open_directory(path)?;
+        self.read_open_directory(&directory)
+            .with_context(|| format!("read confined directory {}", path.label()))
+    }
+
+    /// List raw names from a directory already retained by the caller. The
+    /// stream gets its own open-file description, so retries and concurrent
+    /// scans never share a directory offset.
+    pub(crate) fn read_open_directory(&self, directory: &File) -> Result<Vec<Vec<u8>>> {
         // dup()/try_clone() would share the directory open-file-description
         // offset. Reopen `.` so concurrent scans and retries each start with
         // an independent readable stream, including when the authority is an
         // O_PATH/O_SEARCH descriptor.
-        let readable = open_readable_directory_at(&directory, b".")
-            .with_context(|| format!("open readable confined directory {}", path.label()))?;
+        let readable = open_readable_directory_at(directory, b".")
+            .context("open readable confined directory")?;
         let descriptor = readable.into_raw_fd();
         let stream = unsafe { libc::fdopendir(descriptor) };
         if stream.is_null() {
@@ -830,13 +884,19 @@ impl Root {
 
     pub(crate) fn read_link(&self, path: &RelativePath) -> Result<Vec<u8>> {
         let parent = self.resolve_parent(path)?;
+        self.read_link_in_directory(&parent.directory, parent.leaf.as_bytes())
+            .with_context(|| format!("read confined symlink {}", path.label()))
+    }
+
+    pub(crate) fn read_link_in_directory(&self, directory: &File, name: &[u8]) -> Result<Vec<u8>> {
+        let name = directory_entry_cstring(name)?;
         let mut buffer = vec![0u8; 256];
         loop {
             let read = loop {
                 let result = unsafe {
                     libc::readlinkat(
-                        parent.directory.as_raw_fd(),
-                        parent.leaf.as_ptr(),
+                        directory.as_raw_fd(),
+                        name.as_ptr(),
                         buffer.as_mut_ptr().cast(),
                         buffer.len(),
                     )
@@ -846,7 +906,7 @@ impl Root {
                 }
                 let error = io::Error::last_os_error();
                 if error.kind() != io::ErrorKind::Interrupted {
-                    return Err(error).context("read confined symlink");
+                    return Err(error).context("read confined directory-entry symlink");
                 }
             };
             if read < buffer.len() {
@@ -1189,6 +1249,13 @@ fn component_cstring(component: &[u8]) -> CString {
     CString::new(component).expect("RelativePath already rejected NUL")
 }
 
+fn directory_entry_cstring(name: &[u8]) -> Result<CString> {
+    if name.is_empty() || name == b"." || name == b".." || name.contains(&b'/') {
+        bail!("confined directory entry must be one non-dot component");
+    }
+    CString::new(name).context("confined directory entry contains NUL")
+}
+
 fn operator_components(path: &[u8]) -> VecDeque<Vec<u8>> {
     path.split(|byte| *byte == b'/')
         .filter(|component| !component.is_empty())
@@ -1308,6 +1375,19 @@ fn require_operator_identity(
         != (expected.dev, expected.ino, expected.file_type())
     {
         bail!("{label} changed identity during resolution");
+    }
+    Ok(())
+}
+
+fn require_metadata_identity(
+    expected: RootMetadata,
+    actual: RootMetadata,
+    label: &str,
+) -> Result<()> {
+    if (actual.dev, actual.ino, actual.file_type())
+        != (expected.dev, expected.ino, expected.file_type())
+    {
+        bail!("{label} changed identity");
     }
     Ok(())
 }
@@ -1928,6 +2008,31 @@ mod tests {
                 "accepted {:?}",
                 String::from_utf8_lossy(unsafe_path)
             );
+        }
+    }
+
+    #[test]
+    fn opened_directory_apis_reject_non_component_names() {
+        let tree = TestDir::new("opened-directory-name");
+        let root = Root::open(tree.path()).unwrap();
+        let empty = relative(b"");
+        let directory = root.open_directory(&empty).unwrap();
+        let expected = root.metadata(&empty).unwrap();
+
+        for unsafe_name in [
+            &b""[..],
+            &b"."[..],
+            &b".."[..],
+            &b"child/grandchild"[..],
+            &b"nul\0name"[..],
+        ] {
+            assert!(root.metadata_in_directory(&directory, unsafe_name).is_err());
+            assert!(root
+                .read_link_in_directory(&directory, unsafe_name)
+                .is_err());
+            assert!(root
+                .open_child_directory_verified(&directory, unsafe_name, expected)
+                .is_err());
         }
     }
 

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,21 +1,25 @@
 //! Parallel directory walk producing `Entry` batches in parent-before-child order.
 
-use crate::fsops::{lstat_entry, path_bytes};
+use crate::fsops::{join, lstat_entry, path_bytes, rooted_entry, rooted_entry_in_directory};
 use crate::proto::ContainerGuard;
 use crate::proto::{Entry, PathBytes};
-use crate::rooted::{RelativePath, Root, RootIdentity};
+use crate::rooted::{RelativePath, Root, RootIdentity, RootMetadata};
 use anyhow::{Context, Result};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use jwalk::WalkDirGeneric;
-use std::fs;
+use std::fs::{self, File};
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 pub const BATCH: usize = 4096;
 const FIRST_BATCH: usize = 1000;
 const FIRST_BATCH_MAX_DELAY: Duration = Duration::from_millis(50);
+const DESCRIPTOR_STAT_THREADS: usize = 8;
+const DESCRIPTOR_STAT_PAR_MIN: usize = 32;
+const DESCRIPTOR_DIRECTORY_FDS: usize = 16;
 
 /// Per-entry result of the parallel read_dir hook.
 #[derive(Clone, Default, Debug)]
@@ -166,6 +170,252 @@ fn produce_scan(
     let _ = send_scan_chunk(&tx, &mut chunk, &mut entries_sent, &mut entries_in_chunk);
 }
 
+fn inspect_descriptor_children(
+    root: &Root,
+    directory: &File,
+    parent: &[u8],
+    names: &[PathBytes],
+) -> Vec<(PathBytes, Result<(Entry, RootMetadata)>)> {
+    let inspect = |name: &PathBytes| {
+        let relative = join(parent, name);
+        let result = (|| {
+            let metadata = root.metadata_in_directory(directory, name)?;
+            let entry =
+                rooted_entry_in_directory(root, directory, name, relative.clone(), metadata)?;
+            Ok((entry, metadata))
+        })();
+        (relative, result)
+    };
+    if names.len() < DESCRIPTOR_STAT_PAR_MIN {
+        return names.iter().map(inspect).collect();
+    }
+    let chunk = names.len().div_ceil(DESCRIPTOR_STAT_THREADS).max(1);
+    std::thread::scope(|scope| {
+        let workers: Vec<_> = names
+            .chunks(chunk)
+            .map(|names| scope.spawn(|| names.iter().map(inspect).collect::<Vec<_>>()))
+            .collect();
+        workers
+            .into_iter()
+            .flat_map(|worker| worker.join().expect("descriptor scan stat thread"))
+            .collect()
+    })
+}
+
+struct DescriptorDirectory {
+    relative: PathBytes,
+    expected: RootMetadata,
+    opened: Option<File>,
+}
+
+#[cfg(debug_assertions)]
+fn hold_descriptor_directory_for_test(relative: &[u8]) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let Some(expected) = std::env::var_os("SYQ_TEST_HOLD_DESTINATION_SCAN_DIRECTORY") else {
+        return Ok(());
+    };
+    if expected.as_os_str().as_bytes() != relative {
+        return Ok(());
+    }
+    if let Some(ready) = std::env::var_os("SYQ_TEST_DESTINATION_SCAN_DIRECTORY_READY_FILE") {
+        std::fs::write(&ready, b"ready").with_context(|| {
+            format!(
+                "write destination-scan-ready signal {}",
+                Path::new(&ready).display()
+            )
+        })?;
+    }
+    if let Some(ms) = std::env::var_os("SYQ_TEST_HOLD_DESTINATION_SCAN_DIRECTORY_MS") {
+        if let Ok(ms) = ms.to_string_lossy().parse::<u64>() {
+            std::thread::sleep(Duration::from_millis(ms));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(debug_assertions))]
+fn hold_descriptor_directory_for_test(_relative: &[u8]) -> Result<()> {
+    Ok(())
+}
+
+fn produce_descriptor_scan(
+    root: Arc<Root>,
+    scan_root: PathBytes,
+    scan_root_metadata: RootMetadata,
+    ignore: Option<Gitignore>,
+    report_ignored: bool,
+    tx: SyncSender<ScanChunk>,
+) {
+    let mut chunk = Vec::with_capacity(FIRST_BATCH);
+    let mut entries_sent = 1; // The root entry is already waiting in the consumer.
+    let mut entries_in_chunk = 0;
+    let mut retained_directories = 0usize;
+    let mut directories = vec![DescriptorDirectory {
+        relative: Vec::new(),
+        expected: scan_root_metadata,
+        opened: None,
+    }];
+    while let Some(directory) = directories.pop() {
+        if directory.opened.is_some() {
+            retained_directories -= 1;
+        }
+        if let Err(error) = hold_descriptor_directory_for_test(&directory.relative) {
+            chunk.push(ScanEvent::Warning(format!(
+                "scan: {}: {error:#}",
+                String::from_utf8_lossy(&directory.relative)
+            )));
+            break;
+        }
+        let rooted_directory = match RelativePath::new(&join(&scan_root, &directory.relative)) {
+            Ok(directory) => directory,
+            Err(error) => {
+                chunk.push(ScanEvent::Warning(format!(
+                    "scan: {}: {error:#}",
+                    String::from_utf8_lossy(&directory.relative)
+                )));
+                break;
+            }
+        };
+        let opened = match directory.opened {
+            Some(opened) => opened,
+            None => match root.open_directory_verified(&rooted_directory, directory.expected) {
+                Ok(opened) => opened,
+                Err(error) => {
+                    chunk.push(ScanEvent::Warning(format!(
+                        "scan: {}: {error:#}",
+                        String::from_utf8_lossy(&directory.relative)
+                    )));
+                    if chunk.len() >= FIRST_BATCH
+                        && !send_scan_chunk(
+                            &tx,
+                            &mut chunk,
+                            &mut entries_sent,
+                            &mut entries_in_chunk,
+                        )
+                    {
+                        return;
+                    }
+                    continue;
+                }
+            },
+        };
+        let mut names = match root.read_open_directory(&opened) {
+            Ok(names) => names,
+            Err(error) => {
+                chunk.push(ScanEvent::Warning(format!(
+                    "scan: {}: {error:#}",
+                    String::from_utf8_lossy(&directory.relative)
+                )));
+                if chunk.len() >= FIRST_BATCH
+                    && !send_scan_chunk(&tx, &mut chunk, &mut entries_sent, &mut entries_in_chunk)
+                {
+                    return;
+                }
+                continue;
+            }
+        };
+        names.sort();
+        let mut child_directories = Vec::new();
+        // Bound both stat work and its result storage. In particular, publish
+        // the first thousand entries without waiting to stat a huge directory.
+        for names in names.chunks(FIRST_BATCH) {
+            for (name, (relative, result)) in names.iter().zip(inspect_descriptor_children(
+                &root,
+                &opened,
+                &directory.relative,
+                names,
+            )) {
+                let (entry, metadata) = match result {
+                    Ok(result) => result,
+                    Err(error) => {
+                        chunk.push(ScanEvent::Warning(format!(
+                            "scan: cannot stat {}: {error:#}",
+                            String::from_utf8_lossy(&relative)
+                        )));
+                        if chunk.len() >= FIRST_BATCH
+                            && !send_scan_chunk(
+                                &tx,
+                                &mut chunk,
+                                &mut entries_sent,
+                                &mut entries_in_chunk,
+                            )
+                        {
+                            return;
+                        }
+                        continue;
+                    }
+                };
+                let is_directory = entry.kind == crate::proto::Kind::Dir;
+                if ignore.as_ref().is_some_and(|matcher| {
+                    matcher
+                        .matched(
+                            Path::new(std::ffi::OsStr::from_bytes(&relative)),
+                            is_directory,
+                        )
+                        .is_ignore()
+                }) {
+                    if report_ignored {
+                        chunk.push(ScanEvent::Ignored(relative));
+                    }
+                    continue;
+                }
+                if is_directory {
+                    child_directories.push((relative.clone(), name.clone(), metadata));
+                }
+                entries_in_chunk += 1;
+                chunk.push(ScanEvent::Entry(entry));
+                let first_batch_ready =
+                    entries_sent < FIRST_BATCH && entries_sent + entries_in_chunk >= FIRST_BATCH;
+                if (first_batch_ready || chunk.len() >= FIRST_BATCH)
+                    && !send_scan_chunk(&tx, &mut chunk, &mut entries_sent, &mut entries_in_chunk)
+                {
+                    return;
+                }
+            }
+        }
+        let mut retained_children = Vec::with_capacity(child_directories.len());
+        for (relative, name, expected) in child_directories {
+            let opened_child = if retained_directories < DESCRIPTOR_DIRECTORY_FDS {
+                match root.open_child_directory_verified(&opened, &name, expected) {
+                    Ok(child) => {
+                        retained_directories += 1;
+                        Some(child)
+                    }
+                    Err(error) => {
+                        chunk.push(ScanEvent::Warning(format!(
+                            "scan: {}: {error:#}",
+                            String::from_utf8_lossy(&relative)
+                        )));
+                        if chunk.len() >= FIRST_BATCH
+                            && !send_scan_chunk(
+                                &tx,
+                                &mut chunk,
+                                &mut entries_sent,
+                                &mut entries_in_chunk,
+                            )
+                        {
+                            return;
+                        }
+                        continue;
+                    }
+                }
+            } else {
+                None
+            };
+            retained_children.push(DescriptorDirectory {
+                relative,
+                expected,
+                opened: opened_child,
+            });
+        }
+        // Reverse before pushing so byte-sorted, parent-before-child order is retained.
+        retained_children.reverse();
+        directories.extend(retained_children);
+    }
+    let _ = send_scan_chunk(&tx, &mut chunk, &mut entries_sent, &mut entries_in_chunk);
+}
+
 #[allow(clippy::too_many_arguments)]
 fn receive_scan(
     rx: &Receiver<ScanChunk>,
@@ -276,6 +526,67 @@ pub fn scan(
     received?;
     if producer_panicked {
         anyhow::bail!("scan producer panicked");
+    }
+    if !batch.is_empty() {
+        sink(batch)?;
+    }
+    if !ignored_batch.is_empty() {
+        ignored(ignored_batch)?;
+    }
+    Ok(())
+}
+
+/// Walk a destination subtree beneath an already-adopted authority root. The
+/// request supplies only a strict path relative to that root; no pathname is
+/// reconstructed and descendant symlinks are reported rather than traversed.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn scan_descriptor(
+    root: Arc<Root>,
+    scan_root: &[u8],
+    follow_root: bool,
+    ignore: &[String],
+    report_ignored: bool,
+    sink: &mut dyn FnMut(Vec<Entry>) -> Result<()>,
+    ignored: &mut dyn FnMut(Vec<PathBytes>) -> Result<()>,
+    warn: &mut dyn FnMut(String),
+) -> Result<()> {
+    if follow_root {
+        anyhow::bail!("a descriptor-rooted destination scan never follows a root symlink");
+    }
+    let scan_relative = RelativePath::new(scan_root)?;
+    let metadata = root.metadata(&scan_relative)?;
+    let root_entry = rooted_entry(&root, &scan_relative, Vec::new(), metadata)?;
+    if root_entry.kind != crate::proto::Kind::Dir {
+        return sink(vec![root_entry]);
+    }
+
+    let matcher = build_ignore(ignore)?;
+    let mut batch = Vec::with_capacity(FIRST_BATCH);
+    let scan_started = Instant::now();
+    batch.push(root_entry);
+    let mut ignored_batch = Vec::new();
+    let (tx, rx) = mpsc::sync_channel(BATCH / FIRST_BATCH);
+    let scan_root = scan_root.to_vec();
+    let producer = std::thread::Builder::new()
+        .name("syq-descriptor-scan-producer".into())
+        .spawn(move || {
+            produce_descriptor_scan(root, scan_root, metadata, matcher, report_ignored, tx)
+        })
+        .context("start descriptor scan producer")?;
+    let received = receive_scan(
+        &rx,
+        scan_started,
+        &mut batch,
+        &mut ignored_batch,
+        sink,
+        ignored,
+        warn,
+    );
+    drop(rx);
+    let producer_panicked = producer.join().is_err();
+    received?;
+    if producer_panicked {
+        anyhow::bail!("descriptor scan producer panicked");
     }
     if !batch.is_empty() {
         sink(batch)?;
@@ -410,6 +721,9 @@ fn target_relative_path_bytes(target: &Path, root: &Path) -> Result<PathBytes> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::File;
+    use std::os::unix::ffi::OsStringExt;
+    use std::process::Command;
 
     fn entry() -> Entry {
         Entry {
@@ -428,6 +742,130 @@ mod tests {
             ctime_nsec: 0,
             link: None,
         }
+    }
+
+    fn descriptor_entries(root: Arc<Root>) -> (Vec<Entry>, Vec<PathBytes>, Vec<String>) {
+        let mut entries = Vec::new();
+        let mut ignored = Vec::new();
+        let mut warnings = Vec::new();
+        scan_descriptor(
+            root,
+            b"",
+            false,
+            &[],
+            true,
+            &mut |batch| {
+                entries.extend(batch);
+                Ok(())
+            },
+            &mut |batch| {
+                ignored.extend(batch);
+                Ok(())
+            },
+            &mut |warning| warnings.push(warning),
+        )
+        .unwrap();
+        (entries, ignored, warnings)
+    }
+
+    #[test]
+    fn descriptor_scan_stays_with_replaced_root_and_does_not_follow_symlinks() {
+        let temp = tempfile::tempdir().unwrap();
+        let selected = temp.path().join("selected");
+        let moved = temp.path().join("moved");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(selected.join("directory")).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(selected.join("directory/child"), b"child").unwrap();
+        fs::write(outside.join("secret"), b"secret").unwrap();
+        let non_utf8 = std::ffi::OsString::from_vec(vec![b'n', 0xff]);
+        fs::write(selected.join(&non_utf8), b"raw").unwrap();
+        let root = Arc::new(Root::from_directory(File::open(&selected).unwrap()).unwrap());
+
+        fs::rename(&selected, &moved).unwrap();
+        std::os::unix::fs::symlink(&outside, &selected).unwrap();
+        std::os::unix::fs::symlink(&outside, moved.join("escape")).unwrap();
+
+        let (first, ignored, warnings) = descriptor_entries(root.clone());
+        let (second, _, second_warnings) = descriptor_entries(root);
+        let paths: Vec<_> = first.iter().map(|entry| entry.path.clone()).collect();
+        assert!(paths.contains(&Vec::new()));
+        assert!(paths.contains(&b"directory".to_vec()));
+        assert!(paths.contains(&b"directory/child".to_vec()));
+        assert!(paths.contains(&b"escape".to_vec()));
+        assert!(paths.contains(&non_utf8.as_bytes().to_vec()));
+        assert!(!paths.contains(&b"escape/secret".to_vec()));
+        let directory = paths.iter().position(|path| path == b"directory").unwrap();
+        let child = paths
+            .iter()
+            .position(|path| path == b"directory/child")
+            .unwrap();
+        assert!(directory < child, "directories must precede descendants");
+        assert_eq!(
+            second.iter().map(|entry| &entry.path).collect::<Vec<_>>(),
+            first.iter().map(|entry| &entry.path).collect::<Vec<_>>(),
+            "independent scans must each start directory streams at offset zero"
+        );
+        assert!(ignored.is_empty());
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert!(second_warnings.is_empty(), "{second_warnings:?}");
+    }
+
+    #[test]
+    fn descriptor_scan_handles_deep_and_wide_trees_with_low_fd_limit() {
+        const CHILD_ENV: &str = "SYQ_TEST_DESCRIPTOR_SCAN_LOW_FD_CHILD";
+        const TEST_NAME: &str =
+            "scan::tests::descriptor_scan_handles_deep_and_wide_trees_with_low_fd_limit";
+
+        if std::env::var_os(CHILD_ENV).is_none() {
+            let status = Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", TEST_NAME, "--nocapture"])
+                .env(CHILD_ENV, "1")
+                .status()
+                .unwrap();
+            assert!(status.success(), "low-FD descriptor scan subprocess failed");
+            return;
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut deep = temp.path().to_path_buf();
+        for index in 0..80 {
+            deep.push(format!("d{index:02}"));
+        }
+        fs::create_dir_all(&deep).unwrap();
+        fs::write(deep.join("leaf"), b"leaf").unwrap();
+        for index in 0..256 {
+            let directory = temp.path().join(format!("wide-{index:03}"));
+            fs::create_dir(&directory).unwrap();
+            fs::write(directory.join("leaf"), b"leaf").unwrap();
+        }
+        let root = Arc::new(Root::from_directory(File::open(temp.path()).unwrap()).unwrap());
+
+        let mut limits: libc::rlimit = unsafe { std::mem::zeroed() };
+        assert_eq!(
+            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) },
+            0
+        );
+        assert!(limits.rlim_max >= 64, "hard descriptor limit is below 64");
+        limits.rlim_cur = 64;
+        assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limits) }, 0);
+
+        let (entries, ignored, warnings) = descriptor_entries(root);
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.path.ends_with(b"d79/leaf")),
+            "deep leaf was not scanned"
+        );
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|entry| entry.path.ends_with(b"/leaf"))
+                .count(),
+            257
+        );
+        assert!(ignored.is_empty());
+        assert!(warnings.is_empty(), "{warnings:?}");
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -348,6 +348,17 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 guard,
             } => {
                 let requested_root = root.clone();
+                let destination_scan = if guard.is_none() {
+                    match ops.destination_scan_root(&root) {
+                        Ok(scan) => scan,
+                        Err(error) => {
+                            w.write_msg(&Response::Err(format!("{error:#}")))?;
+                            continue;
+                        }
+                    }
+                } else {
+                    None
+                };
                 let root = match ops.scan_root(&root) {
                     Ok(root) => root,
                     Err(error) => {
@@ -386,6 +397,17 @@ fn serve<R: Read + Send + 'static, W: Write>(
                         &ignore,
                         report_ignored,
                         &guard,
+                        &mut sink,
+                        &mut ignored,
+                        &mut |msg| warns.borrow_mut().push(msg),
+                    )
+                } else if let Some((destination_root, relative)) = destination_scan {
+                    crate::scan::scan_descriptor(
+                        destination_root,
+                        &relative,
+                        follow_root,
+                        &ignore,
+                        report_ignored,
                         &mut sink,
                         &mut ignored,
                         &mut |msg| warns.borrow_mut().push(msg),

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -6856,6 +6856,128 @@ fn destination_root_replacement_after_selection_cannot_redirect_worker() {
     }
 }
 
+#[cfg(debug_assertions)]
+#[test]
+fn destination_prune_scan_uses_retained_root_after_replacement() {
+    for no_tcp in [false, true] {
+        let t = Tmp::new();
+        fs::create_dir_all(t.path("src")).unwrap();
+        write(&t.path("dst/extra"), b"extra");
+        write(&t.path("outside/sentinel"), b"outside");
+        let ready = t.path("anchor-ready");
+
+        let mut command = compat_command();
+        command.args([
+            "-a",
+            "--delete",
+            "--syq-connections",
+            "1",
+            &t.s("src/"),
+            &t.s("dst/"),
+        ]);
+        if no_tcp {
+            command.arg("--syq-no-tcp");
+        }
+        let mut child = command
+            .arg("--no-progress")
+            .env("SYQ_TEST_DESTINATION_ANCHORED_FILE", &ready)
+            .env("SYQ_TEST_HOLD_DESTINATION_ANCHOR_MS", "750")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .start()
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !ready.exists() && std::time::Instant::now() < deadline {
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "syq exited before retaining the destination root"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            ready.exists(),
+            "destination root was not retained before timeout"
+        );
+
+        fs::rename(t.path("dst"), t.path("selected-and-moved")).unwrap();
+        std::os::unix::fs::symlink(t.path("outside"), t.path("dst")).unwrap();
+
+        let output = child.wait_with_output().unwrap();
+        assert_output_ok(&output);
+        assert!(!t.path("selected-and-moved/extra").exists());
+        assert_eq!(read(&t.path("outside/sentinel")), b"outside");
+        assert!(fs::symlink_metadata(t.path("dst"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn destination_prune_scan_refuses_descendant_symlink_swap() {
+    for no_tcp in [false, true] {
+        let t = Tmp::new();
+        fs::create_dir_all(t.path("src/victim")).unwrap();
+        write(&t.path("dst/victim/extra"), b"extra");
+        write(&t.path("outside/sentinel"), b"outside");
+        let ready = t.path("scan-ready");
+
+        let mut command = compat_command();
+        command.args([
+            "-a",
+            "--delete",
+            "--syq-connections",
+            "1",
+            &t.s("src/"),
+            &t.s("dst/"),
+        ]);
+        if no_tcp {
+            command.arg("--syq-no-tcp");
+        }
+        let mut child = command
+            .arg("--no-progress")
+            .env("SYQ_TEST_HOLD_DESTINATION_SCAN_DIRECTORY", "victim")
+            .env("SYQ_TEST_DESTINATION_SCAN_DIRECTORY_READY_FILE", &ready)
+            .env("SYQ_TEST_HOLD_DESTINATION_SCAN_DIRECTORY_MS", "750")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .start()
+            .unwrap();
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !ready.exists() && std::time::Instant::now() < deadline {
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "syq exited before reaching the descendant directory scan"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            ready.exists(),
+            "destination descendant scan was not reached before timeout"
+        );
+
+        fs::rename(t.path("dst/victim"), t.path("displaced-victim")).unwrap();
+        std::os::unix::fs::symlink(t.path("outside"), t.path("dst/victim")).unwrap();
+
+        let output = child.wait_with_output().unwrap();
+        assert_eq!(output.status.code(), Some(23), "{}", stderr_of(&output));
+        assert!(
+            stderr_of(&output).contains("delete victim/extra"),
+            "{}",
+            stderr_of(&output)
+        );
+        assert_eq!(read(&t.path("outside/sentinel")), b"outside");
+        assert_eq!(read(&t.path("displaced-victim/extra")), b"extra");
+        assert!(fs::symlink_metadata(t.path("dst/victim"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+}
+
 #[test]
 fn in_tree_destination_symlink_is_replaced_not_followed() {
     let t = Tmp::new();


### PR DESCRIPTION
## Summary

- route ordinary local and remote destination scans through the session-retained destination capability
- walk with strict descriptor-relative operations, never following descendant symlinks
- retain a bounded queue of verified child-directory descriptors so deep chains are normally linear without risking descriptor exhaustion
- preserve scan ordering, ignore handling, raw path bytes, warning propagation, and first-batch behavior
- validate every descriptor-relative directory-entry API as exactly one non-dot component
- cover selected-root replacement, descendant replacement, repeated scans, and deep/wide trees under a 64-FD limit

## Stack

This is based on `destination-root-apply` / PR #121 at `76f73ca`. It was developed in parallel with the regular-file state slice but should be reviewed as the destination scan and prune-planning cutover.

## Verification

At `42c0d24`:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (278 unit, 284 integration, 7 updater tests)

The rsync conformance job is also part of required CI; its known `files-from-path-clamp` policy-open result is accepted by the ledger, while every compatible test must pass.
