### PR TITLE
Register pinned source capabilities before mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,13 +238,33 @@ the safer way to turn a link chain into an explicit operand.
 
 This is the native selection policy, not yet a complete hostile-namespace
 containment guarantee for copy. Native `rm` retains the resolved directories
-and selected identities through mutation. Copy gives every destination worker
-the selected directory descriptor; destination observation, directory and
-special-file creation, metadata changes, and planned non-recursive deletion
-are relative to that descriptor. Destination scanning, including the walk that
-plans `--delete`, is relative to it too and never follows descendant symlinks.
-Regular-file transfer state, along with ordinary source walks and reads, has
-not all moved to descriptor-relative access yet. The default therefore rejects
+and selected identities through mutation. Copy resolves and registers every
+selected source before destination mutation, and every source worker claims
+those exact directory or parent descriptors during authenticated startup,
+before it reports readiness. Source jobs and requests already carry the
+resulting opaque root ID plus strict relative bytes. This is deliberately
+inert transitional vocabulary: ordinary source scans, stats, hashes, and reads
+still execute the parallel legacy pathname field, and the registered reference
+is not an allowlist or confinement boundary yet. Worker startup validates the
+ticket/root correspondence and retains the exact descriptor; the source-role,
+request-reference, and descriptor-relative access boundary lands with the
+source-operation cutover. Copy also gives
+every destination worker the selected directory descriptor; destination
+observation, directory and special-file creation, metadata changes, and
+planned non-recursive deletion are relative to that descriptor. Destination
+scanning, including the walk that plans `--delete`, is relative to it too and
+never follows descendant symlinks.
+Source registration does not change `--files-from`'s documented treatment of
+symlinks in listed or implied paths; that policy is settled with the source-read
+cutover rather than by worker initialization.
+Registration also budgets the process's currently open descriptors, one
+retained descriptor per source root for the registry, control connection, and
+every worker that may share its process, plus conservative per-worker file
+cache and transport overhead. If the endpoint's open-file limit cannot hold
+that set, the copy fails before destination mutation with guidance to reduce
+selectors or `--connections`.
+Regular-file destination transfer state has not all moved to
+descriptor-relative access yet either. The default therefore rejects
 links present during preflight, while the remaining containment work must also
 prevent a concurrent rename or link substitution from redirecting those
 unmigrated operation families.

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -42,6 +42,7 @@ pub trait Conn: Send {
     fn scan(
         &mut self,
         root: &[u8],
+        _source: Option<&RegisteredPath>,
         follow_root: bool,
         ignore: &[String],
         report_ignored: bool,
@@ -361,19 +362,41 @@ pub fn ok(resp: Response, what: &str) -> Result<Response> {
 pub struct LocalConn {
     ops: FsOps,
     pending: VecDeque<Response>,
+    is_control: bool,
 }
 
 impl LocalConn {
-    pub fn new() -> Self {
+    fn new(
+        is_control: bool,
+        descriptor_session: crate::descriptor_broker::DescriptorSessionSlot,
+    ) -> Self {
         LocalConn {
-            ops: FsOps::new(),
+            ops: FsOps::with_descriptor_session(descriptor_session),
             pending: VecDeque::new(),
+            is_control,
         }
     }
 }
 
 impl Conn for LocalConn {
     fn send(&mut self, req: Request) -> Result<()> {
+        if !self.is_control
+            && matches!(
+                &req,
+                Request::TcpListen { .. }
+                    | Request::NativeRemove { .. }
+                    | Request::CheckOperatorDirectory { .. }
+                    | Request::RegisterSourceRoots { .. }
+                    | Request::CreateOperatorDirectory { .. }
+                    | Request::AnchorDestination { .. }
+                    | Request::Receipt
+            )
+        {
+            self.pending.push_back(Response::Err(
+                "request is allowed only on the control connection".into(),
+            ));
+            return Ok(());
+        }
         let resp = self.ops.handle(&req);
         self.pending.push_back(resp);
         Ok(())
@@ -386,6 +409,7 @@ impl Conn for LocalConn {
     fn scan(
         &mut self,
         root: &[u8],
+        _source: Option<&RegisteredPath>,
         follow_root: bool,
         ignore: &[String],
         report_ignored: bool,
@@ -597,6 +621,7 @@ impl Conn for RemoteConn {
     fn scan(
         &mut self,
         root: &[u8],
+        source: Option<&RegisteredPath>,
         follow_root: bool,
         ignore: &[String],
         report_ignored: bool,
@@ -606,6 +631,7 @@ impl Conn for RemoteConn {
     ) -> Result<()> {
         self.send(Request::Scan {
             root: root.to_vec(),
+            source: source.cloned(),
             follow_root,
             ignore: ignore.to_vec(),
             report_ignored,
@@ -1048,7 +1074,7 @@ impl RemoteSpec {
     /// on first use if the remote lacks it.
     pub fn connect_with(&self, compress: bool, limited: bool) -> Result<RemoteConn> {
         let role = if limited {
-            ConnectionRole::SourceWorker
+            ConnectionRole::SourceWorker { roots: Vec::new() }
         } else {
             ConnectionRole::Control
         };
@@ -1616,7 +1642,7 @@ fn hello(
     token: Vec<u8>,
     role: ConnectionRole,
 ) -> Result<RemoteConn> {
-    let destination_worker = matches!(role, ConnectionRole::DestinationWorker { .. });
+    let worker = !matches!(role, ConnectionRole::Control);
     conn.send(Request::Hello {
         identity: crate::identity::build().to_string(),
         compress,
@@ -1635,11 +1661,11 @@ fn hello(
                 crate::identity::build()
             )
         }
-        Ok(Response::Err(error)) if destination_worker => {
+        Ok(Response::Err(error)) if worker => {
             return Err(WorkerInitializationError(format!("{}: {error}", conn.label)).into())
         }
         Ok(Response::Err(error)) => bail!("{}: {error}", conn.label),
-        Ok(other) if destination_worker => {
+        Ok(other) if worker => {
             return Err(WorkerInitializationError(format!(
                 "{}: unexpected handshake response {other:?}",
                 conn.label
@@ -2064,13 +2090,30 @@ fn valid_sha256(value: &str) -> bool {
             .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
 }
 
-#[derive(Clone, Debug)]
-pub enum Endpoint {
-    Local,
+#[derive(Clone)]
+pub(crate) enum Endpoint {
+    Local {
+        descriptor_session: crate::descriptor_broker::DescriptorSessionSlot,
+    },
     Remote(RemoteSpec),
 }
 
+impl std::fmt::Debug for Endpoint {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Endpoint::Local { .. } => formatter.write_str("Local"),
+            Endpoint::Remote(spec) => formatter.debug_tuple("Remote").field(spec).finish(),
+        }
+    }
+}
+
 impl Endpoint {
+    pub(crate) fn local() -> Self {
+        Self::Local {
+            descriptor_session: Default::default(),
+        }
+    }
+
     pub fn is_remote(&self) -> bool {
         matches!(self, Endpoint::Remote(spec) if !spec.local_process)
     }
@@ -2079,8 +2122,16 @@ impl Endpoint {
         matches!(self, Endpoint::Remote(_))
     }
 
-    pub fn connect(&self, compress: bool) -> Result<Box<dyn Conn>> {
-        self.connect_with_role(compress, ConnectionRole::SourceWorker)
+    pub(crate) fn connect_control(&self, compress: bool) -> Result<Box<dyn Conn>> {
+        self.connect_with_role(compress, ConnectionRole::Control)
+    }
+
+    pub(crate) fn connect_with_sources(
+        &self,
+        compress: bool,
+        roots: Vec<RegisteredSourceRoot>,
+    ) -> Result<Box<dyn Conn>> {
+        self.connect_with_role(compress, ConnectionRole::SourceWorker { roots })
     }
 
     pub(crate) fn connect_with_destination(
@@ -2093,8 +2144,17 @@ impl Endpoint {
 
     fn connect_with_role(&self, compress: bool, role: ConnectionRole) -> Result<Box<dyn Conn>> {
         match self {
-            Endpoint::Local => {
-                let mut conn = LocalConn::new();
+            Endpoint::Local { descriptor_session } => {
+                // Every connection clone for this logical local endpoint uses
+                // the control connection's process-local session slot. Once
+                // the control registers roots, workers clone those retained
+                // descriptors in process instead of claiming SCM_RIGHTS from
+                // the broker after worker threads exist (unsupported on
+                // Darwin).
+                let mut conn = LocalConn::new(
+                    matches!(&role, ConnectionRole::Control),
+                    descriptor_session.clone(),
+                );
                 match role {
                     ConnectionRole::DestinationWorker {
                         destination: Some(destination),
@@ -2112,7 +2172,14 @@ impl Endpoint {
                         )
                         .into())
                     }
-                    ConnectionRole::Control | ConnectionRole::SourceWorker => {}
+                    ConnectionRole::SourceWorker { roots } => {
+                        conn.ops.initialize_sources(&roots).map_err(|error| {
+                            WorkerInitializationError(format!(
+                                "initialize local source worker: {error:#}"
+                            ))
+                        })?
+                    }
+                    ConnectionRole::Control => {}
                 }
                 Ok(Box::new(conn))
             }
@@ -2168,10 +2235,44 @@ impl Endpoint {
 mod tests {
     use super::*;
     use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
 
     struct ExitObserved<R> {
         inner: R,
         dropped: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[test]
+    fn local_workers_clone_the_control_descriptor_session_in_process() {
+        let temporary = tempfile::tempdir().unwrap();
+        let selected = temporary.path().join("selected");
+        std::fs::create_dir(&selected).unwrap();
+        let endpoint = Endpoint::local();
+        let mut control = endpoint.connect_control(false).unwrap();
+        let response = control
+            .call(Request::RegisterSourceRoots {
+                selections: vec![SourceRootSelection {
+                    path: selected.as_os_str().as_bytes().to_vec(),
+                    follow_root: false,
+                }],
+                symlink_policy: OperatorSymlinkPolicy::Refuse,
+                shared_workers: 1,
+            })
+            .unwrap();
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+
+        // Once the socket name is gone, an empty session slot cannot claim the
+        // ticket with SCM_RIGHTS. The endpoint clone still succeeds because it
+        // reaches the control connection's process-local registry instead.
+        std::fs::remove_file(roots[0].ticket.broker_path()).unwrap();
+        endpoint.connect_with_sources(false, roots.clone()).unwrap();
+        let error = Endpoint::local()
+            .connect_with_sources(false, roots)
+            .err()
+            .expect("a fresh local endpoint must not share another session");
+        assert!(format!("{error:#}").contains("connect to descriptor broker"));
     }
 
     impl<R: Read> Read for ExitObserved<R> {
@@ -2279,7 +2380,11 @@ mod tests {
         };
 
         let error = spec
-            .connect_tcp(&info, false, ConnectionRole::SourceWorker)
+            .connect_tcp(
+                &info,
+                false,
+                ConnectionRole::SourceWorker { roots: Vec::new() },
+            )
             .err()
             .expect("unregistered congestion control should fail locally");
         let message = format!("{error:#}");

--- a/src/descriptor_broker.rs
+++ b/src/descriptor_broker.rs
@@ -28,7 +28,7 @@ const RESPONSE_OK: u8 = 0;
 const RESPONSE_REJECTED: u8 = 1;
 const RESPONSE_INTERNAL: u8 = 2;
 const BROKER_IO_TIMEOUT: Duration = Duration::from_secs(10);
-const DEFAULT_MAX_ROOTS: usize = 256;
+pub(crate) const DEFAULT_MAX_ROOTS: usize = 256;
 const DEFAULT_MAX_CONNECTIONS: usize = 256;
 const FD_CONTROL_LEN: usize =
     unsafe { libc::CMSG_SPACE(size_of::<RawFd>() as libc::c_uint) as usize };
@@ -41,6 +41,12 @@ union FdControl {
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub(crate) struct RegisteredRootId(u64);
+
+impl RegisteredRootId {
+    pub(crate) fn get(self) -> u64 {
+        self.0
+    }
+}
 
 struct RegisteredRoot {
     directory: File,
@@ -72,29 +78,50 @@ impl RegisteredRootRegistry {
     }
 
     pub(crate) fn register(&self, directory: File) -> Result<RegisteredRootId> {
-        let metadata = directory
-            .metadata()
-            .context("inspect directory registered with descriptor session")?;
-        if !metadata.is_dir() {
-            bail!("only directories may be registered as session roots");
+        Ok(self.register_many(vec![directory])?.remove(0))
+    }
+
+    pub(crate) fn register_many(&self, directories: Vec<File>) -> Result<Vec<RegisteredRootId>> {
+        if directories.is_empty() {
+            return Ok(Vec::new());
+        }
+        for directory in &directories {
+            let metadata = directory
+                .metadata()
+                .context("inspect directory registered with descriptor session")?;
+            if !metadata.is_dir() {
+                bail!("only directories may be registered as session roots");
+            }
         }
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if state.roots.len() >= self.max_roots {
+        let new_len = state
+            .roots
+            .len()
+            .checked_add(directories.len())
+            .context("descriptor session root count overflow")?;
+        if new_len > self.max_roots {
             bail!(
                 "descriptor session root limit ({}) exceeded; split the operation into fewer distinct roots",
                 self.max_roots
             );
         }
-        let id = RegisteredRootId(state.next_id);
-        state.next_id = state
+        let count = u64::try_from(directories.len()).context("too many session roots")?;
+        let next_id = state
             .next_id
-            .checked_add(1)
+            .checked_add(count)
             .context("descriptor session exhausted root identifiers")?;
-        state.roots.insert(id, RegisteredRoot { directory });
-        Ok(id)
+        let first_id = state.next_id;
+        state.next_id = next_id;
+        let mut ids = Vec::with_capacity(directories.len());
+        for (offset, directory) in directories.into_iter().enumerate() {
+            let id = RegisteredRootId(first_id + offset as u64);
+            state.roots.insert(id, RegisteredRoot { directory });
+            ids.push(id);
+        }
+        Ok(ids)
     }
 
     /// Used by local workers and TCP workers hosted by the control process.
@@ -144,6 +171,15 @@ impl std::fmt::Debug for DescriptorTicket {
 impl DescriptorTicket {
     fn socket_path(&self) -> PathBuf {
         PathBuf::from(OsStr::from_bytes(&self.socket_path))
+    }
+
+    pub(crate) fn root_id(&self) -> RegisteredRootId {
+        self.root_id
+    }
+
+    #[cfg(test)]
+    pub(crate) fn broker_path(&self) -> PathBuf {
+        self.socket_path()
     }
 }
 
@@ -237,6 +273,13 @@ impl Default for DescriptorSessionSlot {
 
 impl DescriptorSessionSlot {
     pub(crate) fn register(&self, directory: File) -> Result<DescriptorTicket> {
+        Ok(self.register_many(vec![directory])?.remove(0))
+    }
+
+    pub(crate) fn register_many(&self, directories: Vec<File>) -> Result<Vec<DescriptorTicket>> {
+        if directories.is_empty() {
+            return Ok(Vec::new());
+        }
         if self.closed.load(Ordering::Acquire) {
             bail!("descriptor session is closed");
         }
@@ -254,8 +297,12 @@ impl DescriptorSessionSlot {
             )?);
         }
         let session = session.as_ref().expect("descriptor session initialized");
-        let root_id = session.register(directory)?;
-        session.ticket(root_id)
+        session
+            .registry
+            .register_many(directories)?
+            .into_iter()
+            .map(|root_id| session.ticket(root_id))
+            .collect()
     }
 
     pub(crate) fn acquire(&self, ticket: &DescriptorTicket) -> Result<File> {
@@ -668,6 +715,37 @@ mod tests {
         assert!(session.registry().acquire(first_id).is_ok());
         let error = session.register(File::open(&first).unwrap()).unwrap_err();
         assert!(error.to_string().contains("root limit (1) exceeded"));
+    }
+
+    #[test]
+    fn batch_registration_checks_capacity_before_consuming_any_root_id() {
+        let temp = tempfile::tempdir().unwrap();
+        let session = DescriptorSession::start(1, 1).unwrap();
+        let error = session
+            .registry()
+            .register_many(vec![
+                File::open(temp.path()).unwrap(),
+                File::open(temp.path()).unwrap(),
+            ])
+            .unwrap_err();
+        assert!(error.to_string().contains("root limit (1) exceeded"));
+
+        let id = session.register(File::open(temp.path()).unwrap()).unwrap();
+        assert_eq!(id.get(), 1);
+    }
+
+    #[test]
+    fn repeated_inode_registrations_keep_distinct_authority_ids() {
+        let temp = tempfile::tempdir().unwrap();
+        let session = DescriptorSession::start(2, 1).unwrap();
+        let ids = session
+            .registry()
+            .register_many(vec![
+                File::open(temp.path()).unwrap(),
+                File::open(temp.path()).unwrap(),
+            ])
+            .unwrap();
+        assert_ne!(ids[0], ids[1]);
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1,7 +1,9 @@
 //! Local filesystem operations. Used directly by the local endpoint and
 //! by `syq --server` for remote endpoints, so both sides behave identically.
 
-use crate::descriptor_broker::{DescriptorSessionSlot, DescriptorTicket};
+use crate::descriptor_broker::{
+    DescriptorSessionSlot, DescriptorTicket, RegisteredRootId, DEFAULT_MAX_ROOTS,
+};
 use crate::proto::*;
 use crate::rooted::{
     OperatorFinalComponent, OperatorResolver, PinnedPath, RelativePath, Root, RootIdentity,
@@ -23,6 +25,17 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 pub const PARTIAL_MARKER: &str = ".syq-part.";
 const FD_CACHE_MAX: usize = 16;
+const SOURCE_FD_RESERVE: usize = 32;
+// A shared worker may fill its source file cache, retain five copies of its
+// transport socket in a TCP serving process, and open one uncached source file
+// for HashBlocks or FileHash. Those operations are sequential per worker, so
+// one uncached descriptor is the peak. Local source workers have no transport
+// themselves and retain only three client-side copies of a destination TCP
+// socket, but budget the larger remote-source shape for both shared variants.
+const SOURCE_TCP_TRANSPORT_FDS: usize = 5;
+const SOURCE_UNCACHED_FILE_FDS: usize = 1;
+const SOURCE_SHARED_WORKER_FD_RESERVE: usize =
+    FD_CACHE_MAX + SOURCE_TCP_TRANSPORT_FDS + SOURCE_UNCACHED_FILE_FDS;
 const COMMON_NAME_MAX: usize = 255;
 const COMPACT_HASH_BYTES: usize = 10;
 const NAME_MAX_CACHE_CAP: usize = 1024;
@@ -770,6 +783,92 @@ fn process_initial_cwd() -> PathBuf {
         .clone()
 }
 
+fn source_descriptor_requirement(
+    current_open: usize,
+    root_count: usize,
+    shared_workers: usize,
+) -> Result<usize> {
+    // Registry + control connection retain each root. Every shared local/TCP
+    // worker retains another descriptor; independent SSH workers pay that
+    // one-root-set cost in their own process. Add live process descriptors and
+    // per-worker cache/transport state separately: a fixed reserve alone does
+    // not grow with concurrency and can admit a setup that later hits EMFILE.
+    root_count
+        .checked_mul(
+            shared_workers
+                .checked_add(2)
+                .context("source worker count overflow")?,
+        )
+        .and_then(|count| {
+            SOURCE_SHARED_WORKER_FD_RESERVE
+                .checked_mul(shared_workers)
+                .and_then(|workers| count.checked_add(workers))
+        })
+        .and_then(|count| count.checked_add(SOURCE_FD_RESERVE))
+        .and_then(|count| count.checked_add(current_open))
+        .context("source descriptor requirement overflow")
+}
+
+/// Count a snapshot of the process's live descriptors. Reading an fd directory keeps
+/// the common Linux and Darwin paths proportional to the number of open
+/// descriptors. Its directory descriptor is visible in the listing, which is
+/// a harmless conservative overcount. The portable fallback scans the finite
+/// descriptor range and treats unexpected `fcntl` errors as open.
+fn current_open_descriptor_count(soft_limit: libc::rlim_t) -> Result<usize> {
+    for fd_directory in ["/proc/self/fd", "/dev/fd"] {
+        if let Ok(entries) = fs::read_dir(fd_directory) {
+            return Ok(entries.count());
+        }
+    }
+
+    let limit = usize::try_from(soft_limit).context("open-file limit does not fit usize")?;
+    let max_fd = usize::try_from(libc::c_int::MAX).expect("c_int maximum fits usize");
+    if limit > max_fd {
+        bail!("cannot conservatively inspect {limit} possible open descriptors on this platform");
+    }
+    let mut open = 0usize;
+    for fd in 0..limit {
+        let fd = fd as libc::c_int;
+        loop {
+            if unsafe { libc::fcntl(fd, libc::F_GETFD) } >= 0 {
+                open += 1;
+                break;
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            if error.raw_os_error() != Some(libc::EBADF) {
+                open += 1;
+            }
+            break;
+        }
+    }
+    Ok(open)
+}
+
+fn require_source_descriptor_capacity(root_count: usize, shared_workers: usize) -> Result<()> {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) } != 0 {
+        return Err(io::Error::last_os_error()).context("read source endpoint file limit");
+    }
+    if limit.rlim_cur == libc::RLIM_INFINITY {
+        return Ok(());
+    }
+    let current_open = current_open_descriptor_count(limit.rlim_cur)?;
+    let required = source_descriptor_requirement(current_open, root_count, shared_workers)?;
+    if required as u128 > limit.rlim_cur as u128 {
+        bail!(
+            "source setup needs about {required} open-file slots ({current_open} currently open) for {root_count} roots and {shared_workers} shared workers, but this endpoint permits {}; reduce the number of source selectors or use a smaller explicit --connections value",
+            limit.rlim_cur
+        );
+    }
+    Ok(())
+}
+
 pub struct FsOps {
     fds: HashMap<FdKey, File>,
     fd_order: Vec<FdKey>,
@@ -778,6 +877,7 @@ pub struct FsOps {
     held_basis: Option<HeldBasis>,
     operator_selection: Option<OperatorDirectorySelection>,
     descriptor_session: DescriptorSessionSlot,
+    source_roots: HashMap<RegisteredRootId, SourceRootHandle>,
     destination_root: Option<Arc<Root>>,
     destination_prefix: Option<PathBytes>,
     initial_cwd: PathBuf,
@@ -787,6 +887,13 @@ struct HeldBasis {
     path: PathBuf,
     partial_id: PartialId,
     file: File,
+}
+
+struct SourceRootHandle {
+    _root: Arc<Root>,
+    /// Transitional selection spelling retained for the source-operation
+    /// cutover. It does not authorize the parallel legacy pathname yet.
+    _selection: PathBytes,
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -828,6 +935,7 @@ impl FsOps {
             held_basis: None,
             operator_selection: None,
             descriptor_session,
+            source_roots: HashMap::new(),
             destination_root: None,
             destination_prefix: None,
             initial_cwd: process_initial_cwd(),
@@ -906,6 +1014,127 @@ impl FsOps {
     pub(crate) fn initialize_destination(&mut self, destination: &DestinationRoot) -> Result<()> {
         let directory = self.descriptor_session.acquire(&destination.ticket)?;
         self.install_destination(directory, &destination.request_prefix)
+    }
+
+    /// Resolve a batch completely before registering any of it. Each result is
+    /// represented by the smallest registration directory that preserves the
+    /// operator selection: the selected directory itself, or a selected
+    /// leaf's opened parent plus its literal name.
+    fn register_source_roots(
+        &mut self,
+        selections: &[SourceRootSelection],
+        symlink_policy: OperatorSymlinkPolicy,
+        shared_workers: usize,
+    ) -> Result<Vec<RegisteredSourceRoot>> {
+        if selections.is_empty() {
+            bail!("source registration requires at least one selection");
+        }
+        if selections.len() > DEFAULT_MAX_ROOTS {
+            bail!(
+                "source root count ({}) exceeds the endpoint-session limit ({DEFAULT_MAX_ROOTS})",
+                selections.len()
+            );
+        }
+        require_source_descriptor_capacity(selections.len(), shared_workers)?;
+        let mut resolved = Vec::with_capacity(selections.len());
+        for selection in selections {
+            let path = resolve(&selection.path);
+            let path = if path.is_absolute() {
+                path
+            } else {
+                self.initial_cwd.join(path)
+            };
+            let mut hops = Vec::new();
+            let pinned = OperatorResolver::resolve_process(
+                path.as_os_str().as_bytes(),
+                symlink_policy,
+                OperatorFinalComponent::Entry {
+                    follow_symlink: selection.follow_root,
+                },
+                false,
+                &mut hops,
+            )
+            .with_context(|| format!("resolve source selection {}", path.display()))?;
+            match pinned {
+                PinnedPath::Directory(directory) => {
+                    let (directory, _) = directory.into_parts();
+                    resolved.push((directory, Vec::new()));
+                }
+                PinnedPath::Leaf(leaf) => {
+                    let (parent, name, _, _) = leaf.into_parts();
+                    resolved.push((parent, name.as_bytes().to_vec()));
+                }
+                PinnedPath::Missing(_) => {
+                    unreachable!("source resolution did not allow a missing suffix")
+                }
+            }
+        }
+
+        let relative: Vec<_> = resolved
+            .iter()
+            .map(|(_, relative)| relative.clone())
+            .collect();
+        let tickets = self.descriptor_session.register_many(
+            resolved
+                .into_iter()
+                .map(|(directory, _)| directory)
+                .collect(),
+        )?;
+        let registered: Vec<_> = tickets
+            .into_iter()
+            .zip(relative)
+            .map(|(ticket, relative)| {
+                let selection = RegisteredPath::new(ticket.root_id(), relative)?;
+                Ok(RegisteredSourceRoot { ticket, selection })
+            })
+            .collect::<Result<_>>()?;
+        self.initialize_sources(&registered)?;
+        Ok(registered)
+    }
+
+    /// Acquire every registered source root before acknowledging worker
+    /// readiness. Local and same-process TCP workers clone from the shared
+    /// process registry; fresh SSH workers claim while still single-threaded.
+    /// Build the new table off to the side so a bad ticket cannot leave a
+    /// partially initialized worker.
+    pub(crate) fn initialize_sources(&mut self, sources: &[RegisteredSourceRoot]) -> Result<()> {
+        if sources.is_empty() {
+            bail!("source worker requires at least one registered root");
+        }
+        if sources.len() > DEFAULT_MAX_ROOTS {
+            bail!(
+                "source worker root count ({}) exceeds the endpoint-session limit ({DEFAULT_MAX_ROOTS})",
+                sources.len()
+            );
+        }
+        let mut roots = HashMap::with_capacity(sources.len());
+        for source in sources {
+            source.validate()?;
+            let id = source.selection.root();
+            if roots.contains_key(&id) {
+                bail!(
+                    "source worker received duplicate registered root {}",
+                    id.get()
+                );
+            }
+            let directory = self.descriptor_session.acquire(&source.ticket)?;
+            roots.insert(
+                id,
+                SourceRootHandle {
+                    _root: Arc::new(Root::from_directory(directory)?),
+                    _selection: source.selection.relative.clone(),
+                },
+            );
+        }
+        self.source_roots = roots;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn source_root_identity(&self, id: RegisteredRootId) -> Option<RootIdentity> {
+        self.source_roots
+            .get(&id)
+            .map(|source| source._root.identity())
     }
 
     fn install_destination(&mut self, directory: File, request_prefix: &[u8]) -> Result<()> {
@@ -1071,7 +1300,7 @@ impl FsOps {
             | Request::HashBlocks { path, guard, .. }
             | Request::WriteRange { path, guard, .. }
             | Request::Finalize { path, guard, .. }
-            | Request::FileHash { path, guard }
+            | Request::FileHash { path, guard, .. }
             | Request::Canonicalize { path, guard } => {
                 if guard.is_none() {
                     map(path)?;
@@ -1098,6 +1327,7 @@ impl FsOps {
             | Request::TcpListen { .. }
             | Request::NativeRemove { .. }
             | Request::CheckOperatorDirectory { .. }
+            | Request::RegisterSourceRoots { .. }
             | Request::CreateOperatorDirectory { .. }
             | Request::AnchorDestination { .. }
             | Request::TransportStats
@@ -3386,6 +3616,7 @@ impl FsOps {
                 paths,
                 follow,
                 guard,
+                ..
             } => Ok(Response::Stats(self.stat_many(
                 paths,
                 *follow,
@@ -3399,6 +3630,13 @@ impl FsOps {
                 .check_operator_directory(path, *allow_missing, *symlink_policy)
                 .with_context(|| format!("resolve operator directory {}", resolve(path).display()))
                 .map(Response::DirectorySelection),
+            Request::RegisterSourceRoots {
+                selections,
+                symlink_policy,
+                shared_workers,
+            } => self
+                .register_source_roots(selections, *symlink_policy, *shared_workers)
+                .map(Response::SourceRootsRegistered),
             Request::CreateOperatorDirectory {
                 mode,
                 require_absent,
@@ -3535,6 +3773,7 @@ impl FsOps {
                 block,
                 len,
                 guard,
+                ..
             } => self
                 .hash_blocks(path, *which, partial_id, *block, *len, guard.as_ref())
                 .map(Response::Hashes),
@@ -3543,6 +3782,7 @@ impl FsOps {
                 attempt,
                 off,
                 len,
+                ..
             } => self.read_range(path, *attempt, *off, *len),
             Request::ReadSmallBatch(reads) => Ok(Response::SmallBlocks(
                 reads
@@ -3600,7 +3840,7 @@ impl FsOps {
                     },
                 )
                 .map(|_| Response::Ok),
-            Request::FileHash { path, guard } => self.file_hash(path, guard.as_ref()),
+            Request::FileHash { path, guard, .. } => self.file_hash(path, guard.as_ref()),
             Request::Canonicalize { path, guard } => {
                 if let Some(guard) = guard {
                     guarded_target(path, guard)
@@ -4657,5 +4897,159 @@ mod tests {
                 0xe4, 0x1f, 0x32, 0x62,
             ]
         );
+    }
+
+    #[test]
+    fn source_workers_adopt_registered_descriptor_after_path_replacement() {
+        let temporary = tempfile::tempdir().unwrap();
+        let selected = temporary.path().join("selected");
+        fs::create_dir(&selected).unwrap();
+        let identity = fs::metadata(&selected).unwrap();
+        let session = DescriptorSessionSlot::default();
+        let mut control = FsOps::with_descriptor_session(session.clone());
+        let response = control.handle(&Request::RegisterSourceRoots {
+            selections: vec![SourceRootSelection {
+                path: selected.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            shared_workers: 0,
+        });
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+        let id = roots[0].selection.root();
+
+        fs::rename(&selected, temporary.path().join("moved")).unwrap();
+        fs::create_dir(&selected).unwrap();
+
+        let mut shared = FsOps::with_descriptor_session(session);
+        shared.initialize_sources(&roots).unwrap();
+        let mut fresh = FsOps::new();
+        fresh.initialize_sources(&roots).unwrap();
+        for worker in [&shared, &fresh] {
+            let adopted = worker.source_root_identity(id).unwrap();
+            assert_eq!((adopted.dev, adopted.ino), (identity.dev(), identity.ino()));
+        }
+        assert_ne!(
+            (
+                fs::metadata(&selected).unwrap().dev(),
+                fs::metadata(&selected).unwrap().ino()
+            ),
+            (identity.dev(), identity.ino())
+        );
+    }
+
+    #[test]
+    fn source_initialization_rejects_mismatched_bad_and_excess_roots_atomically() {
+        let temporary = tempfile::tempdir().unwrap();
+        let first = temporary.path().join("first");
+        let second = temporary.path().join("second");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        let session = DescriptorSessionSlot::default();
+        let mut control = FsOps::with_descriptor_session(session.clone());
+        let response = control.handle(&Request::RegisterSourceRoots {
+            selections: vec![
+                SourceRootSelection {
+                    path: first.as_os_str().as_bytes().to_vec(),
+                    follow_root: false,
+                },
+                SourceRootSelection {
+                    path: second.as_os_str().as_bytes().to_vec(),
+                    follow_root: false,
+                },
+            ],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            shared_workers: 0,
+        });
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+
+        let mut mismatched = roots[0].clone();
+        mismatched.selection = roots[1].selection.clone();
+        let mut worker = FsOps::with_descriptor_session(session.clone());
+        assert!(worker.initialize_sources(&[mismatched]).is_err());
+        assert!(worker.source_roots.is_empty());
+
+        session.close();
+        assert!(worker.initialize_sources(&roots).is_err());
+        assert!(worker.source_roots.is_empty());
+
+        let excess = vec![roots[0].clone(); DEFAULT_MAX_ROOTS + 1];
+        let error = worker.initialize_sources(&excess).unwrap_err();
+        assert!(error.to_string().contains("root count"));
+        assert!(worker.source_roots.is_empty());
+    }
+
+    #[test]
+    fn source_request_reference_is_inert_until_operation_cutover() {
+        let temporary = tempfile::tempdir().unwrap();
+        let selected = temporary.path().join("selected");
+        fs::write(&selected, b"selected").unwrap();
+        fs::write(temporary.path().join("sibling"), b"sibling").unwrap();
+        let session = DescriptorSessionSlot::default();
+        let mut control = FsOps::with_descriptor_session(session.clone());
+        let response = control.handle(&Request::RegisterSourceRoots {
+            selections: vec![SourceRootSelection {
+                path: selected.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            shared_workers: 0,
+        });
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+        assert_eq!(roots[0].selection.relative, b"selected");
+
+        let mut worker = FsOps::with_descriptor_session(session);
+        worker.initialize_sources(&roots).unwrap();
+        let sibling = RegisteredPath::new(roots[0].selection.root(), b"sibling".to_vec()).unwrap();
+        let response = worker.handle(&Request::StatMany {
+            paths: vec![temporary
+                .path()
+                .join("sibling")
+                .as_os_str()
+                .as_bytes()
+                .to_vec()],
+            // This intentionally does not correspond to the legacy pathname.
+            // The field is syntax-only until the source-stat cutover; treating
+            // it as a partial allowlist would create a bypassable boundary.
+            sources: Some(vec![sibling]),
+            follow: false,
+            guard: None,
+        });
+        let Response::Stats(stats) = response else {
+            panic!("unexpected stat response: {response:?}")
+        };
+        assert_eq!(stats.len(), 1);
+        assert!(stats[0].is_some());
+    }
+
+    #[test]
+    fn source_descriptor_budget_accounts_for_registry_control_and_workers() {
+        assert_eq!(SOURCE_SHARED_WORKER_FD_RESERVE, 16 + 5 + 1);
+        assert_eq!(
+            source_descriptor_requirement(7, 4, 3).unwrap(),
+            7 + SOURCE_FD_RESERVE + 4 * 5 + SOURCE_SHARED_WORKER_FD_RESERVE * 3
+        );
+        assert!(source_descriptor_requirement(0, usize::MAX, usize::MAX).is_err());
+    }
+
+    #[test]
+    fn live_descriptor_snapshot_includes_this_process() {
+        let mut limits = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        assert_eq!(
+            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) },
+            0
+        );
+        if limits.rlim_cur != libc::RLIM_INFINITY {
+            assert!(current_open_descriptor_count(limits.rlim_cur).unwrap() >= 3);
+        }
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -5,8 +5,9 @@
 //! flag bit 0 means the payload is zstd-compressed. Each writer decides
 //! independently whether to compress, readers always accept both.
 
-use crate::descriptor_broker::DescriptorTicket;
-use serde::{Deserialize, Serialize};
+use crate::descriptor_broker::{DescriptorTicket, RegisteredRootId};
+use anyhow::{bail, Result};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 
 pub const MAX_FRAME: usize = 256 * 1024 * 1024;
@@ -30,6 +31,73 @@ pub fn hash_response_fits(block: u64, len: u64) -> bool {
 
 /// Path bytes, as given by the user (absolute, or relative to the server's cwd).
 pub type PathBytes = Vec<u8>;
+
+/// Transitional, syntactically strict descriptor-relative path vocabulary.
+///
+/// In the initialization-only protocol this is carried beside a legacy
+/// pathname but is deliberately inert: it neither authorizes nor confines the
+/// operation. The source-operation cutover will make the registered reference
+/// authoritative after the worker has acquired its corresponding ticket.
+#[derive(Serialize, Clone, Debug, Eq, PartialEq)]
+pub struct RegisteredPath {
+    pub(crate) root: RegisteredRootId,
+    pub relative: PathBytes,
+}
+
+impl RegisteredPath {
+    pub(crate) fn new(root: RegisteredRootId, relative: PathBytes) -> Result<Self> {
+        validate_relative_path(&relative)?;
+        Ok(Self { root, relative })
+    }
+
+    pub(crate) fn root(&self) -> RegisteredRootId {
+        self.root
+    }
+
+    pub(crate) fn join(&self, relative: &[u8]) -> Result<Self> {
+        validate_relative_path(relative)?;
+        let mut joined = self.relative.clone();
+        if !joined.is_empty() && !relative.is_empty() {
+            joined.push(b'/');
+        }
+        joined.extend_from_slice(relative);
+        Self::new(self.root, joined)
+    }
+}
+
+impl<'de> Deserialize<'de> for RegisteredPath {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WirePath {
+            root: RegisteredRootId,
+            relative: PathBytes,
+        }
+        let wire = WirePath::deserialize(deserializer)?;
+        RegisteredPath::new(wire.root, wire.relative).map_err(serde::de::Error::custom)
+    }
+}
+
+fn validate_relative_path(path: &[u8]) -> Result<()> {
+    if path.starts_with(b"/") {
+        bail!("registered path must be relative");
+    }
+    if path.contains(&0) {
+        bail!("registered path contains NUL");
+    }
+    if path.is_empty() {
+        return Ok(());
+    }
+    if path
+        .split(|byte| *byte == b'/')
+        .any(|component| component.is_empty() || component == b"." || component == b"..")
+    {
+        bail!("registered path contains an unsafe component");
+    }
+    Ok(())
+}
 /// Full BLAKE3 digest used whenever content equality affects copy behavior.
 pub type ContentDigest = [u8; 32];
 
@@ -149,6 +217,9 @@ pub struct ContainerGuard {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SmallRead {
     pub path: PathBytes,
+    /// Inert registered spelling for `path`; execution remains pathname-based
+    /// until the descriptor source-read cutover.
+    pub source: Option<RegisteredPath>,
     pub attempt: u32,
     pub len: u32,
 }
@@ -274,13 +345,43 @@ pub struct DestinationRoot {
     pub request_prefix: PathBytes,
 }
 
+/// One operator source selection registered by the endpoint control session.
+/// `selection` is either empty beneath a selected directory or a literal leaf
+/// beneath its selected parent.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct RegisteredSourceRoot {
+    pub ticket: DescriptorTicket,
+    pub selection: RegisteredPath,
+}
+
+impl RegisteredSourceRoot {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.ticket.root_id() != self.selection.root() {
+            bail!("source root ticket and registered path identify different roots");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SourceRootSelection {
+    pub path: PathBytes,
+    pub follow_root: bool,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum ConnectionRole {
     /// The one connection allowed to create endpoint-session capabilities and
     /// start its TCP data listener.
     Control,
-    /// A data connection used only to read a source endpoint.
-    SourceWorker,
+    /// A data connection reserved for reading a source endpoint. Request-time
+    /// source-role enforcement lands with the source-operation cutover.
+    SourceWorker {
+        /// Every registered source root is acquired before HelloOk. Local and
+        /// same-process TCP workers clone in process; a fresh SSH helper
+        /// finishes SCM_RIGHTS receipt while single-threaded.
+        roots: Vec<RegisteredSourceRoot>,
+    },
     /// A data connection used to mutate a destination endpoint. Unrestricted
     /// receivers require an exact registered root; restricted receivers derive
     /// their confinement from the signed grant and reject a supplied ticket.
@@ -311,6 +412,9 @@ pub enum Request {
     /// `report_ignored`: also send the paths the patterns pruned (ScanIgnored).
     Scan {
         root: PathBytes,
+        /// Inert registered spelling of `root`; the source scanner cutover
+        /// makes it authoritative.
+        source: Option<RegisteredPath>,
         follow_root: bool,
         ignore: Vec<String>,
         report_ignored: bool,
@@ -330,6 +434,9 @@ pub enum Request {
     /// lstat each path; with `follow`, stat through symlinks instead.
     StatMany {
         paths: Vec<PathBytes>,
+        /// Inert registered spellings for source-side calls; these are not an
+        /// allowlist until the source stat cutover.
+        sources: Option<Vec<RegisteredPath>>,
         follow: bool,
         guard: Option<ContainerGuard>,
     },
@@ -339,6 +446,16 @@ pub enum Request {
         path: PathBytes,
         allow_missing: bool,
         symlink_policy: OperatorSymlinkPolicy,
+    },
+    /// Resolve every operator source selection, then atomically register its
+    /// opened directory or parent descriptor. Only a control connection may
+    /// create these endpoint-session capabilities.
+    RegisterSourceRoots {
+        selections: Vec<SourceRootSelection>,
+        symlink_policy: OperatorSymlinkPolicy,
+        /// Maximum source workers that can share the control helper process.
+        /// Zero still budgets the registry and control connection themselves.
+        shared_workers: usize,
     },
     /// Create the missing suffix retained by CheckOperatorDirectory, then
     /// return the selected directory's stable identity.
@@ -436,6 +553,9 @@ pub enum Request {
     },
     HashBlocks {
         path: PathBytes,
+        /// Inert registered spelling; the descriptor hash cutover makes it
+        /// authoritative.
+        source: Option<RegisteredPath>,
         which: Which,
         partial_id: PartialId,
         block: u64,
@@ -444,6 +564,9 @@ pub enum Request {
     },
     ReadRange {
         path: PathBytes,
+        /// Inert registered spelling; the descriptor read cutover makes it
+        /// authoritative.
+        source: Option<RegisteredPath>,
         attempt: u32,
         off: u64,
         len: u32,
@@ -474,6 +597,9 @@ pub enum Request {
     PutSmallBatch(Vec<SmallPut>),
     FileHash {
         path: PathBytes,
+        /// Inert registered spelling; the descriptor hash cutover makes it
+        /// authoritative.
+        source: Option<RegisteredPath>,
         guard: Option<ContainerGuard>,
     },
     /// Absolute, normalized form of a path on this endpoint (symlinks in the
@@ -523,6 +649,7 @@ pub enum Response {
     /// directory, or None when an allowed missing suffix was reached.
     DirectorySelection(Option<DirectoryAnchor>),
     DestinationRegistered(DescriptorTicket),
+    SourceRootsRegistered(Vec<RegisteredSourceRoot>),
     PathResults(Vec<std::result::Result<PathBytes, String>>),
     BatchPlan {
         partial_paths: Vec<std::result::Result<PathBytes, String>>,
@@ -797,5 +924,35 @@ mod tests {
             incompressible[4], 0,
             "an expanded compressed representation was selected"
         );
+    }
+
+    #[test]
+    fn registered_paths_reject_unsafe_wire_components() {
+        let temporary = tempfile::tempdir().unwrap();
+        let session = crate::descriptor_broker::DescriptorSessionSlot::default();
+        let ticket = session
+            .register(std::fs::File::open(temporary.path()).unwrap())
+            .unwrap();
+        let root = ticket.root_id();
+        assert_eq!(
+            RegisteredPath::new(root, b"safe/non-utf8-\xff".to_vec())
+                .unwrap()
+                .relative,
+            b"safe/non-utf8-\xff"
+        );
+        for relative in [
+            b"/absolute".as_slice(),
+            b"a//b",
+            b".",
+            b"a/../b",
+            b"nul\0byte",
+        ] {
+            let invalid = RegisteredPath {
+                root,
+                relative: relative.to_vec(),
+            };
+            let encoded = postcard::to_allocvec(&invalid).unwrap();
+            assert!(postcard::from_bytes::<RegisteredPath>(&encoded).is_err());
+        }
     }
 }

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -1683,6 +1683,7 @@ impl RestrictedAuthority {
                 paths,
                 follow,
                 guard,
+                ..
             } => {
                 if *follow {
                     bail!("signed destination stat cannot follow symlinks");
@@ -1724,7 +1725,7 @@ impl RestrictedAuthority {
                 self.check_observation_path(path)?;
                 *guard = Some(self.guard.clone());
             }
-            Request::FileHash { path, guard } => {
+            Request::FileHash { path, guard, .. } => {
                 self.check_observation_path(path)?;
                 outcomes.push(PendingOutcome::Observe { path: path.clone() });
                 *guard = Some(self.guard.clone());
@@ -1915,6 +1916,7 @@ impl RestrictedAuthority {
                 bail!("request is not valid on a command-restricted destination")
             }
             Request::CheckOperatorDirectory { .. }
+            | Request::RegisterSourceRoots { .. }
             | Request::CreateOperatorDirectory { .. }
             | Request::AnchorDestination { .. } => {
                 bail!("destination-anchor management is not valid on a root-confined receiver")
@@ -3818,6 +3820,7 @@ mod tests {
 
         let mut stat = Request::StatMany {
             paths: vec![target.clone()],
+            sources: None,
             follow: false,
             guard: Some(ContainerGuard {
                 root: outside.clone(),
@@ -3852,6 +3855,7 @@ mod tests {
 
         let mut outside_stat = Request::StatMany {
             paths: vec![outside.clone()],
+            sources: None,
             follow: false,
             guard: None,
         };
@@ -3924,6 +3928,7 @@ mod tests {
 
         let mut exact = Request::StatMany {
             paths: vec![destination],
+            sources: None,
             follow: false,
             guard: None,
         };
@@ -3967,6 +3972,7 @@ mod tests {
 
         let scan = |ignore: Vec<String>| Request::Scan {
             root: target.clone(),
+            source: None,
             follow_root: false,
             ignore,
             report_ignored: true,
@@ -4758,6 +4764,7 @@ mod tests {
         // An observation the orchestrator asked for is hostB's own view.
         let mut hash = Request::FileHash {
             path: path_bytes(&kept),
+            source: None,
             guard: None,
         };
         let settlement = authority.authorize(&mut hash, false).unwrap();
@@ -4864,6 +4871,7 @@ mod tests {
         fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o600)).unwrap();
         let mut observe = Request::StatMany {
             paths: vec![path_bytes(&kept)],
+            sources: None,
             follow: false,
             guard: None,
         };
@@ -5599,6 +5607,7 @@ mod tests {
         let target = root.join("target").as_os_str().as_bytes().to_vec();
         let request = |block, len| Request::HashBlocks {
             path: target.clone(),
+            source: None,
             which: proto::Which::Final,
             partial_id: [0; 16],
             block,
@@ -5783,6 +5792,7 @@ mod tests {
 
         let mut observation = Request::StatMany {
             paths: vec![target],
+            sources: None,
             follow: false,
             guard: None,
         };
@@ -5823,6 +5833,7 @@ mod tests {
 
         let mut observe_container = Request::StatMany {
             paths: vec![target],
+            sources: None,
             follow: false,
             guard: None,
         };
@@ -5843,6 +5854,7 @@ mod tests {
                 .as_os_str()
                 .as_bytes()
                 .to_vec()],
+            sources: None,
             follow: false,
             guard: None,
         };
@@ -5884,6 +5896,7 @@ mod tests {
         let target = root.join("target").as_os_str().as_bytes().to_vec();
         let mut unfiltered_scan = Request::Scan {
             root: target,
+            source: None,
             follow_root: false,
             ignore: Vec::new(),
             report_ignored: true,
@@ -5988,6 +6001,7 @@ mod tests {
         let target = root.join("target").as_os_str().as_bytes().to_vec();
         let mut scan = Request::Scan {
             root: target.clone(),
+            source: None,
             follow_root: false,
             ignore: Vec::new(),
             report_ignored: false,
@@ -6224,6 +6238,7 @@ mod tests {
 
         let mut scan = Request::Scan {
             root: target.as_os_str().as_bytes().to_vec(),
+            source: None,
             follow_root: false,
             ignore: Vec::new(),
             report_ignored: false,
@@ -6259,6 +6274,7 @@ mod tests {
 
         let response = crate::fsops::FsOps::new().handle(&Request::HashBlocks {
             path: target.join("escape").as_os_str().as_bytes().to_vec(),
+            source: None,
             which: proto::Which::Final,
             partial_id: [0; 16],
             block: 4096,
@@ -6267,5 +6283,25 @@ mod tests {
         });
         assert!(matches!(response, proto::Response::Err(_)));
         assert_eq!(fs::metadata(outside.join("secret")).unwrap().len(), 6);
+    }
+
+    #[test]
+    fn restricted_authority_rejects_caller_source_registration() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let authority = test_authority(&root, DeletionPolicy::Forbid, 1024);
+        let mut request = Request::RegisterSourceRoots {
+            selections: vec![proto::SourceRootSelection {
+                path: root.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: proto::OperatorSymlinkPolicy::Refuse,
+            shared_workers: 0,
+        };
+        let error = authority.authorize(&mut request, true).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("not valid on a root-confined receiver"));
     }
 }

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -1,6 +1,6 @@
 //! Work queue with largest-first file scheduling and range work-stealing.
 
-use crate::proto::{ContainerGuard, Entry, PathBytes};
+use crate::proto::{ContainerGuard, Entry, PathBytes, RegisteredPath};
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::sync::atomic::AtomicU64;
@@ -9,6 +9,9 @@ use std::sync::{Arc, Condvar, Mutex};
 #[derive(Clone, Debug)]
 pub struct FileJob {
     pub src: PathBytes,
+    /// Descriptor-session authority corresponding to `src`. Source workers
+    /// claim its root during Hello; reads switch to it in the next slice.
+    pub source: RegisteredPath,
     pub dst: PathBytes,
     pub rel: String,
     pub entry: Entry,

--- a/src/server.rs
+++ b/src/server.rs
@@ -175,6 +175,20 @@ fn serve<R: Read + Send + 'static, W: Write>(
     let is_control = matches!(&role, ConnectionRole::Control);
     let mut ops = FsOps::with_descriptor_session(descriptor_session.clone());
     match &role {
+        ConnectionRole::SourceWorker { .. } if authority.is_some() => {
+            w.write_msg(&Response::Err(
+                "a command-restricted receiver does not accept caller-supplied source roots".into(),
+            ))?;
+            bail!("command-restricted receiver rejected supplied source roots");
+        }
+        ConnectionRole::SourceWorker { roots } => {
+            if let Err(error) = ops.initialize_sources(roots) {
+                w.write_msg(&Response::Err(format!(
+                    "initialize source worker: {error:#}"
+                )))?;
+                return Err(error).context("initialize source worker");
+            }
+        }
         ConnectionRole::DestinationWorker {
             destination: Some(_),
         } if authority.is_some() => {
@@ -199,9 +213,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 return Err(error).context("initialize destination worker");
             }
         }
-        ConnectionRole::Control
-        | ConnectionRole::SourceWorker
-        | ConnectionRole::DestinationWorker { destination: None } => {}
+        ConnectionRole::Control | ConnectionRole::DestinationWorker { destination: None } => {}
     }
     w.write_msg(&Response::HelloOk {
         identity: crate::identity::build().to_string(),
@@ -230,6 +242,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 Request::TcpListen { .. }
                     | Request::NativeRemove { .. }
                     | Request::CheckOperatorDirectory { .. }
+                    | Request::RegisterSourceRoots { .. }
                     | Request::CreateOperatorDirectory { .. }
                     | Request::AnchorDestination { .. }
                     | Request::Receipt
@@ -342,6 +355,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
             }
             Request::Scan {
                 root,
+                source: _,
                 follow_root,
                 ignore,
                 report_ignored,
@@ -788,6 +802,16 @@ mod tests {
     fn tcp_server_joins_request_reader_on_shutdown() {
         let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let address = listener.local_addr().unwrap();
+        let selected = tempfile::tempdir().unwrap();
+        let descriptor_session = DescriptorSessionSlot::default();
+        let ticket = descriptor_session
+            .register(std::fs::File::open(selected.path()).unwrap())
+            .unwrap();
+        let source = RegisteredSourceRoot {
+            selection: RegisteredPath::new(ticket.root_id(), Vec::new()).unwrap(),
+            ticket,
+        };
+        let server_session = descriptor_session.clone();
         let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let observed = dropped.clone();
         let server = std::thread::spawn(move || {
@@ -804,7 +828,7 @@ mod tests {
                 Some(socket),
                 ServeSession {
                     authority: None,
-                    descriptor_session: DescriptorSessionSlot::default(),
+                    descriptor_session: server_session,
                 },
             )
             .unwrap();
@@ -819,12 +843,28 @@ mod tests {
                 compress: false,
                 debug: false,
                 token: Vec::new(),
-                role: ConnectionRole::SourceWorker,
+                role: ConnectionRole::SourceWorker {
+                    roots: vec![source],
+                },
             })
             .unwrap();
         assert!(matches!(
             reader.read_msg::<Response>().unwrap(),
             Response::HelloOk { .. }
+        ));
+        writer
+            .write_msg(&Request::RegisterSourceRoots {
+                selections: vec![SourceRootSelection {
+                    path: b".".to_vec(),
+                    follow_root: false,
+                }],
+                symlink_policy: OperatorSymlinkPolicy::Refuse,
+                shared_workers: 0,
+            })
+            .unwrap();
+        assert!(matches!(
+            reader.read_msg::<Response>().unwrap(),
+            Response::Err(error) if error.contains("only on the control connection")
         ));
         writer.write_msg(&Request::Shutdown).unwrap();
         server.join().unwrap();
@@ -880,6 +920,59 @@ mod tests {
         assert!(matches!(
             reader.read_msg::<Response>().unwrap(),
             Response::Err(error) if error.contains("initialize destination worker")
+        ));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn rejected_source_ticket_is_not_acknowledged_as_ready() {
+        let selected = tempfile::tempdir().unwrap();
+        let owner = DescriptorSessionSlot::default();
+        let ticket = owner
+            .register(std::fs::File::open(selected.path()).unwrap())
+            .unwrap();
+        let source = RegisteredSourceRoot {
+            selection: RegisteredPath::new(ticket.root_id(), Vec::new()).unwrap(),
+            ticket,
+        };
+        owner.close();
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            serve(
+                socket.try_clone().unwrap(),
+                socket,
+                false,
+                None,
+                None,
+                None,
+                ServeSession {
+                    authority: None,
+                    descriptor_session: DescriptorSessionSlot::default(),
+                },
+            )
+            .unwrap_err()
+        });
+
+        let socket = TcpStream::connect(address).unwrap();
+        let mut writer = FrameWriter::new(socket.try_clone().unwrap(), false);
+        let mut reader = FrameReader::new(socket);
+        writer
+            .write_msg(&Request::Hello {
+                identity: crate::identity::build().to_string(),
+                compress: false,
+                debug: false,
+                token: Vec::new(),
+                role: ConnectionRole::SourceWorker {
+                    roots: vec![source],
+                },
+            })
+            .unwrap();
+        assert!(matches!(
+            reader.read_msg::<Response>().unwrap(),
+            Response::Err(error) if error.contains("initialize source worker")
         ));
         server.join().unwrap();
     }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -100,7 +100,7 @@ pub struct Opts {
 
 pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
     Ok(match &loc.host {
-        None => Endpoint::Local,
+        None => Endpoint::local(),
         Some(h) => {
             let rsh = parse_rsh(&args.rsh)?;
             if loc.port.is_some() && args.rsh.is_some() && !rsh[0].ends_with("ssh") {
@@ -158,7 +158,7 @@ fn operator_symlink_policy(args: &Args) -> OperatorSymlinkPolicy {
 /// limiter: the scan, and therefore every worker, waits on it.
 pub fn connect_ctl(ep: &Endpoint, args: &Args) -> Result<Box<dyn Conn>> {
     match ep {
-        Endpoint::Local => ep.connect(args.compress),
+        Endpoint::Local { .. } => ep.connect_control(args.compress),
         Endpoint::Remote(spec) => spec
             .connect_with(args.compress, false)
             .map(|c| Box::new(c) as Box<dyn Conn>),
@@ -692,6 +692,7 @@ struct DestinationAnchor {
     ino: u64,
 }
 type DestinationAnchorSlot = std::sync::Arc<std::sync::OnceLock<DestinationAnchor>>;
+type SourceRootsSlot = std::sync::Arc<std::sync::OnceLock<Vec<RegisteredSourceRoot>>>;
 
 pub fn debug() -> bool {
     std::env::var_os("SYQ_DEBUG").is_some()
@@ -953,7 +954,7 @@ pub fn run(args: Args) -> Result<i32> {
             interface_option(&args, "--tcp-congestion", "--syq-tcp-congestion")
         );
     }
-    if matches!(dst_ep, Endpoint::Local) {
+    if matches!(dst_ep, Endpoint::Local { .. }) {
         dst_ep = Endpoint::Remote(RemoteSpec::local_receiver(args.quiet));
     }
     // TCP data connections are the default (auto-selecting the fastest reachable
@@ -1054,6 +1055,7 @@ pub fn run(args: Args) -> Result<i32> {
     // may spawn more workers later, so the handles live behind a mutex.
     let gate = Gate::new(args.connections);
     let destination_anchor: DestinationAnchorSlot = std::sync::Arc::new(std::sync::OnceLock::new());
+    let source_roots: SourceRootsSlot = std::sync::Arc::new(std::sync::OnceLock::new());
     let destination_anchor_required = args.restricted_grant.is_none();
     let workers: Arc<Mutex<Vec<std::thread::JoinHandle<Result<()>>>>> =
         Arc::new(Mutex::new(Vec::new()));
@@ -1069,6 +1071,7 @@ pub fn run(args: Args) -> Result<i32> {
             gate,
             workers,
             destination_anchor,
+            source_roots,
             bwlimit,
             transport_stats,
             connect_after_file_plan,
@@ -1081,6 +1084,7 @@ pub fn run(args: Args) -> Result<i32> {
             gate.clone(),
             workers.clone(),
             destination_anchor.clone(),
+            source_roots.clone(),
             bwlimit.clone(),
             transport_stats.clone(),
             connect_after_file_plan.clone(),
@@ -1096,6 +1100,7 @@ pub fn run(args: Args) -> Result<i32> {
                 opts,
                 gate,
                 destination_anchor,
+                source_roots,
                 bwlimit,
                 transport_stats,
                 connect_after_file_plan,
@@ -1107,6 +1112,7 @@ pub fn run(args: Args) -> Result<i32> {
                 opts.clone(),
                 gate.clone(),
                 destination_anchor.clone(),
+                source_roots.clone(),
                 bwlimit.clone(),
                 transport_stats.clone(),
                 connect_after_file_plan.clone(),
@@ -1128,6 +1134,10 @@ pub fn run(args: Args) -> Result<i32> {
                 } else {
                     None
                 };
+                let initial_sources = source_roots
+                    .get()
+                    .context("source roots were not registered before workers started")?
+                    .clone();
                 let mut failures = 0u32;
                 loop {
                     if !gate.retained(id) {
@@ -1135,13 +1145,17 @@ pub fn run(args: Args) -> Result<i32> {
                         return Ok(());
                     }
                     let t0 = std::time::Instant::now();
-                    let conns = src_ep.connect(compress).and_then(|src| {
-                        Ok((
-                            src,
-                            dst_ep
-                                .connect_with_destination(compress, initial_destination.clone())?,
-                        ))
-                    });
+                    let conns = src_ep
+                        .connect_with_sources(compress, initial_sources.clone())
+                        .and_then(|src| {
+                            Ok((
+                                src,
+                                dst_ep.connect_with_destination(
+                                    compress,
+                                    initial_destination.clone(),
+                                )?,
+                            ))
+                        });
                     let (src, dst) = match conns {
                         Ok(conns) => conns,
                         Err(error)
@@ -1298,6 +1312,21 @@ pub fn run(args: Args) -> Result<i32> {
             t0.elapsed().as_secs_f64()
         );
     }
+    let maximum_workers = if autotune {
+        tune::MAX
+    } else {
+        args.connections
+    };
+    let source_shared_workers = match &src_ep {
+        Endpoint::Local { .. } => maximum_workers,
+        Endpoint::Remote(_) if use_tcp => maximum_workers,
+        Endpoint::Remote(_) => 0,
+    };
+    let registered_sources =
+        register_source_roots(&mut *src_ctl, srcs, &args, source_shared_workers)?;
+    source_roots
+        .set(registered_sources)
+        .expect("source roots set once");
     // One spelling for the destination root: every derived key — claims,
     // delete roots, destination-walk paths, receiver-computed sidecar names —
     // flows from this, and the receiver rebuilds paths through `Path`, which
@@ -1730,7 +1759,7 @@ pub fn run(args: Args) -> Result<i32> {
         && [&src_ep, &dst_ep]
             .into_iter()
             .all(|endpoint| match endpoint {
-                Endpoint::Local => true,
+                Endpoint::Local { .. } => true,
                 Endpoint::Remote(spec) => spec
                     .tcp
                     .lock()
@@ -1833,12 +1862,18 @@ pub fn run(args: Args) -> Result<i32> {
             }
             changes
         },
+        active_source: None,
     };
 
     let mut scan_err = None;
     let mut dry_run_mappings = Vec::with_capacity(srcs.len());
     if let Some(mapping) = args.native_mapping.as_deref() {
         let src = &srcs[0];
+        st.active_source = Some(
+            source_roots.get().expect("source roots registered")[0]
+                .selection
+                .clone(),
+        );
         let open = || -> Result<Box<dyn std::io::BufRead>> {
             if mapping == b"-" {
                 return Ok(Box::new(std::io::stdin().lock()));
@@ -1860,6 +1895,11 @@ pub fn run(args: Args) -> Result<i32> {
         }
     } else if args.files_from.is_some() {
         let src = &srcs[0];
+        st.active_source = Some(
+            source_roots.get().expect("source roots registered")[0]
+                .selection
+                .clone(),
+        );
         match st.scan_files_from(
             &mut *src_ctl,
             &src.path,
@@ -1874,10 +1914,16 @@ pub fn run(args: Args) -> Result<i32> {
             Err(e) => scan_err = Some(e),
         }
     }
-    for src in srcs
+    for (source_index, src) in srcs
         .iter()
         .filter(|_| args.files_from.is_none() && args.native_mapping.is_none())
+        .enumerate()
     {
+        st.active_source = Some(
+            source_roots.get().expect("source roots registered")[source_index]
+                .selection
+                .clone(),
+        );
         let src_root = src.path.clone();
         let contents = src.copies_contents();
         let follow_root = src.follows_root(args.native_follow);
@@ -2276,12 +2322,27 @@ fn stat_many(
     paths: Vec<PathBytes>,
     follow: bool,
 ) -> Result<Vec<Option<Entry>>> {
+    stat_many_registered(conn, paths, None, follow)
+}
+
+fn stat_many_registered(
+    conn: &mut dyn Conn,
+    paths: Vec<PathBytes>,
+    sources: Option<Vec<RegisteredPath>>,
+    follow: bool,
+) -> Result<Vec<Option<Entry>>> {
     if paths.is_empty() {
         return Ok(Vec::new());
+    }
+    if let Some(sources) = &sources {
+        if sources.len() != paths.len() {
+            bail!("source stat capability count does not match path count");
+        }
     }
     match ok(
         conn.call(Request::StatMany {
             paths,
+            sources,
             follow,
             guard: None,
         })?,
@@ -2455,6 +2516,40 @@ fn check_operator_directory(
     }
 }
 
+fn register_source_roots(
+    conn: &mut dyn Conn,
+    sources: &[Location],
+    args: &Args,
+    shared_workers: usize,
+) -> Result<Vec<RegisteredSourceRoot>> {
+    let selections = sources
+        .iter()
+        .map(|source| SourceRootSelection {
+            path: source.path.clone(),
+            // --files-from has always required its source operand to resolve
+            // to a directory. Descendant-link policy remains unchanged and is
+            // deliberately not encoded by this selected-root flag.
+            follow_root: args.files_from.is_some() || source.follows_root(args.native_follow),
+        })
+        .collect();
+    match ok(
+        conn.call(Request::RegisterSourceRoots {
+            selections,
+            symlink_policy: operator_symlink_policy(args),
+            shared_workers,
+        })?,
+        "register source roots",
+    )? {
+        Response::SourceRootsRegistered(roots) if roots.len() == sources.len() => Ok(roots),
+        Response::SourceRootsRegistered(roots) => bail!(
+            "source endpoint registered {} roots for {} selections",
+            roots.len(),
+            sources.len()
+        ),
+        other => bail!("unexpected response {other:?}"),
+    }
+}
+
 fn create_operator_directory(
     conn: &mut dyn Conn,
     condition: TargetCondition,
@@ -2534,6 +2629,7 @@ fn stat_and_canonicalize(
     }
     conn.send(Request::StatMany {
         paths: vec![stat_path.to_vec()],
+        sources: None,
         follow: false,
         guard: None,
     })?;
@@ -2563,6 +2659,7 @@ fn scan_into_planner(
     pl: &mut Planner<'_>,
     src: &mut dyn Conn,
     root: &[u8],
+    source: &RegisteredPath,
     follow_root: bool,
     ignore: &[String],
     mut f: impl FnMut(&mut Planner<'_>, Vec<Entry>) -> Result<()>,
@@ -2573,6 +2670,7 @@ fn scan_into_planner(
     let warned = std::cell::Cell::new(false);
     let res = src.scan(
         root,
+        Some(source),
         follow_root,
         ignore,
         report_ignored,
@@ -2771,7 +2869,7 @@ fn remote_data_transport(spec: &RemoteSpec) -> &'static str {
 fn real_remote_spec(endpoint: &Endpoint) -> Option<&RemoteSpec> {
     match endpoint {
         Endpoint::Remote(spec) if !spec.local_process => Some(spec),
-        Endpoint::Local | Endpoint::Remote(_) => None,
+        Endpoint::Local { .. } | Endpoint::Remote(_) => None,
     }
 }
 
@@ -3064,6 +3162,9 @@ struct Planner<'a> {
     delete_roots: Vec<(PathBytes, PathBytes)>,
     deletes: Deletes,
     dry_run_changes: DryRunChanges,
+    /// Descriptor-session capability for the source currently feeding
+    /// planner batches. Buffered jobs retain their own derived path.
+    active_source: Option<RegisteredPath>,
 }
 
 /// What a source entry asserts about its destination path. Two dirs merge;
@@ -3090,6 +3191,7 @@ enum Claim {
 /// mapping loop so the directory pass and the per-kind arms can't disagree.
 struct Planned {
     src: PathBytes,
+    source: RegisteredPath,
     dst: PathBytes,
     dst_rel: PathBytes,
     rel: String,
@@ -3190,68 +3292,80 @@ impl Planner<'_> {
         let mut skip_all = false;
         let mut mapping = None;
         let ignore = self.opts.ignore.clone();
-        scan_into_planner(self, src, src_root, follow_root, &ignore, |pl, batch| {
-            if skip_all {
-                return Ok(());
-            }
-            if first {
-                first = false;
-                if let Some(root) = batch.first() {
-                    validate_native_source_type(src_root, selection, root.kind)?;
-                    if destination.exact && destination.entry_is_dir && root.kind != Kind::Dir {
-                        bail!(
+        let source = self
+            .active_source
+            .clone()
+            .context("registered source reference was not initialized")?;
+        scan_into_planner(
+            self,
+            src,
+            src_root,
+            &source,
+            follow_root,
+            &ignore,
+            |pl, batch| {
+                if skip_all {
+                    return Ok(());
+                }
+                if first {
+                    first = false;
+                    if let Some(root) = batch.first() {
+                        validate_native_source_type(src_root, selection, root.kind)?;
+                        if destination.exact && destination.entry_is_dir && root.kind != Kind::Dir {
+                            bail!(
                             "destination {} is an existing directory; cannot replace it with non-directory source {}",
                             display(dst_root),
                             display(src_root)
                         );
-                    }
-                    if pl.opts.dry_run
-                        && root.kind == Kind::Dir
-                        && !contents
-                        && pl.opts.recursive
-                        && dst_existed
-                        && !destination.entry_is_dir
-                        && !destination.exact
-                        && !pl.opts.existing
-                    {
-                        bail!(
+                        }
+                        if pl.opts.dry_run
+                            && root.kind == Kind::Dir
+                            && !contents
+                            && pl.opts.recursive
+                            && dst_existed
+                            && !destination.entry_is_dir
+                            && !destination.exact
+                            && !pl.opts.existing
+                        {
+                            bail!(
                             "destination {} is not a directory; cannot place directory {} inside it",
                             display(dst_root),
                             display(src_root)
                         );
-                    }
-                    if root.kind != Kind::Dir && !dst_is_dir {
-                        sub.clear();
-                    }
-                    mapping = Some(DryRunMapping {
-                        target: join(dst_root, &sub),
-                        semantics: if destination.exact {
-                            "exact destination path"
-                        } else {
-                            match (root.kind, contents, dst_is_dir) {
-                                (Kind::Dir, true, _) => "directory contents",
-                                (Kind::Dir, false, _) => "directory as child",
-                                (_, _, true) => "entry inside destination directory",
-                                _ => "exact destination path",
-                            }
-                        },
-                    });
-                    if root.kind == Kind::Dir && !pl.opts.recursive {
-                        if !pl.opts.quiet {
-                            pl.progress
-                                .eprintln(&format!("skipping directory {}", display(src_root)));
                         }
-                        skip_all = true;
-                        return Ok(());
-                    }
-                    if root.kind == Kind::Dir {
-                        pl.delete_roots.push((join(dst_root, &sub), sub.clone()));
+                        if root.kind != Kind::Dir && !dst_is_dir {
+                            sub.clear();
+                        }
+                        mapping = Some(DryRunMapping {
+                            target: join(dst_root, &sub),
+                            semantics: if destination.exact {
+                                "exact destination path"
+                            } else {
+                                match (root.kind, contents, dst_is_dir) {
+                                    (Kind::Dir, true, _) => "directory contents",
+                                    (Kind::Dir, false, _) => "directory as child",
+                                    (_, _, true) => "entry inside destination directory",
+                                    _ => "exact destination path",
+                                }
+                            },
+                        });
+                        if root.kind == Kind::Dir && !pl.opts.recursive {
+                            if !pl.opts.quiet {
+                                pl.progress
+                                    .eprintln(&format!("skipping directory {}", display(src_root)));
+                            }
+                            skip_all = true;
+                            return Ok(());
+                        }
+                        if root.kind == Kind::Dir {
+                            pl.delete_roots.push((join(dst_root, &sub), sub.clone()));
+                        }
                     }
                 }
-            }
-            pl.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
-            pl.handle_batch(batch, src_root, &sub, dst_root)
-        })?;
+                pl.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
+                pl.handle_batch(batch, src_root, &sub, dst_root)
+            },
+        )?;
         mapping.ok_or_else(|| anyhow::anyhow!("source scan returned no root entry"))
     }
 
@@ -3271,11 +3385,23 @@ impl Planner<'_> {
         recurse: bool,
     ) -> Result<()> {
         use std::collections::{HashMap, HashSet};
+        let source_base = self
+            .active_source
+            .clone()
+            .context("registered source reference was not initialized")?;
         // Through a symlink: `syq --files-from L link dst` should work like `link/`.
         // Validate the root but never plan it: it isn't in the list, so an
         // existing destination is not stamped with source-root metadata
         // (creation-when-missing happened in run()).
-        match stat_one(src, src_root, true)? {
+        match stat_many_registered(
+            src,
+            vec![src_root.to_vec()],
+            Some(vec![source_base.clone()]),
+            true,
+        )?
+        .pop()
+        .flatten()
+        {
             Some(e) if e.kind == Kind::Dir => {}
             Some(_) => bail!(
                 "--files-from: source {} is not a directory",
@@ -3304,10 +3430,15 @@ impl Planner<'_> {
                 .map(|(i, _)| line[..i].to_vec())
                 .collect()
         };
-        let stat = |src: &mut dyn Conn, paths: Vec<PathBytes>, follow: bool| {
-            stat_many(
+        let stat = |src: &mut dyn Conn, paths: Vec<PathBytes>, follow: bool| -> Result<_> {
+            let registered = paths
+                .iter()
+                .map(|relative| source_base.join(relative))
+                .collect::<Result<Vec<_>>>()?;
+            stat_many_registered(
                 src,
                 paths.iter().map(|r| join(src_root, r)).collect(),
+                Some(registered),
                 follow,
             )
         };
@@ -3448,7 +3579,19 @@ impl Planner<'_> {
     ) -> Result<()> {
         use std::collections::{HashMap, HashSet};
         self.mapping_mode = true;
-        match stat_one(src, src_root, true)? {
+        let source_base = self
+            .active_source
+            .clone()
+            .context("registered source reference was not initialized")?;
+        match stat_many_registered(
+            src,
+            vec![src_root.to_vec()],
+            Some(vec![source_base.clone()]),
+            true,
+        )?
+        .pop()
+        .flatten()
+        {
             Some(e) if e.kind == Kind::Dir => {}
             Some(_) => bail!(
                 "--mapping: source base {} is not a directory",
@@ -3482,9 +3625,14 @@ impl Planner<'_> {
         while remaining.peek().is_some() {
             let chunk: Vec<(u64, ManifestEntry)> =
                 remaining.by_ref().take(crate::scan::BATCH).collect();
-            let stats = stat_many(
+            let source_paths = chunk
+                .iter()
+                .map(|(_, manifest)| source_base.join(&manifest.src))
+                .collect::<Result<Vec<_>>>()?;
+            let stats = stat_many_registered(
                 src,
                 chunk.iter().map(|(_, m)| join(src_root, &m.src)).collect(),
+                Some(source_paths),
                 false,
             )?;
             let mut batch: Vec<Entry> = Vec::new();
@@ -3581,26 +3729,39 @@ impl Planner<'_> {
         dst_root: &[u8],
         emitted: &mut std::collections::HashMap<PathBytes, Kind>,
     ) -> Result<()> {
-        scan_into_planner(self, src, &join(src_root, rel), false, &[], |pl, batch| {
-            let batch: Vec<Entry> = batch
-                .into_iter()
-                .filter(|e| !e.path.is_empty())
-                .map(|mut e| {
-                    e.path = join(rel, &e.path);
-                    e
-                })
-                .filter(|e| {
-                    if emitted.contains_key(&e.path) {
-                        false
-                    } else {
-                        emitted.insert(e.path.clone(), e.kind);
-                        true
-                    }
-                })
-                .collect();
-            pl.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
-            pl.handle_batch(batch, src_root, b"", dst_root)
-        })
+        let source = self
+            .active_source
+            .as_ref()
+            .context("registered source reference was not initialized")?
+            .join(rel)?;
+        scan_into_planner(
+            self,
+            src,
+            &join(src_root, rel),
+            &source,
+            false,
+            &[],
+            |pl, batch| {
+                let batch: Vec<Entry> = batch
+                    .into_iter()
+                    .filter(|e| !e.path.is_empty())
+                    .map(|mut e| {
+                        e.path = join(rel, &e.path);
+                        e
+                    })
+                    .filter(|e| {
+                        if emitted.contains_key(&e.path) {
+                            false
+                        } else {
+                            emitted.insert(e.path.clone(), e.kind);
+                            true
+                        }
+                    })
+                    .collect();
+                pl.progress.scanned.fetch_add(batch.len() as u64, Relaxed);
+                pl.handle_batch(batch, src_root, b"", dst_root)
+            },
+        )
     }
 
     fn handle_batch(
@@ -3720,6 +3881,17 @@ impl Planner<'_> {
                 Some(actual) => join(src_root, actual),
                 None => join(src_root, &e.path),
             };
+            let source_relative = self
+                .src_overrides
+                .get(&e.path)
+                .map(Vec::as_slice)
+                .unwrap_or(&e.path);
+            let source = self
+                .active_source
+                .as_ref()
+                .expect("planner source reference initialized")
+                .join(source_relative)
+                .expect("scanner and manifest paths are strict relative paths");
             match claim {
                 Claim::Dir => dirs.push((dst, dst_rel, e)),
                 Claim::Weak if e.kind == Kind::Other => {
@@ -3736,6 +3908,7 @@ impl Planner<'_> {
                 }
                 Claim::File { .. } | Claim::Leaf => others.push(Planned {
                     src,
+                    source,
                     dst,
                     dst_rel,
                     rel,
@@ -4142,6 +4315,7 @@ impl Planner<'_> {
         for (p, dst_entry) in others.into_iter().zip(stats) {
             let Planned {
                 src: src_path,
+                source,
                 dst: dst_path,
                 dst_rel,
                 rel,
@@ -4249,7 +4423,7 @@ impl Planner<'_> {
                     if opts.verify_only {
                         if dst_entry.as_ref().is_some_and(|d| d.kind == Kind::File) {
                             self.enqueue(
-                                src_path.clone(),
+                                (src_path.clone(), source.clone()),
                                 dst_path.clone(),
                                 rel.clone(),
                                 dst_rel.clone(),
@@ -4337,7 +4511,7 @@ impl Planner<'_> {
                         }
                     } else {
                         self.enqueue(
-                            src_path,
+                            (src_path, source),
                             dst_path,
                             rel,
                             dst_rel.clone(),
@@ -4814,19 +4988,21 @@ impl Planner<'_> {
 
     fn enqueue(
         &mut self,
-        src: PathBytes,
+        source_path: (PathBytes, RegisteredPath),
         dst: PathBytes,
         rel: String,
         rel_bytes: PathBytes,
         entry: Entry,
         dst_entry: Option<Entry>,
     ) {
+        let (src, source) = source_path;
         let target_condition = self.exact_condition_for(&dst);
         let src_rel = self.mapping_source_rel(&rel_bytes);
         self.progress.files_total.fetch_add(1, Relaxed);
         self.progress.bytes_total.fetch_add(entry.size, Relaxed);
         self.sched.push_file(FileJob {
             src,
+            source,
             dst,
             rel,
             rel_bytes,
@@ -4895,6 +5071,7 @@ impl Planner<'_> {
                 std::collections::HashSet::new();
             let res = self.dst.scan(
                 &root,
+                None,
                 false,
                 &ignore,
                 true,
@@ -5437,6 +5614,7 @@ impl Worker {
             .filter(|job| job.entry.size > 0)
             .map(|job| SmallRead {
                 path: job.src.clone(),
+                source: Some(job.source.clone()),
                 attempt: job.attempts,
                 len: job.entry.size as u32,
             })
@@ -5540,7 +5718,8 @@ impl Worker {
         // Did any source change while we were at it?
         let paths: Vec<PathBytes> = jobs.iter().map(|j| j.src.clone()).collect();
         let phase = std::time::Instant::now();
-        let now = stat_many(&mut *self.src, paths, false)?;
+        let registered = jobs.iter().map(|job| job.source.clone()).collect();
+        let now = stat_many_registered(&mut *self.src, paths, Some(registered), false)?;
         self.fast.restat += phase.elapsed().as_secs_f64();
         let phase = std::time::Instant::now();
         for ((idx, j), (res, now)) in batch
@@ -5987,6 +6166,7 @@ impl Worker {
             job,
             Request::HashBlocks {
                 path: job.dst.clone(),
+                source: None,
                 which,
                 partial_id: self.partial_id(),
                 block: self.opts.block,
@@ -6030,6 +6210,7 @@ impl Worker {
         let size = job.entry.size;
         self.src.send(Request::HashBlocks {
             path: job.src.clone(),
+            source: Some(job.source.clone()),
             which: Which::Final,
             partial_id: self.partial_id(),
             block,
@@ -6130,6 +6311,7 @@ impl Worker {
                 self.limit(n);
                 self.src.send(Request::ReadRange {
                     path: job.src.clone(),
+                    source: Some(job.source.clone()),
                     attempt: job.attempts,
                     off,
                     len: n as u32,
@@ -6254,10 +6436,12 @@ impl Worker {
     fn contents_match(&mut self, job: &FileJob) -> Result<bool> {
         self.src.send(Request::FileHash {
             path: job.src.clone(),
+            source: Some(job.source.clone()),
             guard: None,
         })?;
         self.dst.send(Request::FileHash {
             path: job.dst.clone(),
+            source: None,
             guard: None,
         })?;
         let source = self.src.recv();
@@ -6368,10 +6552,12 @@ impl Worker {
         let r = (|| -> Result<bool> {
             self.src.send(Request::FileHash {
                 path: job.src.clone(),
+                source: Some(job.source.clone()),
                 guard: None,
             })?;
             self.dst.send(Request::FileHash {
                 path: job.dst.clone(),
+                source: None,
                 guard: None,
             })?;
             // Keep both reusable connections aligned even if one endpoint

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -116,7 +116,7 @@ struct TuningCache {
 
 fn endpoint_key(endpoint: &Endpoint) -> String {
     match endpoint {
-        Endpoint::Local => "local".into(),
+        Endpoint::Local { .. } => "local".into(),
         Endpoint::Remote(spec) if spec.local_process => "local".into(),
         Endpoint::Remote(spec) => spec.label(),
     }
@@ -124,7 +124,7 @@ fn endpoint_key(endpoint: &Endpoint) -> String {
 
 fn transport_key(endpoint: &Endpoint) -> Option<&'static str> {
     match endpoint {
-        Endpoint::Local => None,
+        Endpoint::Local { .. } => None,
         Endpoint::Remote(spec) if spec.local_process => None,
         Endpoint::Remote(spec) => Some(match spec.data_transport() {
             DataTransport::Ssh => "ssh",
@@ -1288,7 +1288,7 @@ mod tests {
 
     #[test]
     fn cache_key_separates_direction_and_transport() {
-        let local = Endpoint::Local;
+        let local = Endpoint::local();
         let ssh = remote("host", false);
         let tcp = remote("host", true);
         assert_ne!(path_key(&local, &ssh), path_key(&ssh, &local));
@@ -1298,7 +1298,7 @@ mod tests {
 
     #[test]
     fn tcp_fallback_changes_the_cache_key() {
-        let local = Endpoint::Local;
+        let local = Endpoint::local();
         let remote = remote("host", true);
         let initial = path_key(&local, &remote);
         let Endpoint::Remote(spec) = &remote else {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -8,6 +8,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -75,6 +76,73 @@ fn native_syq(args: &[&str]) -> Output {
         .arg("-q")
         .run()
         .expect("run native syq command")
+}
+
+#[test]
+fn source_fd_preflight_rejects_shared_worker_boundary_before_destination_creation() {
+    let t = Tmp::new();
+    write(&t.path("source"), &vec![b'x'; 8 * 1024 * 1024]);
+    let mut command = compat_command();
+    command.args([
+        "-a",
+        "--syq-connections",
+        "64",
+        "--no-progress",
+        &t.s("source"),
+        &t.s("destination"),
+    ]);
+    // Local and remote-TCP sources feed the same shared-worker count into FD
+    // admission. At 64 workers the complete model requires current_open +
+    // 1506 slots. Use a portable low limit here to verify that admission fails
+    // before destination creation; the exact per-worker arithmetic, including
+    // the uncached hash descriptor, is asserted in the FsOps unit test. The
+    // child must retain the lowered hard limit because syq normally raises a
+    // low soft limit to the inherited hard limit during startup. Never try to
+    // raise an inherited hard limit: supported environments commonly cap it
+    // at 1024. getrlimit/setrlimit are async-signal-safe on supported Unix.
+    unsafe {
+        command.pre_exec(|| {
+            let mut inherited = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::getrlimit(libc::RLIMIT_NOFILE, &mut inherited) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            let low_limit = inherited.rlim_max.min(128);
+            let limit = libc::rlimit {
+                rlim_cur: low_limit,
+                rlim_max: low_limit,
+            };
+            if libc::setrlimit(libc::RLIMIT_NOFILE, &limit) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let output = command.run().unwrap();
+    assert!(!output.status.success(), "unexpected success: {output:?}");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("source setup needs about"), "{stderr}");
+    let required: usize = stderr
+        .split("source setup needs about ")
+        .nth(1)
+        .and_then(|tail| tail.split(" open-file slots").next())
+        .unwrap()
+        .parse()
+        .unwrap();
+    let current_open: usize = stderr
+        .split(" open-file slots (")
+        .nth(1)
+        .and_then(|tail| tail.split(" currently open)").next())
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(required, current_open + 1506, "{stderr}");
+    assert!(
+        !t.path("destination").exists(),
+        "source FD admission failed after destination creation"
+    );
 }
 
 fn run_native_ok(args: &[&str]) -> String {


### PR DESCRIPTION
## Summary

- resolve and register source selections before any destination mutation
- hand opaque source capability IDs and descriptors to local, TCP, and fresh SSH workers
- share local descriptor-session state safely across clones, including Darwin's pre-thread descriptor requirement
- reject insufficient file-descriptor capacity during preflight with a conservative per-worker model
- carry source capability references through requests as explicitly inert transition vocabulary until the source operation cutover

## Security boundary

This PR pins and hands off source capabilities, but it intentionally does not yet make request references an authorization allowlist. Source scan/stat/read operations still use their existing paths until the stacked cutover. The protocol and README state that boundary explicitly.

## Verification

At exact commit 756a052:

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets (289 unit, 285 integration, 7 updater)
- focused descriptor broker, local slot, worker handshake, request validation, and near-boundary RLIMIT preflight coverage

Independent review found and this tip fixes a one-FD-per-worker undercount for uncached source hashing.