### PR TITLE
Rename native coordinator placement terminology

### DIFF
--- a/MAPPINGS.md
+++ b/MAPPINGS.md
@@ -1,6 +1,6 @@
 # Mappings: placement as data
 
-A mapping is a file (or stream) of explicit source→target claims that
+A mapping is a file (or stream) of explicit source→destination claims that
 `syq cp` can execute: a generalized `--as` covering many entries at
 once, or a `--files-from` whose entries can also *re-place* each file.
 You author selection and placement — with a script, or by transforming
@@ -32,7 +32,7 @@ One JSON object per line (NDJSON):
 ```
 
 - `src`, `dst` (required): paths relative to the source root (`-C DIR`,
-  default the working directory) and the target container (`--into
+  default the working directory) and the destination container (`--into
   DIR`). Absolute paths, empty paths, and any `.` or `..` component are
   rejected. Paths are tagged: `encoding` is `utf-8`, or `base64` for a
   name that is not valid UTF-8 (`value` is then standard base64 of the
@@ -229,7 +229,7 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
   only; `syq rsync` is unchanged.
 - `syq map` accepts the local selector grammar, including the typed selectors
   `--src-file`/`--src-dir`, plus `--as PATH` (which emits the single selected
-  root under the target's basename). Those selectors are validated exactly as
+  root under the destination's basename). Those selectors are validated exactly as
   native `cp` validates them; see "Emitting a mapping" for the complete
   surface.
 - Fidelity is the native default (`-rlt`). There is no per-entry
@@ -248,7 +248,7 @@ those farms fall short — see [use-cases/link-farms.md](use-cases/link-farms.md
   with `--follow`.
 - Symlinks selected by mapping entries are never resolved by mapping handling:
   a symlink maps as a symlink, and a destination path that would traverse a
-  symlink inside the target container fails that entry. Resolve links before
+  symlink inside the destination container fails that entry. Resolve links before
   emitting the manifest if you want targets instead.
 - `kind: "special"` asserts the source's type; it does not override the
   fixed `-rlt` fidelity, which copies no special files. Such an entry is
@@ -293,14 +293,14 @@ terminal record means the run did not finish; a terminal status other
 than `success` or `partial` means entries may be unsettled.
 
 The results writer lives with the transfer coordinator, so a stream
-requires a local coordinator (an explicit `--run-at local` for a
+requires a local coordinator (an explicit `--coordinate-at local` for a
 remote-to-remote copy). `--results` cannot be combined with `--detach`,
 because the caller would no longer be attached for the complete stream
 and its terminal record. Receiver-attested streams for attached direct
 copies through a command-restricted receiver — records verified and
 decrypted from hostB's receipt, marked `"provenance":"receiver_attested"`
 — exist in the engine and return once wired to the file/descriptor
-targets.
+outputs.
 
 Failed operation records carry `src`, `dst`, and `kind`, so a retry
 manifest is one filter away:

--- a/README.md
+++ b/README.md
@@ -137,14 +137,14 @@ Git-derived identity when an explicit source-built helper is used.
 ## Native commands
 
 Native syntax starts with an operation and keeps endpoints, selectors, and
-target placement in separate arguments:
+destination placement in separate arguments:
 
 ```sh
 syq cp project --to server --into /backup       # named object → /backup/project
 syq cp --src-src project --to server --into /app # project contents → /app
 syq cp --from server --cwd /data --src a --src b --into ./data
 syq cp --from server:2222 data --to backup:2200 --into /archive
-syq cp --from server data --to backup --run-at target --into /archive
+syq cp --from server data --to backup --coordinate-at dest --into /archive
 syq cp --src-file report --src-dir assets --into /backup
 syq cp --src-files a.txt b.txt --src-dirs images fonts --into /archive
 syq cp report --to server --as-new /reports/final
@@ -161,7 +161,7 @@ syq rm --cwd /srv --follow --src-dir current-release
 ```
 
 `--from [USER@]HOST[:PORT]` selects one source endpoint and `--to
-[USER@]HOST[:PORT]` selects one target endpoint; omission means local. Enclose
+[USER@]HOST[:PORT]` selects one destination endpoint; omission means local. Enclose
 an IPv6 address in brackets, for example `alice@[2001:db8::1]:2222`. The port
 override is used consistently for the SSH connection, `ssh -G` policy
 resolution, known-host lookup, automatic enrollment, and later enrollment
@@ -173,7 +173,7 @@ Removal selectors are always relative; native `rm` rejects a leading slash and
 any `.` or `..` component.
 
 Bare paths and repeatable `--src PATH` select named objects. A named directory
-keeps its basename at the target; by default a named symlink is copied as a
+keeps its basename at the destination; by default a named symlink is copied as a
 symlink. A trailing slash is ordinary path spelling and has no semantic effect.
 `--src-file PATH` adds the precondition that the named object is not a
 directory, while `--src-dir DIR` requires a directory. Without `--follow`, a
@@ -181,7 +181,7 @@ symlink satisfies `--src-file` and is copied as a symlink, while it fails the
 `--src-dir` precondition. With `--follow`, the precondition and copy both apply
 to the referent. These typed selectors are available to `cp` and `rm`.
 `--src-src DIR` selects a directory's contents and merges them directly into
-the target container. `--srcs PATH...`, `--src-srcs DIR...`, `--src-files
+the destination container. `--srcs PATH...`, `--src-srcs DIR...`, `--src-files
 PATH...`, and `--src-dirs DIR...` are bulk conveniences for the corresponding
 singular selectors. Symlinks found while traversing a selected directory are
 copied as symlinks and are never followed. Singular selector options consume
@@ -215,7 +215,7 @@ and may replace the symlink itself; `--follow` still controls symlinks in the
 parent path. The `new` and `existing` preconditions test the named entry, so a
 dangling symlink exists for `--as-new` and `--as-existing`.
 
-An `--into` target, by contrast, must be traversed as a container. A symlink
+An `--into` destination, by contrast, must be traversed as a container. A symlink
 there is refused by default and accepted only with `--follow`. If the container
 link is dangling, a placement form that permits creation may create its
 referent directory. Thus, if `live` points to `../releases/v3`,
@@ -247,7 +247,7 @@ changing an identity after that check.
 
 Placement is always explicit in this initial native surface:
 
-| Placement | Mapping | Target precondition |
+| Placement | Mapping | Destination precondition |
 |---|---|---|
 | `--into DIR` | Put selected names inside `DIR` | Use or create the directory |
 | `--into-new DIR` | Put selected names inside `DIR` | Must not exist |
@@ -268,9 +268,9 @@ command-restricted remote-to-remote path the precondition is also signed: the
 receiver checks it against the enrolled root when it claims the grant, and a
 `new` root can only be created without replacing anything.
 
-`cp` copies or updates mapped source objects and keeps unrelated target objects
+`cp` copies or updates mapped source objects and keeps unrelated destination objects
 by default. With `--prune`, it then applies the existing safe deletion planner
-to remove target-only descendants in mapped directory scopes. Pruning never
+to remove destination-only descendants in mapped directory scopes. Pruning never
 removes a source and requires explicit placement; `--max-delete N` keeps its
 all-or-nothing deletion budget.
 
@@ -357,11 +357,11 @@ the file fresh (an existing file is refused — one file, one run), and
 `--results-fd 3 3>run.ndjson` (see
 [docs/automation-v1.md](docs/automation-v1.md)). The stream is written
 by the transfer coordinator, so both forms require it to be local; a
-remote-to-remote copy is refused unless `--run-at local` is passed
+remote-to-remote copy is refused unless `--coordinate-at local` is passed
 explicitly — routing through this machine is never chosen implicitly
 on the stream's behalf. (Receiver-attested streams for restricted
 direct copies, derived locally from the verified receipt, exist in the
-engine and return once wired to these targets.) Both forms are
+engine and return once wired to these output forms.) Both forms are
 rejected with `--detach`. Choose a results path outside the source and
 destination trees; one inside them can make the run's own accounting
 unpredictable. `--mapping` cannot be combined with `--prune` because
@@ -378,20 +378,21 @@ broker/receiver setup. A port in native endpoint syntax can be combined with
 the default SSH command or an explicit command whose executable is `ssh`; an
 arbitrary remote-shell wrapper must carry its own port option.
 
-For two remote endpoints, `--run-at auto` (the default) places the coordinator
-at the source when the paths can be represented in a remote command, and
-refuses otherwise: data is never routed through this machine implicitly.
-`--run-at source` explicitly selects a direct push, `--run-at target` selects
-a direct pull with the SSH edge reversed, and `--run-at local` explicitly
-selects a relay through this machine. Direct placement therefore requires
-UTF-8 paths today. `--run-at` is rejected for copies that do not have two
-remote endpoints.
+For two remote endpoints, `--coordinate-at auto` (the default) places the
+coordinator at the source when the paths can be represented in a remote
+command, and refuses otherwise: data is never routed through this machine
+implicitly.
+`--coordinate-at src` explicitly selects a direct push, `--coordinate-at dest`
+selects a direct pull with the SSH edge reversed, and `--coordinate-at local`
+explicitly selects a relay through this machine. Direct placement therefore
+requires UTF-8 paths today. `--coordinate-at` is rejected for copies that do
+not have two remote endpoints.
 
 The default push uses destination-bound agent authentication plus the
 command-restricted write receiver. Default pull fails closed until the
 corresponding read-restricted receiver is implemented; it never silently
 downgrades to authentication-only confinement. Pull is currently available
-with an explicit `--rsh`, `--no-forward-agent` when the target owns source
+with an explicit `--rsh`, `--no-forward-agent` when the destination owns source
 credentials, `--agent-broker-only`, or
 `--unrestricted-agent-forwarding`. The authentication options and `--detach`
 apply only to a direct copy between distinct remote endpoints. A detached
@@ -460,7 +461,7 @@ streams (or independent SSH processes under `--no-tcp`), so bulk throughput
 does not change. Persistence is not applied to an explicit `--rsh`, a remote
 transfer coordinator, or command-restricted receiver authentication. A global
 preference is simply ignored on those paths; an explicit `--pscope` is refused
-when the requested topology cannot honor it. Use `--run-at local` to keep a
+when the requested topology cannot honor it. Use `--coordinate-at local` to keep a
 native remote-to-remote copy's reusable connections on the invoking machine;
 `syq rsync` does not accept remote-to-remote copies.
 
@@ -586,12 +587,12 @@ syq cp --from hostA --src-src big --to hostB --into big
 syq cp --prune --from hostA --src-src tree --to hostB --into-existing tree
 ```
 
-For paths representable in a remote command, syq starts the orchestrator on
+For paths representable in a remote command, syq starts the coordinator on
 hostA and pushes directly to hostB, so file data does not traverse the invoking
 machine. Matching helpers are installed automatically on both hosts and output
 is streamed back. Raw path bytes that cannot be represented safely in the
-remote command are relayed through the invoking machine. When both endpoints
-name the same host and user, syq runs a local copy on that host.
+remote command require an explicit `--coordinate-at local` relay. When both
+endpoints name the same host and user, syq runs a local copy on that host.
 
 With implicit OpenSSH, the default combines a pre-enrolled forced receiver on
 hostB with a temporary local agent broker. The first transfer to a destination
@@ -972,7 +973,7 @@ counts.
 On the receiving side a file that needs content changes is written beside its
 destination as `.name.syq-part.<job-id>` (preallocated with `fallocate`,
 written with `pwrite` from several workers), given its metadata, and `rename`d
-over the target. Newly created sidecars are mode `0600`; final metadata is
+over the destination. Newly created sidecars are mode `0600`; final metadata is
 applied just before publication. When an existing final file is the comparison
 basis, the receiver retains that open descriptor while its blocks are hashed.
 If every block matches, metadata is applied through the descriptor without
@@ -1291,7 +1292,7 @@ sudo ufw allow from 203.0.113.5   to any port 47600:47699 proto tcp   # a specif
 ```
 
 Use `-vv` to see the route planned for the real transfer. For each remote
-endpoint seen by the active orchestrator it reports the authenticated helper
+endpoint seen by the active coordinator it reports the authenticated helper
 identity and platform, every TCP address syq considered, reachability and
 advertised link speed, why a reachable address was or was not selected by the
 preflight, the resulting planned TCP/ssh transport, and the initial connection
@@ -1306,9 +1307,9 @@ or start transfer workers, and verbosity does not change dry-run's success or
 failure. The reported route is therefore a plan for a real transfer, not a
 claim that a worker data connection was completed.
 
-Native remote-to-remote copies work the same way: the orchestrator on hostA
+Native remote-to-remote copies work the same way: the coordinator on hostA
 connects to hostB's listener. Diagnostics are relative to that active
-orchestrator. If both endpoints name hostA, `-vv` reports a local filesystem
+coordinator. If both endpoints name hostA, `-vv` reports a local filesystem
 route there.
 
 No special server setup is required. For a measurement-first checklist of

--- a/docs/automation-v1.md
+++ b/docs/automation-v1.md
@@ -40,7 +40,7 @@ policy refuses a symlinked `FILE` (pass `--follow` to allow it).
 
 The results writer lives with the transfer coordinator, so both forms
 require a local coordinator. A remote-to-remote copy is refused at
-argument parsing unless `--run-at local` is passed explicitly: the
+argument parsing unless `--coordinate-at local` is passed explicitly: the
 whole point of a remote-to-remote transfer is that data does not
 route through the invoking machine, so the relay topology is never
 chosen implicitly on the stream's behalf. (Streaming from a remote

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -208,7 +208,7 @@ syq.cp(
     no_compress=False,
     bwlimit=None,
     connections=None,
-    run_at=None,
+    coordinate_at=None,
     rsh=None,
     syq_path=None,
     no_bootstrap=False,
@@ -293,11 +293,11 @@ call, so `IgnoreFrom` is the native `--ignore-from` occurrence used inside the
 single ordered stream rather than a new filtering concept.
 
 Native remote controls keep their command names mechanically (on the
-typed surface `run_at` accepts only `auto` and `local`, and a
-remote-to-remote copy requires an explicit `run_at="local"`: the
+typed surface `coordinate_at` accepts only `auto` and `local`, and a
+remote-to-remote copy requires an explicit `coordinate_at="local"`: the
 results stream is written by the transfer coordinator, remote
 placement would move it off this machine, and the local relay is
-never chosen implicitly): `run_at`, `rsh`,
+never chosen implicitly): `coordinate_at`, `rsh`,
 `syq_path`, `no_bootstrap`, `tcp_plain`, `no_tcp`, `tcp_ports`,
 `tcp_congestion`, `no_forward_agent`, `unrestricted_agent_forwarding`, and
 `agent_broker_only`. Endpoint strings passed through `from_` and `to` include

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -42,7 +42,7 @@ preview = client.cp(
 )
 ```
 
-Remote-copy controls use the same names with underscores, including `run_at`,
+Remote-copy controls use the same names with underscores, including `coordinate_at`,
 `rsh`, `syq_path`, `no_bootstrap`, `tcp_plain`, `no_tcp`, `tcp_ports`,
 `tcp_congestion`, and the native agent-forwarding policy flags. `detach` stays
 on raw `run()` because a detached command cannot return typed attached results.

--- a/sdk/python/native-api.json
+++ b/sdk/python/native-api.json
@@ -23,7 +23,7 @@
         "max-delete",
         "dry-run",
         "connections",
-        "run-at",
+        "coordinate-at",
         "rsh",
         "syq-path",
         "no-bootstrap",

--- a/sdk/python/src/syq/async_client.py
+++ b/sdk/python/src/syq/async_client.py
@@ -573,7 +573,7 @@ class AsyncClient:
         no_compress: bool = False,
         bwlimit: str | int | None = None,
         connections: int | None = None,
-        run_at: str | None = None,
+        coordinate_at: str | None = None,
         rsh: str | None = None,
         syq_path: str | os.PathLike[str] | None = None,
         no_bootstrap: bool = False,
@@ -598,14 +598,14 @@ class AsyncClient:
         timeout: float | None = None,
         check: bool = True,
     ) -> CpResult:
-        if from_ is not None and to is not None and run_at != "local":
+        if from_ is not None and to is not None and coordinate_at != "local":
             # A remote-to-remote copy places the coordinator — and the
             # results stream this surface relies on — on a remote host.
             # The local relay topology is never chosen implicitly: routing
             # the transfer through this machine is the operator's call.
             raise SyqInvocationError(
                 "a remote-to-remote copy cannot write the local results "
-                "stream; pass run_at='local' explicitly to route the "
+                "stream; pass coordinate_at='local' explicitly to route the "
                 "transfer through this machine, or use run() for a raw "
                 "invocation"
             )
@@ -645,7 +645,7 @@ class AsyncClient:
         )
         _append_remote_arguments(
             argv,
-            run_at=run_at,
+            coordinate_at=coordinate_at,
             rsh=rsh,
             syq_path=syq_path,
             no_bootstrap=no_bootstrap,
@@ -771,7 +771,6 @@ class AsyncClient:
         )
         if source_count == 0:
             raise SyqInvocationError("syq map needs a source selector")
-        argv.append("--quiet")
         process_base = Path(
             os.fsdecode(
                 os.fspath(self.process_cwd)

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -331,7 +331,7 @@ def _append_text(argv: list[Argument], option: str, value: object | None) -> Non
 def _append_remote_arguments(
     argv: list[Argument],
     *,
-    run_at: str | None,
+    coordinate_at: str | None,
     rsh: str | None,
     syq_path: str | os.PathLike[str] | None,
     no_bootstrap: bool,
@@ -343,20 +343,20 @@ def _append_remote_arguments(
     unrestricted_agent_forwarding: bool,
     agent_broker_only: bool,
 ) -> None:
-    if run_at is not None:
-        if run_at not in {"auto", "local", "source", "target"}:
+    if coordinate_at is not None:
+        if coordinate_at not in {"auto", "local", "src", "dest"}:
             raise SyqInvocationError(
-                "--run-at must be auto, local, source, or target"
+                "--coordinate-at must be auto, local, src, or dest"
             )
-        if run_at in {"source", "target"}:
+        if coordinate_at in {"src", "dest"}:
             # The results stream this library relies on is written by the
             # transfer coordinator, which these placements move to a remote
             # host; syq refuses the combination at argument parsing.
             raise SyqInvocationError(
                 "the results stream needs a local transfer coordinator; "
-                "use run_at='local' (or run() for a raw invocation)"
+                "use coordinate_at='local' (or run() for a raw invocation)"
             )
-        argv.extend(("--run-at", run_at))
+        argv.extend(("--coordinate-at", coordinate_at))
     if rsh is not None:
         argv.extend(("--rsh", _text_arg(rsh, label="rsh")))
     if syq_path is not None:
@@ -730,7 +730,7 @@ class Client:
         no_compress: bool = False,
         bwlimit: str | int | None = None,
         connections: int | None = None,
-        run_at: str | None = None,
+        coordinate_at: str | None = None,
         rsh: str | None = None,
         syq_path: str | os.PathLike[str] | None = None,
         no_bootstrap: bool = False,
@@ -755,14 +755,14 @@ class Client:
         timeout: float | None = None,
         check: bool = True,
     ) -> CpResult:
-        if from_ is not None and to is not None and run_at != "local":
+        if from_ is not None and to is not None and coordinate_at != "local":
             # A remote-to-remote copy places the coordinator — and the
             # results stream this surface relies on — on a remote host.
             # The local relay topology is never chosen implicitly: routing
             # the transfer through this machine is the operator's call.
             raise SyqInvocationError(
                 "a remote-to-remote copy cannot write the local results "
-                "stream; pass run_at='local' explicitly to route the "
+                "stream; pass coordinate_at='local' explicitly to route the "
                 "transfer through this machine, or use run() for a raw "
                 "invocation"
             )
@@ -802,7 +802,7 @@ class Client:
         )
         _append_remote_arguments(
             argv,
-            run_at=run_at,
+            coordinate_at=coordinate_at,
             rsh=rsh,
             syq_path=syq_path,
             no_bootstrap=no_bootstrap,
@@ -912,7 +912,6 @@ class Client:
         )
         if source_count == 0:
             raise SyqInvocationError("syq map needs a source selector")
-        argv.append("--quiet")
         command = (self._executable_value(), *argv)
         process_base = Path(
             os.fsdecode(

--- a/sdk/python/tests/test_async.py
+++ b/sdk/python/tests/test_async.py
@@ -58,7 +58,7 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
             from_="source",
             follow=True,
             to="target",
-            run_at="local",
+            coordinate_at="local",
             into_existing="out",
             dry_run=True,
             hash=True,
@@ -112,7 +112,7 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
             from_="source:2222",
             to="target:2200",
             into="out",
-            run_at="local",
+            coordinate_at="local",
             rsh="ssh -F config",
             syq_path="/opt/syq",
             no_bootstrap=True,
@@ -122,7 +122,7 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
         )
         argv = self.argv()
         for expected in (
-            "--run-at",
+            "--coordinate-at",
             "--rsh",
             "--syq-path",
             "--no-bootstrap",
@@ -146,7 +146,7 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
                     "source",
                     from_="source",
                     to="target",
-                    run_at="local",
+                    coordinate_at="local",
                     into="out",
                     **parameter,
                 )

--- a/sdk/python/tests/test_candidate.py
+++ b/sdk/python/tests/test_candidate.py
@@ -203,13 +203,13 @@ exec /bin/sh -c "$1"
             )
 
             # Remote coordinators cannot write the local stream: the typed
-            # surface refuses source/target placement before spawning.
+            # surface refuses source/destination placement before spawning.
             with self.assertRaises(syq.SyqInvocationError):
                 client.cp(
                     src=source,
                     from_="hostA",
                     to="hostB",
-                    run_at="target",
+                    coordinate_at="dest",
                     as_=destination,
                     rsh=os.fspath(rsh),
                     syq_path=EXECUTABLE,
@@ -221,7 +221,7 @@ exec /bin/sh -c "$1"
                 src=source,
                 from_="hostA",
                 to="hostB",
-                run_at="local",
+                coordinate_at="local",
                 as_=destination,
                 rsh=os.fspath(rsh),
                 syq_path=EXECUTABLE,

--- a/sdk/python/tests/test_native.py
+++ b/sdk/python/tests/test_native.py
@@ -167,7 +167,7 @@ class NativeClientTests(unittest.TestCase):
             from_="source",
             follow=True,
             to="target",
-            run_at="local",
+            coordinate_at="local",
             into_existing="out",
             prune=True,
             max_delete=10,
@@ -236,7 +236,7 @@ class NativeClientTests(unittest.TestCase):
             from_="source:2222",
             to="target:2200",
             into="out",
-            run_at="local",
+            coordinate_at="local",
             rsh="ssh -F config",
             syq_path="/opt/syq",
             no_bootstrap=True,
@@ -246,7 +246,7 @@ class NativeClientTests(unittest.TestCase):
         )
         argv = self.argv()
         for expected in (
-            "--run-at",
+            "--coordinate-at",
             "--rsh",
             "--syq-path",
             "--no-bootstrap",
@@ -274,7 +274,7 @@ class NativeClientTests(unittest.TestCase):
                     "source",
                     from_="source",
                     to="target",
-                    run_at="local",
+                    coordinate_at="local",
                     into="out",
                     **parameter,
                 )
@@ -436,8 +436,8 @@ class NativeClientTests(unittest.TestCase):
             self.client.cp("a", "b", as_="target")
         with self.assertRaisesRegex(syq.SyqInvocationError, "ordinary source"):
             self.client.map(src_src="source", as_="target")
-        with self.assertRaisesRegex(syq.SyqInvocationError, "--run-at"):
-            self.client.cp("source", into="target", run_at="elsewhere")
+        with self.assertRaisesRegex(syq.SyqInvocationError, "--coordinate-at"):
+            self.client.cp("source", into="target", coordinate_at="elsewhere")
         with self.assertRaisesRegex(ValueError, "relative"):
             syq.RelativePath("/absolute")
         with self.assertRaisesRegex(ValueError, "NUL"):

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,16 +42,16 @@ pub enum SourceSelection {
 
 /// Endpoint that owns the transfer coordinator for a native copy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
-pub enum RunAt {
+pub enum CoordinateAt {
     /// Run locally unless both endpoints are remote, then use the source when
-    /// possible and otherwise relay locally.
+    /// possible and otherwise refuse the transfer.
     #[default]
     Auto,
     /// Run the coordinator at the source endpoint.
-    Source,
-    /// Run the coordinator at the target endpoint.
-    Target,
-    /// Keep the coordinator on the invoking machine.
+    Src,
+    /// Run the coordinator at the destination endpoint.
+    Dest,
+    /// Keep the coordinator on the invoking machine and relay the data there.
     Local,
 }
 
@@ -77,7 +77,7 @@ pub struct Args {
     #[arg(skip)]
     pub locations: Vec<Location>,
     /// Endpoint-side base for native removal. Unlike copy's `--cwd`, this is
-    /// not joined into selector strings by the orchestrator.
+    /// not joined into selector strings by the coordinator.
     #[arg(skip)]
     pub native_rm_cwd: Option<Vec<u8>>,
     /// Endpoint-side containment boundary for native removal.
@@ -90,7 +90,7 @@ pub struct Args {
     /// emitted `src` values stay relative to it.
     #[arg(skip)]
     pub native_map_cwd: Option<Vec<u8>>,
-    /// The placement target for `syq map`, kept only for `--as` renaming;
+    /// The placement destination for `syq map`, kept only for `--as` renaming;
     /// `syq map` never contacts a destination.
     #[arg(skip)]
     pub native_map_target: Option<Vec<u8>>,
@@ -107,8 +107,8 @@ pub struct Args {
     pub native_results_fd: Option<i32>,
     /// Native coordinator placement.
     #[arg(skip)]
-    pub run_at: RunAt,
-    /// Native local-relay selection derived from `--run-at local`.
+    pub coordinate_at: CoordinateAt,
+    /// Native local-relay selection derived from `--coordinate-at local`.
     #[arg(skip)]
     pub relay: bool,
     /// Native detached remote coordinator.
@@ -274,7 +274,7 @@ pub struct Args {
     /// Whether --syq-pscope was supplied rather than selected by the user-level policy
     #[arg(skip)]
     pub pscope_explicit: bool,
-    /// Signed receiver grant forwarded to a native source-host orchestrator
+    /// Signed receiver grant forwarded to a native source-host coordinator
     #[arg(skip)]
     pub restricted_grant: Option<String>,
     /// Terminal width for a native remote coordinator's progress display
@@ -577,7 +577,7 @@ fn ordered_ignore_lines(
 
 fn print_root_help() {
     println!(
-        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning target-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a local source selection as an NDJSON mapping\n  rsync        Use the retained rsync-shaped command surface\n  persist      Manage reusable SSH control connections\n  enrollment   Manage command-restricted receiver enrollments (add, list, revoke)\n\nRun `syq <COMMAND> --help` for command-specific help."
+        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning destination-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a local source selection as an NDJSON mapping\n  rsync        Use the retained rsync-shaped command surface\n  persist      Manage reusable SSH control connections\n  enrollment   Manage command-restricted receiver enrollments (add, list, revoke)\n\nRun `syq <COMMAND> --help` for command-specific help."
     );
 }
 
@@ -752,8 +752,8 @@ enum ReceiptMode {
 #[derive(clap::Args, Debug, Default)]
 struct NativeRemoteArgs {
     /// Choose the endpoint that runs the coordinator
-    #[arg(long, value_enum, default_value_t = RunAt::Auto)]
-    run_at: RunAt,
+    #[arg(long, value_enum, default_value_t = CoordinateAt::Auto)]
+    coordinate_at: CoordinateAt,
     /// Remote shell command (default: ssh); the command owns SSH and agent policy when set
     #[arg(long = "rsh", value_name = "COMMAND")]
     rsh: Option<String>,
@@ -811,7 +811,7 @@ enum NativePreserve {
 struct NativeCopyFields {
     #[command(flatten)]
     selection: NativeSelectionArgs,
-    /// Target endpoint ([USER@]HOST[:PORT]); omitted means local
+    /// Destination endpoint ([USER@]HOST[:PORT]); omitted means local
     #[arg(long, value_name = "ENDPOINT")]
     to: Option<String>,
     /// Put selected names inside DIR, creating it if necessary
@@ -907,7 +907,7 @@ struct NativeCopyCommand {
     /// Use an isolated SSH persistence scope created by `syq persist on --ephemeral`
     #[arg(long, value_name = "PATH")]
     pscope: Option<PathBuf>,
-    /// After copying, remove target-only objects in mapped directory scopes;
+    /// After copying, remove destination-only objects in mapped directory scopes;
     /// ignored and size-excluded source paths remain protected
     #[arg(long, conflicts_with = "mapping")]
     prune: bool,
@@ -921,7 +921,7 @@ struct NativeCopyCommand {
     name = "syq map",
     version,
     about = "Print a local source selection as an NDJSON mapping",
-    long_about = "Print a local source selection as an NDJSON mapping.\n\nOne JSON object per line: tagged src and dst paths (src relative to the source base, dst relative to a future target container), the object kind, and size/mtime for regular files. Emission is local and read-only. Names must be valid UTF-8.",
+    long_about = "Print a local source selection as an NDJSON mapping.\n\nOne JSON object per line: tagged src and dst paths (src relative to the source base, dst relative to a future destination container), the object kind, and size/mtime for regular files. Emission is local and read-only. Names must be valid UTF-8.",
     override_usage = "syq map [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]..."
 )]
 struct NativeMapCommand {
@@ -1043,7 +1043,7 @@ fn parse_native_copy(argv: &[OsString]) -> Result<Args> {
         for source in locations.iter().filter(|source| !source.copies_contents()) {
             if native_basename(&source.path).is_none() {
                 bail!(
-                    "named source {:?} has no target basename; use --src-src to select directory contents",
+                    "named source {:?} has no destination basename; use --src-src to select directory contents",
                     String::from_utf8_lossy(&source.path)
                 );
             }
@@ -1053,7 +1053,7 @@ fn parse_native_copy(argv: &[OsString]) -> Result<Args> {
         Some(target) => {
             let target = trim_native_trailing_slashes(target.into_vec());
             if target.is_empty() {
-                bail!("target paths may not be empty");
+                bail!("destination paths may not be empty");
             }
             Some(target)
         }
@@ -1122,13 +1122,12 @@ fn parse_native_copy(argv: &[OsString]) -> Result<Args> {
         // The stream is written by the transfer coordinator. For a
         // remote-to-remote copy that requires the local (relay) topology,
         // which is never chosen implicitly on the stream's behalf: the
-        // operator opts in with an explicit --run-at local, even where
-        // auto placement would have relayed anyway.
+        // operator opts in with an explicit --coordinate-at local.
         let src_remote = args.locations.first().is_some_and(|l| l.host.is_some());
         let dst_remote = args.locations.last().is_some_and(|l| l.host.is_some());
-        if src_remote && dst_remote && args.run_at != RunAt::Local {
+        if src_remote && dst_remote && args.coordinate_at != CoordinateAt::Local {
             bail!(
-                "--results with a remote-to-remote copy needs the local coordinator; pass --run-at local explicitly to route the transfer through this machine"
+                "--results with a remote-to-remote copy needs the local coordinator; pass --coordinate-at local explicitly to route the transfer through this machine"
             );
         }
     }
@@ -1190,11 +1189,11 @@ fn parse_native_map(argv: &[OsString]) -> Result<Args> {
             }
             let target = trim_native_trailing_slashes(target.into_vec());
             if target.is_empty() {
-                bail!("--as target may not be empty");
+                bail!("--as destination may not be empty");
             }
             if native_basename(&target).is_none() {
                 bail!(
-                    "--as target {:?} has no basename",
+                    "--as destination {:?} has no basename",
                     String::from_utf8_lossy(&target)
                 );
             }
@@ -1204,7 +1203,7 @@ fn parse_native_map(argv: &[OsString]) -> Result<Args> {
             for source in locations.iter().filter(|source| !source.copies_contents()) {
                 if native_basename(&source.path).is_none() {
                     bail!(
-                        "named source {:?} has no target basename; use --src-src to select directory contents",
+                        "named source {:?} has no destination basename; use --src-src to select directory contents",
                         String::from_utf8_lossy(&source.path)
                     );
                 }
@@ -1520,7 +1519,7 @@ fn apply_native_copy_operational(
 }
 
 fn apply_native_remote(args: &mut Args, remote: NativeRemoteArgs) -> Result<()> {
-    args.run_at = remote.run_at;
+    args.coordinate_at = remote.coordinate_at;
     args.rsh = remote.rsh;
     args.syq_path = remote.syq_path;
     args.no_bootstrap = remote.no_bootstrap;
@@ -1790,7 +1789,7 @@ fn reject_unsupported_rsync_flags(argv: &[String]) -> Result<()> {
 fn parse_tcp_congestion(value: &str) -> std::result::Result<String, String> {
     // Linux's TCP_CA_NAME_MAX is 16 including the terminating NUL. Keep this
     // validation platform-independent so a forwarded command fails the same
-    // way on every orchestrator. The kernel otherwise looks up the registered
+    // way on every coordinator. The kernel otherwise looks up the registered
     // name exactly, without imposing a character whitelist.
     if value.is_empty() {
         return Err("congestion-control algorithm cannot be empty".into());
@@ -2081,7 +2080,7 @@ mod tests {
     #[test]
     fn native_remote_controls_lower_to_the_shared_engine() {
         let argv = [
-            "--run-at=target",
+            "--coordinate-at=dest",
             "--rsh=ssh -J jump",
             "--syq-path=/opt/syq",
             "--no-bootstrap",
@@ -2094,7 +2093,7 @@ mod tests {
         ]
         .map(std::ffi::OsString::from);
         let args = parse_native_copy(&argv).unwrap();
-        assert_eq!(args.run_at, super::RunAt::Target);
+        assert_eq!(args.coordinate_at, super::CoordinateAt::Dest);
         assert_eq!(args.rsh.as_deref(), Some("ssh -J jump"));
         assert_eq!(args.syq_path.as_deref(), Some("/opt/syq"));
         assert!(args.no_bootstrap);

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1447,7 +1447,7 @@ impl RemoteSpec {
                     Err(error) if is_tcp_congestion_error(&error) => {
                         return Err(error).with_context(|| {
                             format!(
-                                "local/orchestrating host could not configure the connecting data socket to {}",
+                                "coordinator could not configure the connecting data socket to {}",
                                 self.label()
                             )
                         })
@@ -2226,7 +2226,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn connecting_socket_congestion_rejection_is_attributed_locally() {
+    fn connecting_socket_congestion_rejection_is_attributed_to_coordinator() {
         let spec = RemoteSpec {
             local_process: false,
             user: None,
@@ -2260,7 +2260,7 @@ mod tests {
         let message = format!("{error:#}");
         assert!(is_tcp_congestion_error(&error));
         assert!(message.contains(
-            "local/orchestrating host could not configure the connecting data socket to remote.example"
+            "coordinator could not configure the connecting data socket to remote.example"
         ));
     }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1301,7 +1301,7 @@ impl RemoteSpec {
             }
         }
         // Probing is independent of the authenticated control stream. Let the
-        // orchestrator do destination preflight and plan payloads while every
+        // coordinator do destination preflight and plan payloads while every
         // candidate receives its complete bounded probe window.
         let probe = std::thread::spawn(move || {
             probe_reachable(&mut candidates, port);

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -362,7 +362,7 @@ impl FilterPolicy {
                 bail!("signed filter roots must be sorted and unique");
             }
         }
-        // `delete_excluded` is also a scan policy: with it, the orchestrator
+        // `delete_excluded` is also a scan policy: with it, the coordinator
         // inspects the destination unfiltered, and the receiver requires
         // exactly that. It therefore stays meaningful when deletion is
         // forbidden (a dry run, or a zero deletion budget); the receiver's

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -1,4 +1,4 @@
-//! Direct remote-to-remote: run the orchestrator on the source host so data
+//! Direct remote-to-remote: run the coordinator on the source host so data
 //! flows source→destination without passing through this machine.
 
 use crate::cli::{parse_rsh, Args, Existence, Interface, Location, Placement, SourceSelection};
@@ -146,7 +146,7 @@ enum ReceiptLineKind {
     V2,
 }
 
-/// Pass the orchestrator's stdout through byte for byte, keeping only the
+/// Pass the coordinator's stdout through byte for byte, keeping only the
 /// receipt marker lines to ourselves. Used only when a receipt is expected;
 /// other transfers inherit stdout untouched. V2 frames are decoded one line
 /// at a time and spooled rather than accumulated in memory.
@@ -155,7 +155,7 @@ fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<CapturedReceipt>> {
 }
 
 /// Streams every ordinary line straight through without holding more than
-/// one buffer of it, so a hostile orchestrator cannot make this machine
+/// one buffer of it, so a hostile coordinator cannot make this machine
 /// buffer an arbitrarily long line; only a receipt line is collected, up to
 /// its protocol-specific limit.
 fn relay_stdout_bounded(
@@ -185,7 +185,7 @@ fn relay_stdout_bounded(
     loop {
         let buffer = reader
             .fill_buf()
-            .context("read remote orchestrator output")?;
+            .context("read remote coordinator output")?;
         if buffer.is_empty() {
             break;
         }
@@ -207,7 +207,7 @@ fn relay_stdout_bounded(
                         capturing = Some((ReceiptLineKind::V1, head[v1_prefix.len()..].to_vec()));
                     } else {
                         out.write_all(&head)
-                            .context("relay remote orchestrator output")?;
+                            .context("relay remote coordinator output")?;
                     }
                     head.clear();
                 }
@@ -215,7 +215,7 @@ fn relay_stdout_bounded(
                 payload.extend_from_slice(segment);
             } else {
                 out.write_all(segment)
-                    .context("relay remote orchestrator output")?;
+                    .context("relay remote coordinator output")?;
             }
             if let Some((kind, payload)) = capturing.as_mut() {
                 let limit = match kind {
@@ -230,7 +230,7 @@ fn relay_stdout_bounded(
                 if let Some((kind, mut payload)) = capturing.take() {
                     store_receipt_line(&mut receipt, kind, finish_capture(&mut payload))?;
                 } else {
-                    out.flush().context("relay remote orchestrator output")?;
+                    out.flush().context("relay remote coordinator output")?;
                 }
                 decided = false;
             }
@@ -245,13 +245,13 @@ fn relay_stdout_bounded(
             capturing = Some((ReceiptLineKind::V1, head[v1_prefix.len()..].to_vec()));
         } else {
             out.write_all(&head)
-                .context("relay remote orchestrator output")?;
+                .context("relay remote coordinator output")?;
         }
     }
     if let Some((kind, mut payload)) = capturing.take() {
         store_receipt_line(&mut receipt, kind, finish_capture(&mut payload))?;
     }
-    out.flush().context("relay remote orchestrator output")?;
+    out.flush().context("relay remote coordinator output")?;
     Ok(receipt)
 }
 
@@ -263,7 +263,7 @@ fn store_receipt_line(
     match kind {
         ReceiptLineKind::V1 => {
             if captured.is_some() {
-                bail!("the remote orchestrator relayed more than one legacy receipt line");
+                bail!("the remote coordinator relayed more than one legacy receipt line");
             }
             *captured = Some(CapturedReceipt::V1(payload));
         }
@@ -275,7 +275,7 @@ fn store_receipt_line(
                 *captured = Some(CapturedReceipt::V2(CapturedReceiptV2::new()?));
             }
             let Some(CapturedReceipt::V2(receipt)) = captured.as_mut() else {
-                bail!("the remote orchestrator mixed receipt protocol versions");
+                bail!("the remote coordinator mixed receipt protocol versions");
             };
             receipt.push(&encoded)?;
         }
@@ -285,7 +285,7 @@ fn store_receipt_line(
 
 /// Verify hostB's receipt against the grant this machine signed. A missing,
 /// unverifiable, or mismatching receipt fails the transfer regardless of
-/// what the source-side orchestrator reported.
+/// what the source-side coordinator reported.
 fn settle_receipt(
     expectation: &ReceiptExpectation,
     captured: Option<&mut CapturedReceipt>,
@@ -755,9 +755,9 @@ pub fn run(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     run_remote(args, srcs, dst, false)
 }
 
-pub fn run_at_target(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
+pub fn coordinate_at_dest(args: &Args, srcs: &[Location], dst: &Location) -> Result<i32> {
     if args.interface == Interface::Rsync {
-        bail!("--run-at target is available only through native copy syntax");
+        bail!("--coordinate-at dest is available only through native copy syntax");
     }
     if !srcs[0].same_host(dst)
         && args.rsh.is_none()
@@ -766,7 +766,7 @@ pub fn run_at_target(args: &Args, srcs: &[Location], dst: &Location) -> Result<i
         && !args.agent_broker_only
     {
         bail!(
-            "--run-at target requires a read-restricted source enrollment, which is not implemented yet; use --agent-broker-only, --no-forward-agent with target-host credentials, or an explicit --rsh policy"
+            "--coordinate-at dest requires a read-restricted source enrollment, which is not implemented yet; use --agent-broker-only, --no-forward-agent with destination-host credentials, or an explicit --rsh policy"
         );
     }
     run_remote(args, srcs, dst, true)
@@ -776,7 +776,7 @@ fn run_remote(
     args: &Args,
     srcs: &[Location],
     dst: &Location,
-    coordinator_at_target: bool,
+    coordinator_at_destination: bool,
 ) -> Result<i32> {
     match args.native_results.as_deref() {
         Some(b"-") if args.detach => bail!(
@@ -784,12 +784,20 @@ fn run_remote(
         ),
         Some(b"-") | None => {}
         Some(_) => bail!(
-            "a remote transfer coordinator accepts only --results -; use --run-at local to create a named results file"
+            "a remote transfer coordinator accepts only --results -; use --coordinate-at local to create a named results file"
         ),
     }
     let rsh = parse_rsh(&args.rsh)?;
-    let coordinator = if coordinator_at_target { dst } else { &srcs[0] };
-    let peer = if coordinator_at_target { &srcs[0] } else { dst };
+    let coordinator = if coordinator_at_destination {
+        dst
+    } else {
+        &srcs[0]
+    };
+    let peer = if coordinator_at_destination {
+        &srcs[0]
+    } else {
+        dst
+    };
     let coordinator_host = coordinator.host.clone().unwrap();
     let same_host = srcs[0].same_host(dst);
     if args.detach && args.rsh.is_none() && !same_host && !args.no_forward_agent {
@@ -833,7 +841,7 @@ fn run_remote(
         // Native new/existing placement forms travel in the signed grant as the
         // root-existence precondition, so they use the receiver like any other
         // form instead of silently keeping only the constrained broker.
-        let prepared = (!coordinator_at_target && !args.agent_broker_only)
+        let prepared = (!coordinator_at_destination && !args.agent_broker_only)
             .then(|| {
                 crate::restricted::prepare_transfer(
                     args,
@@ -910,7 +918,7 @@ fn run_remote(
         diagnostics: Default::default(),
     };
 
-    // Rebuild the native command for the remote orchestrator. Placement stays
+    // Rebuild the native command for the remote coordinator. Placement stays
     // explicit rather than being translated into trailing-slash heuristics.
     let mut remote: Vec<String> = vec![match args.interface {
         Interface::Rsync => unreachable!("checked above"),
@@ -1018,7 +1026,7 @@ fn run_remote(
         remote.push("--progress".into());
     }
 
-    if coordinator_at_target && !same_host {
+    if coordinator_at_destination && !same_host {
         remote.push("--from".into());
         remote.push(endpoint_arg(
             &srcs[0],
@@ -1040,7 +1048,7 @@ fn run_remote(
         );
         remote.push(utf8_path(&source.path, "source path")?);
     }
-    if !coordinator_at_target && !same_host {
+    if !coordinator_at_destination && !same_host {
         remote.push("--to".into());
         remote.push(endpoint_arg(
             dst,
@@ -1052,7 +1060,7 @@ fn run_remote(
     remote.push(
         restricted_destination_path
             .clone()
-            .unwrap_or(utf8_path(&dst.path, "target path")?),
+            .unwrap_or(utf8_path(&dst.path, "destination path")?),
     );
 
     if args.detach {
@@ -1507,7 +1515,7 @@ mod tests {
         let refused = encode(&refused, request_id);
         assert!(settle(&expectation, Some(&refused)).is_err());
 
-        // An incomplete in-place file contradicts a successful orchestrator
+        // An incomplete in-place file contradicts a successful coordinator
         // but is only a warning beside a failure it already reported.
         let mut partial = crate::receipt::Ledger::default();
         partial.published.insert(

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -156,7 +156,7 @@ impl OperatorDirectorySelection {
                     if metadata.st_mode & libc::S_IFMT == libc::S_IFDIR
                         && !(final_component && require_absent) => {}
                 Ok(metadata) if metadata.st_mode & libc::S_IFMT == libc::S_IFDIR => {
-                    bail!("destination directory appeared after the new-target precondition")
+                    bail!("destination directory appeared after the new-path precondition")
                 }
                 Ok(_) => bail!(
                     "destination path component {:?} appeared with an unsafe type while creating the destination",
@@ -178,7 +178,7 @@ impl OperatorDirectorySelection {
                                 && final_component
                                 && require_absent =>
                         {
-                            bail!("destination directory appeared after the new-target precondition")
+                            bail!("destination directory appeared after the new-path precondition")
                         }
                         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
                             match operator_lstat_at(&self.directory, &component) {
@@ -253,7 +253,7 @@ fn select_operator_directory(
 }
 
 /// Check the current spelling of an operator-supplied local path without
-/// traversing a symlink. This is semantic preflight for orchestrator-local
+/// traversing a symlink. This is semantic preflight for coordinator-local
 /// control files; retaining their opened identity belongs to the broader
 /// descriptor-root migration.
 pub(crate) fn check_operator_path_no_symlinks(
@@ -1317,7 +1317,7 @@ fn apply_one_unrooted(op: &Op) -> Result<()> {
                         fs::create_dir_all(parent)?;
                     }
                 }
-                // The orchestrator resolves an explicitly supplied root
+                // The coordinator resolves an explicitly supplied root
                 // symlink. Symlinks found inside the destination tree are
                 // payload conflicts and must be replaced, never traversed.
                 match condition {
@@ -1325,10 +1325,10 @@ fn apply_one_unrooted(op: &Op) -> Result<()> {
                     TargetCondition::Matches { .. }
                     | TargetCondition::MatchesFingerprint { .. } => {
                         let md = require_target_condition(&p, *condition)?
-                            .expect("matching target condition returns metadata");
+                            .expect("matching destination condition returns metadata");
                         if !md.is_dir() {
                             bail!(
-                                "target {} cannot change type under --as-existing",
+                                "destination {} cannot change type under --as-existing",
                                 p.display()
                             );
                         }
@@ -1361,10 +1361,10 @@ fn apply_one_unrooted(op: &Op) -> Result<()> {
                     TargetCondition::Matches { .. }
                     | TargetCondition::MatchesFingerprint { .. } => {
                         let metadata = require_target_condition(&p, *condition)?
-                            .expect("matching target condition returns metadata");
+                            .expect("matching destination condition returns metadata");
                         if !metadata.file_type().is_symlink() {
                             bail!(
-                                "target {} cannot change type under --as-existing",
+                                "destination {} cannot change type under --as-existing",
                                 p.display()
                             );
                         }
@@ -1392,10 +1392,10 @@ fn apply_one_unrooted(op: &Op) -> Result<()> {
                     TargetCondition::Matches { .. }
                     | TargetCondition::MatchesFingerprint { .. } => {
                         let metadata = require_target_condition(&p, *condition)?
-                            .expect("matching target condition returns metadata");
+                            .expect("matching destination condition returns metadata");
                         if file_type_bits(metadata.mode()) != file_type_bits(*mode) {
                             bail!(
-                                "target {} cannot change type under --as-existing",
+                                "destination {} cannot change type under --as-existing",
                                 p.display()
                             );
                         }
@@ -1422,7 +1422,10 @@ fn apply_one_unrooted(op: &Op) -> Result<()> {
                 match condition {
                     TargetCondition::Any => set_meta_path(&p, meta, *flags),
                     TargetCondition::Absent => {
-                        bail!("target {} appeared before metadata update", p.display())
+                        bail!(
+                            "destination {} appeared before metadata update",
+                            p.display()
+                        )
                     }
                     TargetCondition::Matches { .. }
                     | TargetCondition::MatchesFingerprint { .. } => {
@@ -1546,7 +1549,7 @@ fn guarded_target(path: &[u8], guard: &ContainerGuard) -> Result<GuardedTarget> 
 fn relative_under(root: &Path, target: &Path) -> Result<RelativePath> {
     let relative = target.strip_prefix(root).with_context(|| {
         format!(
-            "target {} is outside guarded root {}",
+            "destination {} is outside guarded root {}",
             target.display(),
             root.display()
         )
@@ -1569,7 +1572,7 @@ fn observe_rooted_condition(
         (TargetCondition::Absent, None) => Ok(None),
         (TargetCondition::Absent, Some(_)) => {
             bail!(
-                "target {} appeared before no-replace creation",
+                "destination {} appeared before no-replace creation",
                 label.display()
             )
         }
@@ -1595,7 +1598,7 @@ fn observe_rooted_condition(
         }
         (TargetCondition::Matches { .. } | TargetCondition::MatchesFingerprint { .. }, _) => {
             bail!(
-                "target {} changed before it could be replaced",
+                "destination {} changed before it could be replaced",
                 label.display()
             )
         }
@@ -1631,7 +1634,7 @@ fn apply_one_rooted(op: &Op, target: &GuardedTarget) -> Result<()> {
                     Ok(())
                 }
                 Some(_) if *condition != TargetCondition::Any => bail!(
-                    "target {} cannot change type under a matched condition",
+                    "destination {} cannot change type under a matched condition",
                     target.label.display()
                 ),
                 Some(_) => {
@@ -1652,7 +1655,7 @@ fn apply_one_rooted(op: &Op, target: &GuardedTarget) -> Result<()> {
             Some(metadata) if *condition != TargetCondition::Any => {
                 if !metadata.is_symlink() {
                     bail!(
-                        "target {} cannot change type under a matched condition",
+                        "destination {} cannot change type under a matched condition",
                         target.label.display()
                     );
                 }
@@ -1677,7 +1680,7 @@ fn apply_one_rooted(op: &Op, target: &GuardedTarget) -> Result<()> {
             Some(metadata) if *condition != TargetCondition::Any => {
                 if file_type_bits(metadata.mode) != file_type_bits(*mode) {
                     bail!(
-                        "target {} cannot change type under a matched condition",
+                        "destination {} cannot change type under a matched condition",
                         target.label.display()
                     );
                 }
@@ -1786,7 +1789,10 @@ fn require_rooted_identity(
     match condition {
         TargetCondition::Any => Ok(()),
         TargetCondition::Absent => {
-            bail!("target {} appeared before metadata update", label.display())
+            bail!(
+                "destination {} appeared before metadata update",
+                label.display()
+            )
         }
         TargetCondition::Matches { dev, ino }
         | TargetCondition::MatchesFingerprint { dev, ino, .. }
@@ -1795,7 +1801,10 @@ fn require_rooted_identity(
             Ok(())
         }
         TargetCondition::Matches { .. } | TargetCondition::MatchesFingerprint { .. } => {
-            bail!("target {} changed during metadata update", label.display())
+            bail!(
+                "destination {} changed during metadata update",
+                label.display()
+            )
         }
     }
 }
@@ -1808,7 +1817,10 @@ fn require_rooted_condition(
     match condition {
         TargetCondition::Any => Ok(()),
         TargetCondition::Absent => {
-            bail!("target {} appeared before metadata update", label.display())
+            bail!(
+                "destination {} appeared before metadata update",
+                label.display()
+            )
         }
         TargetCondition::Matches { dev, ino } if (metadata.dev, metadata.ino) == (dev, ino) => {
             Ok(())
@@ -1828,7 +1840,10 @@ fn require_rooted_condition(
             Ok(())
         }
         TargetCondition::Matches { .. } | TargetCondition::MatchesFingerprint { .. } => {
-            bail!("target {} changed before metadata update", label.display())
+            bail!(
+                "destination {} changed before metadata update",
+                label.display()
+            )
         }
     }
 }
@@ -1837,7 +1852,7 @@ fn require_rooted_metadata(file: &File, expected: RootMetadata, label: &Path) ->
     let opened = file.metadata()?;
     if opened.dev() != expected.dev || opened.ino() != expected.ino {
         bail!(
-            "confined target {} changed while opening it",
+            "confined destination {} changed while opening it",
             label.display()
         );
     }
@@ -1854,14 +1869,17 @@ fn require_rooted_named_identity(
             let metadata = file.metadata()?;
             (metadata.dev(), metadata.ino())
         }
-        TargetCondition::Absent => bail!("new target unexpectedly received metadata repair"),
+        TargetCondition::Absent => bail!("new destination unexpectedly received metadata repair"),
         TargetCondition::Matches { dev, ino }
         | TargetCondition::MatchesFingerprint { dev, ino, .. } => (dev, ino),
     };
     let opened = file.metadata()?;
     let named = target.root.metadata(&target.relative)?;
     if opened.dev() != dev || opened.ino() != ino || named.dev != dev || named.ino != ino {
-        bail!("target {} changed during update", target.label.display());
+        bail!(
+            "destination {} changed during update",
+            target.label.display()
+        );
     }
     Ok(())
 }
@@ -1871,7 +1889,7 @@ fn condition_identity(condition: TargetCondition) -> Result<(u64, u64)> {
         TargetCondition::Matches { dev, ino }
         | TargetCondition::MatchesFingerprint { dev, ino, .. } => Ok((dev, ino)),
         TargetCondition::Any | TargetCondition::Absent => {
-            bail!("target condition does not identify an existing object")
+            bail!("destination condition does not identify an existing object")
         }
     }
 }
@@ -1893,7 +1911,7 @@ fn exact_parent(path: &Path) -> Result<(Root, RelativePath)> {
         .unwrap_or_else(|| Path::new("."));
     let leaf = path
         .file_name()
-        .context("exact replacement target has no leaf name")?;
+        .context("exact replacement destination has no leaf name")?;
     Ok((Root::open(parent)?, RelativePath::new(leaf.as_bytes())?))
 }
 
@@ -1942,7 +1960,7 @@ fn require_target_condition(
         TargetCondition::Absent => match fs::symlink_metadata(path) {
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
             Ok(_) => bail!(
-                "target {} appeared after the new-path precondition was checked",
+                "destination {} appeared after the new-path precondition was checked",
                 path.display()
             ),
             Err(error) => Err(error).with_context(|| format!("stat {}", path.display())),
@@ -1950,7 +1968,7 @@ fn require_target_condition(
         TargetCondition::Matches { dev, ino } => match fs::symlink_metadata(path) {
             Ok(metadata) if metadata.dev() == dev && metadata.ino() == ino => Ok(Some(metadata)),
             Ok(_) | Err(_) => bail!(
-                "target {} changed after the existing-path precondition was checked",
+                "destination {} changed after the existing-path precondition was checked",
                 path.display()
             ),
         },
@@ -1969,7 +1987,7 @@ fn require_target_condition(
                 Ok(Some(metadata))
             }
             Ok(_) | Err(_) => bail!(
-                "target {} changed after the existing-path precondition was checked",
+                "destination {} changed after the existing-path precondition was checked",
                 path.display()
             ),
         },
@@ -1980,14 +1998,14 @@ fn require_open_target(file: &File, path: &Path, condition: TargetCondition) -> 
     match condition {
         TargetCondition::Any => Ok(()),
         TargetCondition::Absent => bail!(
-            "target {} appeared after the new-path precondition was checked",
+            "destination {} appeared after the new-path precondition was checked",
             path.display()
         ),
         TargetCondition::Matches { dev, ino } => {
             let metadata = file.metadata()?;
             if metadata.dev() != dev || metadata.ino() != ino {
                 bail!(
-                    "target {} changed after the existing-path precondition was checked",
+                    "destination {} changed after the existing-path precondition was checked",
                     path.display()
                 );
             }
@@ -2006,7 +2024,7 @@ fn require_open_target(file: &File, path: &Path, condition: TargetCondition) -> 
                 || metadata.ctime_nsec() as u32 != ctime_nsec
             {
                 bail!(
-                    "target {} changed after the existing-path precondition was checked",
+                    "destination {} changed after the existing-path precondition was checked",
                     path.display()
                 );
             }
@@ -2025,7 +2043,7 @@ fn require_named_target_identity(
     match condition {
         TargetCondition::Any => Ok(()),
         TargetCondition::Absent => bail!(
-            "new-target condition cannot validate an in-place update of {}",
+            "new-destination condition cannot validate an in-place update of {}",
             path.display()
         ),
         TargetCondition::Matches { dev, ino }
@@ -2039,7 +2057,7 @@ fn require_named_target_identity(
                 || named.ino() != ino
             {
                 bail!(
-                    "target {} changed during the existing-path update",
+                    "destination {} changed during the existing-path update",
                     path.display()
                 );
             }
@@ -3443,7 +3461,7 @@ fn publish_partial(src: &Path, dst: &Path, condition: TargetCondition) -> Result
             fs::remove_file(src).with_context(|| format!("remove {}", src.display()))
         }
         TargetCondition::Matches { .. } | TargetCondition::MatchesFingerprint { .. } => {
-            bail!("internal error: matched publication must update the held target inode")
+            bail!("internal error: matched publication must update the held destination inode")
         }
     }
 }
@@ -3988,7 +4006,7 @@ mod tests {
         let error = selection.create_missing(0o755, true).unwrap_err();
         assert!(error
             .to_string()
-            .contains("appeared after the new-target precondition"));
+            .contains("appeared after the new-path precondition"));
 
         fs::remove_dir_all(&dir).unwrap();
     }

--- a/src/native_map.rs
+++ b/src/native_map.rs
@@ -72,7 +72,7 @@ pub fn run(args: &Args) -> Result<i32> {
             };
             let dst_name = match (args.placement, &args.native_map_target) {
                 (Placement::As, Some(target)) => native_basename(target)
-                    .ok_or_else(|| anyhow!("--as target has no basename"))?
+                    .ok_or_else(|| anyhow!("--as destination has no basename"))?
                     .to_vec(),
                 _ => native_basename(&location.path)
                     .expect("parse validated that named selectors have a basename")

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -463,7 +463,7 @@ pub enum Request {
         guard: Option<ContainerGuard>,
     },
     /// Kernel TCP_INFO/TCP_CONNECTION_INFO for this end of a direct data
-    /// socket. SSH data transports report None at the orchestrator instead of
+    /// socket. SSH data transports report None at the coordinator instead of
     /// sending this request.
     TransportStats,
     /// Ask a command-restricted receiver for its signed receipt. Issuing it
@@ -487,7 +487,7 @@ pub enum Response {
     },
     /// The peer understood the requested per-socket override but its kernel
     /// could not honor it. Keep this distinct from ordinary TCP reachability
-    /// failures, for which the orchestrator may safely fall back to SSH.
+    /// failures, for which the coordinator may safely fall back to SSH.
     TcpCongestionRejected(String),
     ScanBatch(Vec<Entry>),
     ScanWarn(String),

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -2,8 +2,8 @@
 //! transfer did to its disk.
 //!
 //! Nothing from the receiver reaches the invoking machine except through the
-//! source-side orchestrator, so the receiver signs a summary bound to the
-//! grant's request ID with a key only it holds. The orchestrator relays the
+//! source-side coordinator, so the receiver signs a summary bound to the
+//! grant's request ID with a key only it holds. The coordinator relays the
 //! envelope opaquely; the invoking machine verifies it against the public key
 //! recorded at enrollment. The receipt attests hostB's view; it says nothing
 //! about the source's completeness or authenticity.
@@ -16,7 +16,7 @@ use ssh_key::{HashAlg, LineEnding, PrivateKey, PublicKey, SshSig};
 use std::collections::{BTreeMap, BTreeSet};
 
 pub(crate) const RECEIPT_NAMESPACE: &str = "syq-receipt-v1@greaber.github";
-/// The orchestrator prints the base64 envelope after this prefix as one
+/// The coordinator prints the base64 envelope after this prefix as one
 /// stdout line; the invoking machine filters that line out and verifies it.
 pub(crate) const RECEIPT_LINE_PREFIX: &str = "syq-receipt-v1:";
 const WIRE_MAGIC: &[u8; 8] = b"SYQRCPT\0";
@@ -45,7 +45,7 @@ pub(crate) struct PublishedV1 {
     pub complete: bool,
 }
 
-/// One file the receiver hashed for the orchestrator (`--verify-only`,
+/// One file the receiver hashed for the coordinator (`--verify-only`,
 /// `--hash`); this is hostB's view of that object.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct ObservedV1 {

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -1041,7 +1041,7 @@ impl RestrictedAuthority {
         };
         let failed = |index: usize| outcome_error(index).is_some();
         // Hash completed publications for a hashed receipt now, before the
-        // orchestrator's deferred directory modes can make them unreadable,
+        // coordinator's deferred directory modes can make them unreadable,
         // and before taking the state lock.
         let outcomes: Vec<(PendingOutcome, Option<Result<[u8; 32]>>)> = outcomes
             .into_iter()
@@ -1467,7 +1467,7 @@ impl RestrictedAuthority {
         let target = Path::new(OsStr::from_bytes(path));
         let relative = target.strip_prefix(root_path).with_context(|| {
             format!(
-                "receiver metadata target {} is outside enrolled root {}",
+                "receiver metadata destination {} is outside enrolled root {}",
                 target.display(),
                 root_path.display()
             )
@@ -1545,7 +1545,9 @@ impl RestrictedAuthority {
                         ));
                     };
                     if !metadata.is_dir() {
-                        bail!("receiver-managed directory target changed before authorization");
+                        bail!(
+                            "receiver-managed directory destination changed before authorization"
+                        );
                     }
 
                     // Mkdir itself was constrained to 0700, so a setgid bit
@@ -1715,7 +1717,7 @@ impl RestrictedAuthority {
                         expected_ctime,
                         expected_ctime_nsec,
                     ) == (dev, ino, ctime, ctime_nsec) => {}
-                    _ => bail!("receiver-managed mode target changed before authorization"),
+                    _ => bail!("receiver-managed mode destination changed before authorization"),
                 }
             }
             // From this point on MODE contains receiver-authored data. FsOps
@@ -5315,7 +5317,7 @@ mod tests {
             guard: None,
         };
 
-        // An observation the orchestrator asked for is hostB's own view.
+        // An observation the coordinator asked for is hostB's own view.
         let mut hash = Request::FileHash {
             path: path_bytes(&kept),
             guard: None,
@@ -5831,7 +5833,7 @@ mod tests {
         )
         .unwrap();
 
-        // The orchestrator refuses the same combination before signing. The
+        // The coordinator refuses the same combination before signing. The
         // rsync-shaped parser already makes --inplace and --ignore-existing
         // conflict, so the reachable case is the native --as-new placement.
         let mut args = Args::try_parse_from([

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -868,7 +868,7 @@ impl Root {
             || before.file_type() != expected_type
         {
             bail!(
-                "confined target {} changed before replacement",
+                "confined destination {} changed before replacement",
                 path.label()
             );
         }
@@ -894,10 +894,10 @@ impl Root {
                 parent.directory.as_raw_fd(),
                 &parent.leaf,
             )
-            .with_context(|| format!("restore raced target {}", path.label()))?;
+            .with_context(|| format!("restore raced destination {}", path.label()))?;
             unlink_at(parent.directory.as_raw_fd(), &temporary, 0)?;
             bail!(
-                "confined target {} changed during replacement",
+                "confined destination {} changed during replacement",
                 path.label()
             );
         }
@@ -995,7 +995,7 @@ impl Root {
             })
         {
             bail!(
-                "confined target {} changed before publication",
+                "confined destination {} changed before publication",
                 target.label()
             );
         }
@@ -1017,9 +1017,9 @@ impl Root {
                 target_parent.directory.as_raw_fd(),
                 &target_parent.leaf,
             )
-            .with_context(|| format!("restore raced target {}", target.label()))?;
+            .with_context(|| format!("restore raced destination {}", target.label()))?;
             bail!(
-                "confined target {} changed during publication",
+                "confined destination {} changed during publication",
                 target.label()
             );
         }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -306,7 +306,7 @@ pub fn scan_rooted(
     let target = crate::fsops::resolve(requested_root);
     let target_relative = target.strip_prefix(&root_path).with_context(|| {
         format!(
-            "scan target {} is outside enrolled root {}",
+            "scan destination {} is outside enrolled root {}",
             target.display(),
             root_path.display()
         )

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1,8 +1,9 @@
-//! The orchestrator: scan, diff, schedule, and the per-worker transfer loop.
+//! The coordinator: scan, diff, schedule, and the per-worker transfer loop.
 
 use crate::bwlimit::BandwidthLimit;
 use crate::cli::{
-    parse_rsh, parse_size, Args, Existence, Interface, Location, Placement, RunAt, SourceSelection,
+    parse_rsh, parse_size, Args, CoordinateAt, Existence, Interface, Location, Placement,
+    SourceSelection,
 };
 use crate::conn::{
     ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, SshMultiplexer, TcpCandidate,
@@ -933,9 +934,9 @@ pub(crate) fn uses_remote_coordinator(args: &Args, sources: &[Location], dst: &L
     source.is_remote()
         && dst.is_remote()
         && !args.relay
-        && (args.interface == Interface::Rsync || args.run_at != RunAt::Local)
+        && (args.interface == Interface::Rsync || args.coordinate_at != CoordinateAt::Local)
         && (args.interface == Interface::Rsync
-            || args.run_at != RunAt::Auto
+            || args.coordinate_at != CoordinateAt::Auto
             || direct_paths_are_utf8)
 }
 
@@ -1007,11 +1008,11 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         && dst.is_remote()
         && !original_srcs[0].same_host(dst)
         && !args.relay
-        && args.run_at != RunAt::Local
-        // Native auto placement relays raw path bytes because they cannot be
-        // represented in the remote coordinator's argv. Validate direct-only
-        // controls against the topology that will actually run.
-        && (args.run_at != RunAt::Auto || direct_paths_are_utf8);
+        && args.coordinate_at != CoordinateAt::Local
+        // Native auto placement cannot delegate raw path bytes because they
+        // cannot be represented in the remote coordinator's argv. Validate
+        // direct-only controls against the topology that will actually run.
+        && (args.coordinate_at != CoordinateAt::Auto || direct_paths_are_utf8);
     if (args.detach || args.no_forward_agent || args.agent_broker_only) && !direct_remote_to_remote
     {
         bail!(
@@ -1020,14 +1021,14 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     }
     if args.pscope_explicit && coordinator_is_remote {
         bail!(
-            "--pscope is not supported with a remote transfer coordinator; use --run-at local to keep the reusable connections on this machine"
+            "--pscope is not supported with a remote transfer coordinator; use --coordinate-at local to keep the reusable connections on this machine"
         );
     }
     if args.restricted_grant.is_some()
         && (args.no_tcp || args.tcp_plain || original_srcs[0].is_remote() || !dst.is_remote())
     {
         bail!(
-            "a signed receiver grant is valid only for a local-to-remote orchestrator using encrypted TCP data connections"
+            "a signed receiver grant is valid only for a local-to-remote coordinator using encrypted TCP data connections"
         );
     }
     for source in original_srcs {
@@ -1108,13 +1109,13 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         if args.connections_default {
             args.connections = tune::START_SSH;
         }
-        if args.interface != Interface::Rsync && args.run_at == RunAt::Target {
-            return crate::direct::run_at_target(&args, srcs, dst);
+        if args.interface != Interface::Rsync && args.coordinate_at == CoordinateAt::Dest {
+            return crate::direct::coordinate_at_dest(&args, srcs, dst);
         }
         return crate::direct::run(&args, srcs, dst);
     }
     if srcs[0].is_remote() && dst.is_remote() {
-        if args.interface != Interface::Rsync && args.run_at == RunAt::Local {
+        if args.interface != Interface::Rsync && args.coordinate_at == CoordinateAt::Local {
             args.relay = true;
         }
         if !args.relay {
@@ -1124,14 +1125,14 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             // operands are the planned fix); until then, relaying is the
             // operator's explicit choice.
             bail!(
-                "remote-to-remote copy: these path bytes cannot be carried in a remote command line, so a direct transfer is not possible; pass --run-at local to route the transfer through this machine instead"
+                "remote-to-remote copy: these path bytes cannot be carried in a remote command line, so a direct transfer is not possible; pass --coordinate-at local to route the transfer through this machine instead"
             );
         }
         if !args.quiet {
             eprintln!("syq: remote-to-remote transfer: relaying data through this machine");
         }
-    } else if args.interface != Interface::Rsync && args.run_at != RunAt::Auto {
-        bail!("--run-at currently applies only to copies between two remote endpoints");
+    } else if args.interface != Interface::Rsync && args.coordinate_at != CoordinateAt::Auto {
+        bail!("--coordinate-at currently applies only to copies between two remote endpoints");
     }
     let src_ep = endpoint(&srcs[0], &args)?;
     let mut dst_ep = endpoint(dst, &args)?;
@@ -1149,7 +1150,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     // option forces SSH data.
     // A local receiver uses one child process and a loopback data listener so
     // every worker shares its retained destination cwd without changing the
-    // orchestrator process's cwd.
+    // coordinator process's cwd.
     let use_tcp = !args.no_tcp && (src_ep.has_data_server() || dst_ep.has_data_server());
     // Without -j the worker count is tuned while the transfer runs (see tune.rs);
     // start conservatively until TCP reachability has been established below.
@@ -1164,7 +1165,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     #[cfg(not(target_os = "linux"))]
     if let Some(algorithm) = &args.tcp_congestion {
         bail!(
-            "{} {algorithm} requires a Linux transfer orchestrator and Linux remote endpoints",
+            "{} {algorithm} requires a Linux transfer coordinator and Linux remote endpoints",
             interface_option(&args, "--tcp-congestion", "--syq-tcp-congestion")
         );
     }
@@ -1519,11 +1520,11 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     match args.target_existence {
         Existence::Any => {}
         Existence::New if dst_existed => bail!(
-            "target {} already exists, but the selected placement requires a new path",
+            "destination {} already exists, but the selected placement requires a new path",
             display(&dst_root)
         ),
         Existence::Existing if !dst_existed => bail!(
-            "target {} does not exist, but the selected placement requires an existing path",
+            "destination {} does not exist, but the selected placement requires an existing path",
             display(&dst_root)
         ),
         Existence::New | Existence::Existing => {}
@@ -1537,13 +1538,13 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                     .is_some_and(|entry| entry.kind == Kind::Symlink)
             {
                 bail!(
-                    "--into target {} is a symlink; pass --follow to resolve symlinks",
+                    "--into destination {} is a symlink; pass --follow to resolve symlinks",
                     display(&dst_root)
                 );
             }
             if dst_existed && !dst_entry_is_dir {
                 bail!(
-                    "--into target {} exists but is not a directory",
+                    "--into destination {} exists but is not a directory",
                     display(&dst_root)
                 );
             }
@@ -1564,7 +1565,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         && !dst_entry_is_dir
     {
         bail!(
-            "--into-existing target {} is not an existing directory",
+            "--into-existing destination {} is not an existing directory",
             display(&dst_root)
         );
     }
@@ -2235,7 +2236,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
 
     // With a command-restricted receiver, ask for its signed receipt now that
     // every mutation is settled, and hand its bounded frames to the invoking
-    // machine as marked lines. That machine verifies it; this orchestrator's
+    // machine as marked lines. That machine verifies it; this coordinator's
     // own report is not trusted for what landed.
     if args.restricted_grant.is_some() {
         use base64::Engine as _;
@@ -2570,7 +2571,12 @@ fn mkdir_root(
     }
     stat_one(conn, dst_root, false)?
         .filter(|entry| entry.kind == Kind::Dir)
-        .with_context(|| format!("created target {} is not a directory", display(dst_root)))
+        .with_context(|| {
+            format!(
+                "created destination {} is not a directory",
+                display(dst_root)
+            )
+        })
 }
 
 fn mkdir_root_batches(
@@ -3398,7 +3404,7 @@ impl Planner<'_> {
         match current {
             Some(entry) if entry.dev == dev && entry.ino == ino => Ok(()),
             _ => bail!(
-                "target {} changed after the placement precondition was checked",
+                "destination {} changed after the placement precondition was checked",
                 display(&self.root_path)
             ),
         }
@@ -4315,7 +4321,7 @@ impl Planner<'_> {
                         .pop()
                         .flatten()
                         .filter(|entry| entry.kind == Kind::Dir)
-                        .context("new exact target was not a directory after creation")?;
+                        .context("new exact destination was not a directory after creation")?;
                     self.exact_condition = target_identity(&created);
                     self.mutation_root_condition = target_identity(&created);
                     if self.guard_containers {
@@ -4495,7 +4501,7 @@ impl Planner<'_> {
             };
             if !target_condition_holds {
                 self.progress.error(&format!(
-                    "syq: target {} changed after the placement precondition was checked",
+                    "syq: destination {} changed after the placement precondition was checked",
                     display(&dst_path)
                 ));
                 self.collision = true;

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -230,7 +230,7 @@ fn native_copy_distinguishes_named_contents_and_exact_placement() {
     assert_eq!(read(&t.path("exact/sub/file")), b"data");
     assert!(!t.path("exact/src").exists());
 
-    // Existing target state does not change either placement mapping.
+    // Existing destination state does not change either placement mapping.
     fs::create_dir_all(t.path("named-existing")).unwrap();
     fs::create_dir_all(t.path("exact-existing")).unwrap();
     run_native_ok(&["cp", &t.s("src"), "--into-existing", &t.s("named-existing")]);
@@ -371,7 +371,7 @@ fn native_copy_uses_explicit_endpoints_cwd_and_option_safe_selectors() {
 
     let no_basename = native_syq(&["cp", "..", "--into", &t.s("no-basename")]);
     assert!(!no_basename.status.success());
-    assert!(String::from_utf8_lossy(&no_basename.stderr).contains("no target basename"));
+    assert!(String::from_utf8_lossy(&no_basename.stderr).contains("no destination basename"));
     assert!(!t.path("no-basename").exists());
 }
 
@@ -1147,17 +1147,57 @@ fn native_receiver_ceilings_apply_only_to_direct_remote_copies() {
 }
 
 #[test]
-fn native_rejects_unknown_relay_option() {
-    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
-        .args(["cp", "--relay", "source", "--into", "target"])
-        .run()
-        .unwrap();
-    assert_eq!(out.status.code(), Some(2));
-    assert!(
-        String::from_utf8_lossy(&out.stderr).contains("unexpected argument"),
-        "{}",
-        String::from_utf8_lossy(&out.stderr)
-    );
+fn native_rejects_removed_topology_options() {
+    for arguments in [
+        &["cp", "--relay", "source", "--into", "destination"][..],
+        &[
+            "cp",
+            "--run-at",
+            "source",
+            "--src",
+            "source",
+            "--into",
+            "destination",
+        ][..],
+    ] {
+        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(arguments)
+            .run()
+            .unwrap();
+        assert_eq!(out.status.code(), Some(2));
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains("unexpected argument"),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+#[test]
+fn native_coordinate_at_rejects_old_endpoint_names() {
+    for value in ["source", "target"] {
+        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "cp",
+                "--coordinate-at",
+                value,
+                "--from",
+                "host-a",
+                "source",
+                "--to",
+                "host-b",
+                "--into",
+                "destination",
+            ])
+            .run()
+            .unwrap();
+        assert_eq!(out.status.code(), Some(2));
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains("invalid value"),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
 }
 
 #[test]
@@ -7808,7 +7848,7 @@ fn native_direct_remote_to_remote_forwards_copy_policies() {
 }
 
 #[test]
-fn native_run_at_target_reverses_the_remote_ssh_edge() {
+fn native_coordinate_at_dest_reverses_the_remote_ssh_edge() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
     write(&t.path("src/file"), b"pulled");
@@ -7828,8 +7868,8 @@ fn native_run_at_target_reverses_the_remote_ssh_edge() {
             &t.s("src"),
             "--to",
             "hostB",
-            "--run-at",
-            "target",
+            "--coordinate-at",
+            "dest",
             "--into",
             &t.s("dst"),
             "-q",
@@ -7844,21 +7884,27 @@ fn native_run_at_target_reverses_the_remote_ssh_edge() {
     assert_eq!(read(&t.path("dst/file")), b"pulled");
     let log = fs::read_to_string(t.path("rsh.log")).unwrap();
     let mut invocations = log.lines();
-    let target_command = invocations.next().expect("target coordinator launch");
-    assert!(target_command.contains("--from hostA"), "{target_command}");
-    assert!(target_command.contains("--no-tcp"), "{target_command}");
+    let destination_command = invocations.next().expect("destination coordinator launch");
     assert!(
-        target_command.contains("--tcp-ports=49000-49002"),
-        "{target_command}"
+        destination_command.contains("--from hostA"),
+        "{destination_command}"
+    );
+    assert!(
+        destination_command.contains("--no-tcp"),
+        "{destination_command}"
+    );
+    assert!(
+        destination_command.contains("--tcp-ports=49000-49002"),
+        "{destination_command}"
     );
     assert!(
         invocations.next().is_some(),
-        "the target coordinator never opened the reversed edge to hostA: {log}"
+        "the destination coordinator never opened the reversed edge to hostA: {log}"
     );
 }
 
 #[test]
-fn native_target_dry_run_labels_the_real_endpoints_and_ports() {
+fn native_destination_dry_run_labels_the_real_endpoints_and_ports() {
     let t = Tmp::new();
     let ssh = fake_ssh(&t);
     write(&t.path("src/file"), b"planned");
@@ -7876,8 +7922,8 @@ fn native_target_dry_run_labels_the_real_endpoints_and_ports() {
             &t.s("src"),
             "--to",
             "hostB:2222",
-            "--run-at",
-            "target",
+            "--coordinate-at",
+            "dest",
             "--into",
             &t.s("dst"),
         ])
@@ -7910,7 +7956,7 @@ fn native_target_dry_run_labels_the_real_endpoints_and_ports() {
 }
 
 #[test]
-fn native_auto_raw_path_relay_rejects_direct_only_controls() {
+fn native_auto_raw_path_rejects_direct_only_controls() {
     let mut raw_source = b"/source-".to_vec();
     raw_source.push(0xff);
     let raw_source = std::ffi::OsString::from_vec(raw_source);
@@ -7928,7 +7974,7 @@ fn native_auto_raw_path_relay_rejects_direct_only_controls() {
             .arg(&raw_source)
             .args(["--to", "hostB", "--as", "/target"])
             .run()
-            .expect("reject a direct-only option before automatic relay");
+            .expect("reject a direct-only option before transfer selection");
 
         assert!(!out.status.success(), "{option} unexpectedly succeeded");
         let stderr = stderr_of(&out);
@@ -7974,7 +8020,7 @@ fn native_detach_rejects_an_unattached_results_stream() {
 }
 
 #[test]
-fn native_run_at_local_relays_between_remote_endpoints() {
+fn native_coordinate_at_local_relays_between_remote_endpoints() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
     write(&t.path("src/file"), b"relayed");
@@ -7992,7 +8038,7 @@ fn native_run_at_local_relays_between_remote_endpoints() {
             &t.s("src"),
             "--to",
             "hostB",
-            "--run-at",
+            "--coordinate-at",
             "local",
             "--into",
             &t.s("dst"),
@@ -8016,7 +8062,7 @@ fn native_run_at_local_relays_between_remote_endpoints() {
 }
 
 #[test]
-fn native_run_at_target_fails_closed_without_read_enrollment_support() {
+fn native_coordinate_at_dest_fails_closed_without_read_enrollment_support() {
     let t = Tmp::new();
     let out = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args([
@@ -8027,8 +8073,8 @@ fn native_run_at_target_fails_closed_without_read_enrollment_support() {
             &t.s("src"),
             "--to",
             "hostB",
-            "--run-at",
-            "target",
+            "--coordinate-at",
+            "dest",
             "--into",
             &t.s("dst"),
         ])
@@ -10020,8 +10066,8 @@ fn explicit_pscope_is_refused_for_remote_coordinators() {
             "src",
             "--to",
             "hostB",
-            "--run-at",
-            "target",
+            "--coordinate-at",
+            "dest",
             "--into",
             "dst",
             "-q",
@@ -10033,7 +10079,7 @@ fn explicit_pscope_is_refused_for_remote_coordinators() {
     assert!(!out.status.success());
     let stderr = stderr_of(&out);
     assert!(stderr.contains("remote transfer coordinator"), "{stderr}");
-    assert!(stderr.contains("--run-at local"), "{stderr}");
+    assert!(stderr.contains("--coordinate-at local"), "{stderr}");
 }
 
 #[test]
@@ -10581,12 +10627,12 @@ fn native_results_require_a_local_coordinator() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
     write(&t.path("src"), b"local results");
-    // Every placement except an explicit --run-at local is refused: the
+    // Every placement except an explicit --coordinate-at local is refused: the
     // local (relay) topology is never chosen implicitly on the stream's
     // behalf, auto included.
-    for run_at in [
-        &["--run-at", "target"][..],
-        &["--run-at", "source"][..],
+    for coordinate_at in [
+        &["--coordinate-at", "dest"][..],
+        &["--coordinate-at", "src"][..],
         &[][..],
     ] {
         for flag in [
@@ -10598,7 +10644,7 @@ fn native_results_require_a_local_coordinator() {
                 .arg(&rsh)
                 .args(["--from", "hostA", "--src", &t.s("src")])
                 .args(["--to", "hostB"])
-                .args(run_at)
+                .args(coordinate_at)
                 .args(["--as", &t.s("dst-remote")])
                 .args(flag)
                 .env("FAKE_REMOTE_HOME", t.path("remote-home"))
@@ -10609,7 +10655,7 @@ fn native_results_require_a_local_coordinator() {
             // Usage lane: exit 2, no stream ever existed.
             assert_eq!(out.status.code(), Some(2));
             let stderr = stderr_of(&out);
-            assert!(stderr.contains("--run-at local"), "{stderr}");
+            assert!(stderr.contains("--coordinate-at local"), "{stderr}");
             assert!(!t.path("dst-remote").exists());
             assert!(!t.path("r-remote.ndjson").exists());
         }
@@ -10638,6 +10684,6 @@ fn native_remote_to_remote_never_relays_implicitly() {
         .unwrap();
     assert!(!out.status.success());
     let stderr = stderr_of(&out);
-    assert!(stderr.contains("--run-at local"), "{stderr}");
+    assert!(stderr.contains("--coordinate-at local"), "{stderr}");
     assert!(!stderr.contains("relaying"), "no implicit relay: {stderr}");
 }


### PR DESCRIPTION
## Summary

- replace `--run-at=auto|source|target|local` with `--coordinate-at=auto|src|dest|local`
- standardize public prose and diagnostics on source, destination, and coordinator while retaining the `--src-src` selector family and plural conveniences
- align the Python typed API as `coordinate_at` and remove its obsolete `--quiet` argument to `syq map`

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (275 unit, 301 integration, 7 updater tests)
- `PYTHONPATH=sdk/python/src SYQ_CANDIDATE_EXECUTABLE=target/debug/syq SYQ_CANDIDATE_VERSION=0.1.8 uv run --project sdk/python --frozen python -m unittest discover -s sdk/python/tests` (53 tests)
- `scripts/test-python-sdk-release-tools.sh`
- `python3 scripts/check-python-api-sync.py`