### PR TITLE
Pin local control files before transfer mutation

### DIFF
--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -239,7 +239,13 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
 - The command-line path naming a manifest, the `-C` source base, and the
   `--into` placement are directly supplied paths: native mode refuses to
   traverse symlinks in them by default, while `--follow` resolves them. Paths
-  inside the manifest are data and are not changed by `--follow`.
+  inside the manifest are data and are not changed by `--follow`. A named
+  manifest is read from the identity retained by that resolution, and all its
+  bytes are acquired before destination mutation; replacing its pathname or a
+  followed link afterward cannot redirect the read. `--mapping -` is the
+  portable stream form. A directly named FIFO preserves blocking-open behavior
+  through an exact retained-descriptor reopen on Linux with procfs; systems
+  without that primitive refuse it before destination mutation.
 - When `syq map --follow` resolves a named selector, it emits the referent's
   source-base-relative path so the manifest remains executable without link
   traversal. It refuses a referent outside that base; pass the real path with a
@@ -290,7 +296,12 @@ coordinator connection. A named results file is accepted only when the
 coordinator is local, including `--run-at local`; this avoids interpreting a
 local-looking pathname on a remote host. `--results` cannot be combined with
 `--detach`, because the caller would no longer be attached for the complete
-stream and its terminal record.
+stream and its terminal record. A named file is created relative to its
+retained parent, or identity-checked before an existing regular file is
+truncated. With `--follow`, the retained output is the resolved referent, so a
+later replacement of the link cannot redirect results. Named results refuse
+existing FIFOs, devices, and other non-regular objects; use `--results -` with
+shell redirection for those sinks.
 
 Failed operation records carry `src`, `dst`, and `kind`, so a retry
 manifest is one filter away:

--- a/README.md
+++ b/README.md
@@ -240,10 +240,37 @@ This is the native selection policy, not yet a complete hostile-namespace
 containment guarantee for copy. Native `rm` retains the resolved directories
 and selected identities through mutation, and copy retains its selected
 destination directory, but ordinary copy source walks and descendant
-operations have not all moved to descriptor-relative access. The default
-therefore rejects links present during preflight; the planned containment work
-must additionally prevent a concurrent rename or link substitution from
-changing an identity after that check.
+operations have not all moved to descriptor-relative access. Local control
+inputs are already identity-safe: `--ignore-from`, `--syq-ignore-from`,
+`--files-from`, and a named `--mapping` are read from the file selected by the
+component walk, so replacing their pathname afterward cannot redirect the
+read. Their filenames retain raw Unix path bytes even though ignore-pattern
+contents must be UTF-8. Mapping bytes are acquired before destination mutation.
+On Linux, a selected FIFO input is reopened from its retained `O_PATH`
+descriptor through a verified procfs `/proc/self/fd`; it therefore waits for a
+writer like an ordinary blocking open and still reads the originally selected
+FIFO after a rename. A final Linux procfs descriptor link is opened relative to
+its retained procfs parent, so shell process substitution remains usable
+without a general pathname fallback. A Linux system without procfs, and macOS,
+refuse named FIFO control inputs before destination mutation because they lack
+a safe exact blocking reopen. Use `--files-from -` or `--mapping -` for those
+stdin-capable inputs, or materialize ignore rules in a regular file. A named
+`--results` file is likewise created through its retained parent, or an
+existing selected regular file is identity-checked before truncation. With
+`--follow`, that retained selection is the resolved referent. Replacing the
+link afterward does not redirect the output. Named `--results` deliberately
+refuses an existing FIFO, device, or other non-regular object; use
+`--results -` and redirect stdout when a stream or device sink is intended.
+The remaining planned containment work must provide the same property for
+ordinary source walks and all descendant operations.
+
+Rsync-compatible control paths retain rsync's implicit policy of following a
+symlink owned by root or the endpoint's effective user. Ownership and target
+bytes are taken from the same opened symlink object on Linux and macOS 13 or
+newer. On platforms without a descriptor-bound link-read API (including older
+macOS releases), this implicit trusted-owner traversal fails closed instead of
+re-reading the link by name. Native `--follow` remains the explicit
+ownership-independent convenience policy.
 
 Placement is always explicit in this initial native surface:
 
@@ -441,6 +468,12 @@ the masters still leave after their five-minute idle limit; the inert scope
 can be inspected or removed later with the printed path. Scope paths beginning
 with a literal `~` or containing `${...}` are refused because OpenSSH expands
 those forms before opening a control socket.
+
+`--pscope` is intentionally not an ordinary control-file selection. It names a
+private directory created and permission-checked by the persistence subsystem;
+OpenSSH derives socket names beneath that directory. Its confinement therefore
+comes from that private-directory model, not from the retained single-file
+descriptors used for filters, mappings, file lists, and results.
 
 During either persistence window, anything able to act as the same local user
 can open sessions through the socket without touching the key or agent. This

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
+use crate::proto::OperatorSymlinkPolicy;
 use anyhow::{bail, Result};
 use clap::{CommandFactory, FromArgMatches, Parser, ValueEnum};
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::PathBuf;
 
@@ -94,8 +95,8 @@ pub struct Args {
     /// `syq map` never contacts a destination.
     #[arg(skip)]
     pub native_map_target: Option<Vec<u8>>,
-    /// NDJSON mapping manifest consumed by native cp instead of selectors
-    /// (`-` reads stdin, streamed).
+    /// NDJSON mapping manifest consumed by native cp instead of selectors;
+    /// `-` reads stdin and the complete input is acquired before mutation.
     #[arg(skip)]
     pub native_mapping: Option<Vec<u8>>,
     /// `--results` NDJSON outcome stream for native cp (`-` writes stdout).
@@ -291,9 +292,9 @@ pub struct Args {
         allow_hyphen_values = true
     )]
     pub ignore: Vec<String>,
-    /// SYQ extension: read ignore patterns from FILE (one per line, # comments); repeatable
+    /// SYQ extension: securely open and read ignore patterns from raw-byte FILE (one per line, # comments); repeatable
     #[arg(long = "syq-ignore-from", value_name = "FILE")]
-    pub ignore_from: Vec<String>,
+    pub ignore_from: Vec<OsString>,
     /// All ignore patterns, in command-line order (filled by parse_args)
     #[arg(skip)]
     pub ignore_lines: Vec<String>,
@@ -352,11 +353,12 @@ pub struct Args {
     /// Don't transfer regular files smaller than SIZE
     #[arg(long, value_name = "SIZE")]
     pub min_size: Option<String>,
-    /// Copy only the paths listed in FILE (one per line, relative to the single source
-    /// directory; `-` reads stdin). Listed directories are copied without their contents
-    /// unless -r is given explicitly; missing parent directories are created
+    /// Copy only the paths listed in raw-byte FILE, securely opened before transfer (one per line,
+    /// relative to the single source directory; `-` reads stdin). Listed directories are
+    /// copied without their contents unless -r is given explicitly; missing parent
+    /// directories are created
     #[arg(long, value_name = "FILE", conflicts_with_all = ["ignore", "ignore_from"])]
-    pub files_from: Option<String>,
+    pub files_from: Option<OsString>,
     /// --files-from entries are NUL-separated instead of one per line
     #[arg(long, requires = "files_from")]
     pub from0: bool,
@@ -417,27 +419,19 @@ impl Args {
     }
 
     fn parse_rsync(argv: &[OsString], allow_lifecycle: bool) -> Result<Args> {
-        let utf8_argv: Vec<String> = argv
-            .iter()
-            .map(|arg| {
-                arg.clone()
-                    .into_string()
-                    .map_err(|_| anyhow::anyhow!("rsync-compatible arguments must be valid UTF-8"))
-            })
-            .collect::<Result<_>>()?;
         if !allow_lifecycle
-            && utf8_argv.iter().any(|argument| {
-                matches!(
-                    argument.as_str(),
-                    "--self-update" | "--register-standalone-install"
-                )
-            })
+            && argv
+                .iter()
+                .filter_map(|argument| argument.to_str())
+                .any(|argument| {
+                    matches!(argument, "--self-update" | "--register-standalone-install")
+                })
         {
             bail!("installation lifecycle options are top-level syq options, not rsync options");
         }
-        reject_unsupported_rsync_flags(&utf8_argv)?;
-        let mut full_argv = vec!["syq rsync".to_string()];
-        full_argv.extend(utf8_argv);
+        reject_unsupported_rsync_flags(argv)?;
+        let mut full_argv = vec![OsString::from("syq rsync")];
+        full_argv.extend(argv.iter().cloned());
         let matches = Args::command()
             .try_get_matches_from(full_argv)
             .unwrap_or_else(|error| error.exit());
@@ -498,11 +492,12 @@ fn finish_parse(mut args: Args, matches: &clap::ArgMatches) -> Result<Args> {
         &args.ignore,
         &args.ignore_from,
         matches,
-        true,
+        OperatorSymlinkPolicy::TrustedOwner,
         "--syq-ignore-from",
     )?;
     if let Some(f) = &args.files_from {
-        args.files_from_lines = read_files_from(f, args.from0)?;
+        args.files_from_lines =
+            read_files_from(f, args.from0, OperatorSymlinkPolicy::TrustedOwner)?;
     }
     Ok(args)
 }
@@ -528,44 +523,51 @@ fn reject_remote_to_remote(args: &Args) -> Result<()> {
 
 fn ordered_ignore_lines(
     ignore: &[String],
-    ignore_from: &[String],
+    ignore_from: &[OsString],
     matches: &clap::ArgMatches,
-    follow_paths: bool,
+    symlink_policy: OperatorSymlinkPolicy,
     ignore_from_name: &str,
 ) -> Result<Vec<String>> {
-    let mut items: Vec<(usize, bool, String)> = Vec::new();
+    enum Item {
+        Pattern(String),
+        File(OsString),
+    }
+    let mut items: Vec<(usize, Item)> = Vec::new();
     if let Some(indices) = matches.indices_of("ignore") {
         items.extend(
             indices
                 .zip(ignore)
-                .map(|(index, value)| (index, false, value.clone())),
+                .map(|(index, value)| (index, Item::Pattern(value.clone()))),
         );
     }
     if let Some(indices) = matches.indices_of("ignore_from") {
         items.extend(
             indices
                 .zip(ignore_from)
-                .map(|(index, value)| (index, true, value.clone())),
+                .map(|(index, value)| (index, Item::File(value.clone()))),
         );
     }
-    items.sort_by_key(|(index, _, _)| *index);
+    items.sort_by_key(|(index, _)| *index);
 
     let mut lines = Vec::new();
-    for (_, from_file, value) in items {
-        if from_file {
-            if !follow_paths {
-                crate::fsops::check_operator_path_no_symlinks(value.as_bytes(), false, false)
-                    .map_err(|error| anyhow::anyhow!("{ignore_from_name} {value}: {error}"))?;
+    for (_, item) in items {
+        match item {
+            Item::Pattern(value) => lines.push(value),
+            Item::File(value) => {
+                use std::io::Read;
+                let shown = std::path::Path::new(&value).display();
+                let mut file =
+                    crate::fsops::open_operator_file_read(value.as_bytes(), symlink_policy)
+                        .map_err(|error| anyhow::anyhow!("{ignore_from_name} {shown}: {error}"))?;
+                let mut text = String::new();
+                file.read_to_string(&mut text)
+                    .map_err(|error| anyhow::anyhow!("{ignore_from_name} {shown}: {error}"))?;
+                let text = text.strip_prefix('\u{feff}').unwrap_or(&text);
+                lines.extend(
+                    text.lines()
+                        .map(|line| line.trim_end_matches('\r').to_string()),
+                );
             }
-            let text = std::fs::read_to_string(&value)
-                .map_err(|error| anyhow::anyhow!("{ignore_from_name} {value}: {error}"))?;
-            let text = text.strip_prefix('\u{feff}').unwrap_or(&text);
-            lines.extend(
-                text.lines()
-                    .map(|line| line.trim_end_matches('\r').to_string()),
-            );
-        } else {
-            lines.push(value);
         }
     }
     Ok(lines)
@@ -710,9 +712,9 @@ struct NativeCopyOperationalArgs {
     /// Skip paths matching a gitignore-style pattern (repeatable)
     #[arg(long = "ignore", value_name = "PATTERN", allow_hyphen_values = true)]
     ignore: Vec<String>,
-    /// Read gitignore-style patterns from FILE (repeatable; stacks in command-line order)
+    /// Securely open and read gitignore-style patterns from raw-byte FILE (repeatable; stacks in command-line order)
     #[arg(long, value_name = "FILE")]
-    ignore_from: Vec<String>,
+    ignore_from: Vec<OsString>,
     /// Preserve additional metadata (permissions, ownership, or specials; repeatable/comma-separated)
     #[arg(long, value_name = "ATTRIBUTE", value_delimiter = ',')]
     preserve: Vec<NativePreserve>,
@@ -852,14 +854,14 @@ struct NativeCopyFields {
         allow_hyphen_values = true
     )]
     as_existing: Option<OsString>,
-    /// Copy the entries of an NDJSON mapping manifest (`-` reads stdin)
-    /// instead of selecting sources; entry src paths are relative to -C and
-    /// dst paths are relative to the --into container
+    /// Copy the entries of an NDJSON mapping manifest (`-` reads stdin), acquired before
+    /// destination changes, instead of selecting sources; entry src paths are relative to
+    /// -C and dst paths are relative to the --into container
     #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
     mapping: Option<OsString>,
-    /// Write machine-readable NDJSON operation results to FILE (`-` writes
-    /// to stdout; combine with -q). A named file requires a local coordinator.
-    /// Automation schema version 0, an unstable preview
+    /// Securely create or replace regular FILE with machine-readable NDJSON operation
+    /// results (`-` writes to stdout; combine with -q). A named file requires a local
+    /// coordinator. Automation schema version 0, an unstable preview
     #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
     results: Option<OsString>,
     #[command(flatten)]
@@ -1388,7 +1390,11 @@ fn apply_native_copy_operational(
         &ignore,
         &ignore_from,
         matches,
-        args.native_follow,
+        if args.native_follow {
+            OperatorSymlinkPolicy::FollowAll
+        } else {
+            OperatorSymlinkPolicy::Refuse
+        },
         "--ignore-from",
     )?;
     args.ignore = ignore;
@@ -1589,13 +1595,21 @@ pub(crate) fn parse_native_endpoint(spec: Option<&str>) -> Result<Option<NativeE
 /// `;` are dropped; `.` and empty components (so leading `/`, `./`, trailing
 /// `/`, `a//b`) are removed; `..` components and entries naming the root itself
 /// are rejected.
-fn read_files_from(file: &str, nul: bool) -> Result<Vec<Vec<u8>>> {
+fn read_files_from(
+    file: &OsStr,
+    nul: bool,
+    symlink_policy: OperatorSymlinkPolicy,
+) -> Result<Vec<Vec<u8>>> {
     use std::io::Read;
     let mut raw = Vec::new();
-    if file == "-" {
+    if file.as_bytes() == b"-" {
         std::io::stdin().read_to_end(&mut raw)?;
     } else {
-        raw = std::fs::read(file).map_err(|e| anyhow::anyhow!("--files-from {file}: {e}"))?;
+        crate::fsops::open_operator_file_read(file.as_bytes(), symlink_policy)
+            .and_then(|mut input| input.read_to_end(&mut raw).map_err(Into::into))
+            .map_err(|e| {
+                anyhow::anyhow!("--files-from {}: {e}", std::path::Path::new(file).display())
+            })?;
     }
     let mut out = Vec::new();
     let items: Vec<&[u8]> = if nul {
@@ -1647,7 +1661,7 @@ fn read_files_from(file: &str, nul: bool) -> Result<Vec<Vec<u8>>> {
 /// rsync command tells you exactly what to change. Flags syq *does* accept
 /// (including the compatibility no-ops) are not listed here; genuinely unknown
 /// flags fall through to clap. No translation is performed.
-fn reject_unsupported_rsync_flags(argv: &[String]) -> Result<()> {
+fn reject_unsupported_rsync_flags(argv: &[OsString]) -> Result<()> {
     // Options that consume a following, separate token as their value — skip
     // that token so a value like `-e 'ssh ...'` is never mistaken for a flag.
     let value_long = [
@@ -1666,15 +1680,20 @@ fn reject_unsupported_rsync_flags(argv: &[String]) -> Result<()> {
         "--rsync-path",
     ];
     let mut skip_next = false;
-    for tok in argv {
+    for raw in argv {
         if skip_next {
             skip_next = false;
             continue;
         }
+        let Some(tok) = raw.to_str() else {
+            // Raw-byte values for local control-file options are accepted;
+            // clap still rejects a non-UTF-8 value for every String field.
+            continue;
+        };
         if tok == "--" {
             break; // end of options; the rest are paths
         }
-        if value_long.contains(&tok.as_str()) || matches!(tok.as_str(), "-e" | "-B") {
+        if value_long.contains(&tok) || matches!(tok, "-e" | "-B") {
             skip_next = true;
             continue;
         }

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -249,18 +249,19 @@ fn select_operator_directory(
             ))
         }
         PinnedPath::Leaf(_) => bail!("destination path is not a directory"),
+        PinnedPath::OpenFile(_) => {
+            unreachable!("directory selection never opens a procfs input")
+        }
     }
 }
 
-/// Check the current spelling of an operator-supplied local path without
-/// traversing a symlink. This is semantic preflight for orchestrator-local
-/// control files; retaining their opened identity belongs to the broader
-/// descriptor-root migration.
-pub(crate) fn check_operator_path_no_symlinks(
+fn resolve_operator_entry(
     path: &[u8],
-    allow_final_symlink: bool,
+    symlink_policy: OperatorSymlinkPolicy,
     allow_missing_final: bool,
-) -> Result<()> {
+    follow_final_symlink: bool,
+    readable_final: bool,
+) -> Result<(PathBuf, PinnedPath)> {
     let path = resolve(path);
     let path = if path.is_absolute() {
         path
@@ -272,15 +273,112 @@ pub(crate) fn check_operator_path_no_symlinks(
         bail!("operator path contains NUL");
     }
     let mut hops = Vec::new();
-    match OperatorResolver::resolve_process(
+    let selected = OperatorResolver::resolve_process(
         raw,
-        OperatorSymlinkPolicy::Refuse,
-        OperatorFinalComponent::Entry {
-            follow_symlink: false,
+        symlink_policy,
+        if readable_final {
+            OperatorFinalComponent::ReadableEntry {
+                follow_symlink: follow_final_symlink,
+            }
+        } else {
+            OperatorFinalComponent::Entry {
+                follow_symlink: follow_final_symlink,
+            }
         },
         allow_missing_final,
         &mut hops,
-    )? {
+    )?;
+    Ok((path, selected))
+}
+
+#[cfg(debug_assertions)]
+fn hold_operator_control_path_for_test(path: &Path) -> Result<()> {
+    let Some(expected) = std::env::var_os("SYQ_TEST_CONTROL_PATH") else {
+        return Ok(());
+    };
+    if expected.as_bytes() != path.as_os_str().as_bytes() {
+        return Ok(());
+    }
+    if let Some(ready) = std::env::var_os("SYQ_TEST_CONTROL_PATH_READY_FILE") {
+        fs::write(&ready, b"ready").with_context(|| {
+            format!(
+                "write control-path-ready signal {}",
+                Path::new(&ready).display()
+            )
+        })?;
+    }
+    if let Some(ms) = std::env::var_os("SYQ_TEST_HOLD_CONTROL_PATH_MS") {
+        let ms = ms
+            .to_string_lossy()
+            .parse::<u64>()
+            .context("parse SYQ_TEST_HOLD_CONTROL_PATH_MS")?;
+        std::thread::sleep(std::time::Duration::from_millis(ms));
+    }
+    Ok(())
+}
+
+#[cfg(not(debug_assertions))]
+fn hold_operator_control_path_for_test(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Open an existing operator-supplied input and retain the identity
+/// selected by the component walk. A namespace replacement after resolution
+/// is reported rather than followed.
+pub(crate) fn open_operator_file_read(
+    path: &[u8],
+    symlink_policy: OperatorSymlinkPolicy,
+) -> Result<File> {
+    if path.ends_with(b"/") {
+        bail!("operator file path has a trailing slash");
+    }
+    let (path, selected) = resolve_operator_entry(path, symlink_policy, false, true, true)?;
+    hold_operator_control_path_for_test(&path)?;
+    match selected {
+        PinnedPath::Leaf(leaf) => leaf.open_read(),
+        PinnedPath::OpenFile(file) => Ok(file),
+        PinnedPath::Directory(_) => bail!("operator path selects a directory, not a regular file"),
+        PinnedPath::Missing(_) => Err(io::Error::from_raw_os_error(libc::ENOENT).into()),
+    }
+}
+
+/// Select an operator-supplied ordinary output and open it through retained
+/// descriptors. Existing files are identity-checked before truncation; a
+/// missing last component is created exclusively beneath its pinned parent.
+pub(crate) fn open_operator_file_replace(
+    path: &[u8],
+    symlink_policy: OperatorSymlinkPolicy,
+) -> Result<File> {
+    if path.ends_with(b"/") {
+        bail!("operator file path has a trailing slash");
+    }
+    let (path, selected) = resolve_operator_entry(path, symlink_policy, true, true, false)?;
+    hold_operator_control_path_for_test(&path)?;
+    match selected {
+        PinnedPath::Leaf(leaf) => leaf.open_regular_write(true),
+        PinnedPath::Directory(_) => bail!("operator path selects a directory, not a regular file"),
+        PinnedPath::Missing(missing) => missing.create_regular(0o666),
+        PinnedPath::OpenFile(_) => unreachable!("output resolution never opens a procfs input"),
+    }
+}
+
+/// Check the current spelling of an operator-supplied local path without
+/// traversing a symlink. Source walkers that have not yet moved to retained
+/// descriptors use this only as semantic preflight.
+pub(crate) fn check_operator_path_no_symlinks(
+    path: &[u8],
+    allow_final_symlink: bool,
+    allow_missing_final: bool,
+) -> Result<()> {
+    match resolve_operator_entry(
+        path,
+        OperatorSymlinkPolicy::Refuse,
+        allow_missing_final,
+        false,
+        false,
+    )?
+    .1
+    {
         PinnedPath::Directory(_) => Ok(()),
         PinnedPath::Leaf(leaf) if !leaf.metadata().is_symlink() || allow_final_symlink => Ok(()),
         PinnedPath::Leaf(_) => bail!(
@@ -293,6 +391,9 @@ pub(crate) fn check_operator_path_no_symlinks(
             } else {
                 Err(io::Error::from_raw_os_error(libc::ENOENT).into())
             }
+        }
+        PinnedPath::OpenFile(_) => {
+            unreachable!("semantic preflight never opens a procfs input")
         }
     }
 }

--- a/src/native_rm.rs
+++ b/src/native_rm.rs
@@ -199,6 +199,9 @@ impl Resolver {
                     remove_root,
                 }))
             }
+            PinnedPath::OpenFile(_) => {
+                unreachable!("removal selection never opens a procfs input")
+            }
         }
     }
 }

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -87,7 +87,15 @@ pub(crate) struct RootMetadata {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum OperatorFinalComponent {
     Directory,
-    Entry { follow_symlink: bool },
+    Entry {
+        follow_symlink: bool,
+    },
+    /// An input file whose final procfs magic link may be opened relative to
+    /// its retained procfs parent instead of interpreting its synthetic target
+    /// bytes as an ordinary symlink path.
+    ReadableEntry {
+        follow_symlink: bool,
+    },
 }
 
 /// One symlink hop taken while resolving an operator path. Callers use this
@@ -116,6 +124,66 @@ impl PinnedLeaf {
 
     pub(crate) fn into_parts(self) -> (File, CString, RootMetadata, Option<File>) {
         (self.parent, self.name, self.metadata, self.object)
+    }
+
+    /// Open the selected identity for input without resolving its
+    /// pathname again. The metadata handle retained by the resolver prevents
+    /// inode reuse until the newly opened descriptor has been checked.
+    pub(crate) fn open_read(self) -> Result<File> {
+        if self.metadata.is_dir() || self.metadata.is_symlink() {
+            bail!("operator path does not select a readable file");
+        }
+        if self.metadata.is_fifo() {
+            #[cfg(target_os = "linux")]
+            if let Some(object) = &self.object {
+                if let Some(file) = reopen_pinned_object_for_read(object)? {
+                    let actual = root_metadata_from_std(&file.metadata()?)?;
+                    require_operator_identity(self.metadata, actual, "operator FIFO")?;
+                    return Ok(file);
+                }
+            }
+            bail!(
+                "selected FIFO control input cannot be reopened through an exact descriptor on this platform; use --files-from - or --mapping -, or materialize ignore rules in a regular file"
+            );
+        }
+        // A pathname replacement must not make the candidate open block before
+        // its identity is checked. The selected object is not a FIFO here, but
+        // its replacement may be one. Restore ordinary blocking I/O only after
+        // the opened object has been validated.
+        let flags =
+            libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NOCTTY | libc::O_CLOEXEC | libc::O_NONBLOCK;
+        let file = open_at(self.parent.as_raw_fd(), &self.name, flags, 0)
+            .context("open selected operator file")?;
+        let actual = root_metadata_from_std(&file.metadata()?)?;
+        require_operator_identity(self.metadata, actual, "operator file")?;
+        clear_nonblocking(&file).context("normalize selected operator file flags")?;
+        Ok(file)
+    }
+
+    /// Open the selected identity for ordinary output, validating it before
+    /// truncation so a namespace replacement cannot redirect the write.
+    pub(crate) fn open_regular_write(self, truncate: bool) -> Result<File> {
+        self.open_regular(libc::O_WRONLY, truncate)
+    }
+
+    fn open_regular(self, access: libc::c_int, truncate: bool) -> Result<File> {
+        if !self.metadata.is_file() {
+            bail!("operator path does not select a regular file");
+        }
+        let file = open_at(
+            self.parent.as_raw_fd(),
+            &self.name,
+            access | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_NOCTTY | libc::O_CLOEXEC,
+            0,
+        )
+        .context("open selected operator file")?;
+        let actual = root_metadata_from_std(&file.metadata()?)?;
+        require_operator_identity(self.metadata, actual, "operator file")?;
+        clear_nonblocking(&file).context("normalize selected operator file flags")?;
+        if truncate {
+            file.set_len(0).context("truncate selected operator file")?;
+        }
+        Ok(file)
     }
 }
 
@@ -149,12 +217,48 @@ impl PinnedMissing {
     pub(crate) fn into_parts(self) -> (File, VecDeque<Vec<u8>>) {
         (self.directory, self.components)
     }
+
+    /// Create a single missing regular-file leaf relative to the retained
+    /// parent. Missing parents are deliberately not created for control paths.
+    pub(crate) fn create_regular(self, mode: u32) -> Result<File> {
+        let mut components = self.components;
+        if components.len() != 1 {
+            return Err(io::Error::from_raw_os_error(libc::ENOENT).into());
+        }
+        let name = operator_component_cstring(
+            &components
+                .pop_front()
+                .expect("one missing operator component was checked"),
+        )?;
+        let file = open_at(
+            self.directory.as_raw_fd(),
+            &name,
+            libc::O_WRONLY
+                | libc::O_CREAT
+                | libc::O_EXCL
+                | libc::O_NOFOLLOW
+                | libc::O_NONBLOCK
+                | libc::O_NOCTTY
+                | libc::O_CLOEXEC,
+            mode & 0o777,
+        )
+        .context("create selected operator file")?;
+        let metadata = file.metadata()?;
+        if !metadata.is_file() {
+            bail!("created operator path is not a regular file");
+        }
+        clear_nonblocking(&file).context("normalize selected operator file flags")?;
+        Ok(file)
+    }
 }
 
 pub(crate) enum PinnedPath {
     Missing(PinnedMissing),
     Leaf(PinnedLeaf),
     Directory(PinnedDirectory),
+    /// A readable object opened directly through a retained procfs magic-link
+    /// parent. This is used only for final control-file inputs.
+    OpenFile(File),
 }
 
 struct OperatorCursor {
@@ -309,6 +413,8 @@ impl OperatorResolver {
                     final_component,
                     OperatorFinalComponent::Entry {
                         follow_symlink: true
+                    } | OperatorFinalComponent::ReadableEntry {
+                        follow_symlink: true
                     }
                 );
 
@@ -332,12 +438,64 @@ impl OperatorResolver {
                         object,
                     }));
                 }
-                self.authorize_symlink(metadata, &component)?;
+                // Refusal needs no second observation. Policies that follow
+                // the link pin it first so ownership and target bytes come
+                // from the same symlink object.
+                if self.symlink_policy == OperatorSymlinkPolicy::Refuse {
+                    self.authorize_symlink(metadata, &component)?;
+                    unreachable!("the refusing policy always returns an error for a symlink");
+                }
                 symlink_count += 1;
                 if symlink_count > 40 {
                     bail!("too many symlink levels in operator path");
                 }
-                let target = operator_read_link_at(current.directory.as_raw_fd(), &name)?;
+                let object = open_operator_symlink_at(current.directory.as_raw_fd(), &name)?;
+                let target = if let Some(object) = object {
+                    let opened_metadata = root_metadata_from_std(&object.metadata()?)?;
+                    require_operator_identity(metadata, opened_metadata, "operator symlink")?;
+                    self.authorize_symlink(opened_metadata, &component)?;
+                    hold_open_operator_symlink_for_test(&component)?;
+                    match operator_read_open_link(&object)? {
+                        Some(target) => {
+                            #[cfg(target_os = "linux")]
+                            if final_name
+                                && matches!(
+                                    final_component,
+                                    OperatorFinalComponent::ReadableEntry { .. }
+                                )
+                                && operator_descriptor_is_procfs(&object)?
+                            {
+                                let file = open_at(
+                                    current.directory.as_raw_fd(),
+                                    &name,
+                                    libc::O_RDONLY | libc::O_NOCTTY | libc::O_CLOEXEC,
+                                    0,
+                                )
+                                .context("open selected procfs magic-link input")?;
+                                let after = operator_read_open_link(&object)?
+                                    .context("procfs magic link lost descriptor-bound access")?;
+                                if after != target {
+                                    bail!("procfs magic-link target changed during selection");
+                                }
+                                let metadata = root_metadata_from_std(&file.metadata()?)?;
+                                if metadata.is_dir() || metadata.is_symlink() {
+                                    bail!("operator path does not select a readable file");
+                                }
+                                hops.push(OperatorSymlinkHop { component, target });
+                                return Ok(PinnedPath::OpenFile(file));
+                            }
+                            target
+                        }
+                        None => {
+                            require_operator_link_fallback_allowed(self.symlink_policy)?;
+                            operator_read_link_at(current.directory.as_raw_fd(), &name)?
+                        }
+                    }
+                } else {
+                    self.authorize_symlink(metadata, &component)?;
+                    require_operator_link_fallback_allowed(self.symlink_policy)?;
+                    operator_read_link_at(current.directory.as_raw_fd(), &name)?
+                };
                 hops.push(OperatorSymlinkHop {
                     component,
                     target: target.clone(),
@@ -442,6 +600,10 @@ impl RootMetadata {
 
     pub(crate) fn is_symlink(self) -> bool {
         self.mode & MODE_TYPE_MASK == MODE_SYMLINK
+    }
+
+    pub(crate) fn is_fifo(self) -> bool {
+        self.mode & MODE_TYPE_MASK == MODE_FIFO
     }
 
     pub(crate) fn file_type(self) -> u32 {
@@ -1159,13 +1321,92 @@ fn open_operator_symlink_at(parent: RawFd, name: &CString) -> Result<Option<File
     }
 }
 
+#[cfg(debug_assertions)]
+fn hold_open_operator_symlink_for_test(component: &[u8]) -> Result<()> {
+    let Some(expected) = std::env::var_os("SYQ_TEST_OPERATOR_SYMLINK_COMPONENT") else {
+        return Ok(());
+    };
+    if expected.as_encoded_bytes() != component {
+        return Ok(());
+    }
+    if let Some(ready) = std::env::var_os("SYQ_TEST_OPERATOR_SYMLINK_READY_FILE") {
+        std::fs::write(&ready, b"ready").with_context(|| {
+            format!(
+                "write operator-symlink-ready signal {}",
+                Path::new(&ready).display()
+            )
+        })?;
+    }
+    let Some(release) = std::env::var_os("SYQ_TEST_OPERATOR_SYMLINK_RELEASE_FILE") else {
+        return Ok(());
+    };
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !Path::new(&release).exists() {
+        if std::time::Instant::now() >= deadline {
+            bail!(
+                "timed out waiting for operator-symlink release signal {}",
+                Path::new(&release).display()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    Ok(())
+}
+
+#[cfg(not(debug_assertions))]
+fn hold_open_operator_symlink_for_test(_component: &[u8]) -> Result<()> {
+    Ok(())
+}
+
+/// Read target bytes through an already-open symlink when the platform has a
+/// descriptor-bound API. `None` means that only the insecure pathname API is
+/// available; callers enforcing trusted-owner traversal must fail closed.
+fn operator_read_open_link(object: &File) -> Result<Option<Vec<u8>>> {
+    #[cfg(target_os = "linux")]
+    {
+        let empty = c"";
+        operator_read_link_bytes(|target, capacity| unsafe {
+            libc::readlinkat(object.as_raw_fd(), empty.as_ptr(), target, capacity)
+        })
+        .map(Some)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // `freadlink` was added in macOS 13. Resolve it dynamically so a binary
+        // that can otherwise run on an older release does not gain a hard
+        // loader dependency. Trusted-owner traversal rejects `None` above.
+        type Freadlink =
+            unsafe extern "C" fn(libc::c_int, *mut libc::c_char, libc::size_t) -> libc::ssize_t;
+        let symbol = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"freadlink".as_ptr()) };
+        if symbol.is_null() {
+            return Ok(None);
+        }
+        let freadlink: Freadlink = unsafe { std::mem::transmute(symbol) };
+        operator_read_link_bytes(|target, capacity| unsafe {
+            freadlink(object.as_raw_fd(), target, capacity)
+        })
+        .map(Some)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = object;
+        Ok(None)
+    }
+}
+
 fn operator_read_link_at(parent: RawFd, name: &CString) -> Result<Vec<u8>> {
+    operator_read_link_bytes(|target, capacity| unsafe {
+        libc::readlinkat(parent, name.as_ptr(), target, capacity)
+    })
+}
+
+fn operator_read_link_bytes(
+    mut read: impl FnMut(*mut libc::c_char, usize) -> isize,
+) -> Result<Vec<u8>> {
     let mut capacity = 256usize;
     loop {
         let mut target = Vec::<u8>::with_capacity(capacity);
-        let length = unsafe {
-            libc::readlinkat(parent, name.as_ptr(), target.as_mut_ptr().cast(), capacity)
-        };
+        let length = read(target.as_mut_ptr().cast(), capacity);
         if length < 0 {
             let error = io::Error::last_os_error();
             if error.kind() == io::ErrorKind::Interrupted {
@@ -1200,6 +1441,60 @@ fn require_operator_identity(
 
 fn operator_symlink_owner_is_trusted(owner: u32, euid: u32) -> bool {
     owner == 0 || owner == euid
+}
+
+fn require_operator_link_fallback_allowed(policy: OperatorSymlinkPolicy) -> Result<()> {
+    if policy == OperatorSymlinkPolicy::TrustedOwner {
+        bail!(
+            "trusted-owner symlink traversal requires descriptor-bound link reads on this platform"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn operator_descriptor_is_procfs(file: &File) -> Result<bool> {
+    let mut stats = std::mem::MaybeUninit::<libc::statfs>::uninit();
+    loop {
+        if unsafe { libc::fstatfs(file.as_raw_fd(), stats.as_mut_ptr()) } == 0 {
+            let stats = unsafe { stats.assume_init() };
+            return Ok(stats.f_type as u32 == libc::PROC_SUPER_MAGIC as u32);
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error).context("identify operator descriptor filesystem");
+        }
+    }
+}
+
+/// Upgrade a retained Linux `O_PATH` object to a readable descriptor without
+/// consulting its former pathname. A verified procfs directory makes the
+/// decimal entry an exact reference to `object`, even after namespace rename.
+#[cfg(target_os = "linux")]
+fn reopen_pinned_object_for_read(object: &File) -> Result<Option<File>> {
+    let proc_path = CString::new("/proc/self/fd").expect("fixed procfs path contains no NUL");
+    let proc_fd = match open_at(
+        libc::AT_FDCWD,
+        &proc_path,
+        libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        0,
+    ) {
+        Ok(proc_fd) => proc_fd,
+        Err(_) => return Ok(None),
+    };
+    if !operator_descriptor_is_procfs(&proc_fd)? {
+        return Ok(None);
+    }
+    let name = CString::new(object.as_raw_fd().to_string())
+        .expect("decimal file descriptor contains no NUL");
+    open_at(
+        proc_fd.as_raw_fd(),
+        &name,
+        libc::O_RDONLY | libc::O_NOCTTY | libc::O_CLOEXEC,
+        0,
+    )
+    .map(Some)
+    .context("reopen selected FIFO through its retained descriptor")
 }
 
 fn open_directory_at(parent: &File, component: &[u8]) -> io::Result<File> {
@@ -1651,6 +1946,88 @@ mod tests {
         assert!(operator_symlink_owner_is_trusted(1000, 1000));
         assert!(!operator_symlink_owner_is_trusted(1001, 1000));
         assert!(!operator_symlink_owner_is_trusted(1000, 0));
+    }
+
+    #[test]
+    fn trusted_owner_never_falls_back_to_a_second_pathname_lookup() {
+        assert!(
+            require_operator_link_fallback_allowed(OperatorSymlinkPolicy::TrustedOwner).is_err()
+        );
+        assert!(require_operator_link_fallback_allowed(OperatorSymlinkPolicy::FollowAll).is_ok());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn selected_fifo_reopens_exactly_and_waits_for_a_writer() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let tree = TestDir::new("operator-fifo-read");
+        let fifo = tree.path().join("rules");
+        let fifo_name = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+        let base = File::open(tree.path()).unwrap();
+        let resolver =
+            OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::Refuse).unwrap();
+        let selected = resolver
+            .resolve(
+                b"rules",
+                OperatorFinalComponent::ReadableEntry {
+                    follow_symlink: true,
+                },
+                false,
+                &mut Vec::new(),
+            )
+            .unwrap();
+        let PinnedPath::Leaf(leaf) = selected else {
+            panic!("FIFO was not selected as a leaf");
+        };
+
+        let (opened_tx, opened_rx) = mpsc::sync_channel(1);
+        let opener = std::thread::spawn(move || opened_tx.send(leaf.open_read()).unwrap());
+        assert!(matches!(
+            opened_rx.recv_timeout(Duration::from_millis(100)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        let mut writer = File::options().write(true).open(&fifo).unwrap();
+        writer.write_all(b"drop\n").unwrap();
+        drop(writer);
+        let mut reader = opened_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("exact FIFO reopen did not rendezvous with its writer")
+            .unwrap();
+        let mut contents = Vec::new();
+        reader.read_to_end(&mut contents).unwrap();
+        assert_eq!(contents, b"drop\n");
+        opener.join().unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn selected_fifo_fails_closed_without_an_exact_reopen() {
+        let tree = TestDir::new("operator-fifo-cutout");
+        let fifo = tree.path().join("rules");
+        let fifo_name = CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_name.as_ptr(), 0o600) }, 0);
+        let base = File::open(tree.path()).unwrap();
+        let resolver =
+            OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::Refuse).unwrap();
+        let selected = resolver
+            .resolve(
+                b"rules",
+                OperatorFinalComponent::ReadableEntry {
+                    follow_symlink: true,
+                },
+                false,
+                &mut Vec::new(),
+            )
+            .unwrap();
+        let PinnedPath::Leaf(leaf) = selected else {
+            panic!("FIFO was not selected as a leaf");
+        };
+        let error = leaf.open_read().unwrap_err().to_string();
+        assert!(error.contains("exact descriptor"), "{error}");
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -15,6 +15,7 @@ use crate::sched::{FileJob, Item, RangeHandle, Sched};
 use crate::tune::{self, Gate};
 use anyhow::{bail, Context, Result};
 use std::ffi::OsStr;
+use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::OpenOptionsExt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
@@ -1020,26 +1021,32 @@ pub fn run(args: Args) -> Result<i32> {
         args.width,
         !args.quiet && args.progress_json,
     );
-    if let Some(mapping) = args
-        .native_mapping
-        .as_deref()
-        .filter(|mapping| *mapping != b"-")
-        .filter(|_| !args.native_follow)
-    {
-        crate::fsops::check_operator_path_no_symlinks(mapping, false, false)
-            .map_err(|error| anyhow::anyhow!("--mapping: {error}"))?;
-    }
+    // Acquire the entire mapping through its retained selection before any
+    // destination root can be created. The planner already consumes the whole
+    // manifest; retaining these bytes also makes later namespace replacement
+    // irrelevant.
+    let mapping_contents = if let Some(mapping) = args.native_mapping.as_deref() {
+        let mut contents = Vec::new();
+        if mapping == b"-" {
+            std::io::stdin()
+                .read_to_end(&mut contents)
+                .context("--mapping -: read stdin")?;
+        } else {
+            crate::fsops::open_operator_file_read(mapping, operator_symlink_policy(&args))
+                .and_then(|mut input| input.read_to_end(&mut contents).map_err(Into::into))
+                .map_err(|error| anyhow::anyhow!("--mapping {}: {error}", display(mapping)))?;
+        }
+        Some(contents)
+    } else {
+        None
+    };
     if let Some(results) = args.native_results.as_deref() {
         let out: Box<dyn std::io::Write + Send> = if results == b"-" {
             Box::new(std::io::stdout())
         } else {
-            if !args.native_follow {
-                crate::fsops::check_operator_path_no_symlinks(results, false, true)
-                    .map_err(|error| anyhow::anyhow!("--results: {error}"))?;
-            }
             let path = std::path::PathBuf::from(OsStr::from_bytes(results).to_os_string());
             Box::new(std::io::BufWriter::new(
-                std::fs::File::create(&path)
+                crate::fsops::open_operator_file_replace(results, operator_symlink_policy(&args))
                     .map_err(|e| anyhow::anyhow!("--results {}: {e}", path.display()))?,
             ))
         };
@@ -1839,21 +1846,10 @@ pub fn run(args: Args) -> Result<i32> {
 
     let mut scan_err = None;
     let mut dry_run_mappings = Vec::with_capacity(srcs.len());
-    if let Some(mapping) = args.native_mapping.as_deref() {
+    if let Some(mapping_contents) = mapping_contents.as_deref() {
         let src = &srcs[0];
-        let open = || -> Result<Box<dyn std::io::BufRead>> {
-            if mapping == b"-" {
-                return Ok(Box::new(std::io::stdin().lock()));
-            }
-            let path = std::path::PathBuf::from(OsStr::from_bytes(mapping).to_os_string());
-            Ok(Box::new(std::io::BufReader::new(
-                std::fs::File::open(&path)
-                    .map_err(|e| anyhow::anyhow!("--mapping {}: {e}", path.display()))?,
-            )))
-        };
-        match open().and_then(|mut reader| {
-            st.scan_mapping(&mut *src_ctl, &src.path, &dst_root, &mut *reader)
-        }) {
+        let mut reader = std::io::Cursor::new(mapping_contents);
+        match st.scan_mapping(&mut *src_ctl, &src.path, &dst_root, &mut reader) {
             Ok(()) => dry_run_mappings.push(DryRunMapping {
                 target: dst_root.clone(),
                 semantics: "entries selected by --mapping",
@@ -3448,12 +3444,13 @@ impl Planner<'_> {
         Ok(())
     }
 
-    /// Consume an NDJSON mapping manifest: each entry claims exactly one
-    /// source object (relative to `src_root`) at an explicit destination
-    /// (relative to `dst_root`). Entries stream: chunks are planned and
-    /// applied before the manifest ends, so `--mapping -` starts work long
-    /// before stdin closes. Destination ancestors no entry names are
-    /// synthesized as implicit directories with default metadata.
+    /// Consume an already-acquired NDJSON mapping manifest: each entry claims
+    /// exactly one source object (relative to `src_root`) at an explicit
+    /// destination (relative to `dst_root`). The caller buffers the complete
+    /// input before opening the destination, and this planner validates the
+    /// complete manifest before applying any entry. Destination ancestors with
+    /// no entries are synthesized as implicit directories with default
+    /// metadata.
     fn scan_mapping(
         &mut self,
         src: &mut dyn Conn,

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::unix::ffi::OsStringExt;
-use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -129,6 +129,58 @@ fn read(p: &Path) -> Vec<u8> {
     let mut v = Vec::new();
     File::open(p).unwrap().read_to_end(&mut v).unwrap();
     v
+}
+
+#[cfg(debug_assertions)]
+fn start_held_control_path(
+    command: &mut Command,
+    selected: &Path,
+    ready: &Path,
+) -> std::process::Child {
+    command
+        .env("SYQ_TEST_CONTROL_PATH", selected)
+        .env("SYQ_TEST_CONTROL_PATH_READY_FILE", ready)
+        .env("SYQ_TEST_HOLD_CONTROL_PATH_MS", "2000")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap()
+}
+
+#[cfg(debug_assertions)]
+fn wait_for_control_path_selection(child: &mut std::process::Child, ready: &Path) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !ready.exists() && std::time::Instant::now() < deadline {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "syq exited before retaining the selected control path"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(
+        ready.exists(),
+        "control path was not retained before timeout"
+    );
+}
+
+#[cfg(debug_assertions)]
+fn wait_for_control_path_output(mut child: std::process::Child) -> Output {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            return child.wait_with_output().unwrap();
+        }
+        if std::time::Instant::now() >= deadline {
+            child.kill().unwrap();
+            let output = child.wait_with_output().unwrap();
+            panic!(
+                "syq did not finish after the control-path race\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
 }
 
 fn partial_files(dir: &Path) -> Vec<PathBuf> {
@@ -1025,6 +1077,403 @@ fn native_copy_control_file_paths_use_the_common_follow_policy() {
         &t.s("results-output"),
     ]);
     assert!(!read(&t.path("real-results")).is_empty());
+
+    run_native_ok(&[
+        "cp",
+        "--ignore-from",
+        "/dev/null",
+        "--src-src",
+        &t.s("src"),
+        "--into",
+        &t.s("device-input-output"),
+    ]);
+    assert_eq!(read(&t.path("device-input-output/keep")), b"data");
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn control_input_replacement_symlinks_cannot_redirect_reads() {
+    use std::os::unix::fs::symlink;
+
+    for family in ["native-ignore", "rsync-ignore", "files-from", "mapping"] {
+        let t = Tmp::new();
+        write(&t.path("src/keep"), b"data");
+        let selected = t.path("selected-control");
+        let outside = t.path("outside-control");
+        let control_contents = if family == "mapping" {
+            entry_line("keep", "keep", None)
+        } else if family == "files-from" {
+            "keep\n".to_string()
+        } else {
+            "# no exclusions\n".to_string()
+        };
+        write(&selected, control_contents.as_bytes());
+        write(&outside, control_contents.as_bytes());
+        let destination = t.path("dst");
+        let ready = t.path("control-ready");
+        let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+        match family {
+            "native-ignore" => {
+                command
+                    .args(["cp", "--ignore-from"])
+                    .arg(&selected)
+                    .arg("--src-src")
+                    .arg(t.path("src"))
+                    .arg("--into")
+                    .arg(&destination)
+                    .arg("-q");
+            }
+            "rsync-ignore" => {
+                command
+                    .args(["rsync", "-a", "--syq-ignore-from"])
+                    .arg(&selected)
+                    .arg(t.s("src/"))
+                    .arg(&destination)
+                    .arg("--no-progress");
+            }
+            "files-from" => {
+                command
+                    .args(["rsync", "-a", "--files-from"])
+                    .arg(&selected)
+                    .arg(t.path("src"))
+                    .arg(&destination)
+                    .arg("--no-progress");
+            }
+            "mapping" => {
+                command
+                    .args(["cp", "--mapping"])
+                    .arg(&selected)
+                    .arg("-C")
+                    .arg(t.path("src"))
+                    .arg("--into")
+                    .arg(&destination)
+                    .arg("-q");
+            }
+            _ => unreachable!(),
+        }
+        let mut child = start_held_control_path(&mut command, &selected, &ready);
+        wait_for_control_path_selection(&mut child, &ready);
+
+        fs::rename(&selected, t.path("original-control")).unwrap();
+        symlink(&outside, &selected).unwrap();
+
+        let output = wait_for_control_path_output(child);
+        assert!(
+            !output.status.success(),
+            "{family} followed a replacement symlink"
+        );
+        assert!(
+            stderr_of(&output).contains("operator file"),
+            "{family}: {}",
+            stderr_of(&output)
+        );
+        assert!(
+            !destination.exists(),
+            "{family} mutated its destination after the control-path race"
+        );
+    }
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn regular_control_input_raced_to_fifo_fails_without_blocking() {
+    let t = Tmp::new();
+    write(&t.path("src/keep"), b"data");
+    let selected = t.path("selected-control");
+    write(&selected, b"# no exclusions\n");
+    let destination = t.path("dst");
+    let ready = t.path("control-ready");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+    command
+        .args(["cp", "--ignore-from"])
+        .arg(&selected)
+        .arg("--src-src")
+        .arg(t.path("src"))
+        .arg("--into")
+        .arg(&destination)
+        .arg("-q");
+    let mut child = start_held_control_path(&mut command, &selected, &ready);
+    wait_for_control_path_selection(&mut child, &ready);
+
+    fs::rename(&selected, t.path("original-control")).unwrap();
+    mkfifo(&selected);
+
+    let output = wait_for_control_path_output(child);
+    assert!(!output.status.success());
+    assert!(
+        stderr_of(&output).contains("changed identity"),
+        "{}",
+        stderr_of(&output)
+    );
+    assert!(!destination.exists());
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn selected_fifo_replacement_reads_the_retained_fifo() {
+    use std::sync::mpsc;
+
+    let t = Tmp::new();
+    write(&t.path("src/keep"), b"data");
+    let selected = t.path("selected-control");
+    mkfifo(&selected);
+    let destination = t.path("dst");
+    let ready = t.path("control-ready");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+    command
+        .args(["cp", "--ignore-from"])
+        .arg(&selected)
+        .arg("--src-src")
+        .arg(t.path("src"))
+        .arg("--into")
+        .arg(&destination)
+        .arg("-q");
+    let mut child = start_held_control_path(&mut command, &selected, &ready);
+    wait_for_control_path_selection(&mut child, &ready);
+
+    let original = t.path("original-control");
+    fs::rename(&selected, &original).unwrap();
+    mkfifo(&selected);
+    let (writer_tx, writer_rx) = mpsc::sync_channel(1);
+    let writer = std::thread::spawn(move || {
+        let result = File::options()
+            .write(true)
+            .open(original)
+            .and_then(|mut file| file.write_all(b"# no exclusions\n"));
+        writer_tx.send(result).unwrap();
+    });
+
+    let output = wait_for_control_path_output(child);
+    let used_retained_fifo = match writer_rx.recv_timeout(std::time::Duration::from_secs(2)) {
+        Ok(result) => {
+            result.expect("retained FIFO writer failed");
+            true
+        }
+        Err(_) => {
+            // Unblock the owned writer so a failed assertion never leaks a thread.
+            let _rescue = OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(t.path("original-control"))
+                .unwrap();
+            writer_rx
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("FIFO writer did not finish after rescue")
+                .unwrap();
+            false
+        }
+    };
+    writer.join().unwrap();
+    assert!(
+        used_retained_fifo,
+        "syq opened the replacement FIFO instead of its retained selection"
+    );
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("dst/keep")), b"data");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn named_fifo_control_input_fails_before_destination_mutation() {
+    let t = Tmp::new();
+    write(&t.path("src/keep"), b"data");
+    let selected = t.path("selected-control");
+    mkfifo(&selected);
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--ignore-from"])
+        .arg(&selected)
+        .arg("--src-src")
+        .arg(t.path("src"))
+        .arg("--into")
+        .arg(t.path("dst"))
+        .arg("-q")
+        .run()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(stderr_of(&output).contains("exact descriptor"));
+    assert!(!t.path("dst").exists());
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn trusted_control_symlink_target_is_read_from_the_opened_link() {
+    use std::os::unix::fs::symlink;
+
+    let t = Tmp::new();
+    write(&t.path("src/keep"), b"keep");
+    write(&t.path("src/drop"), b"drop");
+    write(&t.path("original-rules"), b"drop\n");
+    write(&t.path("replacement-rules"), b"keep\n");
+    let selected = t.path("selected-control-link");
+    symlink("original-rules", &selected).unwrap();
+    let destination = t.path("dst");
+    let ready = t.path("symlink-ready");
+    let release = t.path("symlink-release");
+
+    let mut child = compat_command()
+        .args(["-a", "--syq-ignore-from"])
+        .arg(&selected)
+        .arg(t.s("src/"))
+        .arg(&destination)
+        .arg("--no-progress")
+        .env(
+            "SYQ_TEST_OPERATOR_SYMLINK_COMPONENT",
+            "selected-control-link",
+        )
+        .env("SYQ_TEST_OPERATOR_SYMLINK_READY_FILE", &ready)
+        .env("SYQ_TEST_OPERATOR_SYMLINK_RELEASE_FILE", &release)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+    wait_for_control_path_selection(&mut child, &ready);
+
+    fs::rename(&selected, t.path("moved-control-link")).unwrap();
+    symlink("replacement-rules", &selected).unwrap();
+    write(&release, b"continue");
+
+    let output = wait_for_control_path_output(child);
+    assert_output_ok(&output);
+    assert_eq!(listing(&destination), ["keep"]);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn results_replacement_symlinks_cannot_redirect_creation_or_truncation() {
+    use std::os::unix::fs::symlink;
+
+    for initially_exists in [false, true] {
+        let t = Tmp::new();
+        write(&t.path("src"), b"data");
+        let selected = t.path("results.ndjson");
+        let outside = t.path("outside-results");
+        write(&outside, b"do not replace");
+        if initially_exists {
+            write(&selected, b"old results");
+        }
+        let destination = t.path("dst");
+        let ready = t.path("control-ready");
+        let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+        command
+            .args(["cp", "--results"])
+            .arg(&selected)
+            .arg(t.path("src"))
+            .arg("--as")
+            .arg(&destination)
+            .arg("-q");
+        let mut child = start_held_control_path(&mut command, &selected, &ready);
+        wait_for_control_path_selection(&mut child, &ready);
+
+        if initially_exists {
+            fs::rename(&selected, t.path("original-results")).unwrap();
+        }
+        symlink(&outside, &selected).unwrap();
+
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            !output.status.success(),
+            "results {} followed a replacement symlink",
+            if initially_exists {
+                "truncation"
+            } else {
+                "creation"
+            }
+        );
+        assert!(stderr_of(&output).contains("--results"));
+        assert_eq!(read(&outside), b"do not replace");
+        assert!(!destination.exists());
+        if initially_exists {
+            assert_eq!(read(&t.path("original-results")), b"old results");
+        }
+    }
+}
+
+#[test]
+fn named_results_refuse_fifos_devices_and_trailing_slashes() {
+    let t = Tmp::new();
+    write(&t.path("src"), b"data");
+    let fifo = t.path("results-fifo");
+    mkfifo(&fifo);
+    let mut fifo_reader = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK)
+        .open(&fifo)
+        .unwrap();
+
+    for (label, selected) in [("fifo", fifo), ("device", PathBuf::from("/dev/null"))] {
+        let destination = t.path(&format!("{label}-destination"));
+        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(["cp", "--results"])
+            .arg(&selected)
+            .arg(t.path("src"))
+            .arg("--as")
+            .arg(&destination)
+            .arg("-q")
+            .run()
+            .unwrap();
+        assert!(!output.status.success(), "named results accepted {label}");
+        assert!(
+            stderr_of(&output).contains("regular file"),
+            "{label}: {}",
+            stderr_of(&output)
+        );
+        assert!(!destination.exists());
+    }
+    let mut fifo_bytes = Vec::new();
+    fifo_reader.read_to_end(&mut fifo_bytes).unwrap();
+    assert!(fifo_bytes.is_empty(), "the refused FIFO was written");
+
+    let trailing = format!("{}/", t.s("missing-results"));
+    let output = native_syq(&[
+        "cp",
+        "--results",
+        &trailing,
+        &t.s("src"),
+        "--as",
+        &t.s("trailing-destination"),
+    ]);
+    assert!(!output.status.success());
+    assert!(stderr_of(&output).contains("trailing slash"));
+    assert!(!t.path("missing-results").exists());
+    assert!(!t.path("trailing-destination").exists());
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn followed_results_referent_stays_pinned_when_the_link_is_replaced() {
+    use std::os::unix::fs::symlink;
+
+    let t = Tmp::new();
+    write(&t.path("src"), b"data");
+    write(&t.path("intended-results"), b"old results");
+    write(&t.path("outside-results"), b"do not replace");
+    let selected = t.path("results-link");
+    symlink("intended-results", &selected).unwrap();
+    let ready = t.path("control-ready");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+    command
+        .args(["cp", "--follow", "--results"])
+        .arg(&selected)
+        .arg(t.path("src"))
+        .arg("--as")
+        .arg(t.path("dst"))
+        .arg("-q");
+    let mut child = start_held_control_path(&mut command, &selected, &ready);
+    wait_for_control_path_selection(&mut child, &ready);
+
+    fs::remove_file(&selected).unwrap();
+    symlink(t.path("outside-results"), &selected).unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("outside-results")), b"do not replace");
+    let intended = read(&t.path("intended-results"));
+    assert!(
+        String::from_utf8_lossy(&intended).contains("\"type\":\"result\""),
+        "{}",
+        String::from_utf8_lossy(&intended)
+    );
+    assert_eq!(read(&t.path("dst")), b"data");
 }
 
 #[test]
@@ -4751,6 +5200,114 @@ fn ignore_from_file_and_later_negation_wins() {
     ]);
     assert!(!out.status.success());
     assert!(String::from_utf8_lossy(&out.stderr).contains("--syq-ignore-from"));
+}
+
+#[test]
+fn rsync_control_inputs_follow_links_owned_by_the_effective_user() {
+    use std::os::unix::fs::symlink;
+
+    let t = Tmp::new();
+    write(&t.path("src/keep"), b"keep");
+    write(&t.path("src/drop"), b"drop");
+    write(&t.path("patterns"), b"drop\n");
+    write(&t.path("list"), b"keep\n");
+    symlink("patterns", t.path("patterns-link")).unwrap();
+    symlink("list", t.path("list-link")).unwrap();
+
+    run_ok(&[
+        "-a",
+        "--syq-ignore-from",
+        &t.s("patterns-link"),
+        &t.s("src/"),
+        &t.s("ignored"),
+    ]);
+    assert_eq!(listing(&t.path("ignored")), ["keep"]);
+
+    run_ok(&[
+        "-a",
+        "--files-from",
+        &t.s("list-link"),
+        &t.s("src"),
+        &t.s("listed"),
+    ]);
+    assert_eq!(listing(&t.path("listed")), ["keep"]);
+}
+
+#[test]
+fn control_file_names_preserve_non_utf8_bytes() {
+    let t = Tmp::new();
+    write(&t.path("src/keep"), b"keep");
+    write(&t.path("src/drop"), b"drop");
+    let rules = t
+        .path("")
+        .join(std::ffi::OsString::from_vec(b"rules-\xff".to_vec()));
+    let list = t
+        .path("")
+        .join(std::ffi::OsString::from_vec(b"list-\xfe".to_vec()));
+    write(&rules, b"drop\n");
+    write(&list, b"keep\n");
+
+    let native = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--ignore-from"])
+        .arg(&rules)
+        .arg("--src-src")
+        .arg(t.path("src"))
+        .arg("--into")
+        .arg(t.path("native"))
+        .arg("-q")
+        .run()
+        .unwrap();
+    assert_output_ok(&native);
+    assert_eq!(listing(&t.path("native")), ["keep"]);
+
+    let compatible = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["rsync", "-a", "--syq-ignore-from"])
+        .arg(&rules)
+        .arg(t.s("src/"))
+        .arg(t.path("compatible"))
+        .arg("--no-progress")
+        .run()
+        .unwrap();
+    assert_output_ok(&compatible);
+    assert_eq!(listing(&t.path("compatible")), ["keep"]);
+
+    let listed = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["rsync", "-a", "--files-from"])
+        .arg(&list)
+        .arg(t.path("src"))
+        .arg(t.path("listed"))
+        .arg("--no-progress")
+        .run()
+        .unwrap();
+    assert_output_ok(&listed);
+    assert_eq!(listing(&t.path("listed")), ["keep"]);
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn rsync_control_input_accepts_an_inherited_procfs_pipe() {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let t = Tmp::new();
+    write(&t.path("src/keep"), b"keep");
+    write(&t.path("src/drop"), b"drop");
+    let mut descriptors = [0; 2];
+    assert_eq!(unsafe { libc::pipe(descriptors.as_mut_ptr()) }, 0);
+    let reader = unsafe { File::from_raw_fd(descriptors[0]) };
+    let mut writer = unsafe { File::from_raw_fd(descriptors[1]) };
+    writer.write_all(b"drop\n").unwrap();
+    drop(writer);
+    let rules = format!("/proc/self/fd/{}", reader.as_raw_fd());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["rsync", "-a", "--syq-ignore-from", &rules])
+        .arg(t.s("src/"))
+        .arg(t.path("dst"))
+        .arg("--no-progress")
+        .run()
+        .unwrap();
+    assert_output_ok(&output);
+    assert_eq!(listing(&t.path("dst")), ["keep"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- resolve and retain --ignore-from, --syq-ignore-from, --files-from, named --mapping, and named --results selections before destination mutation
- read mapping input fully before endpoint setup or mutation
- identity-check existing result files before truncation and create missing result leaves with O_EXCL under a retained parent
- bind rsync trusted-owner symlink ownership and target extraction to the same opened link object
- preserve raw Unix bytes in control-file names
- preserve named-FIFO blocking semantics on Linux by reopening the retained object through verified procfs
- support final Linux procfs descriptor links, including shell process substitution, without a general pathname fallback

## Platform policy

Linux reads symlink targets through an O_PATH|O_NOFOLLOW descriptor. macOS 13+ uses O_SYMLINK plus runtime-resolved freadlink. Trusted-owner traversal fails closed on older macOS or another platform without a descriptor-bound link read; explicit native FollowAll may retain its documented insecure pathname fallback there.

Linux named FIFO inputs require verified procfs for an exact descriptor reopen. macOS and Linux systems without procfs refuse them before destination mutation; stdin or a materialized regular file remains portable. Existing named result sinks remain regular-file-only; stdout/redirection covers stream sinks.

## Verification

At exact commit b36e8f0:

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets (269 unit, 292 integration, 7 updater)
- focused replacement-race, FIFO, procfs, and raw-byte filename tests
- independent review of the amended implementation

Linux was exercised locally. The macOS-specific ABI and fail-closed FIFO behavior are gated on CI before this PR is review-ready. The worktree is clean.
