### PR TITLE
ci: split premerge and postmerge validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -18,6 +22,11 @@ jobs:
     outputs:
       native: ${{ steps.changes.outputs.native }}
       sdks: ${{ steps.changes.outputs.sdks }}
+      tooling: ${{ steps.changes.outputs.tooling }}
+      mapping_docs: ${{ steps.changes.outputs.mapping_docs }}
+      macos: ${{ steps.changes.outputs.macos }}
+      linux_arm64: ${{ steps.changes.outputs.linux_arm64 }}
+      full_suite: ${{ steps.changes.outputs.full_suite }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -35,14 +44,21 @@ jobs:
       - name: Require successful path classification
         if: needs.scope.result != 'success'
         run: echo 'Path classification failed.' >&2; exit 1
-      - name: Complete the required check for documentation and SDK-only changes
-        if: needs.scope.outputs.native != 'true'
-        run: echo 'Full Rust validation is not needed for this change set.'
+      - name: Complete the required check when Rust and tooling are unaffected
+        if: >-
+          needs.scope.outputs.native != 'true' &&
+          needs.scope.outputs.tooling != 'true' &&
+          needs.scope.outputs.mapping_docs != 'true'
+        run: echo 'Rust, executable documentation, and repository tooling are unaffected.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.scope.outputs.native == 'true'
+        if: >-
+          needs.scope.outputs.native == 'true' ||
+          needs.scope.outputs.tooling == 'true' ||
+          needs.scope.outputs.mapping_docs == 'true'
         with:
           persist-credentials: false
-      - if: needs.scope.outputs.native == 'true'
+      - name: Install Rust check components
+        if: needs.scope.outputs.native == 'true'
         run: rustup component add rustfmt clippy
       - name: Check dependency policy
         if: needs.scope.outputs.native == 'true'
@@ -61,25 +77,69 @@ jobs:
           test "$("$RUNNER_TEMP/$directory/cargo-deny" --version)" = \
             "cargo-deny $CARGO_DENY_VERSION"
           "$RUNNER_TEMP/$directory/cargo-deny" --locked check
-      - if: needs.scope.outputs.native == 'true'
+      - name: Check Rust formatting
+        if: needs.scope.outputs.native == 'true'
         run: cargo fmt --all -- --check
-      - if: needs.scope.outputs.native == 'true'
+      - name: Lint every Rust target
+        if: needs.scope.outputs.native == 'true'
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
-      - if: needs.scope.outputs.native == 'true'
+      - name: Test native units before merge
+        if: >-
+          needs.scope.outputs.native == 'true' &&
+          needs.scope.outputs.full_suite != 'true'
+        run: cargo test --locked --bin syq
+      - name: Test every native target after merge
+        if: >-
+          needs.scope.outputs.native == 'true' &&
+          needs.scope.outputs.full_suite == 'true'
         run: cargo test --locked --all-targets
-      - if: needs.scope.outputs.native == 'true'
+      - name: Test executable mapping documentation
+        if: >-
+          needs.scope.outputs.mapping_docs == 'true' &&
+          (needs.scope.outputs.native != 'true' ||
+           needs.scope.outputs.full_suite != 'true')
+        run: cargo test --locked --test local mappings_md_
+      - name: Test Cargo package identity
+        if: >-
+          needs.scope.outputs.tooling == 'true' ||
+          (needs.scope.outputs.native == 'true' &&
+           needs.scope.outputs.full_suite == 'true')
         run: scripts/test-cargo-package.sh
-      - if: needs.scope.outputs.native == 'true'
+      - name: Test installer tooling
+        if: >-
+          needs.scope.outputs.tooling == 'true' ||
+          (needs.scope.outputs.native == 'true' &&
+           needs.scope.outputs.full_suite == 'true')
         run: scripts/test-installer.sh
-      - if: needs.scope.outputs.native == 'true'
+      - name: Test release tooling
+        if: >-
+          needs.scope.outputs.tooling == 'true' ||
+          (needs.scope.outputs.native == 'true' &&
+           needs.scope.outputs.full_suite == 'true')
         run: scripts/test-release-tools.sh
-      - if: needs.scope.outputs.native == 'true'
+      - name: Test release orchestration
+        if: >-
+          needs.scope.outputs.tooling == 'true' ||
+          (needs.scope.outputs.native == 'true' &&
+           needs.scope.outputs.full_suite == 'true')
         run: scripts/test-release-orchestration.sh
-      - if: needs.scope.outputs.native == 'true'
+      - name: Validate workflow syntax
+        if: >-
+          needs.scope.outputs.tooling == 'true' ||
+          (needs.scope.outputs.native == 'true' &&
+           needs.scope.outputs.full_suite == 'true')
         run: scripts/check-workflows.sh
-      - if: needs.scope.outputs.native == 'true'
+      - name: Test release-secret tooling
+        if: >-
+          needs.scope.outputs.tooling == 'true' ||
+          (needs.scope.outputs.native == 'true' &&
+           needs.scope.outputs.full_suite == 'true')
         run: scripts/test-secret-tools.sh
-      - if: needs.scope.outputs.native == 'true'
+      - name: Lint shell tooling
+        if: >-
+          needs.scope.outputs.tooling == 'true' ||
+          (needs.scope.outputs.native == 'true' &&
+           needs.scope.outputs.full_suite == 'true')
         run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/ci-scope.sh scripts/approve-generated-pr-runs.sh scripts/release-preflight.sh scripts/release-status.sh scripts/check-workflows.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-release-orchestration.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh
 
   sdks:
@@ -90,9 +150,9 @@ jobs:
       - name: Require successful path classification
         if: needs.scope.result != 'success'
         run: echo 'Path classification failed.' >&2; exit 1
-      - name: Complete the required check for documentation-only changes
+      - name: Complete the required check when SDKs are unaffected
         if: needs.scope.outputs.sdks != 'true'
-        run: echo 'Full SDK validation is not needed for this change set.'
+        run: echo 'SDK validation is not needed for this change set.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: needs.scope.outputs.sdks == 'true'
         with:
@@ -182,14 +242,14 @@ jobs:
       - name: Require successful path classification
         if: needs.scope.result != 'success'
         run: echo 'Path classification failed.' >&2; exit 1
-      - name: Complete the required check for documentation and SDK-only changes
-        if: needs.scope.outputs.native != 'true'
-        run: echo 'The ARM build is not affected by this change set.'
+      - name: Complete the required check when ARM validation is deferred
+        if: needs.scope.outputs.linux_arm64 != 'true'
+        run: echo 'ARM validation is deferred to the cumulative post-merge suite.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.scope.outputs.native == 'true'
+        if: needs.scope.outputs.linux_arm64 == 'true'
         with:
           persist-credentials: false
-      - if: needs.scope.outputs.native == 'true'
+      - if: needs.scope.outputs.linux_arm64 == 'true'
         run: cargo check --locked --all-targets
 
   macos:
@@ -200,28 +260,28 @@ jobs:
       - name: Require successful path classification
         if: needs.scope.result != 'success'
         run: echo 'Path classification failed.' >&2; exit 1
-      - name: Complete the required check for documentation and SDK-only changes
-        if: needs.scope.outputs.native != 'true'
-        run: echo 'The macOS build and installer are not affected by this change set.'
+      - name: Complete the required check when macOS validation is deferred
+        if: needs.scope.outputs.macos != 'true'
+        run: echo 'macOS validation is deferred to the cumulative post-merge suite.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.scope.outputs.native == 'true'
+        if: needs.scope.outputs.macos == 'true'
         with:
           persist-credentials: false
-      - if: needs.scope.outputs.native == 'true'
+      - if: needs.scope.outputs.macos == 'true'
         run: cargo check --locked --all-targets
       - name: Exercise macOS symlink descriptor pinning
-        if: needs.scope.outputs.native == 'true'
+        if: needs.scope.outputs.macos == 'true'
         run: >-
           cargo test --locked
           rooted::tests::operator_resolver_selects_a_last_component_symlink_without_following_it
           -- --exact
       - name: Exercise macOS cross-process descriptor handoff
-        if: needs.scope.outputs.native == 'true'
+        if: needs.scope.outputs.macos == 'true'
         run: >-
           cargo test --locked
           descriptor_broker::tests::independent_process_receives_exact_registered_descriptor
           -- --exact
-      - if: needs.scope.outputs.native == 'true'
+      - if: needs.scope.outputs.macos == 'true'
         run: scripts/test-installer.sh
-      - if: needs.scope.outputs.native == 'true'
+      - if: needs.scope.outputs.macos == 'true'
         run: scripts/test-homebrew-formula.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           needs.scope.outputs.tooling == 'true' ||
           (needs.scope.outputs.native == 'true' &&
            needs.scope.outputs.full_suite == 'true')
-        run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/ci-scope.sh scripts/approve-generated-pr-runs.sh scripts/release-preflight.sh scripts/release-status.sh scripts/check-workflows.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-release-orchestration.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh
+        run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-ci.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/ci-scope.sh scripts/approve-generated-pr-runs.sh scripts/release-preflight.sh scripts/release-status.sh scripts/check-workflows.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-release-orchestration.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh
 
   sdks:
     needs: scope

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
     tags: ["v*"]
 
 permissions:
+  actions: read
+  checks: read
   contents: read
 
 concurrency:
@@ -34,7 +36,8 @@ jobs:
         run: |
           scripts/verify-release-tag.sh \
             "$GITHUB_REPOSITORY" "$GITHUB_REF_NAME" "$GITHUB_SHA" master \
-            rust,sdks,macos,linux-arm64
+            rust,sdks,macos,linux-arm64,conformance
+          scripts/verify-release-ci.sh "$GITHUB_REPOSITORY" "$GITHUB_SHA"
 
   build:
     name: build (${{ matrix.name }})

--- a/.github/workflows/rsync-compat.yml
+++ b/.github/workflows/rsync-compat.yml
@@ -6,6 +6,10 @@ on:
     branches: [master]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -34,9 +38,9 @@ jobs:
       - name: Require successful path classification
         if: needs.scope.result != 'success'
         run: echo 'Path classification failed.' >&2; exit 1
-      - name: Complete the required check for documentation and SDK-only changes
+      - name: Complete the required check when conformance is unaffected
         if: needs.scope.outputs.conformance != 'true'
-        run: echo 'Rsync conformance is not affected by this change set.'
+        run: echo 'Rsync conformance is deferred to affected or cumulative post-merge changes.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: needs.scope.outputs.conformance == 'true'
         with:

--- a/.github/workflows/rsync-compat.yml
+++ b/.github/workflows/rsync-compat.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,11 @@ outlive its premise and steer later work in the wrong direction.
 ## Release tag lifecycle
 
 - Before pushing a syq release tag, run
-  `scripts/release-preflight.sh v<version>` from the exact clean, synchronized
-  `master` commit. Treat any failure as a blocker rather than pushing the tag
-  to discover whether the release workflow starts. Use
+  explicit `workflow_dispatch` runs of both `ci.yml` and `rsync-compat.yml` on
+  the exact clean, synchronized `master` commit, wait for both to succeed, and
+  then run `scripts/release-preflight.sh v<version>` from that same commit.
+  Treat any failure as a blocker rather than pushing the tag to discover
+  whether the release workflow starts. Use
   `scripts/release-status.sh v<version>` after the push to correlate the exact
   tag, workflow, approvals, and publication destinations.
 - Except for Go module tags, treat a release tag as provisional until its

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,15 +202,27 @@ every actual update. See `RELEASING.md` for provisioning, backup, and rotation.
 
 **Fix problems, don't skip work**: When a check, test, or verification step fails because a tool isn't installed or a dependency is missing, use the repository's pinned, project-local setup method and retry. Do not silently skip the step. Do not install or upgrade tools globally, use unpinned package sources, or change system configuration without explicit user approval. If the repository has no suitable local setup path or the remaining fix requires privileges or credentials, ask the user for help. This applies broadly — missing tools, broken environments, configuration issues, or any other blocker. The default is to fix the problem, not work around it by skipping.
 
-Run checks proportionate to the change. The normal Rust checks are:
+Run checks proportionate to the change. For a Rust change, the normal
+pre-merge baseline is:
 
 ```bash
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all-targets
+cargo test --bin syq
 ```
 
-For CLI and filesystem behavior, prefer integration tests in `tests/local.rs`;
-they invoke the built binary against temporary trees. State what was and was
-not verified, especially for remote, TCP, platform-specific, or performance
-behavior.
+Then select the integration tests that can plausibly exercise the changed
+behavior. Prefer exact or narrow filters in `tests/local.rs`; those tests invoke
+the built binary against temporary trees. Run `cargo test --all-targets` before
+handoff when a change is broad, crosses subsystem boundaries, changes shared
+test infrastructure, or leaves meaningful uncertainty about the affected
+surface. Do not run unrelated suites merely because they exist.
+
+Pull-request CI intentionally mirrors this policy: it runs formatting, clippy,
+and native unit tests for Rust changes, plus a directly affected SDK, rsync, or
+executable-documentation suite. The agent remains responsible for choosing and
+reporting focused integration tests before review. The cumulative `master` CI
+run executes the complete native and cross-platform suites after merge, so a
+green pull request is not evidence that every repository test ran on that head.
+State exactly what was and was not verified, especially for remote, TCP,
+platform-specific, or performance behavior.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -138,33 +138,37 @@ connection, so enable it only for a trusted release host rather than globally.
    `sdk/python/native-api.json`. A feature may use the `follow_up` disposition
    so its merge is not blocked on SDK work, but `scripts/check-python-api-sync.py`
    and the tag workflow refuse a release until every follow-up is resolved.
-2. Wait for the post-merge `ci` run on `master` to succeed for the release
-   commit. Pull requests are checked against their own head rather than the
-   merged result, and the release workflow refuses a commit whose `rust`,
-   `sdks`, `macos`, and `linux-arm64` checks have not all succeeded. The `sdks`
-   check builds the candidate syq and exercises it through the Python adapter,
-   so tagging a red or still-running `master` only produces a failed release
-   run:
+2. Once the release commit is the exact `master` tip, explicitly dispatch both
+   full validation workflows on it. Selective push checks are insufficient for
+   a release candidate because an unaffected job may have completed with a
+   successful stub. A manual run selects every native, SDK, conformance, ARM,
+   and macOS suite; the release gates require the latest manual run of each
+   workflow on the exact candidate SHA to succeed:
 
    ```sh
-   gh run watch --exit-status "$(gh run list --workflow ci.yml --branch master --commit "$(git rev-parse master)" --json databaseId --jq '.[0].databaseId')"
+   candidate=$(git rev-parse master)
+   gh workflow run ci.yml --ref master
+   gh workflow run rsync-compat.yml --ref master
    ```
 
-   Run the read-only preflight before creating the tag:
+   After both runs complete, verify their exact-SHA certification and run the
+   read-only preflight before creating the tag:
 
    ```sh
+   scripts/verify-release-ci.sh greaber/syq "$candidate"
    scripts/release-preflight.sh v0.1.9
    ```
 
    It requires the exact clean, synchronized `master` tip; no pending Python
-   API follow-ups; matching Cargo metadata; successful required checks on that SHA; an SSH tag-signing key
-   registered with GitHub; the selected-Actions allowlist; the protected
-   `release` environment, tag policy, variables, and secret names; and absence
-   of the tag or version from GitHub, crates.io, and the Homebrew tap. It makes
-   no local or remote changes. Then create and push a signed annotated tag
-   matching the package version. Its signing key and email must be configured
-   on your GitHub account so
-   GitHub reports the tag-object signature as verified:
+   API follow-ups; matching Cargo metadata; successful `rust`, `sdks`,
+   `macos`, `linux-arm64`, and `conformance` checks on that SHA; the two full
+   manual workflow certifications; an SSH tag-signing key registered with
+   GitHub; the selected-Actions allowlist; the protected `release` environment,
+   tag policy, variables, and secret names; and absence of the tag or version
+   from GitHub, crates.io, and the Homebrew tap. It makes no local or remote
+   changes. Then create and push a signed annotated tag matching the package
+   version. Its signing key and email must be configured on your GitHub account
+   so GitHub reports the tag-object signature as verified:
 
    ```sh
    git tag -s v0.1.0 -m 'syq 0.1.0'
@@ -177,8 +181,9 @@ connection, so enable it only for a trusted release host rather than globally.
    boundary. The workflow
    first verifies that the annotated tag's signature is valid and that it
    directly targets the workflow commit, that this commit is reachable
-   from protected `master`, and that the `rust`, `sdks`, `macos`, and
-   `linux-arm64` checks all succeeded on that exact commit. It then builds
+   from protected `master`, that the `rust`, `sdks`, `macos`, `linux-arm64`,
+   and `conformance` checks all succeeded on that exact commit, and that both
+   full manual workflow certifications succeeded. It then builds
    static GNU Linux x86-64/ARM64
    binaries and native macOS Apple Silicon/Intel binaries, embeds an Ed25519
    signature over the manifest's RFC 8785 canonical JSON, verifies the exact
@@ -260,8 +265,9 @@ and macOS suites. Workflow concurrency cancels an older run when a newer commit
 arrives on the same pull request. Each non-PR run has a unique concurrency
 group, including while it is pending, because a later push may affect a
 different subsystem and therefore cannot safely replace the earlier push's
-selected suites. A release candidate must be the exact commit whose post-merge
-checks completed; release preflight rejects a canceled or superseded commit.
+selected suites. A release candidate must additionally have successful,
+exact-SHA manual runs of both workflows; release preflight and tag verification
+reject selective stubs as release evidence.
 
 The checked-in classifier uses a pull request's merge-base diff rather than
 including unrelated base-branch changes. Documentation-only changes finish

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -246,14 +246,30 @@ as their sole release identity.
 ## CI scope
 
 The required `rust`, `sdks`, `linux-arm64`, `macos`, and `conformance` check
-names are stable. A checked-in path classifier lets those jobs finish with a
-small successful validation for documentation-only changes. SDK-only changes
-still run the full `sdks` job, including generated Python mappings, while the
-native and platform jobs finish quickly. Any Rust, test, script, build,
-installer, release-workflow, or otherwise unclassified path runs the complete
-native, SDK, platform, and conformance suites. Manual workflow runs also run
-everything. This keeps branch protection and release-tag verification attached
-to the same check names without repeatedly rebuilding unaffected code.
+names are stable, but the work behind them differs before and after merge.
+Pull requests run a fast affected-surface gate: Rust changes get formatting,
+clippy, and native unit tests; SDK and rsync-owned changes get their respective
+suites; executable examples in `MAPPINGS.md` get their focused integration
+tests; and repository-tooling changes get the packaging, release, workflow, and
+shell checks. Ordinary native pull requests defer the complete filesystem,
+SDK, conformance, ARM, and macOS suites to `master`. The working agent chooses
+and reports any additional integration tests justified by the change.
+
+Every native push to `master` runs the complete native, SDK, conformance, ARM,
+and macOS suites. Workflow concurrency cancels an older run when a newer commit
+arrives on the same pull request. Master runs are retained because a later push
+may affect a different subsystem and therefore cannot safely replace the
+earlier push's selected suites. A release candidate must be the exact commit
+whose post-merge checks completed; release preflight rejects a canceled or
+superseded commit.
+
+The checked-in classifier uses a pull request's merge-base diff rather than
+including unrelated base-branch changes. Documentation-only changes finish
+with small successful required jobs, except for documentation consumed by a
+test or generator. Unknown paths fail safe by selecting every suite. Manual
+workflow runs also select everything. This keeps branch protection and
+release-tag verification attached to stable check names while avoiding the
+same expensive validation on both sides of a merge.
 
 ## macOS signing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -257,11 +257,11 @@ and reports any additional integration tests justified by the change.
 
 Every native push to `master` runs the complete native, SDK, conformance, ARM,
 and macOS suites. Workflow concurrency cancels an older run when a newer commit
-arrives on the same pull request. Master runs are retained because a later push
-may affect a different subsystem and therefore cannot safely replace the
-earlier push's selected suites. A release candidate must be the exact commit
-whose post-merge checks completed; release preflight rejects a canceled or
-superseded commit.
+arrives on the same pull request. Each non-PR run has a unique concurrency
+group, including while it is pending, because a later push may affect a
+different subsystem and therefore cannot safely replace the earlier push's
+selected suites. A release candidate must be the exact commit whose post-merge
+checks completed; release preflight rejects a canceled or superseded commit.
 
 The checked-in classifier uses a pull request's merge-base diff rather than
 including unrelated base-branch changes. Documentation-only changes finish

--- a/scripts/ci-scope.sh
+++ b/scripts/ci-scope.sh
@@ -4,6 +4,19 @@ set -euo pipefail
 
 event_path=${1:-${GITHUB_EVENT_PATH:-}}
 changed_paths=
+full_suite=false
+
+run_everything() {
+  printf '%s\n' \
+    'native=true' \
+    'sdks=true' \
+    'tooling=true' \
+    'mapping_docs=true' \
+    'conformance=true' \
+    'macos=true' \
+    'linux_arm64=true' \
+    'full_suite=true'
+}
 
 if [ -n "${SYQ_TEST_CHANGED_PATHS_FILE:-}" ]; then
   changed_paths=$(cat "$SYQ_TEST_CHANGED_PATHS_FILE")
@@ -13,18 +26,21 @@ elif [ -n "$event_path" ] && [ -f "$event_path" ]; then
     pull_request)
       base=$(jq -er .pull_request.base.sha "$event_path")
       head=$(jq -er .pull_request.head.sha "$event_path")
+      diff_range="$base...$head"
       ;;
     push)
       base=$(jq -er .before "$event_path")
       head=$(jq -er .after "$event_path")
+      full_suite=true
       if [[ "$base" =~ ^0+$ ]]; then
-        printf 'native=true\nsdks=true\nconformance=true\n'
+        run_everything
         echo 'CI scope: new branch or incomplete push history; running every check' >&2
         exit 0
       fi
+      diff_range="$base..$head"
       ;;
     workflow_dispatch)
-      printf 'native=true\nsdks=true\nconformance=true\n'
+      run_everything
       echo 'CI scope: manual run; running every check' >&2
       exit 0
       ;;
@@ -37,7 +53,7 @@ elif [ -n "$event_path" ] && [ -f "$event_path" ]; then
     || { echo "CI scope base commit is unavailable: $base" >&2; exit 1; }
   git cat-file -e "$head^{commit}" 2>/dev/null \
     || { echo "CI scope head commit is unavailable: $head" >&2; exit 1; }
-  changed_paths=$(git diff --name-only "$base" "$head")
+  changed_paths=$(git diff --name-only "$diff_range")
 else
   echo "usage: $0 GITHUB_EVENT_PATH" >&2
   exit 2
@@ -45,19 +61,72 @@ fi
 
 native=false
 sdks=false
+tooling=false
+mapping_docs=false
+conformance=false
+macos=false
+linux_arm64=false
 saw_path=false
 while IFS= read -r path; do
   [ -n "$path" ] || continue
   saw_path=true
   case "$path" in
+    sdk/python/native-api.json)
+      # This SDK-owned specification is compiled into the Rust CLI.
+      native=true
+      sdks=true
+      ;;
     sdk/*)
       sdks=true
       ;;
-    *.md|docs/*|.github/ISSUE_TEMPLATE/*|.github/dependabot.yml|LICENSE)
+    MAPPINGS.md)
+      # The documented jq programs are executable integration-test inputs.
+      mapping_docs=true
       ;;
-    *)
+    tests/rsync-compat/*|scripts/rsync-compat.py)
+      conformance=true
+      ;;
+    tests/fixtures/*)
+      # The same protocol fixtures are consumed by Rust and Python tests.
       native=true
       sdks=true
+      ;;
+    Cargo.toml|Cargo.lock|rust-toolchain.toml|build.rs|src/*|tests/*.rs|schemas/*)
+      native=true
+      ;;
+    .github/workflows/ci.yml)
+      tooling=true
+      sdks=true
+      conformance=true
+      macos=true
+      linux_arm64=true
+      ;;
+    .github/workflows/rsync-compat.yml)
+      tooling=true
+      conformance=true
+      ;;
+    .github/workflows/prepare-python-sdk.yml|.github/workflows/publish-sdks.yml|.github/workflows/python-api-sync.yml)
+      tooling=true
+      sdks=true
+      ;;
+    scripts/generate-homebrew-formula.sh|scripts/test-homebrew-formula.sh|scripts/generate-installer.sh|scripts/test-installer.sh)
+      tooling=true
+      macos=true
+      ;;
+    scripts/*|.github/workflows/*|.env.release|deny.toml)
+      tooling=true
+      ;;
+    *.md|docs/*|use-cases/*|.github/ISSUE_TEMPLATE/*|.github/dependabot.yml|LICENSE|.gitignore|.claude/*)
+      ;;
+    *)
+      # Unknown inputs fail safe until their dependency boundary is explicit.
+      native=true
+      sdks=true
+      tooling=true
+      mapping_docs=true
+      conformance=true
+      macos=true
+      linux_arm64=true
       ;;
   esac
 done <<<"$changed_paths"
@@ -65,7 +134,22 @@ done <<<"$changed_paths"
 if [ "$saw_path" = false ]; then
   native=true
   sdks=true
+  tooling=true
+  mapping_docs=true
+  conformance=true
+  macos=true
+  linux_arm64=true
 fi
 
-printf 'native=%s\nsdks=%s\nconformance=%s\n' "$native" "$sdks" "$native"
-echo "CI scope: native=$native sdks=$sdks conformance=$native" >&2
+# Pull requests run affected fast checks. The cumulative master state gets the
+# broad cross-subsystem and platform suites once after merge.
+if [ "$full_suite" = true ] && [ "$native" = true ]; then
+  sdks=true
+  conformance=true
+  macos=true
+  linux_arm64=true
+fi
+
+printf 'native=%s\nsdks=%s\ntooling=%s\nmapping_docs=%s\nconformance=%s\nmacos=%s\nlinux_arm64=%s\nfull_suite=%s\n' \
+  "$native" "$sdks" "$tooling" "$mapping_docs" "$conformance" "$macos" "$linux_arm64" "$full_suite"
+echo "CI scope: native=$native sdks=$sdks tooling=$tooling mapping_docs=$mapping_docs conformance=$conformance macos=$macos linux_arm64=$linux_arm64 full_suite=$full_suite" >&2

--- a/scripts/ci-scope.sh
+++ b/scripts/ci-scope.sh
@@ -97,8 +97,10 @@ while IFS= read -r path; do
       native=true
       ;;
     .github/workflows/ci.yml)
+      native=true
       tooling=true
       sdks=true
+      mapping_docs=true
       conformance=true
       macos=true
       linux_arm64=true

--- a/scripts/ci-scope.sh
+++ b/scripts/ci-scope.sh
@@ -53,7 +53,9 @@ elif [ -n "$event_path" ] && [ -f "$event_path" ]; then
     || { echo "CI scope base commit is unavailable: $base" >&2; exit 1; }
   git cat-file -e "$head^{commit}" 2>/dev/null \
     || { echo "CI scope head commit is unavailable: $head" >&2; exit 1; }
-  changed_paths=$(git diff --name-only "$diff_range")
+  # Classify both sides of a rename so moving an affected input into an
+  # otherwise inert directory cannot hide its former dependency boundary.
+  changed_paths=$(git diff --no-renames --name-only "$diff_range")
 else
   echo "usage: $0 GITHUB_EVENT_PATH" >&2
   exit 2
@@ -106,6 +108,10 @@ while IFS= read -r path; do
       conformance=true
       ;;
     .github/workflows/prepare-python-sdk.yml|.github/workflows/publish-sdks.yml|.github/workflows/python-api-sync.yml)
+      tooling=true
+      sdks=true
+      ;;
+    scripts/check-python-api-sync.py|scripts/normalize-python-sdist.py|scripts/prepare-python-sdk-release.py|scripts/select-trusted-pr.jq|scripts/test-python-sdk-release-tools.sh)
       tooling=true
       sdks=true
       ;;

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -2,10 +2,11 @@
 # Read-only validation of every locally auditable prerequisite before a tag is pushed.
 set -euo pipefail
 
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 CANONICAL_REPOSITORY=greaber/syq
 HOMEBREW_REPOSITORY=greaber/homebrew-tap
 RELEASE_ENVIRONMENT=release
-REQUIRED_CHECKS=rust,sdks,macos,linux-arm64
+REQUIRED_CHECKS=rust,sdks,macos,linux-arm64,conformance
 CRATES_AUTH_ACTION=rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18
 
 die() { printf 'error: %s\n' "$*" >&2; exit 1; }
@@ -76,12 +77,13 @@ IFS=, read -ra check_names <<<"$REQUIRED_CHECKS"
 for check_name in "${check_names[@]}"; do
   conclusion=$(jq -r --arg name "$check_name" '
     [.check_runs[] | select(.name == $name)] |
-    if length == 0 then "missing" elif length > 1 then "ambiguous"
-    else .[0].conclusion // "pending" end
+    sort_by([(.started_at // .completed_at // ""), (.id // 0)]) |
+    if length == 0 then "missing" else last.conclusion // "pending" end
   ' <<<"$checks")
   [ "$conclusion" = success ] \
     || die "required check $check_name is $conclusion on $head"
 done
+"$script_dir/verify-release-ci.sh" "$CANONICAL_REPOSITORY" "$head"
 
 signing_key=$(git config --get user.signingkey 2>/dev/null || true)
 signing_key=${signing_key#key::}

--- a/scripts/test-cargo-package.sh
+++ b/scripts/test-cargo-package.sh
@@ -8,9 +8,13 @@ repo_dir=$(CDPATH='' cd -- "$script_dir/.." && pwd)
 version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$repo_dir/Cargo.toml" | head -1)
 target_dir=$(cargo metadata --no-deps --format-version 1 \
   --manifest-path "$repo_dir/Cargo.toml" | jq -r .target_directory)
-
-cargo package --locked --manifest-path "$repo_dir/Cargo.toml"
 package="$target_dir/package/syq-$version.crate"
+
+# Cargo can leave trailing bytes when replacing a same-version archive with a
+# shorter one. Remove only this generated package so extraction verifies the
+# newly written archive rather than stale local target state.
+rm -f -- "$package"
+cargo package --locked --manifest-path "$repo_dir/Cargo.toml"
 if [ ! -f "$package" ] || [ -L "$package" ]; then
   echo "cargo did not create $package" >&2
   exit 1

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -4,6 +4,8 @@
 set -euo pipefail
 
 script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+grep -F 'rust,sdks,macos,linux-arm64,conformance' \
+  "$script_dir/../.github/workflows/release.yml" >/dev/null
 work=$(mktemp -d "${TMPDIR:-/tmp}/syq-release-orchestration-test.XXXXXXXX")
 cleanup() { rm -rf "$work"; }
 trap cleanup EXIT HUP INT TERM
@@ -78,7 +80,9 @@ assert_scope "$scope" native false
 printf '.github/workflows/ci.yml\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" tooling true
+assert_scope "$scope" native true
 assert_scope "$scope" sdks true
+assert_scope "$scope" mapping_docs true
 assert_scope "$scope" conformance true
 assert_scope "$scope" macos true
 assert_scope "$scope" linux_arm64 true
@@ -298,6 +302,7 @@ case "$1:$2" in
   api:*)
     case " $* " in
       *'/commits/'*'/check-runs'*) printf '%s\n' "$SYQ_TEST_CHECKS_JSON" ;;
+      *'/actions/workflows/'*'/runs?'*) printf '%s\n' "$SYQ_TEST_WORKFLOW_RUNS_JSON" ;;
       *'/actions/permissions/selected-actions '*) printf '%s\n' "$SYQ_TEST_SELECTED_ACTIONS_JSON" ;;
       *'/actions/permissions '*) printf '{"enabled":true,"allowed_actions":"selected","sha_pinning_required":true}\n' ;;
       *'/deployment-branch-policies '*) printf '{"branch_policies":[{"name":"v*","type":"tag"}]}\n' ;;
@@ -317,7 +322,10 @@ jq -cn --arg version "${SYQ_TEST_EXISTING_CRATE_VERSION:-}" '
   {versions:(if $version == "" then [] else [{num:$version}] end)}'
 EOF
 chmod 755 "$preflight_bin/git" "$preflight_bin/gh" "$preflight_bin/curl"
-checks_json=$(jq -cn '{check_runs:["rust","sdks","macos","linux-arm64"] | map({name:.,conclusion:"success"})}')
+checks_json=$(jq -cn '{check_runs:["rust","sdks","macos","linux-arm64","conformance"] | map({name:.,conclusion:"success"})}')
+workflow_runs_json=$(jq -cn --arg head "$preflight_head" '{workflow_runs:[{
+  id:601,event:"workflow_dispatch",head_sha:$head,status:"completed",
+  conclusion:"success",run_number:1,run_attempt:1}]}')
 selected_json=$(jq -cn '{github_owned_allowed:true,verified_allowed:false,
   patterns_allowed:["rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18"]}')
 formula_b64=$(printf 'url "https://github.com/greaber/syq/releases/download/v9.9.8/syq"\n' | openssl base64 -A)
@@ -325,6 +333,7 @@ preflight_env=(
   SYQ_TEST_PREFLIGHT_HEAD="$preflight_head"
   SYQ_TEST_REAL_GIT="$real_git"
   SYQ_TEST_CHECKS_JSON="$checks_json"
+  SYQ_TEST_WORKFLOW_RUNS_JSON="$workflow_runs_json"
   SYQ_TEST_SELECTED_ACTIONS_JSON="$selected_json"
   SYQ_TEST_SIGNING_KEY="$signing_key"
   SYQ_TEST_FORMULA_B64="$formula_b64"
@@ -333,6 +342,21 @@ preflight_env=(
 (cd "$preflight_repo" && env "${preflight_env[@]}" \
   "$script_dir/release-preflight.sh" v9.9.9) >"$work/preflight.out"
 grep -F "Release preflight passed for v9.9.9 at $preflight_head" "$work/preflight.out" >/dev/null
+checks_without_conformance=$(jq -cn '{check_runs:["rust","sdks","macos","linux-arm64"] | map({name:.,conclusion:"success"})}')
+if (cd "$preflight_repo" && env "${preflight_env[@]}" \
+  SYQ_TEST_CHECKS_JSON="$checks_without_conformance" \
+  "$script_dir/release-preflight.sh" v9.9.9) >"$work/failure.out" 2>&1; then
+  echo 'preflight unexpectedly accepted a missing conformance check' >&2
+  exit 1
+fi
+grep -F 'required check conformance is missing' "$work/failure.out" >/dev/null
+if (cd "$preflight_repo" && env "${preflight_env[@]}" \
+  SYQ_TEST_WORKFLOW_RUNS_JSON='{"workflow_runs":[]}' \
+  "$script_dir/release-preflight.sh" v9.9.9) >"$work/failure.out" 2>&1; then
+  echo 'preflight unexpectedly accepted missing full release CI' >&2
+  exit 1
+fi
+grep -F 'has no workflow_dispatch run' "$work/failure.out" >/dev/null
 if (cd "$preflight_repo" && env "${preflight_env[@]}" \
   SYQ_TEST_EXISTING_CRATE_VERSION=9.9.9 \
   "$script_dir/release-preflight.sh" v9.9.9) >"$work/failure.out" 2>&1; then

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -22,23 +22,63 @@ expect_failure() {
   }
 }
 
-# Scope only the expensive jobs affected by a change while retaining all job
-# names as successful required checks.
+# Scope pull requests to affected fast checks and reserve the cumulative suites
+# for master pushes and explicit manual runs.
+assert_scope() {
+  local output=$1 key=$2 expected=$3
+  grep -Fx "$key=$expected" <<<"$output" >/dev/null
+}
+
 paths="$work/paths"
 printf 'README.md\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
-grep -Fx 'native=false' <<<"$scope" >/dev/null
-grep -Fx 'sdks=false' <<<"$scope" >/dev/null
-grep -Fx 'conformance=false' <<<"$scope" >/dev/null
+for key in native sdks tooling mapping_docs conformance macos linux_arm64 full_suite; do
+  assert_scope "$scope" "$key" false
+done
+printf 'MAPPINGS.md\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" mapping_docs true
+assert_scope "$scope" native false
 printf 'sdk/python/src/syq/syq-release-manifest.json\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
-grep -Fx 'native=false' <<<"$scope" >/dev/null
-grep -Fx 'sdks=true' <<<"$scope" >/dev/null
+assert_scope "$scope" native false
+assert_scope "$scope" sdks true
+printf 'sdk/python/native-api.json\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" native true
+assert_scope "$scope" sdks true
+printf 'tests/rsync-compat/LEDGER.md\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" conformance true
+assert_scope "$scope" native false
 printf 'src/main.rs\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
-grep -Fx 'native=true' <<<"$scope" >/dev/null
-grep -Fx 'sdks=true' <<<"$scope" >/dev/null
-grep -Fx 'conformance=true' <<<"$scope" >/dev/null
+assert_scope "$scope" native true
+assert_scope "$scope" sdks false
+assert_scope "$scope" conformance false
+assert_scope "$scope" macos false
+assert_scope "$scope" linux_arm64 false
+printf 'scripts/test-installer.sh\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" tooling true
+assert_scope "$scope" native false
+printf '.github/workflows/ci.yml\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" tooling true
+assert_scope "$scope" sdks true
+assert_scope "$scope" conformance true
+assert_scope "$scope" macos true
+assert_scope "$scope" linux_arm64 true
+printf '.github/workflows/rsync-compat.yml\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" tooling true
+assert_scope "$scope" conformance true
+assert_scope "$scope" native false
+printf '.github/workflows/python-api-sync.yml\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" tooling true
+assert_scope "$scope" sdks true
+assert_scope "$scope" native false
 
 scope_repo="$work/scope-repo"
 mkdir "$scope_repo"
@@ -58,13 +98,46 @@ scope_event="$work/pull-request-event.json"
 jq -n --arg base "$scope_base" --arg head "$scope_head" \
   '{pull_request:{base:{sha:$base},head:{sha:$head}}}' >"$scope_event"
 scope=$(cd "$scope_repo" && "$script_dir/ci-scope.sh" "$scope_event")
-grep -Fx 'native=false' <<<"$scope" >/dev/null
-grep -Fx 'sdks=true' <<<"$scope" >/dev/null
+assert_scope "$scope" native false
+assert_scope "$scope" sdks true
+assert_scope "$scope" full_suite false
+
+# A pull request branch may lag master. Scope its own three-dot diff rather
+# than treating unrelated base-branch changes as part of the pull request.
+git -C "$scope_repo" switch -qc docs "$scope_base"
+printf 'more documentation\n' >>"$scope_repo/README.md"
+git -C "$scope_repo" commit -qam docs
+docs_head=$(git -C "$scope_repo" rev-parse HEAD)
+git -C "$scope_repo" switch -q master
+mkdir -p "$scope_repo/src"
+printf 'fn main() {}\n' >"$scope_repo/src/main.rs"
+git -C "$scope_repo" add src/main.rs
+git -C "$scope_repo" commit -qm native
+advanced_base=$(git -C "$scope_repo" rev-parse HEAD)
+jq -n --arg base "$advanced_base" --arg head "$docs_head" \
+  '{pull_request:{base:{sha:$base},head:{sha:$head}}}' >"$scope_event"
+scope=$(cd "$scope_repo" && "$script_dir/ci-scope.sh" "$scope_event")
+for key in native sdks tooling mapping_docs conformance macos linux_arm64 full_suite; do
+  assert_scope "$scope" "$key" false
+done
+
+push_event="$work/push-event.json"
+jq -n --arg before "$scope_head" --arg after "$advanced_base" \
+  '{before:$before,after:$after}' >"$push_event"
+scope=$(cd "$scope_repo" && "$script_dir/ci-scope.sh" "$push_event")
+assert_scope "$scope" native true
+assert_scope "$scope" sdks true
+assert_scope "$scope" conformance true
+assert_scope "$scope" macos true
+assert_scope "$scope" linux_arm64 true
+assert_scope "$scope" full_suite true
+
 printf '{}\n' >"$work/workflow-dispatch-event.json"
 scope=$(cd "$scope_repo" && \
   "$script_dir/ci-scope.sh" "$work/workflow-dispatch-event.json")
-grep -Fx 'native=true' <<<"$scope" >/dev/null
-grep -Fx 'sdks=true' <<<"$scope" >/dev/null
+for key in native sdks tooling mapping_docs conformance macos linux_arm64 full_suite; do
+  assert_scope "$scope" "$key" true
+done
 
 # The approval helper binds the PR and both workflow runs to the same trusted
 # repository, native pull_request event, branch, and exact head SHA.

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -47,6 +47,19 @@ printf 'sdk/python/native-api.json\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" native true
 assert_scope "$scope" sdks true
+for sdk_script in \
+  scripts/check-python-api-sync.py \
+  scripts/normalize-python-sdist.py \
+  scripts/prepare-python-sdk-release.py \
+  scripts/select-trusted-pr.jq \
+  scripts/test-python-sdk-release-tools.sh
+do
+  printf '%s\n' "$sdk_script" >"$paths"
+  scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+  assert_scope "$scope" tooling true
+  assert_scope "$scope" sdks true
+  assert_scope "$scope" native false
+done
 printf 'tests/rsync-compat/LEDGER.md\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" conformance true
@@ -86,7 +99,8 @@ git -C "$scope_repo" init -b master -q
 git -C "$scope_repo" config user.name Test
 git -C "$scope_repo" config user.email test@example.com
 printf 'documentation\n' >"$scope_repo/README.md"
-git -C "$scope_repo" add README.md
+printf 'mapping\n' >"$scope_repo/MAPPINGS.md"
+git -C "$scope_repo" add README.md MAPPINGS.md
 git -C "$scope_repo" commit -qm base
 scope_base=$(git -C "$scope_repo" rev-parse HEAD)
 mkdir -p "$scope_repo/sdk/python"
@@ -120,6 +134,19 @@ scope=$(cd "$scope_repo" && "$script_dir/ci-scope.sh" "$scope_event")
 for key in native sdks tooling mapping_docs conformance macos linux_arm64 full_suite; do
   assert_scope "$scope" "$key" false
 done
+
+# Rename detection must expose both the affected source and inert destination.
+git -C "$scope_repo" switch -qc rename "$scope_base"
+mkdir "$scope_repo/docs"
+git -C "$scope_repo" mv MAPPINGS.md docs/mappings.md
+git -C "$scope_repo" commit -qm rename
+rename_head=$(git -C "$scope_repo" rev-parse HEAD)
+jq -n --arg base "$advanced_base" --arg head "$rename_head" \
+  '{pull_request:{base:{sha:$base},head:{sha:$head}}}' >"$scope_event"
+scope=$(cd "$scope_repo" && "$script_dir/ci-scope.sh" "$scope_event")
+assert_scope "$scope" mapping_docs true
+assert_scope "$scope" native false
+assert_scope "$scope" sdks false
 
 push_event="$work/push-event.json"
 jq -n --arg before "$scope_head" --arg after "$advanced_base" \

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -155,6 +155,7 @@ case "$1:$2" in
   api:*/git/tags/*) printf '%s\n' "$SYQ_TEST_TAG_JSON" ;;
   api:*/compare/*) printf '%s\n' "$SYQ_TEST_COMPARE_JSON" ;;
   api:*/check-runs*) printf '%s\n' "$SYQ_TEST_CHECKS_JSON" ;;
+  api:*/actions/workflows/*/runs?*) printf '%s\n' "$SYQ_TEST_WORKFLOW_RUNS_JSON" ;;
   release:download)
     shift 2
     destination=
@@ -179,13 +180,31 @@ tag_json=$(jq -cn --arg commit "$commit" '
 compare_json=$(jq -cn --arg commit "$commit" \
   '{base_commit:{sha:$commit},merge_base_commit:{sha:$commit}}')
 checks_json=$(jq -cn '{check_runs:[
-  {name:"rust",status:"completed",conclusion:"success"},
+  {id:1,name:"rust",started_at:"2026-01-01T00:00:00Z",status:"completed",conclusion:"failure"},
+  {id:2,name:"rust",started_at:"2026-01-01T00:01:00Z",status:"completed",conclusion:"success"},
   {name:"macos",status:"completed",conclusion:"success"},
   {name:"verify signed release tag",status:"in_progress",conclusion:null}]}')
+workflow_runs_json=$(jq -cn --arg commit "$commit" '{workflow_runs:[{
+  id:701,event:"workflow_dispatch",head_sha:$commit,status:"completed",
+  conclusion:"success",run_number:1,run_attempt:1}]}')
 SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
   SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$checks_json" \
   PATH="$fakebin:$PATH" \
   "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos >/dev/null
+
+SYQ_TEST_WORKFLOW_RUNS_JSON="$workflow_runs_json" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-ci.sh" greaber/syq "$commit" >/dev/null
+expect_failure 'has no workflow_dispatch run' env \
+  SYQ_TEST_WORKFLOW_RUNS_JSON='{"workflow_runs":[]}' PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-ci.sh" greaber/syq "$commit"
+failed_workflow_runs=$(jq -cn --arg commit "$commit" '{workflow_runs:[
+  {id:701,event:"workflow_dispatch",head_sha:$commit,status:"completed",
+   conclusion:"success",run_number:1,run_attempt:1},
+  {id:702,event:"workflow_dispatch",head_sha:$commit,status:"completed",
+   conclusion:"failure",run_number:2,run_attempt:1}]}')
+expect_failure 'is completed/failure' env \
+  SYQ_TEST_WORKFLOW_RUNS_JSON="$failed_workflow_runs" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-ci.sh" greaber/syq "$commit"
 
 lightweight=$(jq -cn --arg sha "$commit" '{object:{type:"commit",sha:$sha}}')
 expect_failure 'is lightweight' env \

--- a/scripts/verify-release-ci.sh
+++ b/scripts/verify-release-ci.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Require an explicit full CI certification for one exact release commit.
+set -euo pipefail
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 OWNER/REPOSITORY COMMIT" >&2
+  exit 2
+fi
+repository=$1
+commit=$2
+case "$repository" in
+  */*) ;;
+  *) echo "invalid GitHub repository: $repository" >&2; exit 2 ;;
+esac
+[[ "$commit" =~ ^[0-9a-f]{40}$ ]] \
+  || { echo "invalid release commit: $commit" >&2; exit 2; }
+command -v gh >/dev/null || die 'release CI verification needs gh'
+command -v jq >/dev/null || die 'release CI verification needs jq'
+
+for workflow in ci.yml rsync-compat.yml; do
+  runs=$(gh api \
+    "repos/$repository/actions/workflows/$workflow/runs?event=workflow_dispatch&head_sha=$commit&per_page=100")
+  latest=$(jq -c --arg commit "$commit" '
+    [.workflow_runs[]? |
+      select(.head_sha == $commit and .event == "workflow_dispatch")] |
+    sort_by([(.run_number // 0), (.run_attempt // 0)]) |
+    last // empty
+  ' <<<"$runs")
+  [ -n "$latest" ] \
+    || die "full release CI workflow $workflow has no workflow_dispatch run on $commit"
+  status=$(jq -r '.status // "unknown"' <<<"$latest")
+  conclusion=$(jq -r '.conclusion // "pending"' <<<"$latest")
+  if [ "$status" != completed ] || [ "$conclusion" != success ]; then
+    die "latest full release CI workflow $workflow is $status/$conclusion on $commit"
+  fi
+  run_id=$(jq -er .id <<<"$latest")
+  printf 'Full release CI: %s run %s succeeded on %s.\n' \
+    "$workflow" "$run_id" "$commit"
+done

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -78,8 +78,9 @@ check_runs=$(gh api "repos/$repository/commits/$target_commit/check-runs?filter=
 IFS=, read -ra check_names <<<"$required_checks"
 for check_name in "${check_names[@]}"; do
   conclusion=$(jq -r --arg name "$check_name" '
-    [.check_runs[] | select(.name == $name)] | if length == 0 then "missing"
-    elif length > 1 then "ambiguous" else .[0].conclusion // "pending" end' <<<"$check_runs")
+    [.check_runs[] | select(.name == $name)] |
+    sort_by([(.started_at // .completed_at // ""), (.id // 0)]) |
+    if length == 0 then "missing" else last.conclusion // "pending" end' <<<"$check_runs")
   test "$conclusion" = success || {
     echo "required check $check_name is $conclusion on release commit $target_commit" >&2
     exit 1

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -11,6 +11,8 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(target_os = "linux")]
+use std::sync::OnceLock;
 use std::sync::RwLock;
 
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -1962,59 +1964,78 @@ fn sha256_hex(bytes: &[u8]) -> String {
 }
 
 #[cfg(target_os = "linux")]
-fn setup_release_bootstrap(t: &Tmp) {
-    let binary_bytes = fs::read(env!("CARGO_BIN_EXE_syq")).unwrap();
-    let mut encoder = GzEncoder::new(
-        File::create(t.path("release.gz")).unwrap(),
-        Compression::best(),
-    );
-    encoder.write_all(&binary_bytes).unwrap();
-    encoder.finish().unwrap();
-    let archive_bytes = fs::read(t.path("release.gz")).unwrap();
-    let (target, asset) = match std::env::consts::ARCH {
-        "x86_64" => ("linux-x86_64", "syq-linux-x86_64"),
-        "aarch64" => ("linux-aarch64", "syq-linux-aarch64"),
-        arch => panic!("unsupported test architecture {arch}"),
-    };
-    let manifest = serde_json::json!({
-        "schema": 1,
-        "repository": "https://github.com/greaber/syq",
-        "version": env!("CARGO_PKG_VERSION"),
-        "tag": format!("v{}", env!("CARGO_PKG_VERSION")),
-        "artifacts": {
-            (target): {
-                "binary": {
-                    "name": asset,
-                    "sha256": sha256_hex(&binary_bytes),
-                    "size": binary_bytes.len()
-                },
-                "archive": {
-                    "name": format!("{asset}.gz"),
-                    "sha256": sha256_hex(&archive_bytes),
-                    "size": archive_bytes.len()
+struct ReleaseBootstrapFixture {
+    archive: Vec<u8>,
+    manifest: Vec<u8>,
+    public_key: String,
+    asset: &'static str,
+}
+
+#[cfg(target_os = "linux")]
+static RELEASE_BOOTSTRAP_FIXTURE: OnceLock<ReleaseBootstrapFixture> = OnceLock::new();
+
+#[cfg(target_os = "linux")]
+fn release_bootstrap_fixture() -> &'static ReleaseBootstrapFixture {
+    RELEASE_BOOTSTRAP_FIXTURE.get_or_init(|| {
+        let binary_bytes = fs::read(env!("CARGO_BIN_EXE_syq")).unwrap();
+        // Compression level is not part of the bootstrap contract. Build one
+        // fast archive for the whole test process instead of compressing the
+        // large debug binary independently in every parallel test.
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(&binary_bytes).unwrap();
+        let archive = encoder.finish().unwrap();
+        let (target, asset) = match std::env::consts::ARCH {
+            "x86_64" => ("linux-x86_64", "syq-linux-x86_64"),
+            "aarch64" => ("linux-aarch64", "syq-linux-aarch64"),
+            arch => panic!("unsupported test architecture {arch}"),
+        };
+        let manifest = serde_json::json!({
+            "schema": 1,
+            "repository": "https://github.com/greaber/syq",
+            "version": env!("CARGO_PKG_VERSION"),
+            "tag": format!("v{}", env!("CARGO_PKG_VERSION")),
+            "artifacts": {
+                (target): {
+                    "binary": {
+                        "name": asset,
+                        "sha256": sha256_hex(&binary_bytes),
+                        "size": binary_bytes.len()
+                    },
+                    "archive": {
+                        "name": format!("{asset}.gz"),
+                            "sha256": sha256_hex(&archive),
+                            "size": archive.len()
+                    }
                 }
-            }
-        },
-        "installer": {"name": "install.sh", "sha256": "1".repeat(64), "size": 1},
-        "homebrew_formula": {"name": "syq.rb", "sha256": "2".repeat(64), "size": 1},
-        "signature_scheme": "ed25519-jcs-v1"
-    });
-    let signing = SigningKey::from_bytes(&[19; 32]);
-    let canonical = serde_json_canonicalizer::to_vec(&manifest).unwrap();
-    let signature =
-        base64::engine::general_purpose::STANDARD.encode(signing.sign(&canonical).to_bytes());
-    let mut manifest = manifest;
-    manifest["signature"] = signature.into();
-    let manifest_bytes = serde_json::to_vec_pretty(&manifest).unwrap();
-    write(&t.path("syq-release-manifest.json"), &manifest_bytes);
-    write(&t.path("release-manifest.json"), &manifest_bytes);
-    write(
-        &t.path("release-public-key"),
-        base64::engine::general_purpose::STANDARD
-            .encode(signing.verifying_key().to_bytes())
-            .as_bytes(),
-    );
-    fs::copy(t.path("release.gz"), t.path(&format!("{asset}.gz"))).unwrap();
+            },
+            "installer": {"name": "install.sh", "sha256": "1".repeat(64), "size": 1},
+            "homebrew_formula": {"name": "syq.rb", "sha256": "2".repeat(64), "size": 1},
+            "signature_scheme": "ed25519-jcs-v1"
+        });
+        let signing = SigningKey::from_bytes(&[19; 32]);
+        let canonical = serde_json_canonicalizer::to_vec(&manifest).unwrap();
+        let signature =
+            base64::engine::general_purpose::STANDARD.encode(signing.sign(&canonical).to_bytes());
+        let mut manifest = manifest;
+        manifest["signature"] = signature.into();
+        ReleaseBootstrapFixture {
+            archive,
+            manifest: serde_json::to_vec_pretty(&manifest).unwrap(),
+            public_key: base64::engine::general_purpose::STANDARD
+                .encode(signing.verifying_key().to_bytes()),
+            asset,
+        }
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn setup_release_bootstrap(t: &Tmp) {
+    let fixture = release_bootstrap_fixture();
+    write(&t.path("release.gz"), &fixture.archive);
+    write(&t.path(&format!("{}.gz", fixture.asset)), &fixture.archive);
+    write(&t.path("syq-release-manifest.json"), &fixture.manifest);
+    write(&t.path("release-manifest.json"), &fixture.manifest);
+    write(&t.path("release-public-key"), fixture.public_key.as_bytes());
 
     executable(
         &t.path("remote-bin/curl"),


### PR DESCRIPTION
## Summary

- split CI into an affected-surface pull-request gate and comprehensive native post-merge validation
- defer ordinary macOS, ARM, SDK, conformance, and full integration suites until native changes reach `master`
- cancel superseded pull-request runs while retaining every pending or running post-merge run
- make path classification dependency-aware, rename-safe, and based on merge-base diffs
- require exact-SHA full `workflow_dispatch` certification of both CI workflows before a syq release
- include conformance in local and tag-time release gates
- share the compressed release-bootstrap fixture across integration tests

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets`
- `scripts/test-release-orchestration.sh`
- `scripts/check-workflows.sh`
- `scripts/test-cargo-package.sh`
- `scripts/test-installer.sh`
- `scripts/test-release-tools.sh`
- `scripts/test-python-sdk-release-tools.sh`
- `scripts/test-secret-tools.sh`
- full CI shellcheck command
- live read-only release-CI verification against a historical manually certified commit

The 303-test `tests/local.rs` target completed in 26 seconds locally after the fixture change; the representative pre-change CI target took about 437 seconds.