### PR TITLE
Confine source discovery to registered roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,28 +241,40 @@ containment guarantee for copy. Native `rm` retains the resolved directories
 and selected identities through mutation. Copy resolves and registers every
 selected source before destination mutation, and every source worker claims
 those exact directory or parent descriptors during authenticated startup,
-before it reports readiness. Source jobs and requests already carry the
-resulting opaque root ID plus strict relative bytes. This is deliberately
-inert transitional vocabulary: ordinary source scans, stats, hashes, and reads
-still execute the parallel legacy pathname field, and the registered reference
-is not an allowlist or confinement boundary yet. Worker startup validates the
-ticket/root correspondence and retains the exact descriptor; the source-role,
-request-reference, and descriptor-relative access boundary lands with the
-source-operation cutover. Copy also gives
+before it reports readiness. Source discovery and metadata stats, including
+retry checks, use the resulting opaque root ID plus strict relative bytes as
+their authority. They do not reopen the operator spelling or follow descendant
+symlinks; a selected file authorizes only that exact leaf, not siblings beneath
+its retained parent. The endpoint registry and every initialized worker also
+keep that selected object open, so the pin remains valid even if the control
+connection exits first. Exact-symlink target bytes are snapshotted through the
+opened symlink object and never reread through its mutable directory name.
+Replacing an exact selected leaf is an error, while changed-source retry remains
+available for entries beneath a selected directory. On macOS this
+descriptor-bound symlink operation requires macOS 13 or newer; older releases
+fail source registration rather than fall back to a name-based read. Source
+content hashing, range/small reads, local-copy source opens, and the same-machine
+self-copy canonical-path check still use legacy pathnames and are the remaining
+source-confinement work.
+This is therefore not yet a complete hostile-namespace guarantee for source
+file contents. Copy also gives
 every destination worker the selected directory descriptor; destination
 observation, directory and special-file creation, metadata changes, and
 planned non-recursive deletion are relative to that descriptor. Destination
 scanning, including the walk that plans `--delete`, is relative to it too and
 never follows descendant symlinks.
-Source registration does not change `--files-from`'s documented treatment of
-symlinks in listed or implied paths; that policy is settled with the source-read
-cutover rather than by worker initialization.
+Rsync-mode `--insecure-links` is the explicit compatibility opt-out: that
+session uses the legacy unconfined pathname discovery path, including traversal
+through symlinked `--files-from` ancestors. Native mapping/generated names never
+inherit native `--follow`; they remain strict descendants of the registered
+source root.
 Registration also budgets the process's currently open descriptors, one
-retained descriptor per source root for the registry, control connection, and
-every worker that may share its process, plus conservative per-worker file
-cache and transport overhead. If the endpoint's open-file limit cannot hold
-that set, the copy fails before destination mutation with guidance to reduce
-selectors or `--connections`.
+retained parent descriptor per source root and one object descriptor per exact
+leaf for the registry, control connection, and every worker that may share its
+process, plus conservative per-worker file-cache, transport, and concurrent
+independent-worker broker-claim overhead. If the endpoint's open-file limit
+cannot hold that set, the copy fails before destination mutation with guidance
+to reduce selectors or `--connections`.
 Regular-file destination transfer state has not all moved to
 descriptor-relative access yet either. The default therefore rejects
 links present during preflight, while the remaining containment work must also
@@ -564,6 +576,7 @@ accept them.
 | `--max-size SIZE`, `--min-size SIZE` | Don't transfer regular files larger / smaller than SIZE |
 | `--files-from FILE` | Copy only the listed paths (relative to the one source directory; see below) |
 | `--from0` | `--files-from` entries are NUL-separated |
+| `--insecure-links` | Permit legacy unconfined traversal through symlinked source ancestors, including `--files-from` implied parents |
 | `-h` | No-op for rsync compatibility; sizes are always human-readable. Use `--help` for help |
 
 Like rsync, `-q` suppresses ordinary non-error output: progress, summaries,
@@ -1432,10 +1445,15 @@ the same command would transfer and nothing else.
 relative to the single source directory, to the same relative path under the
 destination. The source is not walked, which is the point on a slow
 filesystem when the list is known. Parent directories of listed paths are
-created (with their metadata). A parent that is a symlink on the source is
-followed — you named a path through it — and becomes a real directory on the
-destination, so nothing is ever written through a destination symlink; a
-parent that resolves to a file or dangles is an error. A listed directory is copied *without*
+created (with their metadata). By default, a parent that is a symlink on the
+source is not traversed and that listed path fails. This is deliberately
+stricter than hardened rsync 3.5.0: rsync may first emit the implied destination
+directory and then fail the content open, while SYQ refuses the path before
+emitting that implied parent. Both report a partial-transfer error (exit 23).
+`--insecure-links` opts the whole source session into the legacy unconfined
+pathname behavior: such a parent is followed and becomes a real directory on
+the destination. A parent that resolves to a file or dangles is an error. A
+listed directory is copied *without*
 its contents unless `-r` is given on the command line itself — `-a` alone
 does not count, as in rsync — so `-a -r --files-from` walks the directories
 the list names (never the implied parents).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -140,6 +140,9 @@ pub struct Args {
     /// Copy symlinks as symlinks
     #[arg(short = 'l', long)]
     pub links: bool,
+    /// Permit unconfined traversal through symlinked source ancestors
+    #[arg(long)]
+    pub insecure_links: bool,
     /// Preserve permissions
     #[arg(short = 'p', long)]
     pub perms: bool,

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -42,7 +42,7 @@ pub trait Conn: Send {
     fn scan(
         &mut self,
         root: &[u8],
-        _source: Option<&RegisteredPath>,
+        source: Option<&RegisteredPath>,
         follow_root: bool,
         ignore: &[String],
         report_ignored: bool,
@@ -362,25 +362,42 @@ pub fn ok(resp: Response, what: &str) -> Result<Response> {
 pub struct LocalConn {
     ops: FsOps,
     pending: VecDeque<Response>,
-    is_control: bool,
+    role: LocalConnectionRole,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LocalConnectionRole {
+    Control,
+    SourceWorker,
+    DestinationWorker,
+}
+
+impl From<&ConnectionRole> for LocalConnectionRole {
+    fn from(role: &ConnectionRole) -> Self {
+        match role {
+            ConnectionRole::Control => Self::Control,
+            ConnectionRole::SourceWorker { .. } => Self::SourceWorker,
+            ConnectionRole::DestinationWorker { .. } => Self::DestinationWorker,
+        }
+    }
 }
 
 impl LocalConn {
     fn new(
-        is_control: bool,
+        role: &ConnectionRole,
         descriptor_session: crate::descriptor_broker::DescriptorSessionSlot,
     ) -> Self {
         LocalConn {
             ops: FsOps::with_descriptor_session(descriptor_session),
             pending: VecDeque::new(),
-            is_control,
+            role: role.into(),
         }
     }
 }
 
 impl Conn for LocalConn {
     fn send(&mut self, req: Request) -> Result<()> {
-        if !self.is_control
+        if self.role != LocalConnectionRole::Control
             && matches!(
                 &req,
                 Request::TcpListen { .. }
@@ -397,6 +414,12 @@ impl Conn for LocalConn {
             ));
             return Ok(());
         }
+        if self.role == LocalConnectionRole::SourceWorker && !req.allowed_on_source_worker() {
+            self.pending.push_back(Response::Err(
+                "request is not valid on a source worker".into(),
+            ));
+            return Ok(());
+        }
         let resp = self.ops.handle(&req);
         self.pending.push_back(resp);
         Ok(())
@@ -409,7 +432,7 @@ impl Conn for LocalConn {
     fn scan(
         &mut self,
         root: &[u8],
-        _source: Option<&RegisteredPath>,
+        source: Option<&RegisteredPath>,
         follow_root: bool,
         ignore: &[String],
         report_ignored: bool,
@@ -417,11 +440,27 @@ impl Conn for LocalConn {
         ignored: &mut dyn FnMut(Vec<PathBytes>) -> Result<()>,
         warn: &mut dyn FnMut(String),
     ) -> Result<()> {
+        if let Some(source) = self.ops.source_scan_root(source)? {
+            return crate::scan::scan_descriptor(
+                source.root,
+                &source.relative,
+                source.expected_leaf,
+                false,
+                false,
+                ignore,
+                report_ignored,
+                sink,
+                ignored,
+                warn,
+            );
+        }
         if let Some((destination_root, relative)) = self.ops.destination_scan_root(root)? {
             return crate::scan::scan_descriptor(
                 destination_root,
                 &relative,
+                None,
                 follow_root,
+                true,
                 ignore,
                 report_ignored,
                 sink,
@@ -452,6 +491,9 @@ impl Conn for LocalConn {
         trace: &mut dyn FnMut(Vec<String>) -> Result<()>,
         sink: &mut dyn FnMut(Vec<NativeRemoveOutcome>) -> Result<()>,
     ) -> Result<()> {
+        if self.role != LocalConnectionRole::Control {
+            bail!("native removal is allowed only on the control connection");
+        }
         crate::native_rm::remove(
             cwd,
             root,
@@ -719,10 +761,13 @@ impl Drop for RemoteConn {
 /// unauthenticated ones, so each failed connect halves the limit (down to
 /// MIN_CONCURRENT_CONNECTS) for the rest of the run, and the retry then
 /// succeeds. The control connection bypasses this entirely.
-const START_CONCURRENT_CONNECTS: usize = 32;
+/// Hard upper bound on simultaneously establishing data connections. A source
+/// endpoint's descriptor broker therefore sees no more concurrent independent
+/// SSH worker claims than this, even when tuning warms a larger candidate set.
+pub(crate) const MAX_CONCURRENT_CONNECTS: usize = 32;
 const MIN_CONCURRENT_CONNECTS: usize = 4;
 static CONNECT_LIMIT: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(START_CONCURRENT_CONNECTS);
+    std::sync::atomic::AtomicUsize::new(MAX_CONCURRENT_CONNECTS);
 static CONNECTS: std::sync::Mutex<usize> = std::sync::Mutex::new(0);
 static CONNECTS_CV: std::sync::Condvar = std::sync::Condvar::new();
 
@@ -2151,10 +2196,7 @@ impl Endpoint {
                 // descriptors in process instead of claiming SCM_RIGHTS from
                 // the broker after worker threads exist (unsupported on
                 // Darwin).
-                let mut conn = LocalConn::new(
-                    matches!(&role, ConnectionRole::Control),
-                    descriptor_session.clone(),
-                );
+                let mut conn = LocalConn::new(&role, descriptor_session.clone());
                 match role {
                     ConnectionRole::DestinationWorker {
                         destination: Some(destination),
@@ -2256,7 +2298,9 @@ mod tests {
                     follow_root: false,
                 }],
                 symlink_policy: OperatorSymlinkPolicy::Refuse,
+                allow_unconfined_paths: false,
                 shared_workers: 1,
+                independent_claim_workers: 0,
             })
             .unwrap();
         let Response::SourceRootsRegistered(roots) = response else {
@@ -2273,6 +2317,85 @@ mod tests {
             .err()
             .expect("a fresh local endpoint must not share another session");
         assert!(format!("{error:#}").contains("connect to descriptor broker"));
+    }
+
+    #[test]
+    fn local_source_worker_rejects_destination_mutation_requests() {
+        let temporary = tempfile::tempdir().unwrap();
+        let selected = temporary.path().join("selected");
+        std::fs::create_dir(&selected).unwrap();
+        let marker = selected.join("marker");
+        std::fs::write(&marker, b"marker").unwrap();
+        let endpoint = Endpoint::local();
+        let mut control = endpoint.connect_control(false).unwrap();
+        let response = control
+            .call(Request::RegisterSourceRoots {
+                selections: vec![SourceRootSelection {
+                    path: selected.as_os_str().as_bytes().to_vec(),
+                    follow_root: false,
+                }],
+                symlink_policy: OperatorSymlinkPolicy::Refuse,
+                allow_unconfined_paths: false,
+                shared_workers: 1,
+                independent_claim_workers: 0,
+            })
+            .unwrap();
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+        let mut source = endpoint.connect_with_sources(false, roots).unwrap();
+        let response = source
+            .call(Request::Apply {
+                ops: vec![Op::Unlink {
+                    path: marker.as_os_str().as_bytes().to_vec(),
+                }],
+                guard: None,
+            })
+            .unwrap();
+        assert!(
+            matches!(response, Response::Err(error) if error.contains("not valid on a source worker"))
+        );
+        assert_eq!(std::fs::read(&marker).unwrap(), b"marker");
+
+        let selection = [NativeRemoveSelection {
+            path: b"marker".to_vec(),
+            kind: NativeRemoveKind::File,
+        }];
+        let mut trace = |_| Ok(());
+        let mut sink = |_| Ok(());
+        let error = source
+            .native_remove(
+                Some(selected.as_os_str().as_bytes()),
+                None,
+                &selection,
+                false,
+                false,
+                1,
+                &mut trace,
+                &mut sink,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("only on the control connection"));
+        assert_eq!(std::fs::read(&marker).unwrap(), b"marker");
+
+        // Match the remote server's non-control gate for destination workers
+        // too; this direct trait method must not be a role bypass.
+        let role = ConnectionRole::DestinationWorker { destination: None };
+        let mut destination = LocalConn::new(&role, Default::default());
+        let error = destination
+            .native_remove(
+                Some(selected.as_os_str().as_bytes()),
+                None,
+                &selection,
+                false,
+                false,
+                1,
+                &mut trace,
+                &mut sink,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("only on the control connection"));
+        assert_eq!(std::fs::read(&marker).unwrap(), b"marker");
     }
 
     impl<R: Read> Read for ExitObserved<R> {

--- a/src/descriptor_broker.rs
+++ b/src/descriptor_broker.rs
@@ -1,9 +1,10 @@
-//! Session-scoped directory registration and exact cross-process handoff.
+//! Session-scoped descriptor registration and exact cross-process handoff.
 //!
-//! A control process owns the registry and keeps every registered directory
-//! open. Threads in that process clone roots directly; independent workers use
-//! a private, secret-authenticated Unix socket and receive the same open file
-//! description with `SCM_RIGHTS`. No worker reopens an operator pathname.
+//! A control process owns the registry and keeps every registered root and
+//! exact source-leaf object open. Threads in that process clone descriptors
+//! directly; independent workers use a private, secret-authenticated Unix
+//! socket and receive the same open file descriptions with `SCM_RIGHTS`. No
+//! worker reopens an operator pathname.
 
 use crate::private_broker::{PrivateBroker, PrivateBrokerConfig, TrackedStream};
 use anyhow::{anyhow, bail, Context, Result};
@@ -23,7 +24,7 @@ use std::time::Duration;
 
 const CLAIM_MAGIC: &[u8; 8] = b"SYQFD001";
 const SECRET_LEN: usize = 32;
-const CLAIM_LEN: usize = CLAIM_MAGIC.len() + SECRET_LEN + size_of::<u64>();
+const CLAIM_LEN: usize = CLAIM_MAGIC.len() + SECRET_LEN + size_of::<u64>() + 1;
 const RESPONSE_OK: u8 = 0;
 const RESPONSE_REJECTED: u8 = 1;
 const RESPONSE_INTERNAL: u8 = 2;
@@ -50,6 +51,30 @@ impl RegisteredRootId {
 
 struct RegisteredRoot {
     directory: File,
+    source_leaf: Option<File>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+enum RegisteredDescriptorKind {
+    Directory,
+    SourceLeaf,
+}
+
+impl RegisteredDescriptorKind {
+    fn wire_byte(self) -> u8 {
+        match self {
+            Self::Directory => 0,
+            Self::SourceLeaf => 1,
+        }
+    }
+
+    fn from_wire_byte(byte: u8) -> Option<Self> {
+        match byte {
+            0 => Some(Self::Directory),
+            1 => Some(Self::SourceLeaf),
+            _ => None,
+        }
+    }
 }
 
 struct RegistryState {
@@ -93,6 +118,52 @@ impl RegisteredRootRegistry {
                 bail!("only directories may be registered as session roots");
             }
         }
+        self.register_entries(
+            directories
+                .into_iter()
+                .map(|directory| RegisteredRoot {
+                    directory,
+                    source_leaf: None,
+                })
+                .collect(),
+        )
+    }
+
+    fn register_source_handles(
+        &self,
+        handles: Vec<(File, Option<File>)>,
+    ) -> Result<Vec<RegisteredRootId>> {
+        for (directory, source_leaf) in &handles {
+            let metadata = directory
+                .metadata()
+                .context("inspect source directory registered with descriptor session")?;
+            if !metadata.is_dir() {
+                bail!("source authority roots must be directories");
+            }
+            if let Some(source_leaf) = source_leaf {
+                let metadata = source_leaf
+                    .metadata()
+                    .context("inspect source leaf registered with descriptor session")?;
+                if metadata.is_dir() {
+                    bail!("exact source objects must not be directories");
+                }
+            }
+        }
+        self.register_entries(
+            handles
+                .into_iter()
+                .map(|(directory, source_leaf)| RegisteredRoot {
+                    directory,
+                    source_leaf,
+                })
+                .collect(),
+        )
+    }
+
+    fn register_entries(&self, roots: Vec<RegisteredRoot>) -> Result<Vec<RegisteredRootId>> {
+        if roots.is_empty() {
+            return Ok(Vec::new());
+        }
         let mut state = self
             .state
             .lock()
@@ -100,7 +171,7 @@ impl RegisteredRootRegistry {
         let new_len = state
             .roots
             .len()
-            .checked_add(directories.len())
+            .checked_add(roots.len())
             .context("descriptor session root count overflow")?;
         if new_len > self.max_roots {
             bail!(
@@ -108,17 +179,17 @@ impl RegisteredRootRegistry {
                 self.max_roots
             );
         }
-        let count = u64::try_from(directories.len()).context("too many session roots")?;
+        let count = u64::try_from(roots.len()).context("too many session roots")?;
         let next_id = state
             .next_id
             .checked_add(count)
             .context("descriptor session exhausted root identifiers")?;
         let first_id = state.next_id;
         state.next_id = next_id;
-        let mut ids = Vec::with_capacity(directories.len());
-        for (offset, directory) in directories.into_iter().enumerate() {
+        let mut ids = Vec::with_capacity(roots.len());
+        for (offset, root) in roots.into_iter().enumerate() {
             let id = RegisteredRootId(first_id + offset as u64);
-            state.roots.insert(id, RegisteredRoot { directory });
+            state.roots.insert(id, root);
             ids.push(id);
         }
         Ok(ids)
@@ -126,27 +197,39 @@ impl RegisteredRootRegistry {
 
     /// Used by local workers and TCP workers hosted by the control process.
     pub(crate) fn acquire(&self, id: RegisteredRootId) -> Result<File> {
-        self.acquire_optional(id)?
+        self.acquire_optional(id, RegisteredDescriptorKind::Directory)?
             .with_context(|| format!("unknown descriptor session root {}", id.0))
     }
 
-    fn acquire_optional(&self, id: RegisteredRootId) -> Result<Option<File>> {
+    fn acquire_optional(
+        &self,
+        id: RegisteredRootId,
+        kind: RegisteredDescriptorKind,
+    ) -> Result<Option<File>> {
         self.state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .roots
             .get(&id)
-            .map(|root| root.directory.try_clone())
+            .and_then(|root| match kind {
+                RegisteredDescriptorKind::Directory => Some(&root.directory),
+                RegisteredDescriptorKind::SourceLeaf => root.source_leaf.as_ref(),
+            })
+            .map(File::try_clone)
             .transpose()
-            .context("duplicate registered session root")
+            .context("duplicate registered session descriptor")
     }
 
-    fn contains(&self, id: RegisteredRootId) -> bool {
+    fn contains(&self, id: RegisteredRootId, kind: RegisteredDescriptorKind) -> bool {
         self.state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .roots
-            .contains_key(&id)
+            .get(&id)
+            .is_some_and(|root| match kind {
+                RegisteredDescriptorKind::Directory => true,
+                RegisteredDescriptorKind::SourceLeaf => root.source_leaf.is_some(),
+            })
     }
 }
 
@@ -156,6 +239,7 @@ pub struct DescriptorTicket {
     socket_path: Vec<u8>,
     secret: [u8; SECRET_LEN],
     root_id: RegisteredRootId,
+    kind: RegisteredDescriptorKind,
 }
 
 impl std::fmt::Debug for DescriptorTicket {
@@ -164,6 +248,7 @@ impl std::fmt::Debug for DescriptorTicket {
             .debug_struct("DescriptorTicket")
             .field("socket_path", &self.socket_path())
             .field("root_id", &self.root_id)
+            .field("kind", &self.kind)
             .finish_non_exhaustive()
     }
 }
@@ -175,6 +260,21 @@ impl DescriptorTicket {
 
     pub(crate) fn root_id(&self) -> RegisteredRootId {
         self.root_id
+    }
+
+    /// Tickets belong to the same endpoint session only when both the private
+    /// broker address and unguessable session secret match. Root IDs restart
+    /// per registry and therefore cannot establish this relationship alone.
+    pub(crate) fn same_session(&self, other: &Self) -> bool {
+        self.socket_path == other.socket_path && self.secret == other.secret
+    }
+
+    pub(crate) fn is_directory(&self) -> bool {
+        self.kind == RegisteredDescriptorKind::Directory
+    }
+
+    pub(crate) fn is_source_leaf(&self) -> bool {
+        self.kind == RegisteredDescriptorKind::SourceLeaf
     }
 
     #[cfg(test)]
@@ -228,13 +328,26 @@ impl DescriptorSession {
     }
 
     pub(crate) fn ticket(&self, root_id: RegisteredRootId) -> Result<DescriptorTicket> {
-        if !self.registry.contains(root_id) {
+        self.ticket_for(root_id, RegisteredDescriptorKind::Directory)
+    }
+
+    fn source_leaf_ticket(&self, root_id: RegisteredRootId) -> Result<DescriptorTicket> {
+        self.ticket_for(root_id, RegisteredDescriptorKind::SourceLeaf)
+    }
+
+    fn ticket_for(
+        &self,
+        root_id: RegisteredRootId,
+        kind: RegisteredDescriptorKind,
+    ) -> Result<DescriptorTicket> {
+        if !self.registry.contains(root_id, kind) {
             bail!("unknown descriptor session root {}", root_id.0);
         }
         Ok(DescriptorTicket {
             socket_path: self.broker.socket_path().as_os_str().as_bytes().to_vec(),
             secret: self.secret,
             root_id,
+            kind,
         })
     }
 
@@ -244,7 +357,9 @@ impl DescriptorSession {
         {
             bail!("descriptor ticket does not belong to this endpoint session");
         }
-        self.registry.acquire(ticket.root_id)
+        self.registry
+            .acquire_optional(ticket.root_id, ticket.kind)?
+            .with_context(|| format!("unknown descriptor session root {}", ticket.root_id.0))
     }
 }
 
@@ -305,6 +420,51 @@ impl DescriptorSessionSlot {
             .collect()
     }
 
+    /// Atomically register each source authority directory together with its
+    /// optional exact-leaf object. Both tickets share one opaque root ID but
+    /// carry distinct descriptor kinds, so neither can be substituted for the
+    /// other during worker initialization.
+    pub(crate) fn register_source_handles(
+        &self,
+        handles: Vec<(File, Option<File>)>,
+    ) -> Result<Vec<(DescriptorTicket, Option<DescriptorTicket>)>> {
+        if handles.is_empty() {
+            return Ok(Vec::new());
+        }
+        if self.closed.load(Ordering::Acquire) {
+            bail!("descriptor session is closed");
+        }
+        let mut session = self
+            .session
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.closed.load(Ordering::Acquire) {
+            bail!("descriptor session is closed");
+        }
+        if session.is_none() {
+            *session = Some(DescriptorSession::start(
+                self.max_roots,
+                self.max_connections,
+            )?);
+        }
+        let session = session.as_ref().expect("descriptor session initialized");
+        let has_leaf: Vec<_> = handles.iter().map(|(_, leaf)| leaf.is_some()).collect();
+        session
+            .registry
+            .register_source_handles(handles)?
+            .into_iter()
+            .zip(has_leaf)
+            .map(|(root_id, has_leaf)| {
+                Ok((
+                    session.ticket(root_id)?,
+                    has_leaf
+                        .then(|| session.source_leaf_ticket(root_id))
+                        .transpose()?,
+                ))
+            })
+            .collect()
+    }
+
     pub(crate) fn acquire(&self, ticket: &DescriptorTicket) -> Result<File> {
         let session = self
             .session
@@ -351,7 +511,10 @@ pub(crate) fn claim_descriptor(ticket: &DescriptorTicket) -> Result<File> {
     claim[..CLAIM_MAGIC.len()].copy_from_slice(CLAIM_MAGIC);
     let secret_start = CLAIM_MAGIC.len();
     claim[secret_start..secret_start + SECRET_LEN].copy_from_slice(&ticket.secret);
-    claim[secret_start + SECRET_LEN..].copy_from_slice(&ticket.root_id.0.to_be_bytes());
+    let root_start = secret_start + SECRET_LEN;
+    let root_end = root_start + size_of::<u64>();
+    claim[root_start..root_end].copy_from_slice(&ticket.root_id.0.to_be_bytes());
+    claim[root_end] = ticket.kind.wire_byte();
     stream.write_all(&claim)?;
 
     let (status, descriptor) = receive_descriptor(stream.as_raw_fd())?;
@@ -381,12 +544,18 @@ fn serve_claim(
         stream.write_all(&[RESPONSE_REJECTED])?;
         return Ok(());
     }
+    let root_start = secret_start + SECRET_LEN;
+    let root_end = root_start + size_of::<u64>();
     let root_id = RegisteredRootId(u64::from_be_bytes(
-        claim[secret_start + SECRET_LEN..]
+        claim[root_start..root_end]
             .try_into()
             .expect("claim root identifier has a fixed length"),
     ));
-    match registry.acquire_optional(root_id) {
+    let Some(kind) = RegisteredDescriptorKind::from_wire_byte(claim[root_end]) else {
+        stream.write_all(&[RESPONSE_REJECTED])?;
+        return Ok(());
+    };
+    match registry.acquire_optional(root_id, kind) {
         Ok(Some(directory)) => send_descriptor(stream.as_raw_fd(), directory.as_raw_fd())?,
         Ok(None) => stream.write_all(&[RESPONSE_REJECTED])?,
         Err(_) => stream.write_all(&[RESPONSE_INTERNAL])?,
@@ -585,6 +754,7 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
+            kind: RegisteredDescriptorKind::Directory,
         }
     }
 
@@ -627,6 +797,52 @@ mod tests {
             );
             assert_eq!(read_at(&directory, c"marker"), b"original");
         }
+    }
+
+    #[test]
+    fn source_parent_and_object_are_distinct_repeatable_capabilities() {
+        let temp = tempfile::tempdir().unwrap();
+        let selected = temp.path().join("selected");
+        std::fs::write(&selected, b"selected").unwrap();
+        let object = File::open(&selected).unwrap();
+        let object_identity = object.metadata().unwrap();
+        let session = DescriptorSessionSlot::default();
+        let mut registrations = session
+            .register_source_handles(vec![(File::open(temp.path()).unwrap(), Some(object))])
+            .unwrap();
+        let (directory_ticket, leaf_ticket) = registrations.remove(0);
+        let leaf_ticket = leaf_ticket.unwrap();
+        assert!(directory_ticket.is_directory());
+        assert!(leaf_ticket.is_source_leaf());
+        assert_eq!(directory_ticket.root_id(), leaf_ticket.root_id());
+        assert!(directory_ticket.same_session(&leaf_ticket));
+
+        // An empty slot takes the independent-worker SCM_RIGHTS path. Both
+        // kinds can be claimed repeatedly and each receipt is close-on-exec.
+        let fresh = DescriptorSessionSlot::default();
+        let directory = fresh.acquire(&directory_ticket).unwrap();
+        assert!(directory.metadata().unwrap().is_dir());
+        for object in [
+            fresh.acquire(&leaf_ticket).unwrap(),
+            fresh.acquire(&leaf_ticket).unwrap(),
+        ] {
+            let metadata = object.metadata().unwrap();
+            assert_eq!(
+                (metadata.dev(), metadata.ino()),
+                (object_identity.dev(), object_identity.ino())
+            );
+            assert_ne!(
+                unsafe { libc::fcntl(object.as_raw_fd(), libc::F_GETFD) } & libc::FD_CLOEXEC,
+                0
+            );
+        }
+
+        let mut missing_object = session.register(File::open(temp.path()).unwrap()).unwrap();
+        missing_object.kind = RegisteredDescriptorKind::SourceLeaf;
+        assert!(claim_descriptor(&missing_object)
+            .unwrap_err()
+            .to_string()
+            .contains("rejected"));
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -6,8 +6,8 @@ use crate::descriptor_broker::{
 };
 use crate::proto::*;
 use crate::rooted::{
-    OperatorFinalComponent, OperatorResolver, PinnedPath, RelativePath, Root, RootIdentity,
-    RootMetadata,
+    read_open_symlink, root_metadata_from_std, OperatorFinalComponent, OperatorResolver,
+    PinnedPath, RelativePath, Root, RootIdentity, RootMetadata,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use sha2::{Digest, Sha256};
@@ -700,6 +700,38 @@ pub(crate) fn rooted_entry(
     Ok(entry_from_root_metadata(path, metadata, kind, link))
 }
 
+/// Build an entry for a registered source. An exact symlink's target is the
+/// descriptor-bound registration snapshot: reading it through `relative`
+/// would let a same-inode A -> B -> A name race return B's target.
+pub(crate) fn rooted_source_entry(
+    root: &Root,
+    relative: &RelativePath,
+    path: PathBytes,
+    metadata: RootMetadata,
+    expected: Option<&SourceLeafIdentity>,
+) -> Result<Entry> {
+    let Some(expected) = expected else {
+        return rooted_entry(root, relative, path, metadata);
+    };
+    require_source_leaf_identity(expected, metadata)?;
+    if metadata.is_symlink() {
+        let target = expected
+            .symlink_target
+            .clone()
+            .context("registered source symlink is missing its pinned target")?;
+        return Ok(entry_from_root_metadata(
+            path,
+            metadata,
+            Kind::Symlink,
+            Some(target),
+        ));
+    }
+    if expected.symlink_target.is_some() {
+        bail!("registered non-symlink source carries a symlink target");
+    }
+    rooted_entry(root, relative, path, metadata)
+}
+
 /// Build an entry relative to a directory already opened by a descriptor
 /// scanner. Symlink target reads and the confirming stat use that same parent
 /// descriptor, so neither operation has to rewalk a possibly renamed path.
@@ -787,22 +819,29 @@ fn source_descriptor_requirement(
     current_open: usize,
     root_count: usize,
     shared_workers: usize,
+    independent_workers: usize,
 ) -> Result<usize> {
-    // Registry + control connection retain each root. Every shared local/TCP
-    // worker retains another descriptor; independent SSH workers pay that
-    // one-root-set cost in their own process. Add live process descriptors and
-    // per-worker cache/transport state separately: a fixed reserve alone does
-    // not grow with concurrency and can admit a setup that later hits EMFILE.
+    // Conservatively treat every selection as an exact leaf. The registry,
+    // control connection, and each shared worker then retain both its parent
+    // and object. Independent SSH workers retain those descriptors in their
+    // own processes, but each concurrent broker claim transiently costs this
+    // process an accepted socket, tracked socket clone, and descriptor clone.
     root_count
         .checked_mul(
             shared_workers
                 .checked_add(2)
                 .context("source worker count overflow")?,
         )
+        .and_then(|count| count.checked_mul(2))
         .and_then(|count| {
             SOURCE_SHARED_WORKER_FD_RESERVE
                 .checked_mul(shared_workers)
                 .and_then(|workers| count.checked_add(workers))
+        })
+        .and_then(|count| {
+            independent_workers
+                .checked_mul(3)
+                .and_then(|claims| count.checked_add(claims))
         })
         .and_then(|count| count.checked_add(SOURCE_FD_RESERVE))
         .and_then(|count| count.checked_add(current_open))
@@ -847,7 +886,11 @@ fn current_open_descriptor_count(soft_limit: libc::rlim_t) -> Result<usize> {
     Ok(open)
 }
 
-fn require_source_descriptor_capacity(root_count: usize, shared_workers: usize) -> Result<()> {
+fn require_source_descriptor_capacity(
+    root_count: usize,
+    shared_workers: usize,
+    independent_workers: usize,
+) -> Result<()> {
     let mut limit = libc::rlimit {
         rlim_cur: 0,
         rlim_max: 0,
@@ -859,10 +902,15 @@ fn require_source_descriptor_capacity(root_count: usize, shared_workers: usize) 
         return Ok(());
     }
     let current_open = current_open_descriptor_count(limit.rlim_cur)?;
-    let required = source_descriptor_requirement(current_open, root_count, shared_workers)?;
+    let required = source_descriptor_requirement(
+        current_open,
+        root_count,
+        shared_workers,
+        independent_workers,
+    )?;
     if required as u128 > limit.rlim_cur as u128 {
         bail!(
-            "source setup needs about {required} open-file slots ({current_open} currently open) for {root_count} roots and {shared_workers} shared workers, but this endpoint permits {}; reduce the number of source selectors or use a smaller explicit --connections value",
+            "source setup needs about {required} open-file slots ({current_open} currently open) for {root_count} roots, {shared_workers} shared workers, and {independent_workers} independent workers, but this endpoint permits {}; reduce the number of source selectors or use a smaller explicit --connections value",
             limit.rlim_cur
         );
     }
@@ -878,6 +926,7 @@ pub struct FsOps {
     operator_selection: Option<OperatorDirectorySelection>,
     descriptor_session: DescriptorSessionSlot,
     source_roots: HashMap<RegisteredRootId, SourceRootHandle>,
+    allow_unconfined_source_paths: bool,
     destination_root: Option<Arc<Root>>,
     destination_prefix: Option<PathBytes>,
     initial_cwd: PathBuf,
@@ -890,10 +939,47 @@ struct HeldBasis {
 }
 
 struct SourceRootHandle {
-    _root: Arc<Root>,
-    /// Transitional selection spelling retained for the source-operation
-    /// cutover. It does not authorize the parallel legacy pathname yet.
-    _selection: PathBytes,
+    root: Arc<Root>,
+    /// Each worker retains its own exact-object clone for the entire worker
+    /// lifetime. It is not used for content I/O; it prevents inode reuse while
+    /// the literal name is checked against `expected_leaf`.
+    _leaf_object: Option<File>,
+    /// An empty selection authorizes the whole registered directory. A
+    /// non-empty selection is one exact leaf beneath the registered parent.
+    selection: PathBytes,
+    expected_leaf: Option<SourceLeafIdentity>,
+}
+
+struct RegisteredSourceTarget {
+    root: Arc<Root>,
+    relative: RelativePath,
+    expected_leaf: Option<SourceLeafIdentity>,
+}
+
+pub(crate) struct SourceScanRoot {
+    pub(crate) root: Arc<Root>,
+    pub(crate) relative: PathBytes,
+    pub(crate) expected_leaf: Option<SourceLeafIdentity>,
+}
+
+pub(crate) fn require_source_leaf_identity(
+    expected: &SourceLeafIdentity,
+    metadata: RootMetadata,
+) -> Result<()> {
+    if (metadata.dev, metadata.ino, metadata.file_type())
+        != (expected.dev, expected.ino, expected.file_type)
+    {
+        bail!(
+            "registered source leaf changed identity (expected {}:{} type {:#o}, found {}:{} type {:#o})",
+            expected.dev,
+            expected.ino,
+            expected.file_type,
+            metadata.dev,
+            metadata.ino,
+            metadata.file_type()
+        );
+    }
+    Ok(())
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -936,6 +1022,7 @@ impl FsOps {
             operator_selection: None,
             descriptor_session,
             source_roots: HashMap::new(),
+            allow_unconfined_source_paths: false,
             destination_root: None,
             destination_prefix: None,
             initial_cwd: process_initial_cwd(),
@@ -1024,8 +1111,13 @@ impl FsOps {
         &mut self,
         selections: &[SourceRootSelection],
         symlink_policy: OperatorSymlinkPolicy,
+        allow_unconfined_paths: bool,
         shared_workers: usize,
+        independent_workers: usize,
     ) -> Result<Vec<RegisteredSourceRoot>> {
+        if !self.source_roots.is_empty() {
+            bail!("source roots are already registered on this control connection");
+        }
         if selections.is_empty() {
             bail!("source registration requires at least one selection");
         }
@@ -1035,7 +1127,7 @@ impl FsOps {
                 selections.len()
             );
         }
-        require_source_descriptor_capacity(selections.len(), shared_workers)?;
+        require_source_descriptor_capacity(selections.len(), shared_workers, independent_workers)?;
         let mut resolved = Vec::with_capacity(selections.len());
         for selection in selections {
             let path = resolve(&selection.path);
@@ -1058,11 +1150,31 @@ impl FsOps {
             match pinned {
                 PinnedPath::Directory(directory) => {
                     let (directory, _) = directory.into_parts();
-                    resolved.push((directory, Vec::new()));
+                    resolved.push((directory, Vec::new(), None, None));
                 }
                 PinnedPath::Leaf(leaf) => {
-                    let (parent, name, _, _) = leaf.into_parts();
-                    resolved.push((parent, name.as_bytes().to_vec()));
+                    let (parent, name, metadata, object) = leaf.into_parts();
+                    let object = object
+                        .context("this platform cannot retain the selected source leaf safely")?;
+                    let symlink_target = if metadata.is_symlink() {
+                        Some(
+                            read_open_symlink(&object)?
+                                .context("this platform cannot snapshot a selected source symlink through its pinned object (macOS 13 or newer is required on Darwin)")?,
+                        )
+                    } else {
+                        None
+                    };
+                    resolved.push((
+                        parent,
+                        name.as_bytes().to_vec(),
+                        Some(SourceLeafIdentity {
+                            dev: metadata.dev,
+                            ino: metadata.ino,
+                            file_type: metadata.file_type(),
+                            symlink_target,
+                        }),
+                        Some(object),
+                    ));
                 }
                 PinnedPath::Missing(_) => {
                     unreachable!("source resolution did not allow a missing suffix")
@@ -1070,25 +1182,47 @@ impl FsOps {
             }
         }
 
-        let relative: Vec<_> = resolved
+        let registrations: Vec<_> = resolved
             .iter()
-            .map(|(_, relative)| relative.clone())
+            .map(|(_, relative, expected_leaf, _)| (relative.clone(), expected_leaf.clone()))
             .collect();
-        let tickets = self.descriptor_session.register_many(
+        let tickets = self.descriptor_session.register_source_handles(
             resolved
                 .into_iter()
-                .map(|(directory, _)| directory)
+                .map(|(directory, _, _, object)| (directory, object))
                 .collect(),
         )?;
         let registered: Vec<_> = tickets
             .into_iter()
-            .zip(relative)
-            .map(|(ticket, relative)| {
+            .zip(registrations)
+            .map(|((ticket, leaf_ticket), (relative, expected_leaf))| {
                 let selection = RegisteredPath::new(ticket.root_id(), relative)?;
-                Ok(RegisteredSourceRoot { ticket, selection })
+                Ok(RegisteredSourceRoot {
+                    ticket,
+                    leaf_ticket,
+                    selection,
+                    expected_leaf,
+                    allow_unconfined_paths,
+                })
             })
             .collect::<Result<_>>()?;
         self.initialize_sources(&registered)?;
+        #[cfg(debug_assertions)]
+        {
+            if let Some(ready) = std::env::var_os("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE") {
+                fs::write(&ready, b"ready").with_context(|| {
+                    format!(
+                        "write source-registration-ready signal {}",
+                        Path::new(&ready).display()
+                    )
+                })?;
+            }
+            if let Some(ms) = std::env::var_os("SYQ_TEST_HOLD_SOURCE_ROOTS_MS") {
+                if let Ok(ms) = ms.to_string_lossy().parse::<u64>() {
+                    std::thread::sleep(std::time::Duration::from_millis(ms));
+                }
+            }
+        }
         Ok(registered)
     }
 
@@ -1108,8 +1242,16 @@ impl FsOps {
             );
         }
         let mut roots = HashMap::with_capacity(sources.len());
+        let endpoint_ticket = &sources[0].ticket;
+        let allow_unconfined_paths = sources[0].allow_unconfined_paths;
         for source in sources {
             source.validate()?;
+            if !source.ticket.same_session(endpoint_ticket) {
+                bail!("source roots belong to different endpoint sessions");
+            }
+            if source.allow_unconfined_paths != allow_unconfined_paths {
+                bail!("source worker received inconsistent unconfined-path permissions");
+            }
             let id = source.selection.root();
             if roots.contains_key(&id) {
                 bail!(
@@ -1118,15 +1260,49 @@ impl FsOps {
                 );
             }
             let directory = self.descriptor_session.acquire(&source.ticket)?;
+            let leaf_object = match (&source.leaf_ticket, &source.expected_leaf) {
+                (Some(ticket), Some(expected)) => {
+                    let object = self.descriptor_session.acquire(ticket)?;
+                    let metadata = root_metadata_from_std(
+                        &object
+                            .metadata()
+                            .context("inspect registered exact source object")?,
+                    )?;
+                    require_source_leaf_identity(expected, metadata)?;
+                    match (metadata.is_symlink(), expected.symlink_target.as_ref()) {
+                        (true, Some(expected_target)) => {
+                            let target = read_open_symlink(&object)?.context(
+                                "this platform cannot validate a registered source symlink through its pinned object (macOS 13 or newer is required on Darwin)",
+                            )?;
+                            if &target != expected_target {
+                                bail!("registered source symlink target does not match its pinned capability");
+                            }
+                        }
+                        (true, None) => {
+                            bail!("registered source symlink capability is missing its target")
+                        }
+                        (false, Some(_)) => {
+                            bail!("registered non-symlink source carries a symlink target")
+                        }
+                        (false, None) => {}
+                    }
+                    Some(object)
+                }
+                (None, None) => None,
+                _ => bail!("source root leaf selection and object ticket disagree"),
+            };
             roots.insert(
                 id,
                 SourceRootHandle {
-                    _root: Arc::new(Root::from_directory(directory)?),
-                    _selection: source.selection.relative.clone(),
+                    root: Arc::new(Root::from_directory(directory)?),
+                    _leaf_object: leaf_object,
+                    selection: source.selection.relative.clone(),
+                    expected_leaf: source.expected_leaf.clone(),
                 },
             );
         }
         self.source_roots = roots;
+        self.allow_unconfined_source_paths = allow_unconfined_paths;
         Ok(())
     }
 
@@ -1134,7 +1310,79 @@ impl FsOps {
     fn source_root_identity(&self, id: RegisteredRootId) -> Option<RootIdentity> {
         self.source_roots
             .get(&id)
-            .map(|source| source._root.identity())
+            .map(|source| source.root.identity())
+    }
+
+    fn registered_source_target(&self, source: &RegisteredPath) -> Result<RegisteredSourceTarget> {
+        let handle = self
+            .source_roots
+            .get(&source.root())
+            .with_context(|| format!("unknown registered source root {}", source.root().get()))?;
+        if !handle.selection.is_empty() && source.relative != handle.selection {
+            bail!("registered source leaf does not authorize the requested path");
+        }
+        Ok(RegisteredSourceTarget {
+            root: handle.root.clone(),
+            relative: RelativePath::new(&source.relative)?,
+            expected_leaf: handle.expected_leaf.clone(),
+        })
+    }
+
+    /// Resolve a source scan to its retained root. Once source roots exist,
+    /// omission is never an implicit fallback: only a registration carrying
+    /// the explicit `--insecure-links` permission may use the legacy pathname.
+    pub(crate) fn source_scan_root(
+        &self,
+        source: Option<&RegisteredPath>,
+    ) -> Result<Option<SourceScanRoot>> {
+        if let Some(source) = source {
+            let target = self.registered_source_target(source)?;
+            return Ok(Some(SourceScanRoot {
+                root: target.root,
+                relative: source.relative.clone(),
+                expected_leaf: target.expected_leaf,
+            }));
+        }
+        if self.source_roots.is_empty() {
+            return Ok(None);
+        }
+        if self.allow_unconfined_source_paths {
+            return Ok(None);
+        }
+        bail!("source scan omitted its registered source reference")
+    }
+
+    /// A source worker never accepts destination-style caller guards. Those
+    /// guards carry a fresh pathname root and would otherwise bypass the
+    /// endpoint-session source capabilities, even on request variants whose
+    /// source-reference cutover has not landed yet.
+    pub(crate) fn validate_source_session_request(&self, request: &Request) -> Result<()> {
+        if self.source_roots.is_empty() {
+            return Ok(());
+        }
+        let has_guard = match request {
+            Request::Scan { guard, .. }
+            | Request::StatMany { guard, .. }
+            | Request::PartialPaths { guard, .. }
+            | Request::Apply { guard, .. }
+            | Request::PlanBatch { guard, .. }
+            | Request::ProbePartial { guard, .. }
+            | Request::Prepare { guard, .. }
+            | Request::HashAndHold { guard, .. }
+            | Request::FinishBasis { guard, .. }
+            | Request::SeedBasis { guard, .. }
+            | Request::HashBlocks { guard, .. }
+            | Request::WriteRange { guard, .. }
+            | Request::Finalize { guard, .. }
+            | Request::FileHash { guard, .. }
+            | Request::Canonicalize { guard, .. } => guard.is_some(),
+            Request::PutSmallBatch(puts) => puts.iter().any(|put| put.guard.is_some()),
+            _ => false,
+        };
+        if has_guard {
+            bail!("an initialized source session rejects caller-supplied guards");
+        }
+        Ok(())
     }
 
     fn install_destination(&mut self, directory: File, request_prefix: &[u8]) -> Result<()> {
@@ -1487,6 +1735,64 @@ impl FsOps {
             };
             md.ok().map(|md| entry_from_meta(Vec::new(), &full, &md))
         })
+    }
+
+    fn stat_many_request(
+        &mut self,
+        paths: &[PathBytes],
+        sources: Option<&[RegisteredPath]>,
+        follow: bool,
+        guard: Option<&ContainerGuard>,
+    ) -> Result<Vec<Option<Entry>>> {
+        if guard.is_some() && sources.is_some() {
+            bail!("a guarded destination stat cannot carry source references");
+        }
+        if let Some(sources) = sources {
+            if sources.len() != paths.len() {
+                bail!("source stat capability count does not match path count");
+            }
+            let targets = sources
+                .iter()
+                .map(|source| self.registered_source_target(source))
+                .collect::<Result<Vec<_>>>()?;
+            // `follow` describes the legacy pathname request. A registered
+            // selection has already applied the operator-root policy, and no
+            // descendant component gains symlink-traversal authority here.
+            return parallel_map(&targets, |target| {
+                let Some(expected) = target.expected_leaf.as_ref() else {
+                    let Some(metadata) = target.root.metadata(&target.relative).ok() else {
+                        return Ok(None);
+                    };
+                    return Ok(
+                        rooted_entry(&target.root, &target.relative, Vec::new(), metadata).ok(),
+                    );
+                };
+                let metadata = target
+                    .root
+                    .metadata(&target.relative)
+                    .context("inspect registered source leaf")?;
+                require_source_leaf_identity(expected, metadata)?;
+                let entry = rooted_source_entry(
+                    &target.root,
+                    &target.relative,
+                    Vec::new(),
+                    metadata,
+                    Some(expected),
+                )?;
+                let after = target
+                    .root
+                    .metadata(&target.relative)
+                    .context("recheck registered source leaf")?;
+                require_source_leaf_identity(expected, after)?;
+                Ok(Some(entry))
+            })
+            .into_iter()
+            .collect();
+        }
+        if !self.source_roots.is_empty() && !self.allow_unconfined_source_paths {
+            bail!("source stat omitted its registered source references");
+        }
+        Ok(self.stat_many(paths, follow, guard))
     }
 
     pub fn partial_paths(
@@ -3598,6 +3904,9 @@ impl FsOps {
 
     /// Dispatch a request that has a single response (everything except Scan).
     pub fn handle(&mut self, req: &Request) -> Response {
+        if let Err(error) = self.validate_source_session_request(req) {
+            return Response::Err(errstr(&error));
+        }
         let req = match self.map_request(req) {
             Ok(req) => req,
             Err(error) => return Response::Err(errstr(&error)),
@@ -3614,14 +3923,12 @@ impl FsOps {
         let r: Result<Response> = match &req {
             Request::StatMany {
                 paths,
+                sources,
                 follow,
                 guard,
-                ..
-            } => Ok(Response::Stats(self.stat_many(
-                paths,
-                *follow,
-                guard.as_ref(),
-            ))),
+            } => self
+                .stat_many_request(paths, sources.as_deref(), *follow, guard.as_ref())
+                .map(Response::Stats),
             Request::CheckOperatorDirectory {
                 path,
                 allow_missing,
@@ -3633,9 +3940,17 @@ impl FsOps {
             Request::RegisterSourceRoots {
                 selections,
                 symlink_policy,
+                allow_unconfined_paths,
                 shared_workers,
+                independent_claim_workers,
             } => self
-                .register_source_roots(selections, *symlink_policy, *shared_workers)
+                .register_source_roots(
+                    selections,
+                    *symlink_policy,
+                    *allow_unconfined_paths,
+                    *shared_workers,
+                    *independent_claim_workers,
+                )
                 .map(Response::SourceRootsRegistered),
             Request::CreateOperatorDirectory {
                 mode,
@@ -4904,6 +5219,7 @@ mod tests {
         let temporary = tempfile::tempdir().unwrap();
         let selected = temporary.path().join("selected");
         fs::create_dir(&selected).unwrap();
+        fs::write(selected.join("original"), b"original").unwrap();
         let identity = fs::metadata(&selected).unwrap();
         let session = DescriptorSessionSlot::default();
         let mut control = FsOps::with_descriptor_session(session.clone());
@@ -4913,28 +5229,50 @@ mod tests {
                 follow_root: false,
             }],
             symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
             shared_workers: 0,
+            independent_claim_workers: 0,
         });
         let Response::SourceRootsRegistered(roots) = response else {
             panic!("unexpected source registration response: {response:?}")
         };
         let id = roots[0].selection.root();
 
-        fs::rename(&selected, temporary.path().join("moved")).unwrap();
-        fs::create_dir(&selected).unwrap();
+        let moved = temporary.path().join("moved");
+        let replacement = temporary.path().join("replacement");
+        fs::rename(&selected, &moved).unwrap();
+        fs::create_dir(&replacement).unwrap();
+        fs::write(replacement.join("replacement"), b"replacement").unwrap();
+        std::os::unix::fs::symlink(&replacement, &selected).unwrap();
 
         let mut shared = FsOps::with_descriptor_session(session);
         shared.initialize_sources(&roots).unwrap();
         let mut fresh = FsOps::new();
         fresh.initialize_sources(&roots).unwrap();
-        for worker in [&shared, &fresh] {
+        for worker in [&mut shared, &mut fresh] {
             let adopted = worker.source_root_identity(id).unwrap();
             assert_eq!((adopted.dev, adopted.ino), (identity.dev(), identity.ino()));
+            let original = roots[0].selection.join(b"original").unwrap();
+            let response = worker.handle(&Request::StatMany {
+                paths: vec![selected.join("original").as_os_str().as_bytes().to_vec()],
+                sources: Some(vec![original]),
+                follow: false,
+                guard: None,
+            });
+            assert!(matches!(response, Response::Stats(stats) if stats[0].is_some()));
+            let replacement = roots[0].selection.join(b"replacement").unwrap();
+            let response = worker.handle(&Request::StatMany {
+                paths: vec![selected.join("replacement").as_os_str().as_bytes().to_vec()],
+                sources: Some(vec![replacement]),
+                follow: false,
+                guard: None,
+            });
+            assert!(matches!(response, Response::Stats(stats) if stats[0].is_none()));
         }
         assert_ne!(
             (
-                fs::metadata(&selected).unwrap().dev(),
-                fs::metadata(&selected).unwrap().ino()
+                fs::metadata(&replacement).unwrap().dev(),
+                fs::metadata(&replacement).unwrap().ino()
             ),
             (identity.dev(), identity.ino())
         );
@@ -4961,7 +5299,9 @@ mod tests {
                 },
             ],
             symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
             shared_workers: 0,
+            independent_claim_workers: 0,
         });
         let Response::SourceRootsRegistered(roots) = response else {
             panic!("unexpected source registration response: {response:?}")
@@ -4971,6 +5311,16 @@ mod tests {
         mismatched.selection = roots[1].selection.clone();
         let mut worker = FsOps::with_descriptor_session(session.clone());
         assert!(worker.initialize_sources(&[mismatched]).is_err());
+        assert!(worker.source_roots.is_empty());
+
+        let mut malformed = roots[0].clone();
+        malformed.expected_leaf = Some(SourceLeafIdentity {
+            dev: 1,
+            ino: 2,
+            file_type: 0,
+            symlink_target: None,
+        });
+        assert!(worker.initialize_sources(&[malformed]).is_err());
         assert!(worker.source_roots.is_empty());
 
         session.close();
@@ -4984,7 +5334,185 @@ mod tests {
     }
 
     #[test]
-    fn source_request_reference_is_inert_until_operation_cutover() {
+    fn source_initialization_rejects_missing_mistyped_and_cross_session_leaf_tickets() {
+        let temporary = tempfile::tempdir().unwrap();
+        let first = temporary.path().join("first");
+        let second = temporary.path().join("second");
+        fs::write(&first, b"first").unwrap();
+        fs::write(&second, b"second").unwrap();
+        let register = |control: &mut FsOps, path: &Path| {
+            let response = control.handle(&Request::RegisterSourceRoots {
+                selections: vec![SourceRootSelection {
+                    path: path.as_os_str().as_bytes().to_vec(),
+                    follow_root: false,
+                }],
+                symlink_policy: OperatorSymlinkPolicy::Refuse,
+                allow_unconfined_paths: false,
+                shared_workers: 0,
+                independent_claim_workers: 0,
+            });
+            let Response::SourceRootsRegistered(roots) = response else {
+                panic!("unexpected source registration response: {response:?}")
+            };
+            roots.into_iter().next().unwrap()
+        };
+
+        let mut first_control = FsOps::new();
+        let first_root = register(&mut first_control, &first);
+        let mut second_control = FsOps::new();
+        let second_root = register(&mut second_control, &second);
+        assert_eq!(
+            first_root.selection.root(),
+            second_root.selection.root(),
+            "independent registries should exercise coincident numeric IDs"
+        );
+
+        let mut worker = FsOps::new();
+        let mut missing = first_root.clone();
+        missing.leaf_ticket = None;
+        assert!(worker.initialize_sources(&[missing]).is_err());
+        assert!(worker.source_roots.is_empty());
+
+        let mut mistyped = first_root.clone();
+        mistyped.leaf_ticket = Some(mistyped.ticket.clone());
+        assert!(worker.initialize_sources(&[mistyped]).is_err());
+        assert!(worker.source_roots.is_empty());
+
+        let mut nested = first_root.clone();
+        nested.selection =
+            RegisteredPath::new(nested.selection.root(), b"nested/leaf".to_vec()).unwrap();
+        assert!(worker.initialize_sources(&[nested]).is_err());
+        assert!(worker.source_roots.is_empty());
+
+        let mut impossible_target = first_root.clone();
+        impossible_target
+            .expected_leaf
+            .as_mut()
+            .unwrap()
+            .symlink_target = Some(b"not-a-regular-file-property".to_vec());
+        assert!(worker.initialize_sources(&[impossible_target]).is_err());
+        assert!(worker.source_roots.is_empty());
+
+        let mut cross_session_pair = first_root.clone();
+        cross_session_pair.leaf_ticket = second_root.leaf_ticket.clone();
+        assert!(worker.initialize_sources(&[cross_session_pair]).is_err());
+        assert!(worker.source_roots.is_empty());
+
+        // All roots in one Hello must come from the same endpoint session,
+        // even when each root/leaf pair is internally consistent.
+        assert!(worker
+            .initialize_sources(&[first_root, second_root])
+            .is_err());
+        assert!(worker.source_roots.is_empty());
+    }
+
+    #[test]
+    fn independent_source_worker_keeps_exact_object_after_control_and_broker_close() {
+        let temporary = tempfile::tempdir().unwrap();
+        let selected = temporary.path().join("selected");
+        fs::write(&selected, b"original").unwrap();
+        let session = DescriptorSessionSlot::default();
+        let mut control = FsOps::with_descriptor_session(session.clone());
+        let response = control.handle(&Request::RegisterSourceRoots {
+            selections: vec![SourceRootSelection {
+                path: selected.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
+            shared_workers: 0,
+            independent_claim_workers: 1,
+        });
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+        let expected = roots[0].expected_leaf.clone().unwrap();
+
+        // An empty slot exercises the independent-worker broker claim path.
+        let mut worker = FsOps::new();
+        worker.initialize_sources(&roots).unwrap();
+        drop(control);
+        session.close();
+
+        let original = temporary.path().join("original-unlinked");
+        fs::rename(&selected, &original).unwrap();
+        fs::remove_file(&original).unwrap();
+        fs::write(&selected, b"replacement").unwrap();
+        let held = worker.source_roots[&roots[0].selection.root()]
+            ._leaf_object
+            .as_ref()
+            .unwrap()
+            .metadata()
+            .unwrap();
+        assert_eq!((held.dev(), held.ino()), (expected.dev, expected.ino));
+        assert_eq!(held.nlink(), 0);
+
+        let response = worker.handle(&Request::StatMany {
+            paths: vec![selected.as_os_str().as_bytes().to_vec()],
+            sources: Some(vec![roots[0].selection.clone()]),
+            follow: false,
+            guard: None,
+        });
+        assert!(matches!(
+            response,
+            Response::Err(error) if error.contains("registered source leaf changed identity")
+        ));
+    }
+
+    #[test]
+    fn repeated_source_registration_keeps_the_original_root_and_leaf_pin() {
+        let temporary = tempfile::tempdir().unwrap();
+        let first = temporary.path().join("first");
+        let second = temporary.path().join("second");
+        fs::write(&first, b"first").unwrap();
+        fs::write(&second, b"second").unwrap();
+        let mut control = FsOps::new();
+        let register = |path: &Path| Request::RegisterSourceRoots {
+            selections: vec![SourceRootSelection {
+                path: path.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
+            shared_workers: 0,
+            independent_claim_workers: 0,
+        };
+        let response = control.handle(&register(&first));
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+        let original_id = roots[0].selection.root();
+        let expected = roots[0].expected_leaf.clone().unwrap();
+        assert_eq!(control.source_roots.len(), 1);
+        assert!(control.source_roots[&original_id]._leaf_object.is_some());
+
+        let response = control.handle(&register(&second));
+        assert!(matches!(
+            response,
+            Response::Err(error) if error.contains("already registered")
+        ));
+        assert_eq!(control.source_roots.len(), 1);
+        let pin = control.source_roots[&original_id]
+            ._leaf_object
+            .as_ref()
+            .unwrap();
+        let metadata = pin.metadata().unwrap();
+        assert_eq!(
+            (metadata.dev(), metadata.ino()),
+            (expected.dev, expected.ino)
+        );
+
+        let response = control.handle(&Request::StatMany {
+            paths: vec![first.as_os_str().as_bytes().to_vec()],
+            sources: Some(vec![roots[0].selection.clone()]),
+            follow: false,
+            guard: None,
+        });
+        assert!(matches!(response, Response::Stats(stats) if stats[0].is_some()));
+    }
+
+    #[test]
+    fn source_stat_enforces_exact_leaf_authority_and_ignores_parallel_path() {
         let temporary = tempfile::tempdir().unwrap();
         let selected = temporary.path().join("selected");
         fs::write(&selected, b"selected").unwrap();
@@ -4997,15 +5525,36 @@ mod tests {
                 follow_root: false,
             }],
             symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
             shared_workers: 0,
+            independent_claim_workers: 0,
         });
         let Response::SourceRootsRegistered(roots) = response else {
             panic!("unexpected source registration response: {response:?}")
         };
         assert_eq!(roots[0].selection.relative, b"selected");
+        assert!(roots[0].expected_leaf.is_some());
+        assert!(control.source_roots[&roots[0].selection.root()]
+            ._leaf_object
+            .is_some());
 
         let mut worker = FsOps::with_descriptor_session(session);
         worker.initialize_sources(&roots).unwrap();
+        let response = worker.handle(&Request::StatMany {
+            // A contradictory display spelling cannot redirect the registered
+            // selected leaf.
+            paths: vec![temporary
+                .path()
+                .join("sibling")
+                .as_os_str()
+                .as_bytes()
+                .to_vec()],
+            sources: Some(vec![roots[0].selection.clone()]),
+            follow: false,
+            guard: None,
+        });
+        assert!(matches!(response, Response::Stats(stats) if stats[0].is_some()));
+
         let sibling = RegisteredPath::new(roots[0].selection.root(), b"sibling".to_vec()).unwrap();
         let response = worker.handle(&Request::StatMany {
             paths: vec![temporary
@@ -5014,28 +5563,238 @@ mod tests {
                 .as_os_str()
                 .as_bytes()
                 .to_vec()],
-            // This intentionally does not correspond to the legacy pathname.
-            // The field is syntax-only until the source-stat cutover; treating
-            // it as a partial allowlist would create a bypassable boundary.
             sources: Some(vec![sibling]),
             follow: false,
             guard: None,
         });
-        let Response::Stats(stats) = response else {
-            panic!("unexpected stat response: {response:?}")
+        assert!(matches!(response, Response::Err(error) if error.contains("does not authorize")));
+
+        let response = worker.handle(&Request::StatMany {
+            paths: vec![selected.as_os_str().as_bytes().to_vec()],
+            sources: None,
+            follow: false,
+            guard: None,
+        });
+        assert!(matches!(response, Response::Err(error) if error.contains("omitted")));
+
+        fs::rename(&selected, temporary.path().join("selected-original")).unwrap();
+        fs::write(&selected, b"replacement").unwrap();
+        let response = worker.handle(&Request::StatMany {
+            paths: vec![selected.as_os_str().as_bytes().to_vec()],
+            sources: Some(vec![roots[0].selection.clone()]),
+            follow: false,
+            guard: None,
+        });
+        assert!(matches!(
+            response,
+            Response::Err(error) if error.contains("registered source leaf changed identity")
+        ));
+    }
+
+    #[test]
+    fn source_scan_rejects_a_replaced_exact_symlink() {
+        let temporary = tempfile::tempdir().unwrap();
+        fs::write(temporary.path().join("target-a"), b"a").unwrap();
+        fs::write(temporary.path().join("target-b"), b"b").unwrap();
+        let selected = temporary.path().join("selected");
+        std::os::unix::fs::symlink("target-a", &selected).unwrap();
+        let session = DescriptorSessionSlot::default();
+        let mut control = FsOps::with_descriptor_session(session);
+        let response = control.handle(&Request::RegisterSourceRoots {
+            selections: vec![SourceRootSelection {
+                path: selected.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
+            shared_workers: 0,
+            independent_claim_workers: 0,
+        });
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
         };
-        assert_eq!(stats.len(), 1);
-        assert!(stats[0].is_some());
+        assert!(control.source_roots[&roots[0].selection.root()]
+            ._leaf_object
+            .is_some());
+
+        let mut worker = FsOps::new();
+        worker.initialize_sources(&roots).unwrap();
+        fs::rename(&selected, temporary.path().join("selected-original")).unwrap();
+        std::os::unix::fs::symlink("target-b", &selected).unwrap();
+        let source = worker
+            .source_scan_root(Some(&roots[0].selection))
+            .unwrap()
+            .unwrap();
+        let error = crate::scan::scan_descriptor(
+            source.root,
+            &source.relative,
+            source.expected_leaf,
+            false,
+            false,
+            &[],
+            false,
+            &mut |_| Ok(()),
+            &mut |_| Ok(()),
+            &mut |_| {},
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("registered source leaf changed identity"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn exact_symlink_scan_uses_the_descriptor_bound_raw_target_snapshot() {
+        let temporary = tempfile::tempdir().unwrap();
+        let selected = temporary.path().join("selected");
+        let target = OsString::from_vec(b"raw-target-\xff".to_vec());
+        symlink(Path::new(&target), &selected).unwrap();
+        let session = DescriptorSessionSlot::default();
+        let mut control = FsOps::with_descriptor_session(session);
+        let response = control.handle(&Request::RegisterSourceRoots {
+            selections: vec![SourceRootSelection {
+                path: selected.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
+            shared_workers: 0,
+            independent_claim_workers: 1,
+        });
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+        assert_eq!(
+            roots[0]
+                .expected_leaf
+                .as_ref()
+                .unwrap()
+                .symlink_target
+                .as_deref(),
+            Some(target.as_bytes())
+        );
+
+        let mut worker = FsOps::new();
+        worker.initialize_sources(&roots).unwrap();
+        // Temporarily replace the name, then restore the original symlink
+        // object. The emitted target belongs to that pinned object; discovery
+        // never obtains it with readlinkat(parent, name).
+        let original = temporary.path().join("selected-original");
+        fs::rename(&selected, &original).unwrap();
+        symlink("different-target", &selected).unwrap();
+        fs::remove_file(&selected).unwrap();
+        fs::rename(&original, &selected).unwrap();
+
+        let source = worker
+            .source_scan_root(Some(&roots[0].selection))
+            .unwrap()
+            .unwrap();
+        let mut entries = Vec::new();
+        crate::scan::scan_descriptor(
+            source.root,
+            &source.relative,
+            source.expected_leaf,
+            false,
+            false,
+            &[],
+            false,
+            &mut |batch| {
+                entries.extend(batch);
+                Ok(())
+            },
+            &mut |_| Ok(()),
+            &mut |_| {},
+        )
+        .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].kind, Kind::Symlink);
+        assert_eq!(entries[0].link.as_deref(), Some(target.as_bytes()));
+    }
+
+    #[test]
+    fn source_stat_does_not_follow_intermediate_symlinks() {
+        let temporary = tempfile::tempdir().unwrap();
+        let selected = temporary.path().join("selected");
+        let outside = temporary.path().join("outside");
+        fs::create_dir(&selected).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::write(outside.join("secret"), b"secret").unwrap();
+        std::os::unix::fs::symlink("../outside", selected.join("link")).unwrap();
+        let session = DescriptorSessionSlot::default();
+        let mut control = FsOps::with_descriptor_session(session.clone());
+        let response = control.handle(&Request::RegisterSourceRoots {
+            selections: vec![SourceRootSelection {
+                path: selected.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
+            shared_workers: 0,
+            independent_claim_workers: 0,
+        });
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+        let secret = roots[0].selection.join(b"link/secret").unwrap();
+        let mut worker = FsOps::with_descriptor_session(session);
+        worker.initialize_sources(&roots).unwrap();
+        let response = worker.handle(&Request::StatMany {
+            paths: vec![selected.join("link/secret").as_os_str().as_bytes().to_vec()],
+            sources: Some(vec![secret]),
+            follow: true,
+            guard: None,
+        });
+        assert!(
+            matches!(response, Response::Stats(stats) if stats.len() == 1 && stats[0].is_none())
+        );
+    }
+
+    #[test]
+    fn source_legacy_stat_requires_explicit_unconfined_registration() {
+        let temporary = tempfile::tempdir().unwrap();
+        let selected = temporary.path().join("selected");
+        let sibling = temporary.path().join("sibling");
+        fs::write(&selected, b"selected").unwrap();
+        fs::write(&sibling, b"sibling").unwrap();
+        let session = DescriptorSessionSlot::default();
+        let mut control = FsOps::with_descriptor_session(session.clone());
+        let response = control.handle(&Request::RegisterSourceRoots {
+            selections: vec![SourceRootSelection {
+                path: selected.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: true,
+            shared_workers: 0,
+            independent_claim_workers: 0,
+        });
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+        let mut worker = FsOps::with_descriptor_session(session);
+        worker.initialize_sources(&roots).unwrap();
+        let response = worker.handle(&Request::StatMany {
+            paths: vec![sibling.as_os_str().as_bytes().to_vec()],
+            sources: None,
+            follow: false,
+            guard: None,
+        });
+        assert!(
+            matches!(response, Response::Stats(stats) if stats.len() == 1 && stats[0].is_some())
+        );
     }
 
     #[test]
     fn source_descriptor_budget_accounts_for_registry_control_and_workers() {
         assert_eq!(SOURCE_SHARED_WORKER_FD_RESERVE, 16 + 5 + 1);
         assert_eq!(
-            source_descriptor_requirement(7, 4, 3).unwrap(),
-            7 + SOURCE_FD_RESERVE + 4 * 5 + SOURCE_SHARED_WORKER_FD_RESERVE * 3
+            source_descriptor_requirement(7, 4, 3, 2).unwrap(),
+            7 + SOURCE_FD_RESERVE + 2 * 4 * 5 + SOURCE_SHARED_WORKER_FD_RESERVE * 3 + 3 * 2
         );
-        assert!(source_descriptor_requirement(0, usize::MAX, usize::MAX).is_err());
+        assert!(source_descriptor_requirement(0, usize::MAX, usize::MAX, usize::MAX).is_err());
     }
 
     #[test]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -17,6 +17,10 @@ const HASH_RESPONSE_BYTES_PER_ENTRY: u64 = 32;
 const HASH_RESPONSE_OVERHEAD: u64 = 24;
 const COMPRESS_MIN: usize = 512;
 const COMPRESS_LEVEL: i32 = 1;
+#[cfg(target_os = "linux")]
+const MODE_SYMLINK: u32 = libc::S_IFLNK;
+#[cfg(not(target_os = "linux"))]
+const MODE_SYMLINK: u32 = libc::S_IFLNK as u32;
 
 pub fn hash_response_fits(block: u64, len: u64) -> bool {
     if !(MIN_HASH_BLOCK_BYTES..=MAX_HASH_BLOCK_BYTES).contains(&block) {
@@ -32,12 +36,10 @@ pub fn hash_response_fits(block: u64, len: u64) -> bool {
 /// Path bytes, as given by the user (absolute, or relative to the server's cwd).
 pub type PathBytes = Vec<u8>;
 
-/// Transitional, syntactically strict descriptor-relative path vocabulary.
+/// A syntactically strict descriptor-relative source path.
 ///
-/// In the initialization-only protocol this is carried beside a legacy
-/// pathname but is deliberately inert: it neither authorizes nor confines the
-/// operation. The source-operation cutover will make the registered reference
-/// authoritative after the worker has acquired its corresponding ticket.
+/// Source discovery and stat operations use this reference as their authority;
+/// the parallel legacy pathname is only a display/compatibility spelling.
 #[derive(Serialize, Clone, Debug, Eq, PartialEq)]
 pub struct RegisteredPath {
     pub(crate) root: RegisteredRootId,
@@ -345,19 +347,76 @@ pub struct DestinationRoot {
     pub request_prefix: PathBytes,
 }
 
+/// Serialized identity of one exact non-directory source selection. The
+/// descriptor session and every initialized worker keep the originally opened
+/// object alive while workers use this identity to reject a replaced name
+/// beneath the retained parent. Symlink targets are snapshotted through that
+/// opened object and are never reread through the mutable name.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct SourceLeafIdentity {
+    pub dev: u64,
+    pub ino: u64,
+    pub file_type: u32,
+    pub symlink_target: Option<PathBytes>,
+}
+
 /// One operator source selection registered by the endpoint control session.
 /// `selection` is either empty beneath a selected directory or a literal leaf
 /// beneath its selected parent.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RegisteredSourceRoot {
     pub ticket: DescriptorTicket,
+    /// Present only for an exact non-directory selection. This typed ticket
+    /// names the original selected object, not its containing directory.
+    pub leaf_ticket: Option<DescriptorTicket>,
     pub selection: RegisteredPath,
+    /// Present only for an exact leaf. Every worker acquires and retains its
+    /// own clone of `leaf_ticket` before acknowledging readiness, preventing
+    /// identity reuse even if the control connection exits first.
+    pub expected_leaf: Option<SourceLeafIdentity>,
+    /// Permit this explicitly opted-in rsync session to use legacy unconfined
+    /// source pathnames for `--insecure-links` compatibility.
+    pub allow_unconfined_paths: bool,
 }
 
 impl RegisteredSourceRoot {
     pub(crate) fn validate(&self) -> Result<()> {
+        if !self.ticket.is_directory() {
+            bail!("source root requires a directory descriptor ticket");
+        }
         if self.ticket.root_id() != self.selection.root() {
             bail!("source root ticket and registered path identify different roots");
+        }
+        let exact_leaf = !self.selection.relative.is_empty();
+        if exact_leaf != self.expected_leaf.is_some() || exact_leaf != self.leaf_ticket.is_some() {
+            bail!("source root leaf selection and expected identity disagree");
+        }
+        if exact_leaf && self.selection.relative.contains(&b'/') {
+            bail!("exact source leaf selection must be one literal component");
+        }
+        if let Some(expected) = &self.expected_leaf {
+            let is_symlink = expected.file_type == MODE_SYMLINK;
+            if is_symlink != expected.symlink_target.is_some() {
+                bail!("source leaf type and symlink target disagree");
+            }
+            if expected
+                .symlink_target
+                .as_ref()
+                .is_some_and(|target| target.len() > libc::PATH_MAX as usize * 2)
+            {
+                bail!("registered source symlink target is too long");
+            }
+        }
+        if let Some(ticket) = &self.leaf_ticket {
+            if !ticket.is_source_leaf() {
+                bail!("source leaf requires an exact-object descriptor ticket");
+            }
+            if ticket.root_id() != self.selection.root() {
+                bail!("source leaf ticket and registered path identify different roots");
+            }
+            if !ticket.same_session(&self.ticket) {
+                bail!("source parent and leaf tickets belong to different endpoint sessions");
+            }
         }
         Ok(())
     }
@@ -374,12 +433,13 @@ pub enum ConnectionRole {
     /// The one connection allowed to create endpoint-session capabilities and
     /// start its TCP data listener.
     Control,
-    /// A data connection reserved for reading a source endpoint. Request-time
-    /// source-role enforcement lands with the source-operation cutover.
+    /// A data connection reserved for reading a source endpoint. Discovery
+    /// and stat are confined to the registered roots; content reads are
+    /// migrated in a later protocol slice.
     SourceWorker {
-        /// Every registered source root is acquired before HelloOk. Local and
-        /// same-process TCP workers clone in process; a fresh SSH helper
-        /// finishes SCM_RIGHTS receipt while single-threaded.
+        /// Every registered parent and exact-object descriptor is acquired
+        /// before HelloOk. Local and same-process TCP workers clone in process;
+        /// a fresh SSH helper finishes SCM_RIGHTS receipt while single-threaded.
         roots: Vec<RegisteredSourceRoot>,
     },
     /// A data connection used to mutate a destination endpoint. Unrestricted
@@ -412,8 +472,8 @@ pub enum Request {
     /// `report_ignored`: also send the paths the patterns pruned (ScanIgnored).
     Scan {
         root: PathBytes,
-        /// Inert registered spelling of `root`; the source scanner cutover
-        /// makes it authoritative.
+        /// Authoritative registered source reference. Its parallel `root`
+        /// spelling is used only by the explicit `--insecure-links` opt-out.
         source: Option<RegisteredPath>,
         follow_root: bool,
         ignore: Vec<String>,
@@ -434,8 +494,8 @@ pub enum Request {
     /// lstat each path; with `follow`, stat through symlinks instead.
     StatMany {
         paths: Vec<PathBytes>,
-        /// Inert registered spellings for source-side calls; these are not an
-        /// allowlist until the source stat cutover.
+        /// Authoritative registered source references. Parallel `paths` are
+        /// used only outside a source session or by `--insecure-links`.
         sources: Option<Vec<RegisteredPath>>,
         follow: bool,
         guard: Option<ContainerGuard>,
@@ -449,13 +509,20 @@ pub enum Request {
     },
     /// Resolve every operator source selection, then atomically register its
     /// opened directory or parent descriptor. Only a control connection may
-    /// create these endpoint-session capabilities.
+    /// create these endpoint-session capabilities, and it may do so only once
+    /// so every issued worker identity keeps its original pins alive.
     RegisterSourceRoots {
         selections: Vec<SourceRootSelection>,
         symlink_policy: OperatorSymlinkPolicy,
+        /// Explicit rsync compatibility opt-out. It permits legacy unconfined
+        /// source discovery only for the session created by this registration.
+        allow_unconfined_paths: bool,
         /// Maximum source workers that can share the control helper process.
         /// Zero still budgets the registry and control connection themselves.
         shared_workers: usize,
+        /// Maximum concurrent independent-worker claims against the control
+        /// process's private descriptor broker.
+        independent_claim_workers: usize,
     },
     /// Create the missing suffix retained by CheckOperatorDirectory, then
     /// return the selected directory's stable identity.
@@ -616,6 +683,25 @@ pub enum Request {
     /// ends the grant's mutation authority.
     Receipt,
     Shutdown,
+}
+
+impl Request {
+    /// Requests an authenticated source-worker connection may execute. Keep
+    /// this protocol boundary shared by remote dispatch and the in-process
+    /// adapter so choosing a local endpoint cannot grant mutation authority.
+    pub(crate) fn allowed_on_source_worker(&self) -> bool {
+        matches!(
+            self,
+            Request::Scan { .. }
+                | Request::StatMany { .. }
+                | Request::HashBlocks { .. }
+                | Request::ReadRange { .. }
+                | Request::ReadSmallBatch(_)
+                | Request::FileHash { .. }
+                | Request::TransportStats
+                | Request::Shutdown
+        )
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -1658,11 +1658,15 @@ impl RestrictedAuthority {
             }
             Request::Scan {
                 root,
+                source,
                 follow_root,
                 ignore,
                 guard,
                 ..
             } => {
+                if source.is_some() {
+                    bail!("source references are not valid on a command-restricted destination");
+                }
                 if *follow_root {
                     bail!("signed destination scans cannot follow a root symlink");
                 }
@@ -1681,10 +1685,14 @@ impl RestrictedAuthority {
             }
             Request::StatMany {
                 paths,
+                sources,
                 follow,
                 guard,
                 ..
             } => {
+                if sources.is_some() {
+                    bail!("source references are not valid on a command-restricted destination");
+                }
                 if *follow {
                     bail!("signed destination stat cannot follow symlinks");
                 }
@@ -6297,11 +6305,28 @@ mod tests {
                 follow_root: false,
             }],
             symlink_policy: proto::OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
             shared_workers: 0,
+            independent_claim_workers: 0,
         };
         let error = authority.authorize(&mut request, true).unwrap_err();
         assert!(error
             .to_string()
             .contains("not valid on a root-confined receiver"));
+
+        let session = crate::descriptor_broker::DescriptorSessionSlot::default();
+        let ticket = session.register(fs::File::open(&root).unwrap()).unwrap();
+        let mut scan = Request::Scan {
+            root: root.as_os_str().as_bytes().to_vec(),
+            source: Some(proto::RegisteredPath::new(ticket.root_id(), Vec::new()).unwrap()),
+            follow_root: false,
+            ignore: Vec::new(),
+            report_ignored: false,
+            guard: None,
+        };
+        let error = authority.authorize(&mut scan, true).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("source references are not valid"));
     }
 }

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -1341,12 +1341,52 @@ fn open_operator_symlink_at(parent: RawFd, name: &CString) -> Result<Option<File
 }
 
 fn operator_read_link_at(parent: RawFd, name: &CString) -> Result<Vec<u8>> {
+    read_link_bytes(|target, capacity| unsafe {
+        libc::readlinkat(parent, name.as_ptr(), target, capacity)
+    })
+}
+
+/// Read raw target bytes through an already-open symlink object. `None` means
+/// the running platform lacks a descriptor-bound API; security-sensitive
+/// callers must fail closed instead of reopening the symlink by name.
+pub(crate) fn read_open_symlink(object: &File) -> Result<Option<Vec<u8>>> {
+    #[cfg(target_os = "linux")]
+    {
+        let empty = c"";
+        read_link_bytes(|target, capacity| unsafe {
+            libc::readlinkat(object.as_raw_fd(), empty.as_ptr(), target, capacity)
+        })
+        .map(Some)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // `freadlink` was added in macOS 13. Resolve it dynamically so a binary
+        // that otherwise runs on an older release does not gain a hard loader
+        // dependency. Callers reject `None` rather than re-address by name.
+        type Freadlink =
+            unsafe extern "C" fn(libc::c_int, *mut libc::c_char, libc::size_t) -> libc::ssize_t;
+        let symbol = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"freadlink".as_ptr()) };
+        if symbol.is_null() {
+            return Ok(None);
+        }
+        let freadlink: Freadlink = unsafe { std::mem::transmute(symbol) };
+        read_link_bytes(|target, capacity| unsafe {
+            freadlink(object.as_raw_fd(), target, capacity)
+        })
+        .map(Some)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        let _ = object;
+        Ok(None)
+    }
+}
+
+fn read_link_bytes(mut read: impl FnMut(*mut libc::c_char, usize) -> isize) -> Result<Vec<u8>> {
     let mut capacity = 256usize;
     loop {
         let mut target = Vec::<u8>::with_capacity(capacity);
-        let length = unsafe {
-            libc::readlinkat(parent, name.as_ptr(), target.as_mut_ptr().cast(), capacity)
-        };
+        let length = read(target.as_mut_ptr().cast(), capacity);
         if length < 0 {
             let error = io::Error::last_os_error();
             if error.kind() == io::ErrorKind::Interrupted {
@@ -1502,7 +1542,7 @@ fn metadata_at(parent: RawFd, name: &CString) -> io::Result<RootMetadata> {
     })
 }
 
-fn root_metadata_from_std(metadata: &std::fs::Metadata) -> Result<RootMetadata> {
+pub(crate) fn root_metadata_from_std(metadata: &std::fs::Metadata) -> Result<RootMetadata> {
     Ok(RootMetadata {
         dev: metadata.dev(),
         ino: metadata.ino(),

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,8 +1,11 @@
 //! Parallel directory walk producing `Entry` batches in parent-before-child order.
 
-use crate::fsops::{join, lstat_entry, path_bytes, rooted_entry, rooted_entry_in_directory};
+use crate::fsops::{
+    join, lstat_entry, path_bytes, require_source_leaf_identity, rooted_entry_in_directory,
+    rooted_source_entry,
+};
 use crate::proto::ContainerGuard;
-use crate::proto::{Entry, PathBytes};
+use crate::proto::{Entry, PathBytes, SourceLeafIdentity};
 use crate::rooted::{RelativePath, Root, RootIdentity, RootMetadata};
 use anyhow::{Context, Result};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
@@ -243,6 +246,7 @@ fn produce_descriptor_scan(
     root: Arc<Root>,
     scan_root: PathBytes,
     scan_root_metadata: RootMetadata,
+    hold_destination_for_test: bool,
     ignore: Option<Gitignore>,
     report_ignored: bool,
     tx: SyncSender<ScanChunk>,
@@ -260,12 +264,14 @@ fn produce_descriptor_scan(
         if directory.opened.is_some() {
             retained_directories -= 1;
         }
-        if let Err(error) = hold_descriptor_directory_for_test(&directory.relative) {
-            chunk.push(ScanEvent::Warning(format!(
-                "scan: {}: {error:#}",
-                String::from_utf8_lossy(&directory.relative)
-            )));
-            break;
+        if hold_destination_for_test {
+            if let Err(error) = hold_descriptor_directory_for_test(&directory.relative) {
+                chunk.push(ScanEvent::Warning(format!(
+                    "scan: {}: {error:#}",
+                    String::from_utf8_lossy(&directory.relative)
+                )));
+                break;
+            }
         }
         let rooted_directory = match RelativePath::new(&join(&scan_root, &directory.relative)) {
             Ok(directory) => directory,
@@ -536,14 +542,16 @@ pub fn scan(
     Ok(())
 }
 
-/// Walk a destination subtree beneath an already-adopted authority root. The
+/// Walk a subtree beneath an already-adopted endpoint authority root. The
 /// request supplies only a strict path relative to that root; no pathname is
 /// reconstructed and descendant symlinks are reported rather than traversed.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn scan_descriptor(
     root: Arc<Root>,
     scan_root: &[u8],
+    expected_root: Option<SourceLeafIdentity>,
     follow_root: bool,
+    hold_destination_for_test: bool,
     ignore: &[String],
     report_ignored: bool,
     sink: &mut dyn FnMut(Vec<Entry>) -> Result<()>,
@@ -551,11 +559,23 @@ pub(crate) fn scan_descriptor(
     warn: &mut dyn FnMut(String),
 ) -> Result<()> {
     if follow_root {
-        anyhow::bail!("a descriptor-rooted destination scan never follows a root symlink");
+        anyhow::bail!("a descriptor-rooted scan never follows a root symlink");
     }
     let scan_relative = RelativePath::new(scan_root)?;
     let metadata = root.metadata(&scan_relative)?;
-    let root_entry = rooted_entry(&root, &scan_relative, Vec::new(), metadata)?;
+    if let Some(expected) = expected_root.as_ref() {
+        require_source_leaf_identity(expected, metadata)?;
+    }
+    let root_entry = rooted_source_entry(
+        &root,
+        &scan_relative,
+        Vec::new(),
+        metadata,
+        expected_root.as_ref(),
+    )?;
+    if let Some(expected) = expected_root.as_ref() {
+        require_source_leaf_identity(expected, root.metadata(&scan_relative)?)?;
+    }
     if root_entry.kind != crate::proto::Kind::Dir {
         return sink(vec![root_entry]);
     }
@@ -570,7 +590,15 @@ pub(crate) fn scan_descriptor(
     let producer = std::thread::Builder::new()
         .name("syq-descriptor-scan-producer".into())
         .spawn(move || {
-            produce_descriptor_scan(root, scan_root, metadata, matcher, report_ignored, tx)
+            produce_descriptor_scan(
+                root,
+                scan_root,
+                metadata,
+                hold_destination_for_test,
+                matcher,
+                report_ignored,
+                tx,
+            )
         })
         .context("start descriptor scan producer")?;
     let received = receive_scan(
@@ -751,6 +779,8 @@ mod tests {
         scan_descriptor(
             root,
             b"",
+            None,
+            false,
             false,
             &[],
             true,

--- a/src/server.rs
+++ b/src/server.rs
@@ -173,6 +173,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
         bail!("control role is not allowed on a TCP data connection");
     }
     let is_control = matches!(&role, ConnectionRole::Control);
+    let is_source_worker = matches!(&role, ConnectionRole::SourceWorker { .. });
     let mut ops = FsOps::with_descriptor_session(descriptor_session.clone());
     match &role {
         ConnectionRole::SourceWorker { .. } if authority.is_some() => {
@@ -253,6 +254,12 @@ fn serve<R: Read + Send + 'static, W: Write>(
             ))?;
             continue;
         }
+        if is_source_worker && !req.allowed_on_source_worker() {
+            w.write_msg(&Response::Err(
+                "request is not valid on a source worker".into(),
+            ))?;
+            continue;
+        }
         let settlement = match &authority {
             Some(authority) => match authority.authorize(&mut req, over_ssh) {
                 Ok(settlement) => Some(settlement),
@@ -263,6 +270,10 @@ fn serve<R: Read + Send + 'static, W: Write>(
             },
             None => None,
         };
+        if let Err(error) = ops.validate_source_session_request(&req) {
+            w.write_msg(&Response::Err(format!("{error:#}")))?;
+            continue;
+        }
         match &req {
             Request::WriteRange { data, .. } => {
                 blocks += 1;
@@ -355,13 +366,24 @@ fn serve<R: Read + Send + 'static, W: Write>(
             }
             Request::Scan {
                 root,
-                source: _,
+                source,
                 follow_root,
                 ignore,
                 report_ignored,
                 guard,
             } => {
                 let requested_root = root.clone();
+                let source_scan = if guard.is_none() {
+                    match ops.source_scan_root(source.as_ref()) {
+                        Ok(scan) => scan,
+                        Err(error) => {
+                            w.write_msg(&Response::Err(format!("{error:#}")))?;
+                            continue;
+                        }
+                    }
+                } else {
+                    None
+                };
                 let destination_scan = if guard.is_none() {
                     match ops.destination_scan_root(&root) {
                         Ok(scan) => scan,
@@ -415,11 +437,26 @@ fn serve<R: Read + Send + 'static, W: Write>(
                         &mut ignored,
                         &mut |msg| warns.borrow_mut().push(msg),
                     )
+                } else if let Some(source) = source_scan {
+                    crate::scan::scan_descriptor(
+                        source.root,
+                        &source.relative,
+                        source.expected_leaf,
+                        false,
+                        false,
+                        &ignore,
+                        report_ignored,
+                        &mut sink,
+                        &mut ignored,
+                        &mut |msg| warns.borrow_mut().push(msg),
+                    )
                 } else if let Some((destination_root, relative)) = destination_scan {
                     crate::scan::scan_descriptor(
                         destination_root,
                         &relative,
+                        None,
                         follow_root,
+                        true,
                         &ignore,
                         report_ignored,
                         &mut sink,
@@ -779,6 +816,8 @@ impl<R: Read> Read for TimeoutOnce<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
 
     struct ExitObserved<R> {
         inner: R,
@@ -803,6 +842,8 @@ mod tests {
         let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let address = listener.local_addr().unwrap();
         let selected = tempfile::tempdir().unwrap();
+        let marker = selected.path().join("marker");
+        std::fs::write(&marker, b"marker").unwrap();
         let descriptor_session = DescriptorSessionSlot::default();
         let ticket = descriptor_session
             .register(std::fs::File::open(selected.path()).unwrap())
@@ -810,6 +851,9 @@ mod tests {
         let source = RegisteredSourceRoot {
             selection: RegisteredPath::new(ticket.root_id(), Vec::new()).unwrap(),
             ticket,
+            leaf_ticket: None,
+            expected_leaf: None,
+            allow_unconfined_paths: false,
         };
         let server_session = descriptor_session.clone();
         let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -852,6 +896,51 @@ mod tests {
             reader.read_msg::<Response>().unwrap(),
             Response::HelloOk { .. }
         ));
+        let selected_metadata = std::fs::metadata(selected.path()).unwrap();
+        let guard = ContainerGuard {
+            root: selected.path().as_os_str().as_bytes().to_vec(),
+            dev: selected_metadata.dev(),
+            ino: selected_metadata.ino(),
+        };
+        writer
+            .write_msg(&Request::Scan {
+                root: selected.path().as_os_str().as_bytes().to_vec(),
+                source: None,
+                follow_root: false,
+                ignore: Vec::new(),
+                report_ignored: false,
+                guard: Some(guard.clone()),
+            })
+            .unwrap();
+        assert!(matches!(
+            reader.read_msg::<Response>().unwrap(),
+            Response::Err(error) if error.contains("source session rejects caller-supplied guards")
+        ));
+        writer
+            .write_msg(&Request::Apply {
+                ops: vec![Op::Unlink {
+                    path: marker.as_os_str().as_bytes().to_vec(),
+                }],
+                guard: None,
+            })
+            .unwrap();
+        assert!(matches!(
+            reader.read_msg::<Response>().unwrap(),
+            Response::Err(error) if error.contains("not valid on a source worker")
+        ));
+        assert_eq!(std::fs::read(&marker).unwrap(), b"marker");
+        writer
+            .write_msg(&Request::StatMany {
+                paths: vec![selected.path().as_os_str().as_bytes().to_vec()],
+                sources: None,
+                follow: false,
+                guard: Some(guard),
+            })
+            .unwrap();
+        assert!(matches!(
+            reader.read_msg::<Response>().unwrap(),
+            Response::Err(error) if error.contains("source session rejects caller-supplied guards")
+        ));
         writer
             .write_msg(&Request::RegisterSourceRoots {
                 selections: vec![SourceRootSelection {
@@ -859,7 +948,9 @@ mod tests {
                     follow_root: false,
                 }],
                 symlink_policy: OperatorSymlinkPolicy::Refuse,
+                allow_unconfined_paths: false,
                 shared_workers: 0,
+                independent_claim_workers: 0,
             })
             .unwrap();
         assert!(matches!(
@@ -934,6 +1025,9 @@ mod tests {
         let source = RegisteredSourceRoot {
             selection: RegisteredPath::new(ticket.root_id(), Vec::new()).unwrap(),
             ticket,
+            leaf_ticket: None,
+            expected_leaf: None,
+            allow_unconfined_paths: false,
         };
         owner.close();
 

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -91,6 +91,9 @@ pub struct Opts {
     pub ignore_existing: bool,
     /// --existing: never create a destination path that doesn't exist.
     pub existing: bool,
+    /// Explicit rsync compatibility escape hatch for unconfined source
+    /// discovery through symlinked descendant components.
+    pub insecure_links: bool,
     /// Symlink policy for the operator-selected destination path.
     pub operator_symlink_policy: OperatorSymlinkPolicy,
     /// --max-size / --min-size: regular files outside the range are not transferred.
@@ -570,6 +573,9 @@ fn semantic_flags(opts: &Opts, args: &Args, srcs: &[Location]) -> String {
     {
         flags["source_modes"] = serde_json::json!(source_modes);
     }
+    if opts.insecure_links {
+        flags["insecure_links"] = serde_json::json!(true);
+    }
     flags.to_string()
 }
 
@@ -1008,6 +1014,7 @@ pub fn run(args: Args) -> Result<i32> {
         update: args.update,
         ignore_existing: args.ignore_existing,
         existing: args.existing,
+        insecure_links: args.interface == Interface::Rsync && args.insecure_links,
         operator_symlink_policy: operator_symlink_policy(&args),
         max_size,
         min_size,
@@ -1322,8 +1329,17 @@ pub fn run(args: Args) -> Result<i32> {
         Endpoint::Remote(_) if use_tcp => maximum_workers,
         Endpoint::Remote(_) => 0,
     };
-    let registered_sources =
-        register_source_roots(&mut *src_ctl, srcs, &args, source_shared_workers)?;
+    let source_independent_claim_workers = match &src_ep {
+        Endpoint::Local { .. } => 0,
+        Endpoint::Remote(_) => maximum_workers.min(crate::conn::MAX_CONCURRENT_CONNECTS),
+    };
+    let registered_sources = register_source_roots(
+        &mut *src_ctl,
+        srcs,
+        &args,
+        source_shared_workers,
+        source_independent_claim_workers,
+    )?;
     source_roots
         .set(registered_sources)
         .expect("source roots set once");
@@ -1456,25 +1472,14 @@ pub fn run(args: Args) -> Result<i32> {
         }
     }
     if args.interface != Interface::Rsync {
-        // This semantic preflight rejects a static symlink in every parent
-        // component of a directly supplied source path. The broader rooted
-        // copy migration will make the retained identity survive scanning and
-        // content opens in the presence of concurrent namespace mutation.
-        for source in srcs {
-            check_operator_directory(
-                &mut *src_ctl,
-                &parent_path(&source.path),
-                false,
-                operator_symlink_policy(&args),
-            )?;
-        }
         // Native selectors are structural: validate every selected root before
-        // a missing --into target can be created. Contents selectors require
-        // a directory and resolve a selected link only under --follow.
-        for source in srcs {
-            match stat_one(
+        // a missing --into target can be created. The registered selection is
+        // authoritative here, so its operator path is not resolved again.
+        for (source_index, source) in srcs.iter().enumerate() {
+            match stat_one_registered(
                 &mut *src_ctl,
                 &source.path,
+                &source_roots.get().expect("source roots registered")[source_index].selection,
                 source.follows_root(args.native_follow),
             )? {
                 Some(entry) => {
@@ -1579,12 +1584,21 @@ pub fn run(args: Args) -> Result<i32> {
         // Both ends are one machine, so either control connection resolves
         // paths the way that machine's kernel does (symlinks included).
         let remote = dst.is_remote();
-        for s in srcs {
+        for (source_index, s) in srcs.iter().enumerate() {
             // Only a directory source can trigger the recurse-into-itself trap.
             // Judge the source the way the scan will, including the interface's
             // explicit selected-root link policy.
             let follow_root = args.files_from.is_some() || s.follows_root(args.native_follow);
-            let src_is_dir = matches!(stat_one(&mut *src_ctl, &s.path, follow_root)?, Some(ref e) if e.kind == Kind::Dir);
+            let src_is_dir = matches!(
+                stat_one_registered(
+                    &mut *src_ctl,
+                    &s.path,
+                    &source_roots.get().expect("source roots registered")[source_index]
+                        .selection,
+                    follow_root,
+                )?,
+                Some(ref e) if e.kind == Kind::Dir
+            );
             if !src_is_dir {
                 continue;
             }
@@ -2497,6 +2511,22 @@ fn stat_one(conn: &mut dyn Conn, path: &[u8], follow: bool) -> Result<Option<Ent
         .flatten())
 }
 
+fn stat_one_registered(
+    conn: &mut dyn Conn,
+    path: &[u8],
+    source: &RegisteredPath,
+    follow: bool,
+) -> Result<Option<Entry>> {
+    Ok(stat_many_registered(
+        conn,
+        vec![path.to_vec()],
+        Some(vec![source.clone()]),
+        follow,
+    )?
+    .pop()
+    .flatten())
+}
+
 fn check_operator_directory(
     conn: &mut dyn Conn,
     path: &[u8],
@@ -2521,6 +2551,7 @@ fn register_source_roots(
     sources: &[Location],
     args: &Args,
     shared_workers: usize,
+    independent_claim_workers: usize,
 ) -> Result<Vec<RegisteredSourceRoot>> {
     let selections = sources
         .iter()
@@ -2536,7 +2567,9 @@ fn register_source_roots(
         conn.call(Request::RegisterSourceRoots {
             selections,
             symlink_policy: operator_symlink_policy(args),
+            allow_unconfined_paths: args.interface == Interface::Rsync && args.insecure_links,
             shared_workers,
+            independent_claim_workers,
         })?,
         "register source roots",
     )? {
@@ -2659,7 +2692,7 @@ fn scan_into_planner(
     pl: &mut Planner<'_>,
     src: &mut dyn Conn,
     root: &[u8],
-    source: &RegisteredPath,
+    source: Option<&RegisteredPath>,
     follow_root: bool,
     ignore: &[String],
     mut f: impl FnMut(&mut Planner<'_>, Vec<Entry>) -> Result<()>,
@@ -2670,7 +2703,7 @@ fn scan_into_planner(
     let warned = std::cell::Cell::new(false);
     let res = src.scan(
         root,
-        Some(source),
+        source,
         follow_root,
         ignore,
         report_ignored,
@@ -3300,7 +3333,11 @@ impl Planner<'_> {
             self,
             src,
             src_root,
-            &source,
+            if self.opts.insecure_links {
+                None
+            } else {
+                Some(&source)
+            },
             follow_root,
             &ignore,
             |pl, batch| {
@@ -3371,11 +3408,10 @@ impl Planner<'_> {
 
     /// --files-from: instead of walking the source, stat each listed path (and
     /// the directories leading to it) and feed them to the planner as if a scan
-    /// had produced them. Implied parents are stat'ed through symlinks and must
-    /// resolve to directories; they become real directories on the destination,
-    /// so nothing is ever written through a destination symlink. Listed
-    /// directories — only those, not implied parents — are walked with an
-    /// explicit -r.
+    /// had produced them. By default, implied parents are descriptor-relative
+    /// and never traversed through symlinks. `--insecure-links` selects the
+    /// legacy unconfined pathname behavior explicitly. Listed directories —
+    /// only those, not implied parents — are walked with an explicit -r.
     fn scan_files_from(
         &mut self,
         src: &mut dyn Conn,
@@ -3389,19 +3425,19 @@ impl Planner<'_> {
             .active_source
             .clone()
             .context("registered source reference was not initialized")?;
-        // Through a symlink: `syq --files-from L link dst` should work like `link/`.
         // Validate the root but never plan it: it isn't in the list, so an
-        // existing destination is not stamped with source-root metadata
-        // (creation-when-missing happened in run()).
-        match stat_many_registered(
-            src,
-            vec![src_root.to_vec()],
-            Some(vec![source_base.clone()]),
-            true,
-        )?
-        .pop()
-        .flatten()
-        {
+        // existing destination is not stamped with source-root metadata.
+        let mut source_root_stat = if self.opts.insecure_links {
+            stat_many(src, vec![src_root.to_vec()], true)?
+        } else {
+            stat_many_registered(
+                src,
+                vec![src_root.to_vec()],
+                Some(vec![source_base.clone()]),
+                true,
+            )?
+        };
+        match source_root_stat.pop().flatten() {
             Some(e) if e.kind == Kind::Dir => {}
             Some(_) => bail!(
                 "--files-from: source {} is not a directory",
@@ -3412,12 +3448,10 @@ impl Planner<'_> {
         self.progress.scanned.fetch_add(1, Relaxed);
 
         // Listed paths are lstat'ed (a listed symlink copies as a symlink).
-        // Implied ancestors are stat'ed *through* symlinks and must resolve to
-        // directories: the user named a path through them, and on the
-        // destination they become real directories, so nothing is ever
-        // written through a symlink there. Results are kept for the whole
-        // list, since a later line may repeat a path or name one first seen
-        // as a parent.
+        // Implied ancestors must be directories. Registered stats never follow
+        // descendant symlinks; only --insecure-links uses legacy followed
+        // pathname stats. Results are kept for the whole list, since a later
+        // line may repeat a path or name one first seen as a parent.
         let mut leaves: HashMap<PathBytes, Option<Entry>> = HashMap::new();
         let mut parents: HashMap<PathBytes, Option<Entry>> = HashMap::new();
         // What the planner has been given for each path (Dir or not).
@@ -3431,16 +3465,15 @@ impl Planner<'_> {
                 .collect()
         };
         let stat = |src: &mut dyn Conn, paths: Vec<PathBytes>, follow: bool| -> Result<_> {
+            let legacy_paths = paths.iter().map(|r| join(src_root, r)).collect();
+            if self.opts.insecure_links {
+                return stat_many(src, legacy_paths, follow);
+            }
             let registered = paths
                 .iter()
                 .map(|relative| source_base.join(relative))
                 .collect::<Result<Vec<_>>>()?;
-            stat_many_registered(
-                src,
-                paths.iter().map(|r| join(src_root, r)).collect(),
-                Some(registered),
-                follow,
-            )
+            stat_many_registered(src, legacy_paths, Some(registered), follow)
         };
         for chunk in lines.chunks(crate::scan::BATCH) {
             let mut want_parents: Vec<PathBytes> = Vec::new();
@@ -3738,7 +3771,11 @@ impl Planner<'_> {
             self,
             src,
             &join(src_root, rel),
-            &source,
+            if self.opts.insecure_links {
+                None
+            } else {
+                Some(&source)
+            },
             false,
             &[],
             |pl, batch| {
@@ -5718,8 +5755,12 @@ impl Worker {
         // Did any source change while we were at it?
         let paths: Vec<PathBytes> = jobs.iter().map(|j| j.src.clone()).collect();
         let phase = std::time::Instant::now();
-        let registered = jobs.iter().map(|job| job.source.clone()).collect();
-        let now = stat_many_registered(&mut *self.src, paths, Some(registered), false)?;
+        let now = if self.opts.insecure_links {
+            stat_many(&mut *self.src, paths, false)?
+        } else {
+            let registered = jobs.iter().map(|job| job.source.clone()).collect();
+            stat_many_registered(&mut *self.src, paths, Some(registered), false)?
+        };
         self.fast.restat += phase.elapsed().as_secs_f64();
         let phase = std::time::Instant::now();
         for ((idx, j), (res, now)) in batch
@@ -6477,7 +6518,11 @@ impl Worker {
     /// the source changed during that work.
     fn complete_file(&mut self, idx: usize, job: FileJob, matched: bool) -> Result<()> {
         // Did the source change under us?
-        let now = stat_one(&mut *self.src, &job.src, false)?;
+        let now = if self.opts.insecure_links {
+            stat_one(&mut *self.src, &job.src, false)?
+        } else {
+            stat_one_registered(&mut *self.src, &job.src, &job.source, false)?
+        };
         let changed = match &now {
             Some(e) => {
                 e.kind != Kind::File

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -92,11 +92,12 @@ fn source_fd_preflight_rejects_shared_worker_boundary_before_destination_creatio
         &t.s("destination"),
     ]);
     // Local and remote-TCP sources feed the same shared-worker count into FD
-    // admission. At 64 workers the complete model requires current_open +
-    // 1506 slots. Use a portable low limit here to verify that admission fails
-    // before destination creation; the exact per-worker arithmetic, including
-    // the uncached hash descriptor, is asserted in the FsOps unit test. The
-    // child must retain the lowered hard limit because syq normally raises a
+    // admission. At 64 workers the conservative exact-leaf model requires
+    // current_open + 1572 slots. Use a portable low limit here to verify that
+    // admission fails before destination creation; the exact per-worker
+    // arithmetic, including the uncached hash descriptor, is asserted in the
+    // FsOps unit test. The child must retain the lowered hard limit because syq
+    // normally raises a
     // low soft limit to the inherited hard limit during startup. Never try to
     // raise an inherited hard limit: supported environments commonly cap it
     // at 1024. getrlimit/setrlimit are async-signal-safe on supported Unix.
@@ -138,11 +139,225 @@ fn source_fd_preflight_rejects_shared_worker_boundary_before_destination_creatio
         .unwrap()
         .parse()
         .unwrap();
-    assert_eq!(required, current_open + 1506, "{stderr}");
+    // Conservatively budget every selector as parent + exact object for the
+    // registry, control, and all 64 shared workers, plus worker/cache reserve.
+    assert_eq!(required, current_open + 1572, "{stderr}");
     assert!(
         !t.path("destination").exists(),
         "source FD admission failed after destination creation"
     );
+}
+
+#[test]
+fn source_fd_preflight_accounts_for_independent_ssh_broker_claims() {
+    let t = Tmp::new();
+    let ssh = fake_ssh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    write(&t.path("source"), &vec![b'x'; 8 * 1024 * 1024]);
+    let cache = t.path("tuning.json");
+    write(
+        &cache,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "paths": { "v1|fake>local|ssh": 64 }
+        }))
+        .unwrap()
+        .as_bytes(),
+    );
+    let remote = format!("fake:{}", t.s("source"));
+    let mut command = compat_command();
+    command
+        .arg("-e")
+        .arg(&ssh)
+        .args([
+            "--syq-no-bootstrap",
+            "--syq-no-tcp",
+            "--no-progress",
+            &remote,
+            &t.s("destination"),
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("SYQ_TUNING_CACHE", &cache);
+    unsafe {
+        command.pre_exec(|| {
+            let mut inherited = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::getrlimit(libc::RLIMIT_NOFILE, &mut inherited) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            let low_limit = inherited.rlim_max.min(128);
+            let limit = libc::rlimit {
+                rlim_cur: low_limit,
+                rlim_max: low_limit,
+            };
+            if libc::setrlimit(libc::RLIMIT_NOFILE, &limit) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let output = command.run().unwrap();
+    assert!(!output.status.success(), "unexpected success: {output:?}");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("32 independent workers"), "{stderr}");
+    assert!(
+        !t.path("destination").exists(),
+        "independent-claim FD admission failed after destination creation"
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn source_scan_uses_registered_root_after_operator_path_replacement() {
+    let t = Tmp::new();
+    write(&t.path("src/original"), b"original");
+    write(&t.path("outside/replacement"), b"replacement");
+    let ready = t.path("source-ready");
+
+    let mut child = compat_command()
+        .args([
+            "-anv",
+            "--syq-connections",
+            "1",
+            &t.s("src/"),
+            &t.s("dst/"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
+        .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !ready.exists() && std::time::Instant::now() < deadline {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "syq exited before registering the source root"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(
+        ready.exists(),
+        "source root was not registered before timeout"
+    );
+
+    fs::rename(t.path("src"), t.path("selected-and-moved")).unwrap();
+    std::os::unix::fs::symlink(t.path("outside"), t.path("src")).unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_output_ok(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("/original (destination missing)"),
+        "{stdout}"
+    );
+    assert!(
+        !stdout.contains("/replacement (destination missing)"),
+        "{stdout}"
+    );
+    assert!(
+        !t.path("dst").exists(),
+        "dry run unexpectedly created output"
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn exact_regular_source_replacement_is_rejected_after_registration() {
+    let t = Tmp::new();
+    write(&t.path("selected"), b"original");
+    let ready = t.path("source-ready");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--src-file",
+            &t.s("selected"),
+            "--as-new",
+            &t.s("destination"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
+        .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !ready.exists() && std::time::Instant::now() < deadline {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "syq exited before registering the exact regular source"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(ready.exists(), "source registration timed out");
+    fs::rename(t.path("selected"), t.path("selected-original")).unwrap();
+    write(&t.path("selected"), b"replacement");
+
+    let output = child.wait_with_output().unwrap();
+    assert!(!output.status.success(), "unexpected success: {output:?}");
+    assert!(
+        stderr_of(&output).contains("registered source leaf changed identity"),
+        "{}",
+        stderr_of(&output)
+    );
+    assert!(!t.path("destination").exists());
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn exact_symlink_source_replacement_is_rejected_after_registration() {
+    let t = Tmp::new();
+    write(&t.path("target-a"), b"a");
+    write(&t.path("target-b"), b"b");
+    std::os::unix::fs::symlink("target-a", t.path("selected")).unwrap();
+    let ready = t.path("source-ready");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--src-file",
+            &t.s("selected"),
+            "--as-new",
+            &t.s("destination"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
+        .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !ready.exists() && std::time::Instant::now() < deadline {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "syq exited before registering the exact symlink source"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(ready.exists(), "source registration timed out");
+    fs::rename(t.path("selected"), t.path("selected-original")).unwrap();
+    std::os::unix::fs::symlink("target-b", t.path("selected")).unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert!(!output.status.success(), "unexpected success: {output:?}");
+    assert!(
+        stderr_of(&output).contains("registered source leaf changed identity"),
+        "{}",
+        stderr_of(&output)
+    );
+    assert!(!t.path("destination").exists());
 }
 
 fn run_native_ok(args: &[&str]) -> String {
@@ -5287,17 +5502,37 @@ fn files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs() {
         &t.s("src"),
         &t.s("dst"),
     ]);
-    // `link` resolves to a directory, so the listed path is followed: the
-    // implied parent becomes a real directory on the destination (never a
-    // symlink a later write could go through). `a` was not recursed into
-    // despite -r: only listed directories are walked.
+    // SYQ deliberately refuses this earlier than hardened rsync 3.5: neither
+    // follows the implied source ancestor and both exit 23, but SYQ also avoids
+    // emitting the implied destination directory. Other valid paths complete.
+    assert_eq!(out.status.code(), Some(23));
+    assert!(stderr_of(&out).contains("link is not a directory"));
+    assert_eq!(listing(&t.path("dst")), ["a", "a/listed"]);
+    assert!(!t.path("dst/link/secret").exists());
+
+    // The compatibility escape hatch is explicit and unconfined. It restores
+    // the old followed-ancestor behavior; implied parents are materialized as
+    // real destination directories. `a` is still not recursively walked.
+    let out = syq(&[
+        "-a",
+        "-r",
+        "--insecure-links",
+        "--files-from",
+        &t.s("list"),
+        &t.s("src"),
+        &t.s("dst-insecure"),
+    ]);
     assert!(out.status.success(), "{}", stderr_of(&out));
     assert_eq!(
-        listing(&t.path("dst")),
+        listing(&t.path("dst-insecure")),
         ["a", "a/listed", "link", "link/secret"]
     );
-    assert!(t.path("dst/link").symlink_metadata().unwrap().is_dir());
-    assert_eq!(read(&t.path("dst/link/secret")), b"secret");
+    assert!(t
+        .path("dst-insecure/link")
+        .symlink_metadata()
+        .unwrap()
+        .is_dir());
+    assert_eq!(read(&t.path("dst-insecure/link/secret")), b"secret");
 
     // An ancestor that resolves to a file, or dangles, is an error.
     std::os::unix::fs::symlink("a/listed", t.path("src/tofile")).unwrap();
@@ -5305,6 +5540,7 @@ fn files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs() {
     write(&t.path("list2"), b"tofile/x\ndangling/y\n");
     let out = syq(&[
         "-a",
+        "--insecure-links",
         "--files-from",
         &t.s("list2"),
         &t.s("src"),
@@ -5323,6 +5559,7 @@ fn files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs() {
     write(&t.path("list3"), b"link\nlink/secret\n");
     let out = syq(&[
         "-a",
+        "--insecure-links",
         "--files-from",
         &t.s("list3"),
         &t.s("src"),
@@ -6737,8 +6974,8 @@ fn changed_source_retry_uses_published_file_as_block_basis() {
     let original = vec![b'a'; 8 * 1024 * 1024];
     let mut changed = original.clone();
     changed[0] = b'b';
-    write(&t.path("src"), &original);
-    set_mtime(&t.path("src"), 1_600_000_000);
+    write(&t.path("src/file"), &original);
+    set_mtime(&t.path("src/file"), 1_600_000_000);
 
     let child = compat_command()
         .args([
@@ -6747,8 +6984,8 @@ fn changed_source_retry_uses_published_file_as_block_basis() {
             "--bwlimit",
             "1G",
             "--no-progress",
-            &t.s("src"),
-            &t.s("dst"),
+            &t.s("src/"),
+            &t.s("dst/"),
         ])
         .env("SYQ_TEST_HOLD_AFTER_FINALIZE_MS", "1000")
         .stdout(Stdio::piped())
@@ -6756,15 +6993,15 @@ fn changed_source_retry_uses_published_file_as_block_basis() {
         .start()
         .unwrap();
     for _ in 0..200 {
-        if t.path("dst").exists() {
+        if t.path("dst/file").exists() {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
-    assert!(t.path("dst").exists(), "first attempt never finalized");
+    assert!(t.path("dst/file").exists(), "first attempt never finalized");
     write(&t.path("replacement"), &changed);
     set_mtime(&t.path("replacement"), 1_600_000_001);
-    fs::rename(t.path("replacement"), t.path("src")).unwrap();
+    fs::rename(t.path("replacement"), t.path("src/file")).unwrap();
 
     let output = child.wait_with_output().unwrap();
     assert!(
@@ -6773,7 +7010,7 @@ fn changed_source_retry_uses_published_file_as_block_basis() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(read(&t.path("dst")), changed);
+    assert_eq!(read(&t.path("dst/file")), changed);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("bytes transferred: 12,582,912"),
@@ -6787,11 +7024,11 @@ fn changed_source_retry_still_uses_copy_file_range() {
     let t = Tmp::new();
     let original = vec![b'a'; 8 * 1024 * 1024];
     let changed = vec![b'b'; 8 * 1024 * 1024];
-    write(&t.path("src"), &original);
-    set_mtime(&t.path("src"), 1_600_000_000);
+    write(&t.path("src/file"), &original);
+    set_mtime(&t.path("src/file"), 1_600_000_000);
 
     let child = compat_command()
-        .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
         .env("SYQ_TEST_HOLD_AFTER_FINALIZE_MS", "1000")
         .env("SYQ_TEST_FAIL_HASH_BASIS", "1")
         .stdout(Stdio::piped())
@@ -6799,15 +7036,15 @@ fn changed_source_retry_still_uses_copy_file_range() {
         .start()
         .unwrap();
     for _ in 0..200 {
-        if t.path("dst").exists() {
+        if t.path("dst/file").exists() {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
-    assert!(t.path("dst").exists(), "first attempt never finalized");
+    assert!(t.path("dst/file").exists(), "first attempt never finalized");
     write(&t.path("replacement"), &changed);
     set_mtime(&t.path("replacement"), 1_600_000_001);
-    fs::rename(t.path("replacement"), t.path("src")).unwrap();
+    fs::rename(t.path("replacement"), t.path("src/file")).unwrap();
 
     let output = child.wait_with_output().unwrap();
     assert!(
@@ -6816,7 +7053,7 @@ fn changed_source_retry_still_uses_copy_file_range() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(read(&t.path("dst")), changed);
+    assert_eq!(read(&t.path("dst/file")), changed);
 }
 
 // A destination given as a symlink to a directory is that directory, whether
@@ -7531,13 +7768,11 @@ fn files_from_symlink_conflict_is_order_independent() {
             stderr_of(&out)
         );
         let md = t.path(&format!("dst{n}/link")).symlink_metadata().unwrap();
-        // Either the symlink alone (order 1) or a real directory (order 2) —
-        // never a write through a destination symlink.
-        assert!(md.is_symlink() || md.is_dir());
+        // The listed symlink itself is preserved in either order, while the
+        // path through it is rejected before any implied directory is emitted.
+        assert!(md.is_symlink());
         assert!(!t.path("outside/secret2").exists());
     }
-    assert_eq!(read(&t.path("dst2/link/secret")), b"s");
-    assert!(t.path("dst2/link").symlink_metadata().unwrap().is_dir());
 }
 
 #[test]
@@ -8931,6 +9166,32 @@ fn native_cp_mapping_hard_refusals() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("cannot be used with"), "{stderr}");
     assert!(stderr.contains("--prune"), "{stderr}");
+}
+
+#[test]
+fn native_mapping_names_never_inherit_operator_follow() {
+    let t = Tmp::new();
+    fs::create_dir_all(t.path("src")).unwrap();
+    write(&t.path("outside/secret"), b"secret");
+    std::os::unix::fs::symlink("../outside", t.path("src/link")).unwrap();
+    let manifest = entry_line("link/secret", "copied", None);
+    let out = syq_cp_in(
+        &t.path(""),
+        &[
+            "--follow",
+            "--mapping",
+            "-",
+            "-C",
+            "src",
+            "--into",
+            "dst",
+            "-q",
+        ],
+        Some(manifest.as_bytes()),
+    );
+    assert_eq!(out.status.code(), Some(23), "{}", stderr_of(&out));
+    assert!(stderr_of(&out).contains("source link/secret does not exist"));
+    assert!(!t.path("dst/copied").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- cut `Scan` and source `StatMany` over from operator pathnames to registered source roots plus strict relative paths
- use the bounded descriptor scanner for ordinary source discovery without following descendant symlinks
- preserve explicit rsync `--insecure-links` as the only legacy unconfined source-discovery path
- bind each exact selected leaf to typed, same-session parent and object tickets; the registry, control connection, and every worker retain the exact object
- snapshot exact-symlink target bytes through the pinned object, never through a replaceable directory name
- reject replacement of an exact leaf while preserving changed-source retry for descendants of a selected directory
- enforce a shared read-only request allowlist on remote and in-process source workers, including the direct native-removal path
- budget shared-worker retained descriptors and the 32-connection ceiling for independent SSH broker claims before destination mutation
- document SYQ's deliberate early-refusal difference from rsync 3.5 for implied `--files-from` symlink ancestors

## Security boundary

This slice closes source discovery and metadata stat. Hashes, range/small reads, local-copy source opens, and same-machine identity are intentionally left to the stacked source-content slice; the README names that partial boundary.

Native `--follow` applies only while selecting the operator source capability. Scanner-, manifest-, and peer-supplied descendant names never inherit it. Rsync `--insecure-links` is an explicit authority expansion and retains the legacy pathname behavior.

On Linux, exact symlink targets are read through the pinned `O_PATH` descriptor. On macOS this requires `freadlink` (macOS 13+); older releases fail closed during exact-symlink registration rather than reverting to a raced pathname read.

## Verification

At exact commit dd9310a, based on `source-root-initialization` at 67b3f8b:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (298 unit, 290 integration, 7 updater)
- adversarial exact-symlink, cross-session ticket-splicing, worker-lifetime, source-role mutation, low-FD/autotuned-SSH, mapping-follow, and root-replacement regressions
- independent re-review of dd9310a with no findings

The worktree is clean. The macOS path was compile-checked locally; CI supplies the runtime platform check.
