### PR TITLE
Add fresh-target capacity preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,6 +906,7 @@ syq: dry-run summary
   changes: 82,411 regular files; 96 directories; 14 symlinks; 3 metadata-only entries; 2 type replacements among them
   deletions: 7 entries planned after a successful copy
   logical data: 1.70 TiB in 82,411 files needing content work (upper bound); 340 GiB in 18,204 files with unchanged content
+  capacity: 1.70 TiB logical data required; 2.30 TiB available; 82,522 destination objects; 14,200,000 inodes available (appears sufficient)
   exclusions: 3 paths/subtrees pruned by ignore rules; 12 other entries
   route: encrypted TCP to gpu01; 16 initial connections (auto-tuned)
 ```
@@ -928,7 +929,25 @@ old leaf (including an old symlink).
 The logical-data upper bound is the full size of regular files that fail the
 planning-time metadata check. Resume state, block reuse, reflinks, compression,
 server-side copying, or a content comparison can make the real I/O or wire-byte
-count smaller. An ignored directory is pruned without scanning its descendants,
+count smaller.
+
+When the effective destination is missing or is an existing empty directory,
+SYQ also has a useful simple capacity check: no replaced destination payload can
+release space, and newly created descendants cannot already cross filesystem
+boundaries. After scanning the selected source entries, SYQ rechecks the same
+destination filesystem and refuses a real copy if their logical file sizes
+exceed the space available to the receiving user, or if their object count
+exceeds an available inode count reported by the filesystem. The dry-run
+`capacity` line shows the same assessment. The line is omitted for a nonempty
+destination, an unsupported receiver/filesystem, or a changed filesystem;
+those cases retain allocation-time checks because updates, mounts, and
+replacement order make a simple whole-copy estimate misleading. An
+insufficient dry run exits unsuccessfully while still printing its plan and
+capacity line. This is a sanity check rather than a reservation, and it imposes
+no separate free-space reserve: another process can still consume or release
+space after it runs.
+
+An ignored directory is pruned without scanning its descendants,
 so the exclusions line counts that directory as one `path/subtree`; it does not
 invent a descendant count. Other exclusions cover state and size options and
 unsupported entry types. With `--delete`, the destination is walked and the
@@ -980,7 +999,10 @@ On the receiving side a file that needs content changes is written beside its
 destination as `.name.syq-part.<job-id>` (preallocated with `fallocate`,
 written with `pwrite` from several workers), given its metadata, and `rename`d
 over the destination. Newly created sidecars are mode `0600`; final metadata is
-applied just before publication. When an existing final file is the comparison
+applied just before publication. On Linux, SYQ uses the sparse-length fallback
+only when `fallocate` is unsupported; actual space and quota failures remain
+errors and abort the whole transfer instead of letting later files keep filling
+the filesystem. When an existing final file is the comparison
 basis, the receiver retains that open descriptor while its blocks are hashed.
 If every block matches, metadata is applied through the descriptor without
 allocating or publishing a sidecar; otherwise that exact descriptor seeds the

--- a/docs/automation-v1.md
+++ b/docs/automation-v1.md
@@ -140,8 +140,9 @@ refusal, e.g. `--max-delete`), `usage`, `internal`. `os_kind`
 appears on endpoint operations where the OS error is known: `not_found`,
 `permission_denied`, `already_exists`, `invalid_input`, `no_space`,
 `quota_exceeded`, `read_only`, `other`. Filesystem errors preserve their OS
-error number across remote connections when one is available; errors without
-one cannot always be classified more narrowly than `other`.
+error meaning across remote connections even when the endpoints use different
+numeric errno values. Errors without an OS classification cannot always be
+classified more narrowly than `other`.
 
 ### `result` — exactly one, always last, flushed
 

--- a/docs/automation-v1.md
+++ b/docs/automation-v1.md
@@ -137,10 +137,11 @@ The seven classes each call for different consumer behavior: `io`
 retry), `conflict` (permanent for this entry as given), `integrity`
 (alarming — verification mismatch), `safety_limit` (a deliberate
 refusal, e.g. `--max-delete`), `usage`, `internal`. `os_kind`
-appears on local operations where the OS error is known: `not_found`,
+appears on endpoint operations where the OS error is known: `not_found`,
 `permission_denied`, `already_exists`, `invalid_input`, `no_space`,
-`read_only`, `other`. Remote errors currently arrive as strings and
-carry `class` only where the caller knows it.
+`quota_exceeded`, `read_only`, `other`. Filesystem errors preserve their OS
+error number across remote connections when one is available; errors without
+one cannot always be classified more narrowly than `other`.
 
 ### `result` — exactly one, always last, flushed
 

--- a/schemas/automation-v1.schema.json
+++ b/schemas/automation-v1.schema.json
@@ -75,6 +75,7 @@
         "already_exists",
         "invalid_input",
         "no_space",
+        "quota_exceeded",
         "read_only",
         "other"
       ]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -151,6 +151,7 @@ fn worker_initialization_response(response: Response) -> Result<()> {
     match response {
         Response::Ok => Ok(()),
         Response::Err(error) => Err(WorkerInitializationError(error).into()),
+        Response::EndpointError(error) => Err(WorkerInitializationError(error.message).into()),
         other => Err(WorkerInitializationError(format!(
             "unexpected worker initialization response {other:?}"
         ))
@@ -371,7 +372,17 @@ pub(crate) fn tcp_socket_stats(_stream: &TcpStream) -> Option<TcpSocketStats> {
 pub fn ok(resp: Response, what: &str) -> Result<Response> {
     match resp {
         Response::Err(e) => Err(anyhow!("{what}: {e}")),
+        Response::EndpointError(error) => Err(endpoint_error(error)).context(what.to_owned()),
         r => Ok(r),
+    }
+}
+
+pub fn endpoint_error(error: WireError) -> anyhow::Error {
+    match error.raw_os_error {
+        Some(raw) => {
+            anyhow::Error::new(std::io::Error::from_raw_os_error(raw)).context(error.message)
+        }
+        None => anyhow!(error.message),
     }
 }
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -378,12 +378,7 @@ pub fn ok(resp: Response, what: &str) -> Result<Response> {
 }
 
 pub fn endpoint_error(error: WireError) -> anyhow::Error {
-    match error.raw_os_error {
-        Some(raw) => {
-            anyhow::Error::new(std::io::Error::from_raw_os_error(raw)).context(error.message)
-        }
-        None => anyhow!(error.message),
-    }
+    anyhow::Error::new(error)
 }
 
 pub struct LocalConn {

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -708,6 +708,17 @@ fn errstr(e: &anyhow::Error) -> String {
     format!("{e:#}")
 }
 
+fn wire_error(error: &anyhow::Error) -> WireError {
+    let raw_os_error = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<io::Error>())
+        .and_then(io::Error::raw_os_error);
+    WireError {
+        message: errstr(error),
+        raw_os_error,
+    }
+}
+
 fn cstr(p: &Path) -> Result<CString> {
     CString::new(p.as_os_str().as_bytes()).map_err(|_| anyhow!("path contains NUL"))
 }
@@ -893,6 +904,78 @@ impl FsOps {
         Ok(())
     }
 
+    fn destination_filesystem_info(&self, check_empty: bool) -> Result<DestinationFilesystemInfo> {
+        let (directory, selected_path) = if let Some(directory) = &self.destination_root {
+            (directory, None)
+        } else {
+            let selection = self
+                .operator_selection
+                .as_ref()
+                .context("destination directory has not been selected")?;
+            (&selection.directory, Some(selection.path.as_slice()))
+        };
+        let metadata = directory.metadata()?;
+        let mut stats = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+        if unsafe { libc::fstatvfs(directory.as_raw_fd(), stats.as_mut_ptr()) } != 0 {
+            return Err(io::Error::last_os_error()).context("inspect destination filesystem");
+        }
+        let stats = unsafe { stats.assume_init() };
+        let fragment_size = if stats.f_frsize == 0 {
+            stats.f_bsize
+        } else {
+            stats.f_frsize
+        };
+        let mut available_bytes = stats.f_bavail.saturating_mul(fragment_size);
+        let mut available_inodes =
+            (stats.f_files != 0 && stats.f_favail <= stats.f_files).then_some(stats.f_favail);
+        #[cfg(debug_assertions)]
+        {
+            if let Some(value) = std::env::var_os("SYQ_TEST_AVAILABLE_BYTES") {
+                available_bytes = value
+                    .to_string_lossy()
+                    .parse()
+                    .context("parse SYQ_TEST_AVAILABLE_BYTES")?;
+            }
+            if let Some(value) = std::env::var_os("SYQ_TEST_AVAILABLE_INODES") {
+                available_inodes = Some(
+                    value
+                        .to_string_lossy()
+                        .parse()
+                        .context("parse SYQ_TEST_AVAILABLE_INODES")?,
+                );
+            }
+        }
+        let empty = if check_empty {
+            selected_path.and_then(|path| self.selected_directory_empty(path, directory))
+        } else {
+            None
+        };
+        Ok(DestinationFilesystemInfo {
+            device: metadata.dev(),
+            available_bytes,
+            available_inodes,
+            empty,
+        })
+    }
+
+    /// Use the retained descriptor's identity to make an ordinary read_dir
+    /// observation useful without trusting a path that was replaced before or
+    /// after the read. A concurrent replace-and-restore can still make the
+    /// observation stale, like every other unlocked preflight observation; it
+    /// cannot redirect the later descriptor-rooted writes.
+    fn selected_directory_empty(&self, path: &[u8], directory: &File) -> Option<bool> {
+        let absolute = PathBuf::from(OsStr::from_bytes(&self.initial_absolute(path)));
+        let mut entries = fs::read_dir(&absolute).ok()?;
+        let empty = match entries.next() {
+            None => true,
+            Some(Ok(_)) => false,
+            Some(Err(_)) => return None,
+        };
+        let selected = directory.metadata().ok()?;
+        let named = fs::metadata(absolute).ok()?;
+        (selected.dev() == named.dev() && selected.ino() == named.ino()).then_some(empty)
+    }
+
     fn destination_relative(&self, path: &[u8]) -> Result<PathBytes> {
         let Some(prefix) = self.destination_prefix.as_deref() else {
             return Ok(path.to_vec());
@@ -1064,6 +1147,7 @@ impl FsOps {
             | Request::CheckOperatorDirectory { .. }
             | Request::CreateOperatorDirectory { .. }
             | Request::AnchorDestination { .. }
+            | Request::DestinationFilesystemInfo { .. }
             | Request::TransportStats
             | Request::Receipt
             | Request::Shutdown => {}
@@ -1226,7 +1310,7 @@ impl FsOps {
 
     /// Ops within a batch are independent (the planner orders batches so that
     /// parents come first), so they run in parallel too.
-    pub fn apply(&mut self, ops: &[Op], guard: Option<&ContainerGuard>) -> Vec<Option<String>> {
+    pub fn apply(&mut self, ops: &[Op], guard: Option<&ContainerGuard>) -> Vec<Option<WireError>> {
         // SetMeta depends on the object existing, so create everything first,
         // then apply metadata — otherwise a parallel SetMeta can beat its
         // Symlink/Mknod/Mkdir. Both phases still run in parallel internally.
@@ -1244,9 +1328,9 @@ impl FsOps {
             .filter(|&i| !is_meta(&ops[i]) && !is_guarded_create(&ops[i]))
             .collect();
         let meta_idx: Vec<usize> = (0..ops.len()).filter(|&i| is_meta(&ops[i])).collect();
-        let mut out: Vec<Option<String>> = vec![None; ops.len()];
+        let mut out: Vec<Option<WireError>> = vec![None; ops.len()];
         let gres = parallel_map(&guarded_idx, |&i| {
-            apply_one(&ops[i], guard).err().as_ref().map(errstr)
+            apply_one(&ops[i], guard).err().as_ref().map(wire_error)
         });
         for (i, r) in guarded_idx.iter().zip(gres) {
             out[*i] = r;
@@ -1259,13 +1343,13 @@ impl FsOps {
             return out;
         }
         let cres = parallel_map(&create_idx, |&i| {
-            apply_one(&ops[i], guard).err().as_ref().map(errstr)
+            apply_one(&ops[i], guard).err().as_ref().map(wire_error)
         });
         for (i, r) in create_idx.iter().zip(cres) {
             out[*i] = r;
         }
         let mres = parallel_map(&meta_idx, |&i| {
-            apply_one(&ops[i], guard).err().as_ref().map(errstr)
+            apply_one(&ops[i], guard).err().as_ref().map(wire_error)
         });
         for (i, r) in meta_idx.iter().zip(mres) {
             out[*i] = r;
@@ -3181,7 +3265,7 @@ impl FsOps {
     pub fn handle(&mut self, req: &Request) -> Response {
         let req = match self.map_request(req) {
             Ok(req) => req,
-            Err(error) => return Response::Err(errstr(&error)),
+            Err(error) => return Response::EndpointError(wire_error(&error)),
         };
         // HashAndHold's next request must consume the retained descriptor.
         // Any other request means the controller abandoned that comparison
@@ -3231,6 +3315,9 @@ impl FsOps {
                     *symlink_policy,
                 )
                 .map(|_| Response::Ok),
+            Request::DestinationFilesystemInfo { check_empty } => self
+                .destination_filesystem_info(*check_empty)
+                .map(Response::DestinationFilesystemInfo),
             Request::PartialPaths {
                 paths,
                 partial_id,
@@ -3343,7 +3430,8 @@ impl FsOps {
                             put.condition,
                         )
                         .err()
-                        .map(|error| errstr(&error))
+                        .as_ref()
+                        .map(wire_error)
                     })
                     .collect(),
             )),
@@ -3438,7 +3526,7 @@ impl FsOps {
         };
         match r {
             Ok(resp) => self.rebase_response(resp),
-            Err(e) => Response::Err(errstr(&e)),
+            Err(e) => Response::EndpointError(wire_error(&e)),
         }
     }
 }
@@ -3655,15 +3743,43 @@ fn preallocate(f: &File, size: u64) -> Result<()> {
     #[cfg(target_os = "linux")]
     {
         use std::os::unix::io::AsRawFd;
-        let r = unsafe { libc::fallocate(f.as_raw_fd(), 0, 0, size as libc::off_t) };
-        if r == 0 {
-            return Ok(());
+        let fallocate_error = if let Some(raw) = test_fallocate_errno() {
+            Some(io::Error::from_raw_os_error(raw))
+        } else {
+            let length = libc::off_t::try_from(size).context("file is too large to preallocate")?;
+            let result = unsafe { libc::fallocate(f.as_raw_fd(), 0, 0, length) };
+            (result != 0).then(io::Error::last_os_error)
+        };
+        match fallocate_error {
+            None => return Ok(()),
+            Some(error)
+                if matches!(
+                    error.raw_os_error(),
+                    Some(libc::EOPNOTSUPP) | Some(libc::ENOSYS) | Some(libc::EINVAL)
+                ) => {}
+            Some(error) => return Err(error).context("preallocate destination file"),
         }
         // Unsupported filesystem (tmpfs, some NFS): fall through to sparse.
     }
     // Portable fallback (also macOS): a sparse file of the right size.
     f.set_len(size)?;
     Ok(())
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+fn test_fallocate_errno() -> Option<i32> {
+    let value = std::env::var_os("SYQ_TEST_FALLOCATE_ERRNO")?;
+    match value.to_string_lossy().as_ref() {
+        "unsupported" => Some(libc::EOPNOTSUPP),
+        "no_space" => Some(libc::ENOSPC),
+        "quota" => Some(libc::EDQUOT),
+        value => value.parse().ok(),
+    }
+}
+
+#[cfg(all(target_os = "linux", not(debug_assertions)))]
+fn test_fallocate_errno() -> Option<i32> {
+    None
 }
 
 fn timespec(sec: i64, nsec: u32) -> libc::timespec {
@@ -4098,7 +4214,8 @@ mod tests {
             None,
         );
         assert!(errs[0]
-            .as_deref()
+            .as_ref()
+            .map(WireError::as_str)
             .is_some_and(|e| e.contains("is now a directory")));
         assert!(
             dir.join("d/inside").is_dir(),

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -709,14 +709,33 @@ fn errstr(e: &anyhow::Error) -> String {
 }
 
 fn wire_error(error: &anyhow::Error) -> WireError {
-    let raw_os_error = error
+    let io_error = error
         .chain()
-        .find_map(|cause| cause.downcast_ref::<io::Error>())
-        .and_then(io::Error::raw_os_error);
+        .find_map(|cause| cause.downcast_ref::<io::Error>());
     WireError {
         message: errstr(error),
-        raw_os_error,
+        io_kind: io_error.map(wire_io_kind),
+        raw_os_error: io_error.and_then(io::Error::raw_os_error),
     }
+}
+
+fn wire_io_kind(error: &io::Error) -> WireIoKind {
+    match error.raw_os_error() {
+        Some(libc::ENOSPC) => WireIoKind::NoSpace,
+        Some(libc::EDQUOT) => WireIoKind::QuotaExceeded,
+        Some(libc::EROFS) => WireIoKind::ReadOnly,
+        _ => match error.kind() {
+            io::ErrorKind::NotFound => WireIoKind::NotFound,
+            io::ErrorKind::PermissionDenied => WireIoKind::PermissionDenied,
+            io::ErrorKind::AlreadyExists => WireIoKind::AlreadyExists,
+            io::ErrorKind::InvalidInput => WireIoKind::InvalidInput,
+            _ => WireIoKind::Other,
+        },
+    }
+}
+
+fn statvfs_counter<T: Into<u64>>(value: T) -> u64 {
+    value.into()
 }
 
 fn cstr(p: &Path) -> Result<CString> {
@@ -921,13 +940,16 @@ impl FsOps {
         }
         let stats = unsafe { stats.assume_init() };
         let fragment_size = if stats.f_frsize == 0 {
-            stats.f_bsize
+            statvfs_counter(stats.f_bsize)
         } else {
-            stats.f_frsize
+            statvfs_counter(stats.f_frsize)
         };
-        let mut available_bytes = stats.f_bavail.saturating_mul(fragment_size);
+        let blocks_available = statvfs_counter(stats.f_bavail);
+        let files = statvfs_counter(stats.f_files);
+        let files_available = statvfs_counter(stats.f_favail);
+        let mut available_bytes = blocks_available.saturating_mul(fragment_size);
         let mut available_inodes =
-            (stats.f_files != 0 && stats.f_favail <= stats.f_files).then_some(stats.f_favail);
+            (files != 0 && files_available <= files).then_some(files_available);
         #[cfg(debug_assertions)]
         {
             if let Some(value) = std::env::var_os("SYQ_TEST_AVAILABLE_BYTES") {
@@ -1376,6 +1398,8 @@ fn op_path(op: &Op) -> &[u8] {
 }
 
 fn apply_one(op: &Op, guard: Option<&ContainerGuard>) -> Result<()> {
+    #[cfg(debug_assertions)]
+    fail_apply_capacity_for_test(&resolve(op_path(op)))?;
     #[cfg(debug_assertions)]
     if matches!(op, Op::SetMeta { .. } | Op::SetFileMetaIfSame { .. }) {
         fail_set_meta_for_test(&resolve(op_path(op)))?;
@@ -2243,6 +2267,17 @@ fn fail_set_meta_for_test(p: &Path) -> Result<()> {
     if let Some(pat) = std::env::var_os("SYQ_TEST_FAIL_SETMETA") {
         if !pat.is_empty() && p.as_os_str().as_bytes().ends_with(pat.as_bytes()) {
             return Err(anyhow!("set metadata {}: injected failure", p.display()));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(debug_assertions)]
+fn fail_apply_capacity_for_test(p: &Path) -> Result<()> {
+    if let Some(pat) = std::env::var_os("SYQ_TEST_FAIL_APPLY_ENOSPC") {
+        if !pat.is_empty() && p.as_os_str().as_bytes().ends_with(pat.as_bytes()) {
+            return Err(io::Error::from_raw_os_error(libc::ENOSPC))
+                .with_context(|| format!("apply {}: injected capacity failure", p.display()));
         }
     }
     Ok(())

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -923,8 +923,43 @@ impl FsOps {
         Ok(())
     }
 
-    fn destination_filesystem_info(&self, check_empty: bool) -> Result<DestinationFilesystemInfo> {
-        let (directory, selected_path) = if let Some(directory) = &self.destination_root {
+    fn destination_filesystem_info(
+        &self,
+        check_empty: bool,
+        target: Option<&DestinationFilesystemTarget>,
+    ) -> Result<DestinationFilesystemInfo> {
+        let target_directory = if let Some(target) = target {
+            if target.relative_path.is_empty()
+                || target.relative_path.contains(&0)
+                || target.relative_path.contains(&b'/')
+                || matches!(target.relative_path.as_slice(), b"." | b"..")
+            {
+                bail!("destination filesystem target is not one relative path component");
+            }
+            let (base, full_path) = if let Some(base) = &self.destination_root {
+                (base, self.destination_full(&target.relative_path))
+            } else {
+                let selection = self
+                    .operator_selection
+                    .as_ref()
+                    .context("destination directory has not been selected")?;
+                (
+                    &selection.directory,
+                    join(&selection.path, &target.relative_path),
+                )
+            };
+            let directory = open_operator_directory_at(base, &target.relative_path)?;
+            let metadata = directory.metadata()?;
+            if (metadata.dev(), metadata.ino()) != (target.dev, target.ino) {
+                bail!("destination filesystem target changed while inspecting capacity");
+            }
+            Some((directory, full_path))
+        } else {
+            None
+        };
+        let (directory, selected_path) = if let Some((directory, path)) = &target_directory {
+            (directory, Some(path.as_slice()))
+        } else if let Some(directory) = &self.destination_root {
             (directory, None)
         } else {
             let selection = self
@@ -3350,8 +3385,11 @@ impl FsOps {
                     *symlink_policy,
                 )
                 .map(|_| Response::Ok),
-            Request::DestinationFilesystemInfo { check_empty } => self
-                .destination_filesystem_info(*check_empty)
+            Request::DestinationFilesystemInfo {
+                check_empty,
+                target,
+            } => self
+                .destination_filesystem_info(*check_empty, target.as_ref())
                 .map(Response::DestinationFilesystemInfo),
             Request::PartialPaths {
                 paths,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -335,6 +335,14 @@ pub enum Request {
         request_prefix: PathBytes,
         symlink_policy: OperatorSymlinkPolicy,
     },
+    /// Inspect the filesystem containing the receiver's retained destination
+    /// directory. Before anchoring this is the exact selected directory, or
+    /// the nearest existing ancestor of a missing destination.
+    DestinationFilesystemInfo {
+        /// Only meaningful for an existing selected destination directory.
+        /// Failure to prove emptiness is reported as None, not as an error.
+        check_empty: bool,
+    },
     /// Compute the exact receiver-side sidecar names for collision preflight.
     PartialPaths {
         paths: Vec<PathBytes>,
@@ -502,6 +510,7 @@ pub enum Response {
     /// Absolute operator spelling plus device/inode of the securely opened
     /// directory, or None when an allowed missing suffix was reached.
     DirectorySelection(Option<DirectoryAnchor>),
+    DestinationFilesystemInfo(DestinationFilesystemInfo),
     PathResults(Vec<std::result::Result<PathBytes, String>>),
     BatchPlan {
         partial_paths: Vec<std::result::Result<PathBytes, String>>,
@@ -510,7 +519,7 @@ pub enum Response {
         /// caller must apply directory changes before inspecting leaves.
         others: Option<Vec<Option<Entry>>>,
     },
-    Applied(Vec<Option<String>>),
+    Applied(Vec<Option<WireError>>),
     PartialSize(Option<u64>),
     Hashes(Vec<ContentDigest>),
     HeldHashes {
@@ -534,7 +543,53 @@ pub enum Response {
     /// inside the canonical frame encoding.
     ReceiptV2(#[serde(with = "serde_bytes")] Vec<u8>),
     Ok,
+    /// An endpoint operation failed with a preserved OS error number. Server
+    /// and authorization protocol failures continue to use Err(String).
+    EndpointError(WireError),
     Err(String),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct DestinationFilesystemInfo {
+    pub device: u64,
+    pub available_bytes: u64,
+    /// Filesystems that do not expose a meaningful inode population report
+    /// None rather than a misleading zero.
+    pub available_inodes: Option<u64>,
+    pub empty: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct WireError {
+    pub message: String,
+    pub raw_os_error: Option<i32>,
+}
+
+impl WireError {
+    pub fn as_str(&self) -> &str {
+        &self.message
+    }
+}
+
+impl From<String> for WireError {
+    fn from(message: String) -> Self {
+        WireError {
+            message,
+            raw_os_error: None,
+        }
+    }
+}
+
+impl From<&str> for WireError {
+    fn from(message: &str) -> Self {
+        message.to_owned().into()
+    }
+}
+
+impl std::fmt::Display for WireError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -562,7 +562,22 @@ pub struct DestinationFilesystemInfo {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct WireError {
     pub message: String,
+    /// Receiver-derived meaning. Numeric errno values are retained only for
+    /// diagnostics because their values differ between operating systems.
+    pub io_kind: Option<WireIoKind>,
     pub raw_os_error: Option<i32>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WireIoKind {
+    NotFound,
+    PermissionDenied,
+    AlreadyExists,
+    InvalidInput,
+    NoSpace,
+    QuotaExceeded,
+    ReadOnly,
+    Other,
 }
 
 impl WireError {
@@ -575,6 +590,7 @@ impl From<String> for WireError {
     fn from(message: String) -> Self {
         WireError {
             message,
+            io_kind: None,
             raw_os_error: None,
         }
     }
@@ -591,6 +607,8 @@ impl std::fmt::Display for WireError {
         formatter.write_str(&self.message)
     }
 }
+
+impl std::error::Error for WireError {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct DirectoryAnchor {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -336,12 +336,13 @@ pub enum Request {
         symlink_policy: OperatorSymlinkPolicy,
     },
     /// Inspect the filesystem containing the receiver's retained destination
-    /// directory. Before anchoring this is the exact selected directory, or
-    /// the nearest existing ancestor of a missing destination.
+    /// directory. `target` selects an observed descendant directory when
+    /// exact placement retains its parent rather than the directory itself.
     DestinationFilesystemInfo {
         /// Only meaningful for an existing selected destination directory.
         /// Failure to prove emptiness is reported as None, not as an error.
         check_empty: bool,
+        target: Option<DestinationFilesystemTarget>,
     },
     /// Compute the exact receiver-side sidecar names for collision preflight.
     PartialPaths {
@@ -557,6 +558,14 @@ pub struct DestinationFilesystemInfo {
     /// None rather than a misleading zero.
     pub available_inodes: Option<u64>,
     pub empty: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct DestinationFilesystemTarget {
+    /// Directory path relative to the retained destination root.
+    pub relative_path: PathBytes,
+    pub dev: u64,
+    pub ino: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -962,9 +962,10 @@ impl RestrictedAuthority {
         let outcome_error = |index: usize| -> Option<&str> {
             match response {
                 proto::Response::Err(error) => Some(error.as_str()),
-                proto::Response::Applied(results) => {
-                    results.get(index).and_then(|error| error.as_deref())
-                }
+                proto::Response::EndpointError(error) => Some(error.as_str()),
+                proto::Response::Applied(results) => results
+                    .get(index)
+                    .and_then(|error| error.as_ref().map(proto::WireError::as_str)),
                 _ => None,
             }
         };
@@ -1980,6 +1981,9 @@ impl RestrictedAuthority {
                     self.check_observation_path(path)?;
                 }
                 *guard = Some(self.guard.clone());
+            }
+            Request::DestinationFilesystemInfo { .. } => {
+                bail!("destination filesystem inspection is not authorized by the signed grant")
             }
             Request::PartialPaths { paths, guard, .. } => {
                 for path in paths {
@@ -6475,7 +6479,7 @@ mod tests {
             len: 1,
             guard: Some(guard),
         });
-        assert!(matches!(response, proto::Response::Err(_)));
+        assert!(matches!(response, proto::Response::EndpointError(_)));
         assert_eq!(fs::metadata(outside.join("secret")).unwrap().len(), 6);
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -6,8 +6,8 @@ use crate::cli::{
     SourceSelection,
 };
 use crate::conn::{
-    ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec, SshMultiplexer, TcpCandidate,
-    TcpPairStats,
+    endpoint_error, ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec,
+    SshMultiplexer, TcpCandidate, TcpPairStats,
 };
 use crate::fsops::{content_digest, is_partial_name, join};
 use crate::progress::{commas, human, Progress, WorkerStatus};
@@ -961,10 +961,25 @@ fn os_kind_of(error: &anyhow::Error) -> Option<&'static str> {
         std::io::ErrorKind::InvalidInput => "invalid_input",
         _ => match io.raw_os_error() {
             Some(libc::ENOSPC) => "no_space",
+            Some(libc::EDQUOT) => "quota_exceeded",
             Some(libc::EROFS) => "read_only",
             _ => "other",
         },
     })
+}
+
+fn wire_os_kind(error: &WireError) -> Option<&'static str> {
+    match error.raw_os_error {
+        Some(libc::ENOSPC) => Some("no_space"),
+        Some(libc::EDQUOT) => Some("quota_exceeded"),
+        Some(libc::EACCES) | Some(libc::EPERM) => Some("permission_denied"),
+        Some(libc::EROFS) => Some("read_only"),
+        _ => None,
+    }
+}
+
+fn capacity_os_kind(kind: Option<&str>) -> bool {
+    matches!(kind, Some("no_space" | "quota_exceeded"))
 }
 
 fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
@@ -1696,6 +1711,34 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             dst_entry_is_dir = true;
         }
     }
+    // A missing target, or an existing empty container, has no destination
+    // payload whose replacement could release space during this copy. That
+    // makes its selected source population a useful whole-copy capacity
+    // sanity check. Inspect the retained selection before anchoring or
+    // creating the target; if the endpoint cannot expose reliable counters or
+    // emptiness, simply retain the normal allocation-time checks.
+    let initial_destination_filesystem = if use_operator_anchor
+        && !args.verify_only
+        && !args.existing
+        && (dst_root_entry.is_none() || dst_is_dir)
+    {
+        destination_filesystem_info(&mut *dst_ctl, dst_root_entry.is_some() && dst_is_dir)?
+    } else {
+        None
+    };
+    let fresh_capacity = initial_destination_filesystem.and_then(|info| {
+        let fresh = dst_root_entry.is_none()
+            || (dst_is_dir && dst_root_entry.is_some() && info.empty == Some(true));
+        fresh.then_some(FreshCapacityPlan {
+            device: info.device,
+            root_existed: dst_root_entry.is_some(),
+            logical_bytes: 0,
+            objects: 0,
+            overflowed: false,
+        })
+    });
+    let defer_destination_mutations = multiple_distinct_sources
+        || (fresh_capacity.is_some() && !args.dry_run && !args.verify_only);
     // Native new/existing forms are intentionally only the lightweight
     // pathname checks above. Once they pass, use the ordinary engine's target
     // conditions and publication behavior; this adapter does not add an
@@ -1799,9 +1842,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     }
 
     // Create a missing directory destination — never in the read-only modes,
-    // and never under --existing. With several sources this waits until
-    // their scans have been checked against each other, so a conflicting
-    // command leaves nothing behind.
+    // and never under --existing. With several sources, or while a fresh-target
+    // capacity check is pending, this waits until the complete scan has passed
+    // its namespace and capacity preflights.
     let create_root = dst_root_entry.is_none()
         && dst_is_dir
         && !args.dry_run
@@ -1815,7 +1858,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             && !args.dry_run
             && !args.verify_only
             && !args.existing
-            && (!dst_is_dir || !multiple_distinct_sources);
+            && (!dst_is_dir || !defer_destination_mutations);
         if create_operator_directory_now {
             let condition = if dst_is_dir {
                 root_create_condition
@@ -1848,7 +1891,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 .set(anchor)
                 .expect("destination anchor set once");
         }
-    } else if create_root && !multiple_distinct_sources {
+    } else if create_root && !defer_destination_mutations {
         let created = mkdir_root(
             &mut *dst_ctl,
             &dst_root,
@@ -1976,15 +2019,16 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         mutation_root_condition,
         container_guard,
         guard_containers,
-        buffer: if multiple_distinct_sources {
+        buffer: if defer_destination_mutations {
             Some(Vec::new())
         } else {
             None
         },
+        fresh_capacity,
         src_overrides: std::collections::HashMap::new(),
         implicit_dirs: std::collections::HashSet::new(),
         mapping_mode: false,
-        create_root: if create_root && multiple_distinct_sources {
+        create_root: if create_root && defer_destination_mutations {
             Some((dst_root.clone(), root_create_condition))
         } else {
             None
@@ -2004,6 +2048,8 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     };
 
     let mut scan_err = None;
+    let mut fresh_capacity_assessment = None;
+    let mut fresh_capacity_shortage = None;
     let mut dry_run_mappings = Vec::with_capacity(srcs.len());
     if let Some(mapping) = args.native_mapping.as_deref() {
         let src = &srcs[0];
@@ -2086,6 +2132,31 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             scan_err = Some(e);
         }
     }
+    if scan_err.is_none() && !st.collision {
+        match st.assess_fresh_capacity() {
+            Ok(assessment) => {
+                fresh_capacity_assessment = assessment;
+                fresh_capacity_shortage = assessment.filter(|value| !value.sufficient());
+                if let Some(assessment) = fresh_capacity_shortage.filter(|_| !args.dry_run) {
+                    scan_err = Some(fresh_capacity_error(assessment));
+                }
+            }
+            Err(error) => scan_err = Some(error),
+        }
+    }
+    if scan_err.is_none() && !st.collision {
+        if let Err(error) = st.replay_buffered() {
+            scan_err = Some(error);
+        }
+    }
+    // A dry run still completes its virtual replay so the summary remains a
+    // truthful plan, then reports the same capacity refusal a real run would
+    // hit. No destination operation occurs during that replay.
+    if scan_err.is_none() && args.dry_run {
+        if let Some(assessment) = fresh_capacity_shortage {
+            scan_err = Some(fresh_capacity_error(assessment));
+        }
+    }
     if debug() {
         eprintln!(
             "syq: payload planning complete at {:.2}s",
@@ -2107,7 +2178,8 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     let collision = st.collision;
     progress.scan_done.store(true, Relaxed);
     if let Some(e) = &scan_err {
-        progress.error(&format!("syq: {e:#}"));
+        let os_kind = os_kind_of(e);
+        progress.error_classified(&format!("syq: {e:#}"), os_kind.map(|_| "io"), os_kind);
         sched.abort();
     } else if collision {
         sched.abort();
@@ -2410,7 +2482,8 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
 
     let elapsed = progress.start.elapsed().as_secs_f64();
     let done = progress.bytes_done.load(Relaxed);
-    if !args.quiet && !aborted {
+    let capacity_only_dry_run_abort = opts.dry_run && fresh_capacity_shortage.is_some();
+    if !args.quiet && (!aborted || capacity_only_dry_run_abort) {
         if opts.dry_run {
             if args.verbose > 0 && dry_run_creates_root {
                 println!(
@@ -2429,6 +2502,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 &progress,
                 delete_plan,
                 &dry_run_changes,
+                fresh_capacity_assessment,
             );
         } else if opts.verify_only {
             println!(
@@ -2721,6 +2795,19 @@ fn create_operator_directory(
         "create destination directory",
     )? {
         Response::DirectorySelection(Some(selection)) => Ok(selection),
+        other => bail!("unexpected response {other:?}"),
+    }
+}
+
+fn destination_filesystem_info(
+    conn: &mut dyn Conn,
+    check_empty: bool,
+) -> Result<Option<DestinationFilesystemInfo>> {
+    match conn.call(Request::DestinationFilesystemInfo { check_empty })? {
+        Response::DestinationFilesystemInfo(info) => Ok(Some(info)),
+        // Not every filesystem or receiver topology can expose meaningful
+        // capacity. Absence of the optimization must not block the copy.
+        Response::EndpointError(_) | Response::Err(_) => Ok(None),
         other => bail!("unexpected response {other:?}"),
     }
 }
@@ -3091,6 +3178,60 @@ struct DryRunMapping {
     semantics: &'static str,
 }
 
+#[derive(Clone, Copy)]
+struct FreshCapacityPlan {
+    device: u64,
+    root_existed: bool,
+    logical_bytes: u64,
+    objects: u64,
+    overflowed: bool,
+}
+
+#[derive(Clone, Copy)]
+struct FreshCapacityAssessment {
+    logical_bytes: u64,
+    objects: u64,
+    available_bytes: u64,
+    available_inodes: Option<u64>,
+}
+
+impl FreshCapacityAssessment {
+    fn byte_shortage(self) -> bool {
+        self.logical_bytes > self.available_bytes
+    }
+
+    fn inode_shortage(self) -> bool {
+        self.available_inodes
+            .is_some_and(|available| self.objects > available)
+    }
+
+    fn sufficient(self) -> bool {
+        !self.byte_shortage() && !self.inode_shortage()
+    }
+}
+
+fn fresh_capacity_error(capacity: FreshCapacityAssessment) -> anyhow::Error {
+    let mut shortages = Vec::new();
+    if capacity.byte_shortage() {
+        shortages.push(format!(
+            "{} of logical file data is required but only {} is available",
+            human(capacity.logical_bytes),
+            human(capacity.available_bytes)
+        ));
+    }
+    if capacity.inode_shortage() {
+        shortages.push(format!(
+            "{} destination objects are required but only {} inodes are available",
+            commas(capacity.objects),
+            commas(capacity.available_inodes.unwrap_or_default())
+        ));
+    }
+    anyhow::Error::new(std::io::Error::from_raw_os_error(libc::ENOSPC)).context(format!(
+        "fresh destination capacity preflight failed: {}",
+        shortages.join("; ")
+    ))
+}
+
 /// A typed summary of final-state mutations found during a dry run. Type
 /// replacements overlap the primary categories; all others are disjoint.
 #[derive(Default)]
@@ -3184,6 +3325,7 @@ fn print_dry_run_summary(
     progress: &Progress,
     deletes: DeletePlan,
     changes: &DryRunChanges,
+    capacity: Option<FreshCapacityAssessment>,
 ) {
     println!("syq: dry-run summary");
     for (source, mapping) in srcs.iter().zip(mappings) {
@@ -3220,6 +3362,33 @@ fn print_dry_run_summary(
         human(progress.bytes_skipped.load(Relaxed)),
         count_label(progress.files_skipped.load(Relaxed), "file", "files")
     );
+    if let Some(capacity) = capacity {
+        let inode_detail = capacity.available_inodes.map_or_else(
+            || {
+                format!(
+                    "{} destination objects; free inode count unavailable",
+                    commas(capacity.objects)
+                )
+            },
+            |available| {
+                format!(
+                    "{} destination objects; {} inodes available",
+                    commas(capacity.objects),
+                    commas(available)
+                )
+            },
+        );
+        println!(
+            "  capacity: {} logical data required; {} available; {inode_detail} ({})",
+            human(capacity.logical_bytes),
+            human(capacity.available_bytes),
+            if capacity.sufficient() {
+                "appears sufficient"
+            } else {
+                "insufficient"
+            }
+        );
+    }
 
     let ignored = progress.paths_ignored.load(Relaxed);
     let other = progress.files_excluded.load(Relaxed);
@@ -3305,6 +3474,10 @@ struct Planner<'a> {
     /// Several sources: mapped batches waiting for all scans to finish
     /// (see `Mapped`). None with a single source, where batches stream.
     buffer: Option<Vec<Mapped>>,
+    /// A missing or observed-empty target has no old payload to release and
+    /// cannot contain descendant mounts. Its selected source population gives
+    /// us one useful whole-copy capacity sanity check.
+    fresh_capacity: Option<FreshCapacityPlan>,
     /// --mapping: per-destination source override. A manifest entry's `path`
     /// carries the destination-relative path so claims, ordering, and job
     /// naming work unchanged; the read side looks the actual source up here.
@@ -3403,6 +3576,77 @@ impl Deletes {
 }
 
 impl Planner<'_> {
+    fn record_fresh_entry(&mut self, dst: &[u8], entry: &Entry, new_object: bool) {
+        if !new_object {
+            return;
+        }
+        let included = match entry.kind {
+            Kind::Dir => true,
+            Kind::File => {
+                self.opts
+                    .max_size
+                    .is_none_or(|maximum| entry.size <= maximum)
+                    && self
+                        .opts
+                        .min_size
+                        .is_none_or(|minimum| entry.size >= minimum)
+            }
+            Kind::Symlink => self.opts.links,
+            Kind::Fifo | Kind::Socket | Kind::CharDev | Kind::BlockDev => self.opts.devices,
+            Kind::Other => false,
+        };
+        if !included {
+            return;
+        }
+        let reuses_existing_root = dst == self.root_path && entry.kind == Kind::Dir;
+        let Some(plan) = &mut self.fresh_capacity else {
+            return;
+        };
+        // When source contents map directly into an existing empty container,
+        // the source's root directory reuses that one existing inode.
+        if !(plan.root_existed && reuses_existing_root) {
+            match plan.objects.checked_add(1) {
+                Some(objects) => plan.objects = objects,
+                None => plan.overflowed = true,
+            }
+        }
+        if entry.kind == Kind::File {
+            match plan.logical_bytes.checked_add(entry.size) {
+                Some(bytes) => plan.logical_bytes = bytes,
+                None => plan.overflowed = true,
+            }
+        }
+    }
+
+    fn assess_fresh_capacity(&mut self) -> Result<Option<FreshCapacityAssessment>> {
+        let Some(plan) = self.fresh_capacity else {
+            return Ok(None);
+        };
+        if plan.overflowed {
+            return Err(std::io::Error::from_raw_os_error(libc::ENOSPC)).context(
+                "fresh destination logical size or object count exceeds supported limits",
+            );
+        }
+        let response = self
+            .dst
+            .call(Request::DestinationFilesystemInfo { check_empty: false })?;
+        let info = match response {
+            Response::DestinationFilesystemInfo(info) if info.device == plan.device => info,
+            Response::DestinationFilesystemInfo(_) => return Ok(None),
+            // Capacity inspection is a best-effort optimization. Actual
+            // allocations remain authoritative when a filesystem cannot
+            // expose useful counters.
+            Response::EndpointError(_) | Response::Err(_) => return Ok(None),
+            other => bail!("unexpected response {other:?}"),
+        };
+        Ok(Some(FreshCapacityAssessment {
+            logical_bytes: plan.logical_bytes,
+            objects: plan.objects,
+            available_bytes: info.available_bytes,
+            available_inodes: info.available_inodes,
+        }))
+    }
+
     fn exact_condition_for(&self, path: &[u8]) -> TargetCondition {
         if path == self.root_path {
             self.exact_condition
@@ -3957,9 +4201,9 @@ impl Planner<'_> {
         Ok(())
     }
 
-    /// All sources scanned and the sidecar namespace preflight passed: apply
-    /// what was held back. With several sources that is every batch, after
-    /// the cross-source claim check; otherwise only the deferred payloads.
+    /// All sources scanned and the sidecar namespace preflight passed: retire
+    /// its maps and add deferred payloads to the buffer. The caller runs the
+    /// fresh-target capacity check before replaying that buffer.
     fn finish_planning(&mut self) -> Result<()> {
         // The preflight maps are dead now — except the sidecar set, which
         // --delete needs (only its keys) to tell a live sidecar from an
@@ -3975,7 +4219,6 @@ impl Planner<'_> {
         let deferred = std::mem::take(&mut self.deferred_payloads);
         if let Some(buf) = &mut self.buffer {
             buf.extend(deferred);
-            self.replay_buffered()?;
         } else {
             for m in deferred {
                 self.apply_mapped(m)?;
@@ -4038,9 +4281,18 @@ impl Planner<'_> {
                 }
                 _ => Claim::Weak,
             };
+            // A later real claim can replace a weak claim from an entry that
+            // is not copied. In that case it is the first capacity-relevant
+            // object at this path even though the namespace was already seen.
+            let new_capacity_object = match self.dst_seen.get(&dst) {
+                None => true,
+                Some(Claim::Weak) if claim != Claim::Weak => true,
+                Some(_) => false,
+            };
             let Some(contested) = self.claim_dst(&dst, &rel, claim) else {
                 continue;
             };
+            self.record_fresh_entry(&dst, &e, new_capacity_object);
             let src = match self.src_overrides.get(&e.path) {
                 Some(actual) => join(src_root, actual),
                 None => join(src_root, &e.path),
@@ -4953,7 +5205,7 @@ impl Planner<'_> {
                         retryable: error.is_some().then_some("unknown"),
                         class: error.is_some().then_some("io"),
                         os_kind: None,
-                        message: error.as_deref(),
+                        message: error.as_ref().map(WireError::as_str),
                     });
                 }
             }
@@ -5731,7 +5983,7 @@ impl Planner<'_> {
         }
     }
 
-    fn apply(&mut self, ops: Vec<Op>) -> Result<Vec<Option<String>>> {
+    fn apply(&mut self, ops: Vec<Op>) -> Result<Vec<Option<WireError>>> {
         match ok(
             self.dst.call(Request::Apply {
                 ops,
@@ -5739,7 +5991,16 @@ impl Planner<'_> {
             })?,
             "apply",
         )? {
-            Response::Applied(v) => Ok(v),
+            Response::Applied(v) => {
+                if let Some(error) = v
+                    .iter()
+                    .flatten()
+                    .find(|error| capacity_os_kind(wire_os_kind(error)))
+                {
+                    return Err(endpoint_error(error.clone())).context("apply destination changes");
+                }
+                Ok(v)
+            }
             other => bail!("unexpected response {other:?}"),
         }
     }
@@ -6099,7 +6360,7 @@ impl Worker {
             } else {
                 match applied.next().flatten() {
                     None => Ok(()),
-                    Some(error) => Err(anyhow::anyhow!("put: {error}")),
+                    Some(error) => Err(endpoint_error(error)).context("put"),
                 }
             };
             results.push(res);
@@ -6126,6 +6387,9 @@ impl Worker {
                 );
                 self.emit_file_result_failed(j, "unknown", os_kind, &message);
                 self.sched.fail_file(*idx);
+                if capacity_os_kind(os_kind) {
+                    self.sched.abort();
+                }
                 continue;
             }
             let changed = match &now {
@@ -6217,6 +6481,9 @@ impl Worker {
             );
             self.emit_file_result_failed(&job, "unknown", os_kind, &message);
             self.sched.fail_file(idx);
+            if capacity_os_kind(os_kind) {
+                self.sched.abort();
+            }
         }
         Ok(())
     }
@@ -6540,6 +6807,8 @@ impl Worker {
                 }
                 Ok(true)
             }
+            Response::EndpointError(error) if error.message.contains("EXDEV") => Ok(false),
+            Response::EndpointError(error) => Err(endpoint_error(error)),
             Response::Err(e) if e.contains("EXDEV") => Ok(false),
             Response::Err(e) => bail!("{e}"),
             other => bail!("unexpected response {other:?}"),

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -951,6 +951,12 @@ pub(crate) fn uses_remote_coordinator(args: &Args, sources: &[Location], dst: &L
 }
 
 fn os_kind_of(error: &anyhow::Error) -> Option<&'static str> {
+    if let Some(error) = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<WireError>())
+    {
+        return wire_os_kind(error);
+    }
     let io = error
         .chain()
         .find_map(|cause| cause.downcast_ref::<std::io::Error>())?;
@@ -969,17 +975,28 @@ fn os_kind_of(error: &anyhow::Error) -> Option<&'static str> {
 }
 
 fn wire_os_kind(error: &WireError) -> Option<&'static str> {
-    match error.raw_os_error {
-        Some(libc::ENOSPC) => Some("no_space"),
-        Some(libc::EDQUOT) => Some("quota_exceeded"),
-        Some(libc::EACCES) | Some(libc::EPERM) => Some("permission_denied"),
-        Some(libc::EROFS) => Some("read_only"),
-        _ => None,
-    }
+    Some(match error.io_kind? {
+        WireIoKind::NotFound => "not_found",
+        WireIoKind::PermissionDenied => "permission_denied",
+        WireIoKind::AlreadyExists => "already_exists",
+        WireIoKind::InvalidInput => "invalid_input",
+        WireIoKind::NoSpace => "no_space",
+        WireIoKind::QuotaExceeded => "quota_exceeded",
+        WireIoKind::ReadOnly => "read_only",
+        WireIoKind::Other => "other",
+    })
 }
 
 fn capacity_os_kind(kind: Option<&str>) -> bool {
     matches!(kind, Some("no_space" | "quota_exceeded"))
+}
+
+fn first_capacity_error(errors: &[Option<WireError>]) -> Option<WireError> {
+    errors
+        .iter()
+        .flatten()
+        .find(|error| capacity_os_kind(wire_os_kind(error)))
+        .cloned()
 }
 
 fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
@@ -1853,12 +1870,18 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     let dry_run_creates_root =
         args.dry_run && dst_root_entry.is_none() && dst_is_dir && !args.existing;
     let root_create_condition = TargetCondition::Any;
+    let defer_operator_directory_creation = use_operator_anchor
+        && directory_selection.is_none()
+        && !args.dry_run
+        && !args.verify_only
+        && !args.existing
+        && defer_destination_mutations;
     if use_operator_anchor {
         let create_operator_directory_now = directory_selection.is_none()
             && !args.dry_run
             && !args.verify_only
             && !args.existing
-            && (!dst_is_dir || !defer_destination_mutations);
+            && !defer_operator_directory_creation;
         if create_operator_directory_now {
             let condition = if dst_is_dir {
                 root_create_condition
@@ -2028,8 +2051,18 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         src_overrides: std::collections::HashMap::new(),
         implicit_dirs: std::collections::HashSet::new(),
         mapping_mode: false,
-        create_root: if create_root && defer_destination_mutations {
-            Some((dst_root.clone(), root_create_condition))
+        create_root: if defer_operator_directory_creation {
+            Some((
+                request_prefix.clone(),
+                if dst_is_dir {
+                    root_create_condition
+                } else {
+                    TargetCondition::Any
+                },
+                dst_is_dir,
+            ))
+        } else if !use_operator_anchor && create_root && defer_destination_mutations {
+            Some((dst_root.clone(), root_create_condition, true))
         } else {
             None
         },
@@ -3493,9 +3526,11 @@ struct Planner<'a> {
     mutation_root_condition: TargetCondition,
     container_guard: Option<ContainerGuard>,
     guard_containers: bool,
-    /// Several sources into a destination that doesn't exist yet: create it
-    /// only once the scans have been validated against each other.
-    create_root: Option<(PathBytes, TargetCondition)>,
+    /// A missing retained operator directory: (request prefix, creation
+    /// condition, whether it is the destination root). Create it only after
+    /// namespace and fresh-capacity preflight. Restricted transfers use the
+    /// same slot only for their missing destination root.
+    create_root: Option<(PathBytes, TargetCondition, bool)>,
     destination_anchor: &'a DestinationAnchorSlot,
     use_operator_anchor: bool,
     /// --files-from: listed directories are created even without -r (which
@@ -4201,10 +4236,24 @@ impl Planner<'_> {
         Ok(())
     }
 
-    /// All sources scanned and the sidecar namespace preflight passed: retire
-    /// its maps and add deferred payloads to the buffer. The caller runs the
-    /// fresh-target capacity check before replaying that buffer.
+    /// All sources scanned and the sidecar namespace preflight passed: add
+    /// deferred payloads to the buffer. The caller runs the fresh-target
+    /// capacity check before replaying that buffer. Planning maps remain live
+    /// until replay because applying buffered entries still consults them.
     fn finish_planning(&mut self) -> Result<()> {
+        let deferred = std::mem::take(&mut self.deferred_payloads);
+        if let Some(buf) = &mut self.buffer {
+            buf.extend(deferred);
+        } else {
+            for m in deferred {
+                self.apply_mapped(m)?;
+            }
+            self.retire_planning_state();
+        }
+        Ok(())
+    }
+
+    fn retire_planning_state(&mut self) {
         // The preflight maps are dead now — except the sidecar set, which
         // --delete needs (only its keys) to tell a live sidecar from an
         // orphan. On multi-million-file trees these are the difference
@@ -4216,15 +4265,6 @@ impl Planner<'_> {
             keys.sort_unstable();
             self.live_sidecars = keys;
         }
-        let deferred = std::mem::take(&mut self.deferred_payloads);
-        if let Some(buf) = &mut self.buffer {
-            buf.extend(deferred);
-        } else {
-            for m in deferred {
-                self.apply_mapped(m)?;
-            }
-        }
-
         // These sets exist only to validate and apply mapped scan entries.
         // Jobs already own the source spelling needed by workers. Deletion
         // alone still needs the destination claims and live sidecar names.
@@ -4243,7 +4283,6 @@ impl Planner<'_> {
             self.live_sidecars = Vec::new();
             self.delete_roots = Vec::new();
         }
-        Ok(())
     }
 
     /// The mapping loop: decide and claim everything about each entry.
@@ -4380,9 +4419,10 @@ impl Planner<'_> {
             }
         }
         if self.collision {
+            self.retire_planning_state();
             return Ok(());
         }
-        if let Some((root, condition)) = self.create_root.take() {
+        if let Some((root, condition, is_destination_root)) = self.create_root.take() {
             if self.use_operator_anchor {
                 let selection = create_operator_directory(self.dst, condition)?;
                 let anchor = activate_control_destination(
@@ -4391,21 +4431,24 @@ impl Planner<'_> {
                     root.clone(),
                     self.opts.operator_symlink_policy,
                 )?;
-                self.mutation_root_condition = TargetCondition::Matches {
-                    dev: anchor.dev,
-                    ino: anchor.ino,
-                };
-                if self.guard_containers {
-                    self.container_guard = Some(ContainerGuard {
-                        root,
+                if is_destination_root {
+                    self.mutation_root_condition = TargetCondition::Matches {
                         dev: anchor.dev,
                         ino: anchor.ino,
-                    });
+                    };
+                    if self.guard_containers {
+                        self.container_guard = Some(ContainerGuard {
+                            root,
+                            dev: anchor.dev,
+                            ino: anchor.ino,
+                        });
+                    }
                 }
                 self.destination_anchor
                     .set(anchor)
                     .expect("destination anchor set once");
             } else {
+                debug_assert!(is_destination_root);
                 let created =
                     mkdir_root(self.dst, &root, condition, self.opts.restricted_receiver)?;
                 self.mutation_root_condition = target_identity(&created);
@@ -4424,6 +4467,7 @@ impl Planner<'_> {
         for m in buffered {
             self.apply_mapped(m)?;
         }
+        self.retire_planning_state();
         Ok(())
     }
 
@@ -4609,7 +4653,15 @@ impl Planner<'_> {
                     let root_op = new_dirs.remove(root_index);
                     let error = self.apply(vec![root_op])?.into_iter().next().flatten();
                     if let Some(error) = error {
-                        self.progress.error(&format!("syq: {error}"));
+                        let os_kind = wire_os_kind(&error);
+                        self.progress.error_classified(
+                            &format!("syq: {error}"),
+                            Some("io"),
+                            os_kind,
+                        );
+                        if capacity_os_kind(os_kind) {
+                            return Err(endpoint_error(error)).context("apply destination changes");
+                        }
                         self.collision = true;
                         return Ok(());
                     }
@@ -4641,18 +4693,20 @@ impl Planner<'_> {
                         })
                         .collect();
                     let errs = self.apply(new_dirs)?;
+                    let capacity_error = first_capacity_error(&errs);
                     let mut failed = 0;
                     let mut reopened = 0;
                     for ((name, condition), err) in op_info.iter().zip(errs) {
                         let preexisting = existing_dirs.contains(name);
                         let succeeded = err.is_none();
                         let created = succeeded && !preexisting;
-                        if let Some(err) = err {
+                        let os_kind = err.as_ref().and_then(wire_os_kind);
+                        if let Some(err) = &err {
                             failed += 1;
                             self.progress.error_classified(
                                 &format!("syq: {err}"),
                                 Some("io"),
-                                None,
+                                os_kind,
                             );
                             if name == &self.root_path && *condition != TargetCondition::Any {
                                 self.collision = true;
@@ -4692,14 +4746,17 @@ impl Planner<'_> {
                                     "unknown"
                                 }),
                                 class: (!created).then_some("io"),
-                                os_kind: None,
-                                message: None,
+                                os_kind,
+                                message: err.as_ref().map(WireError::as_str),
                             });
                         }
                     }
                     self.progress
                         .dirs_created
                         .fetch_add((n - failed - reopened) as u64, Relaxed);
+                    if let Some(error) = capacity_error {
+                        return Err(endpoint_error(error)).context("apply destination changes");
+                    }
                 }
                 let mut flags = opts.flags;
                 if !opts.perms {
@@ -5159,20 +5216,27 @@ impl Planner<'_> {
             }
         }
         if !meta_fixes.is_empty() {
-            for err in self.apply(meta_fixes)?.into_iter().flatten() {
+            let errors = self.apply(meta_fixes)?;
+            let capacity_error = first_capacity_error(&errors);
+            for err in errors.into_iter().flatten() {
                 self.progress.error(&format!("syq: {err}"));
+            }
+            if let Some(error) = capacity_error {
+                return Err(endpoint_error(error)).context("apply destination changes");
             }
         }
         if !ops.is_empty() {
             let errs = self.apply(ops)?;
+            let capacity_error = first_capacity_error(&errs);
             // Two ops per item: creation then metadata.
             for (i, queued) in op_names.iter().enumerate() {
                 let e1 = errs.get(2 * i).cloned().flatten();
                 let e2 = errs.get(2 * i + 1).cloned().flatten();
                 let error = e1.or(e2);
+                let os_kind = error.as_ref().and_then(wire_os_kind);
                 if let Some(e) = &error {
                     self.progress
-                        .error_classified(&format!("syq: {e}"), Some("io"), None);
+                        .error_classified(&format!("syq: {e}"), Some("io"), os_kind);
                 } else {
                     // Counted only once the operation settles: a fatal
                     // unwind between queueing and applying must not leave
@@ -5204,10 +5268,13 @@ impl Planner<'_> {
                         attempts: None,
                         retryable: error.is_some().then_some("unknown"),
                         class: error.is_some().then_some("io"),
-                        os_kind: None,
+                        os_kind,
                         message: error.as_ref().map(WireError::as_str),
                     });
                 }
+            }
+            if let Some(error) = capacity_error {
+                return Err(endpoint_error(error)).context("apply destination changes");
             }
         }
         Ok(())
@@ -5991,16 +6058,7 @@ impl Planner<'_> {
             })?,
             "apply",
         )? {
-            Response::Applied(v) => {
-                if let Some(error) = v
-                    .iter()
-                    .flatten()
-                    .find(|error| capacity_os_kind(wire_os_kind(error)))
-                {
-                    return Err(endpoint_error(error.clone())).context("apply destination changes");
-                }
-                Ok(v)
-            }
+            Response::Applied(v) => Ok(v),
             other => bail!("unexpected response {other:?}"),
         }
     }
@@ -6019,8 +6077,13 @@ impl Planner<'_> {
                     condition: *condition,
                 })
                 .collect();
-            for err in self.apply(ops)?.into_iter().flatten() {
+            let errors = self.apply(ops)?;
+            let capacity_error = first_capacity_error(&errors);
+            for err in errors.into_iter().flatten() {
                 self.progress.error(&format!("syq: {err}"));
+            }
+            if let Some(error) = capacity_error {
+                return Err(endpoint_error(error)).context("apply destination changes");
             }
         }
         Ok(())
@@ -7296,6 +7359,21 @@ impl Worker {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn endpoint_semantic_error_kind_wins_over_numeric_errno() {
+        let error = WireError {
+            message: "receiver quota exhausted".into(),
+            io_kind: Some(WireIoKind::QuotaExceeded),
+            // Deliberately contradict the semantic kind. Numeric errno values
+            // belong to the receiver ABI and must never drive coordinator
+            // policy.
+            raw_os_error: Some(libc::ENOSPC),
+        };
+        assert_eq!(wire_os_kind(&error), Some("quota_exceeded"));
+        assert!(capacity_os_kind(wire_os_kind(&error)));
+        assert_eq!(os_kind_of(&endpoint_error(error)), Some("quota_exceeded"));
+    }
 
     #[test]
     fn raw_path_identity_is_lossless_without_changing_utf8_identity() {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1734,20 +1734,49 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     // sanity check. Inspect the retained selection before anchoring or
     // creating the target; if the endpoint cannot expose reliable counters or
     // emptiness, simply retain the normal allocation-time checks.
+    let exact_capacity_target = if dst_entry_is_dir
+        && !dst_is_dir
+        && !expand_exact_home
+        && operator_directory != operator_dst_root
+    {
+        let entry = dst_root_entry
+            .as_ref()
+            .expect("known existing exact directory has metadata");
+        let relative_path = operator_dst_root
+            .rsplit(|byte| *byte == b'/')
+            .next()
+            .unwrap_or_default()
+            .to_vec();
+        (!matches!(relative_path.as_slice(), b"" | b"." | b"..")).then_some(
+            DestinationFilesystemTarget {
+                relative_path,
+                dev: entry.dev,
+                ino: entry.ino,
+            },
+        )
+    } else {
+        None
+    };
+    let can_inspect_existing_destination = dst_is_dir
+        || expand_exact_home
+        || operator_directory == operator_dst_root
+        || exact_capacity_target.is_some();
     let initial_destination_filesystem = if use_operator_anchor
         && !args.verify_only
         && !args.existing
-        && (dst_root_entry.is_none() || dst_is_dir)
+        && (dst_root_entry.is_none() || (dst_entry_is_dir && can_inspect_existing_destination))
     {
-        destination_filesystem_info(&mut *dst_ctl, dst_root_entry.is_some() && dst_is_dir)?
+        let check_empty = dst_root_entry.is_some() && dst_entry_is_dir;
+        destination_filesystem_info(&mut *dst_ctl, check_empty, exact_capacity_target.clone())?
     } else {
         None
     };
     let fresh_capacity = initial_destination_filesystem.and_then(|info| {
         let fresh = dst_root_entry.is_none()
-            || (dst_is_dir && dst_root_entry.is_some() && info.empty == Some(true));
+            || (dst_entry_is_dir && dst_root_entry.is_some() && info.empty == Some(true));
         fresh.then_some(FreshCapacityPlan {
             device: info.device,
+            target: exact_capacity_target,
             root_existed: dst_root_entry.is_some(),
             logical_bytes: 0,
             objects: 0,
@@ -2835,8 +2864,12 @@ fn create_operator_directory(
 fn destination_filesystem_info(
     conn: &mut dyn Conn,
     check_empty: bool,
+    target: Option<DestinationFilesystemTarget>,
 ) -> Result<Option<DestinationFilesystemInfo>> {
-    match conn.call(Request::DestinationFilesystemInfo { check_empty })? {
+    match conn.call(Request::DestinationFilesystemInfo {
+        check_empty,
+        target,
+    })? {
         Response::DestinationFilesystemInfo(info) => Ok(Some(info)),
         // Not every filesystem or receiver topology can expose meaningful
         // capacity. Absence of the optimization must not block the copy.
@@ -3211,9 +3244,10 @@ struct DryRunMapping {
     semantics: &'static str,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct FreshCapacityPlan {
     device: u64,
+    target: Option<DestinationFilesystemTarget>,
     root_existed: bool,
     logical_bytes: u64,
     objects: u64,
@@ -3654,7 +3688,7 @@ impl Planner<'_> {
     }
 
     fn assess_fresh_capacity(&mut self) -> Result<Option<FreshCapacityAssessment>> {
-        let Some(plan) = self.fresh_capacity else {
+        let Some(plan) = self.fresh_capacity.clone() else {
             return Ok(None);
         };
         if plan.overflowed {
@@ -3662,9 +3696,10 @@ impl Planner<'_> {
                 "fresh destination logical size or object count exceeds supported limits",
             );
         }
-        let response = self
-            .dst
-            .call(Request::DestinationFilesystemInfo { check_empty: false })?;
+        let response = self.dst.call(Request::DestinationFilesystemInfo {
+            check_empty: false,
+            target: plan.target.clone(),
+        })?;
         let info = match response {
             Response::DestinationFilesystemInfo(info) if info.device == plan.device => info,
             Response::DestinationFilesystemInfo(_) => return Ok(None),

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3721,6 +3721,261 @@ fn dry_run_creates_nothing() {
     assert!(out.contains("logical data:"), "{out}");
 }
 
+#[cfg(debug_assertions)]
+#[test]
+fn fresh_missing_destination_refuses_clear_byte_shortage_before_creation() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+
+    let output = compat_command()
+        .args(["-a", &t.s("src/"), &t.s("dst"), "--no-progress"])
+        .env("SYQ_TEST_AVAILABLE_BYTES", "1")
+        .run()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("fresh destination capacity preflight failed"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("7 B") && stderr.contains("1 B"), "{stderr}");
+    assert!(
+        !t.path("dst").exists(),
+        "the capacity preflight must precede destination creation"
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn fresh_existing_empty_destination_refuses_clear_byte_shortage_automatically() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+    fs::create_dir(t.path("dst")).unwrap();
+
+    let output = compat_command()
+        .args(["-a", &t.s("src/"), &t.s("dst"), "--no-progress"])
+        .env("SYQ_TEST_AVAILABLE_BYTES", "1")
+        .run()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("fresh destination capacity preflight failed"),
+        "{stderr}"
+    );
+    assert_eq!(fs::read_dir(t.path("dst")).unwrap().count(), 0);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn nonempty_destination_skips_the_whole_copy_capacity_estimate() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+    write(&t.path("dst/existing"), b"keep");
+
+    let output = compat_command()
+        .args(["-a", &t.s("src/"), &t.s("dst"), "--no-progress"])
+        .env("SYQ_TEST_AVAILABLE_BYTES", "0")
+        .env("SYQ_TEST_AVAILABLE_INODES", "0")
+        .run()
+        .unwrap();
+
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("dst/file")), b"payload");
+    assert_eq!(read(&t.path("dst/existing")), b"keep");
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn fresh_destination_refuses_clear_inode_shortage() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+
+    let output = compat_command()
+        .args(["-a", &t.s("src/"), &t.s("dst"), "--no-progress"])
+        .env("SYQ_TEST_AVAILABLE_BYTES", "1048576")
+        .env("SYQ_TEST_AVAILABLE_INODES", "0")
+        .run()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("destination objects are required"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("0 inodes are available"), "{stderr}");
+    assert!(!t.path("dst").exists());
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn fresh_destination_dry_run_reports_capacity_sanity_check() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+
+    let output = compat_command()
+        .args(["-an", &t.s("src/"), &t.s("dst"), "--no-progress"])
+        .env("SYQ_TEST_AVAILABLE_BYTES", "1048576")
+        .env("SYQ_TEST_AVAILABLE_INODES", "10")
+        .run()
+        .unwrap();
+
+    assert_output_ok(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("capacity: 7 B logical data required"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("10 inodes available"), "{stdout}");
+    assert!(stdout.contains("appears sufficient"), "{stdout}");
+    assert!(!t.path("dst").exists());
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn fresh_destination_dry_run_reports_insufficient_capacity() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+
+    let output = compat_command()
+        .args(["-an", &t.s("src/"), &t.s("dst"), "--no-progress"])
+        .env("SYQ_TEST_AVAILABLE_BYTES", "1")
+        .run()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("capacity: 7 B logical data required"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("(insufficient)"), "{stdout}");
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("fresh destination capacity preflight failed"));
+    assert!(!t.path("dst").exists());
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+#[test]
+fn fallocate_no_space_is_fatal_and_stops_later_files() {
+    let t = Tmp::new();
+    write(&t.path("src/a-large"), &vec![b'x'; 256 * 1024]);
+    write(
+        &t.path("src/z-small"),
+        b"must not be copied after disk-full",
+    );
+    write(&t.path("dst/existing"), b"make this an update");
+
+    let output = compat_command()
+        .args([
+            "-a",
+            "--block-size",
+            "64K",
+            "--bwlimit",
+            "1G",
+            "--syq-connections",
+            "1",
+            &t.s("src/"),
+            &t.s("dst"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_FALLOCATE_ERRNO", "no_space")
+        .run()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "injected ENOSPC unexpectedly succeeded:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("preallocate destination file"), "{stderr}");
+    assert!(!t.path("dst/a-large").exists());
+    assert!(
+        !t.path("dst/z-small").exists(),
+        "disk-full must abort the transfer instead of continuing per-file"
+    );
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+#[test]
+fn fallocate_unsupported_filesystem_still_uses_sparse_fallback() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), &vec![b'x'; 256 * 1024]);
+    write(&t.path("dst/existing"), b"make this an update");
+
+    let output = compat_command()
+        .args([
+            "-a",
+            "--block-size",
+            "64K",
+            "--bwlimit",
+            "1G",
+            "--syq-connections",
+            "1",
+            &t.s("src/"),
+            &t.s("dst"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_FALLOCATE_ERRNO", "unsupported")
+        .run()
+        .unwrap();
+
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("dst/file")), vec![b'x'; 256 * 1024]);
+}
+
+#[cfg(all(target_os = "linux", debug_assertions))]
+#[test]
+fn fallocate_quota_error_is_preserved_in_results() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), &vec![b'x'; 5 * 1024 * 1024]);
+    write(&t.path("dst/existing"), b"make this an update");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--src-src",
+            "src",
+            "--into-existing",
+            "dst",
+            "--bwlimit",
+            "1G",
+            "--connections",
+            "1",
+            "--results",
+            "results.ndjson",
+            "-q",
+        ])
+        .current_dir(&t.0)
+        .env("SYQ_TEST_FALLOCATE_ERRNO", "quota")
+        .run()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(
+        t.path("results.ndjson").exists(),
+        "results stream was not created:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let records: Vec<serde_json::Value> = String::from_utf8(read(&t.path("results.ndjson")))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert!(
+        records
+            .iter()
+            .any(|record| record["os_kind"] == "quota_exceeded"),
+        "quota classification missing from {records:#?}"
+    );
+}
+
 #[test]
 fn dry_run_reports_typed_preflight_summary() {
     let t = Tmp::new();
@@ -9566,9 +9821,9 @@ fn native_cp_mapping_whole_manifest_preflight_writes_nothing() {
     );
     assert!(!out.status.success());
     assert!(String::from_utf8_lossy(&out.stderr).contains("duplicate destination"));
-    // The --into container is created eagerly as with --files-from, but no
-    // entry may have been applied.
-    assert_eq!(fs::read_dir(t.path("dst")).unwrap().count(), 0);
+    // Fresh-target preflight defers the --into container too, so a manifest
+    // refusal leaves no destination namespace behind.
+    assert!(!t.path("dst").exists());
     // Declared-kind ancestor conflict is refused up front too.
     let conflict = format!(
         "{}{}",
@@ -9582,7 +9837,7 @@ fn native_cp_mapping_whole_manifest_preflight_writes_nothing() {
     );
     assert!(!out.status.success());
     assert!(String::from_utf8_lossy(&out.stderr).contains("not dir"));
-    assert_eq!(fs::read_dir(t.path("dst")).unwrap().count(), 0);
+    assert!(!t.path("dst").exists());
 }
 
 #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3796,6 +3796,28 @@ fn fresh_existing_empty_destination_refuses_clear_byte_shortage_automatically() 
 
 #[cfg(debug_assertions)]
 #[test]
+fn fresh_exact_existing_empty_directory_refuses_clear_byte_shortage() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+    fs::create_dir(t.path("dst")).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", &t.s("src"), "--as-existing", &t.s("dst"), "-q"])
+        .env("SYQ_TEST_AVAILABLE_BYTES", "1")
+        .run()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("fresh destination capacity preflight failed"),
+        "{stderr}"
+    );
+    assert_eq!(fs::read_dir(t.path("dst")).unwrap().count(), 0);
+}
+
+#[cfg(debug_assertions)]
+#[test]
 fn nonempty_destination_skips_the_whole_copy_capacity_estimate() {
     let t = Tmp::new();
     write(&t.path("src/file"), b"payload");

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3748,6 +3748,32 @@ fn fresh_missing_destination_refuses_clear_byte_shortage_before_creation() {
 
 #[cfg(debug_assertions)]
 #[test]
+fn fresh_exact_destination_refuses_shortage_before_creating_missing_parents() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), b"payload");
+
+    let output = compat_command()
+        .args([
+            "-a",
+            &t.s("src/file"),
+            &t.s("missing/parent/file"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_AVAILABLE_BYTES", "1")
+        .run()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("fresh destination capacity preflight failed"));
+    assert!(
+        !t.path("missing").exists(),
+        "the capacity preflight must precede parent creation"
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
 fn fresh_existing_empty_destination_refuses_clear_byte_shortage_automatically() {
     let t = Tmp::new();
     write(&t.path("src/file"), b"payload");
@@ -3974,6 +4000,56 @@ fn fallocate_quota_error_is_preserved_in_results() {
             .any(|record| record["os_kind"] == "quota_exceeded"),
         "quota classification missing from {records:#?}"
     );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn capacity_failure_reports_other_settled_apply_outcomes_before_aborting() {
+    let t = Tmp::new();
+    fs::create_dir_all(t.path("src")).unwrap();
+    std::os::unix::fs::symlink("good-target", t.path("src/a-good")).unwrap();
+    std::os::unix::fs::symlink("full-target", t.path("src/z-full")).unwrap();
+    write(&t.path("dst/existing"), b"make this an update");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--src-src",
+            "src",
+            "--into-existing",
+            "dst",
+            "--results",
+            "results.ndjson",
+            "-q",
+        ])
+        .current_dir(&t.0)
+        .env("SYQ_TEST_FAIL_APPLY_ENOSPC", "z-full")
+        .run()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        fs::read_link(t.path("dst/a-good")).unwrap(),
+        Path::new("good-target")
+    );
+    assert!(!t.path("dst/z-full").exists());
+    let records: Vec<serde_json::Value> = String::from_utf8(read(&t.path("results.ndjson")))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let operation = |name: &str| {
+        records
+            .iter()
+            .find(|record| record["type"] == "operation_result" && record["dst"]["value"] == name)
+            .unwrap_or_else(|| panic!("missing operation result for {name}: {records:#?}"))
+    };
+    assert_eq!(operation("a-good")["disposition"], "succeeded");
+    assert_eq!(operation("z-full")["disposition"], "failed");
+    assert_eq!(operation("z-full")["os_kind"], "no_space");
+    let terminal = records.last().unwrap();
+    assert_eq!(terminal["status"], "aborted");
+    assert_eq!(terminal["symlinks_created"], 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- automatically preflight available bytes and inodes when the effective destination is missing or an existing empty directory, with no new option required
- hold fresh-target mutations until the full selected source population passes the check, and expose the assessment in dry-run output
- preserve endpoint OS errors so disk-full and quota failures are classified distinctly and abort the whole transfer
- fix Linux preallocation so only unsupported `fallocate` errors use the sparse fallback; ENOSPC and EDQUOT remain fatal
- leave nonempty updates on the existing allocation-time path, without a reserve-space policy or prompts

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`