### PR TITLE
Stop passing --quiet to the dedicated map surface

### DIFF
--- a/sdk/python/src/syq/async_client.py
+++ b/sdk/python/src/syq/async_client.py
@@ -771,7 +771,6 @@ class AsyncClient:
         )
         if source_count == 0:
             raise SyqInvocationError("syq map needs a source selector")
-        argv.append("--quiet")
         process_base = Path(
             os.fsdecode(
                 os.fspath(self.process_cwd)

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -912,7 +912,6 @@ class Client:
         )
         if source_count == 0:
             raise SyqInvocationError("syq map needs a source selector")
-        argv.append("--quiet")
         command = (self._executable_value(), *argv)
         process_base = Path(
             os.fsdecode(


### PR DESCRIPTION
#124's dedicated map CLI no longer accepts --quiet, so the Python SDK's map argv made every real-binary invocation exit 2. Only CI's candidate tests catch this — the local suite skips them without SYQ_CANDIDATE_EXECUTABLE — which is why the sdks job went red on the #109 merge while required checks stayed green.

Verified locally with the candidate environment set: all 53 SDK tests pass with no skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZUmpPYue9iHrVTkmeDf8K