### PR TITLE
Confine same-machine copies to registered roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,15 +254,17 @@ its mutable directory name. Replacing an exact selected leaf is an error, while
 changed-source retry remains available for entries beneath a selected
 directory. On macOS this descriptor-bound symlink operation requires macOS 13
 or newer; older releases fail source registration rather than fall back to a
-name-based read. Same-machine `CopyLocal` source opens and the canonical-path
-self-copy check still use legacy pathnames and are the remaining
-source-confinement work. This is therefore not yet a complete hostile-namespace
-guarantee for copies that take the local-copy optimization. Copy also gives
-every destination worker the selected directory descriptor; destination
-observation, directory and special-file creation, metadata changes, and
-planned non-recursive deletion are relative to that descriptor. Destination
-scanning, including the walk that plans `--delete`, is relative to it too and
-never follows descendant symlinks.
+name-based read. On Linux, the same-machine `CopyLocal` optimization gives its
+destination worker both endpoints' exact capabilities during authenticated
+startup, then opens the source and destination relative to those descriptors.
+Rsync-mode `--insecure-links` skips that optimization because its explicitly
+unconfined source names cannot be represented by the capability-only request.
+The canonical-path directory self-copy preflight remains source-confinement
+work. Copy also gives every destination worker the selected directory
+descriptor; destination observation, directory and special-file creation,
+metadata changes, and planned non-recursive deletion are relative to that
+descriptor. Destination scanning, including the walk that plans `--delete`, is
+relative to it too and never follows descendant symlinks.
 Rsync-mode `--insecure-links` is the explicit compatibility opt-out: that
 session uses the legacy unconfined pathname discovery and content-read paths,
 including traversal through symlinked `--files-from` ancestors. Native
@@ -272,9 +274,10 @@ Registration also budgets the process's currently open descriptors, one
 retained parent descriptor per source root and one object descriptor per exact
 leaf for the registry, control connection, and every worker that may share its
 process, plus conservative per-worker file-cache, transport, and concurrent
-independent-worker broker-claim overhead. If the endpoint's open-file limit
-cannot hold that set, the copy fails before destination mutation with guidance
-to reduce selectors or `--connections`.
+independent-worker broker-claim overhead. Same-machine Linux copies include
+the destination workers' cross-session claims in that admission check. If the
+endpoint's open-file limit cannot hold that set, the copy fails before
+destination mutation with guidance to reduce selectors or `--connections`.
 Regular-file destination transfer state has not all moved to
 descriptor-relative access yet either. The default therefore rejects
 links present during preflight, while the remaining containment work must also

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2179,12 +2179,19 @@ impl Endpoint {
         self.connect_with_role(compress, ConnectionRole::SourceWorker { roots })
     }
 
-    pub(crate) fn connect_with_destination(
+    pub(crate) fn connect_with_copy_capabilities(
         &self,
         compress: bool,
         destination: Option<DestinationRoot>,
+        copy_sources: Vec<RegisteredSourceRoot>,
     ) -> Result<Box<dyn Conn>> {
-        self.connect_with_role(compress, ConnectionRole::DestinationWorker { destination })
+        self.connect_with_role(
+            compress,
+            ConnectionRole::DestinationWorker {
+                destination,
+                copy_sources,
+            },
+        )
     }
 
     fn connect_with_role(&self, compress: bool, role: ConnectionRole) -> Result<Box<dyn Conn>> {
@@ -2200,15 +2207,28 @@ impl Endpoint {
                 match role {
                     ConnectionRole::DestinationWorker {
                         destination: Some(destination),
-                    } => conn
-                        .ops
-                        .initialize_destination(&destination)
-                        .map_err(|error| {
-                            WorkerInitializationError(format!(
-                                "initialize local destination worker: {error:#}"
-                            ))
-                        })?,
-                    ConnectionRole::DestinationWorker { destination: None } => {
+                        copy_sources,
+                    } => {
+                        conn.ops
+                            .initialize_destination(&destination)
+                            .map_err(|error| {
+                                WorkerInitializationError(format!(
+                                    "initialize local destination worker: {error:#}"
+                                ))
+                            })?;
+                        if !copy_sources.is_empty() {
+                            conn.ops
+                                .initialize_copy_sources(&copy_sources)
+                                .map_err(|error| {
+                                    WorkerInitializationError(format!(
+                                        "initialize local copy sources: {error:#}"
+                                    ))
+                                })?;
+                        }
+                    }
+                    ConnectionRole::DestinationWorker {
+                        destination: None, ..
+                    } => {
                         return Err(WorkerInitializationError(
                             "local destination worker requires a registered root".into(),
                         )
@@ -2393,7 +2413,10 @@ mod tests {
 
         // Match the remote server's non-control gate for destination workers
         // too; this direct trait method must not be a role bypass.
-        let role = ConnectionRole::DestinationWorker { destination: None };
+        let role = ConnectionRole::DestinationWorker {
+            destination: None,
+            copy_sources: Vec::new(),
+        };
         let mut destination = LocalConn::new(&role, Default::default());
         let error = destination
             .native_remove(
@@ -2570,12 +2593,14 @@ mod tests {
                 role:
                     ConnectionRole::DestinationWorker {
                         destination: Some(destination),
+                        copy_sources,
                     },
                 ..
             } = hello
             else {
                 panic!("destination initialization was not carried in Hello");
             };
+            assert!(copy_sources.is_empty());
             assert_eq!(destination.request_prefix, b"destination");
 
             let mut writer = FrameWriter::new(socket, false);
@@ -2606,6 +2631,7 @@ mod tests {
             Vec::new(),
             ConnectionRole::DestinationWorker {
                 destination: Some(destination),
+                copy_sources: Vec::new(),
             },
         )
         .unwrap();

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -2,7 +2,7 @@
 //! by `syq --server` for remote endpoints, so both sides behave identically.
 
 use crate::descriptor_broker::{
-    DescriptorSessionSlot, DescriptorTicket, RegisteredRootId, DEFAULT_MAX_ROOTS,
+    claim_descriptor, DescriptorSessionSlot, DescriptorTicket, RegisteredRootId, DEFAULT_MAX_ROOTS,
 };
 use crate::proto::*;
 use crate::rooted::{
@@ -56,6 +56,46 @@ struct FileSystemTraits {
 struct CopyLocalPolicy {
     inplace: bool,
     allow_sequential_nfs_fallback: bool,
+}
+
+#[cfg(target_os = "linux")]
+fn discard_rooted_copy_partial(
+    root: &Root,
+    relative: &RelativePath,
+    label: &Path,
+    expected_dev: u64,
+    expected_ino: u64,
+) -> Result<()> {
+    match root.metadata_optional(relative)? {
+        Some(current)
+            if is_safe_rooted_partial(current)
+                && current.dev == expected_dev
+                && current.ino == expected_ino =>
+        {
+            root.unlink(relative)
+                .with_context(|| format!("remove {}", label.display()))?;
+        }
+        Some(_) | None => {}
+    }
+    Ok(())
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+fn hold_copy_local_before_destination_open_for_test() -> Result<()> {
+    if let Some(ready) = std::env::var_os("SYQ_TEST_COPY_LOCAL_READY_FILE") {
+        fs::write(&ready, b"ready").with_context(|| {
+            format!(
+                "write local-copy-ready signal {}",
+                Path::new(&ready).display()
+            )
+        })?;
+    }
+    if let Some(ms) = std::env::var_os("SYQ_TEST_HOLD_COPY_LOCAL_MS") {
+        if let Ok(ms) = ms.to_string_lossy().parse::<u64>() {
+            std::thread::sleep(std::time::Duration::from_millis(ms));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
@@ -1262,6 +1302,40 @@ impl FsOps {
     /// Build the new table off to the side so a bad ticket cannot leave a
     /// partially initialized worker.
     pub(crate) fn initialize_sources(&mut self, sources: &[RegisteredSourceRoot]) -> Result<()> {
+        self.initialize_source_capabilities(sources, false)
+    }
+
+    /// Install the source half of a same-machine copy worker. These tickets
+    /// intentionally belong to the source endpoint session rather than this
+    /// destination endpoint, so claim their exact descriptors from that
+    /// session's private broker during worker initialization.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn initialize_copy_sources(
+        &mut self,
+        sources: &[RegisteredSourceRoot],
+    ) -> Result<()> {
+        if self.destination_root.is_none() {
+            bail!("local copy sources require a registered destination root");
+        }
+        if sources.iter().any(|source| source.allow_unconfined_paths) {
+            bail!("local copy sources must be confined registered capabilities");
+        }
+        self.initialize_source_capabilities(sources, true)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub(crate) fn initialize_copy_sources(
+        &mut self,
+        _sources: &[RegisteredSourceRoot],
+    ) -> Result<()> {
+        bail!("same-machine local copy capabilities require Linux")
+    }
+
+    fn initialize_source_capabilities(
+        &mut self,
+        sources: &[RegisteredSourceRoot],
+        claim_foreign_session: bool,
+    ) -> Result<()> {
         if sources.is_empty() {
             bail!("source worker requires at least one registered root");
         }
@@ -1289,10 +1363,17 @@ impl FsOps {
                     id.get()
                 );
             }
-            let directory = self.descriptor_session.acquire(&source.ticket)?;
+            let acquire = |ticket: &DescriptorTicket| {
+                if claim_foreign_session {
+                    claim_descriptor(ticket)
+                } else {
+                    self.descriptor_session.acquire(ticket)
+                }
+            };
+            let directory = acquire(&source.ticket)?;
             let leaf_object = match (&source.leaf_ticket, &source.expected_leaf) {
                 (Some(ticket), Some(expected)) => {
-                    let object = self.descriptor_session.acquire(ticket)?;
+                    let object = acquire(ticket)?;
                     let metadata = root_metadata_from_std(
                         &object
                             .metadata()
@@ -1366,6 +1447,12 @@ impl FsOps {
         &self,
         source: Option<&RegisteredPath>,
     ) -> Result<Option<SourceScanRoot>> {
+        if self.destination_root.is_some() {
+            if source.is_some() {
+                bail!("source scan is not valid on a destination worker");
+            }
+            return Ok(None);
+        }
         if let Some(source) = source {
             let target = self.registered_source_target(source)?;
             return Ok(Some(SourceScanRoot {
@@ -1388,7 +1475,7 @@ impl FsOps {
     /// endpoint-session source capabilities, even on request variants whose
     /// source-reference cutover has not landed yet.
     pub(crate) fn validate_source_session_request(&self, request: &Request) -> Result<()> {
-        if self.source_roots.is_empty() {
+        if self.source_roots.is_empty() || self.destination_root.is_some() {
             return Ok(());
         }
         let has_guard = match request {
@@ -1532,16 +1619,6 @@ impl FsOps {
         }
     }
 
-    fn initial_absolute(&self, path: &[u8]) -> PathBytes {
-        let path = resolve(path);
-        let absolute = if path.is_absolute() {
-            path
-        } else {
-            self.initial_cwd.join(path)
-        };
-        path_bytes(&absolute)
-    }
-
     fn map_request(&self, req: &Request) -> Result<Request> {
         if self.destination_prefix.is_none() {
             return Ok(req.clone());
@@ -1609,10 +1686,7 @@ impl FsOps {
                 }
             }
             Request::ReadRange { path, .. } => map(path)?,
-            Request::CopyLocal { src, dst, .. } => {
-                *src = self.initial_absolute(src);
-                map(dst)?;
-            }
+            Request::CopyLocal { dst, .. } => map(dst)?,
             Request::ReadSmallBatch(reads) => {
                 for read in reads {
                     map(&mut read.path)?;
@@ -1829,6 +1903,9 @@ impl FsOps {
             bail!("a guarded destination stat cannot carry source references");
         }
         if let Some(sources) = sources {
+            if self.destination_root.is_some() {
+                bail!("source stat is not valid on a destination worker");
+            }
             if sources.len() != paths.len() {
                 bail!("source stat capability count does not match path count");
             }
@@ -1870,7 +1947,10 @@ impl FsOps {
             .into_iter()
             .collect();
         }
-        if !self.source_roots.is_empty() && !self.allow_unconfined_source_paths {
+        if self.destination_root.is_none()
+            && !self.source_roots.is_empty()
+            && !self.allow_unconfined_source_paths
+        {
             bail!("source stat omitted its registered source references");
         }
         Ok(self.stat_many(paths, follow, guard))
@@ -3468,7 +3548,7 @@ impl FsOps {
     #[cfg(target_os = "linux")]
     fn copy_local(
         &mut self,
-        src: &[u8],
+        source: &RegisteredPath,
         dst: &[u8],
         policy: CopyLocalPolicy,
         partial_id: &PartialId,
@@ -3479,8 +3559,12 @@ impl FsOps {
             inplace,
             allow_sequential_nfs_fallback,
         } = policy;
-        let sp = resolve(src);
-        let s = open_existing_regular(&sp, false)?;
+        let source_target = self
+            .registered_source_target(source)
+            .context("resolve registered local-copy source")?;
+        let source_label = PathBuf::from(OsStr::from_bytes(&source.relative));
+        let s = open_registered_source(&source_target)
+            .with_context(|| format!("open registered source {}", source_label.display()))?;
         // The kernel copy reads the source through the page cache, so the
         // larger readahead window this hint enables is what keeps a cold
         // source disk streaming (cp does the same; measured 10-20 % faster
@@ -3488,30 +3572,94 @@ impl FsOps {
         unsafe {
             libc::posix_fadvise(s.as_raw_fd(), 0, 0, libc::POSIX_FADV_SEQUENTIAL);
         }
-        let dp = resolve(dst);
-        // Never truncate the source: if the destination resolves to the same
-        // file (same path, a hardlink, or a symlink pointing back), refuse.
-        if let (Ok(sm), Ok(dm)) = (s.metadata(), fs::metadata(&dp)) {
-            if sm.dev() == dm.dev() && sm.ino() == dm.ino() {
-                bail!("source and destination are the same file: {}", dp.display());
-            }
+        let destination_root = self
+            .destination_root
+            .clone()
+            .context("local copy requires a registered destination root")?;
+        let dp = PathBuf::from(OsStr::from_bytes(dst));
+        let destination_relative = RelativePath::new(dst)?;
+        let destination_label = self.logical_destination_path(&dp);
+        #[cfg(debug_assertions)]
+        hold_copy_local_before_destination_open_for_test()?;
+        let source_metadata = s.metadata()?;
+        // A staged copy could safely replace a hard-linked destination, but a
+        // command that names the same file is still a self-copy and should not
+        // silently replace its own selected source. The in-place open repeats
+        // this check against the exact descriptor before truncation.
+        if destination_root
+            .metadata_optional(&destination_relative)?
+            .is_some_and(|metadata| {
+                metadata.is_file()
+                    && metadata.dev == source_metadata.dev()
+                    && metadata.ino == source_metadata.ino()
+            })
+        {
+            bail!(
+                "source and destination are the same file: {}",
+                destination_label.display()
+            );
         }
         self.uncache(&dp);
-        let target = if inplace {
-            dp.clone()
+        let (target_relative, target_path, target_label) = if inplace {
+            (destination_relative, dp.clone(), destination_label)
         } else {
-            self.partial_path(&dp, partial_id)?
+            let partial = self.partial_path(&dp, partial_id)?;
+            let relative = RelativePath::new(partial.as_os_str().as_bytes())?;
+            let label = self.logical_destination_path(&partial);
+            (relative, partial, label)
         };
-        self.uncache(&target);
-        if let Some(parent) = target.parent() {
-            if !parent.as_os_str().is_empty() && !parent.exists() {
-                fs::create_dir_all(parent).ok();
-            }
-        }
+        self.uncache(&target_path);
         let d = if inplace {
-            open_regular_write(&target, mode, true)?
+            let mut opened = None;
+            for _ in 0..8 {
+                match destination_root.metadata_optional(&target_relative)? {
+                    Some(metadata) if metadata.is_file() => {
+                        let file = destination_root.open_regular_write(&target_relative, false)?;
+                        require_rooted_metadata(&file, metadata, &target_label)?;
+                        let metadata = file.metadata()?;
+                        if metadata.dev() == source_metadata.dev()
+                            && metadata.ino() == source_metadata.ino()
+                        {
+                            bail!(
+                                "source and destination are the same file: {}",
+                                target_label.display()
+                            );
+                        }
+                        file.set_len(0).with_context(|| {
+                            format!("truncate confined file {}", target_label.display())
+                        })?;
+                        opened = Some(file);
+                        break;
+                    }
+                    Some(metadata) if metadata.is_dir() => {
+                        bail!("destination {} is a directory", target_label.display())
+                    }
+                    Some(_) => destination_root.unlink(&target_relative)?,
+                    None => match destination_root.create_file(&target_relative, mode) {
+                        Ok(file) => {
+                            opened = Some(file);
+                            break;
+                        }
+                        Err(error)
+                            if error.downcast_ref::<io::Error>().is_some_and(|error| {
+                                error.kind() == io::ErrorKind::AlreadyExists
+                            }) => {}
+                        Err(error) => return Err(error),
+                    },
+                }
+            }
+            opened.with_context(|| {
+                format!(
+                    "destination {} changed repeatedly while opening it",
+                    target_label.display()
+                )
+            })?
         } else {
-            let (d, _) = self.open_private_partial(&target)?;
+            let (d, _) = self.open_private_partial_rooted(
+                &destination_root,
+                &target_relative,
+                &target_label,
+            )?;
             // Only discard stale content. ext4 treats any truncate to zero,
             // even of an empty file, as "replace via truncate" and then
             // flushes every dirty page of the file on close (auto_da_alloc),
@@ -3554,10 +3702,16 @@ impl FsOps {
             if use_sequential_nfs_fallback {
                 userspace_fallback = true;
             } else {
+                let partial_metadata = d.metadata()?;
                 drop(d);
                 if !inplace {
-                    fs::remove_file(&target)
-                        .with_context(|| format!("remove {}", target.display()))?;
+                    discard_rooted_copy_partial(
+                        &destination_root,
+                        &target_relative,
+                        &target_label,
+                        partial_metadata.dev(),
+                        partial_metadata.ino(),
+                    )?;
                 }
                 bail!("EXDEV");
             }
@@ -3589,13 +3743,19 @@ impl FsOps {
                         userspace_fallback = true;
                         continue;
                     }
+                    let partial_metadata = d.metadata()?;
                     drop(d);
                     if !inplace {
                         // The planner probed before this empty sidecar existed.
                         // A content-identical fallback completes through its
                         // retained basis fd and would otherwise orphan it.
-                        fs::remove_file(&target)
-                            .with_context(|| format!("remove {}", target.display()))?;
+                        discard_rooted_copy_partial(
+                            &destination_root,
+                            &target_relative,
+                            &target_label,
+                            partial_metadata.dev(),
+                            partial_metadata.ino(),
+                        )?;
                     }
                     bail!("EXDEV");
                 }
@@ -3603,7 +3763,11 @@ impl FsOps {
                     continue;
                 }
                 return Err(e).with_context(|| {
-                    format!("copy_file_range {} -> {}", sp.display(), target.display())
+                    format!(
+                        "copy_file_range {} -> {}",
+                        source_label.display(),
+                        target_label.display()
+                    )
                 });
             }
             if n == 0 {
@@ -3622,13 +3786,13 @@ impl FsOps {
                 let want = remaining.min(buffer.len() as u64) as usize;
                 let n = source
                     .read(&mut buffer[..want])
-                    .with_context(|| format!("read {}", sp.display()))?;
+                    .with_context(|| format!("read {}", source_label.display()))?;
                 if n == 0 {
-                    bail!("source shortened while copying {}", sp.display());
+                    bail!("source shortened while copying {}", source_label.display());
                 }
                 destination
                     .write_all(&buffer[..n])
-                    .with_context(|| format!("write {}", target.display()))?;
+                    .with_context(|| format!("write {}", target_label.display()))?;
                 remaining -= n as u64;
             }
             d.set_len(size)?;
@@ -3639,7 +3803,7 @@ impl FsOps {
     #[cfg(not(target_os = "linux"))]
     fn copy_local(
         &mut self,
-        _src: &[u8],
+        _source: &RegisteredPath,
         _dst: &[u8],
         _policy: CopyLocalPolicy,
         _partial_id: &PartialId,
@@ -3724,7 +3888,9 @@ impl FsOps {
         block: u64,
         len: u64,
     ) -> Result<Vec<ContentDigest>> {
-        if target.source.is_some() || !self.source_roots.is_empty() {
+        if target.source.is_some()
+            || (self.destination_root.is_none() && !self.source_roots.is_empty())
+        {
             if target.guard.is_some() {
                 bail!("source block hash cannot carry a destination guard");
             }
@@ -3987,7 +4153,9 @@ impl FsOps {
         source: Option<&RegisteredPath>,
         guard: Option<&ContainerGuard>,
     ) -> Result<Response> {
-        let mut f = if source.is_some() || !self.source_roots.is_empty() {
+        let mut f = if source.is_some()
+            || (self.destination_root.is_none() && !self.source_roots.is_empty())
+        {
             if guard.is_some() {
                 bail!("source file hash cannot carry a destination guard");
             }
@@ -4161,7 +4329,7 @@ impl FsOps {
                 .seed_basis(path, partial_id, *len, guard.as_ref())
                 .map(|_| Response::Ok),
             Request::CopyLocal {
-                src,
+                source,
                 dst,
                 inplace,
                 allow_sequential_nfs_fallback,
@@ -4170,7 +4338,7 @@ impl FsOps {
                 mode,
             } => self
                 .copy_local(
-                    src,
+                    source,
                     dst,
                     CopyLocalPolicy {
                         inplace: *inplace,
@@ -5449,6 +5617,59 @@ mod tests {
                 fs::metadata(&replacement).unwrap().ino()
             ),
             (identity.dev(), identity.ino())
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn destination_worker_claims_copy_sources_from_the_foreign_session() {
+        let temporary = tempfile::tempdir().unwrap();
+        let source = temporary.path().join("source");
+        let destination = temporary.path().join("destination");
+        fs::create_dir(&source).unwrap();
+        fs::create_dir(&destination).unwrap();
+        fs::write(source.join("file"), b"source").unwrap();
+        fs::write(destination.join("file"), b"destination").unwrap();
+
+        let source_session = DescriptorSessionSlot::default();
+        let mut source_control = FsOps::with_descriptor_session(source_session);
+        let response = source_control.handle(&Request::RegisterSourceRoots {
+            selections: vec![SourceRootSelection {
+                path: source.as_os_str().as_bytes().to_vec(),
+                follow_root: false,
+            }],
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            allow_unconfined_paths: false,
+            shared_workers: 0,
+            independent_claim_workers: 1,
+        });
+        let Response::SourceRootsRegistered(roots) = response else {
+            panic!("unexpected source registration response: {response:?}")
+        };
+
+        // Initialize an unrelated endpoint session so the copy worker cannot
+        // accidentally clone the source root from its own registry.
+        let destination_session = DescriptorSessionSlot::default();
+        destination_session
+            .register(File::open(&destination).unwrap())
+            .unwrap();
+        let mut worker = FsOps::with_descriptor_session(destination_session);
+        worker.destination_root = Some(Arc::new(Root::open(&destination).unwrap()));
+        worker.destination_prefix = Some(b".".to_vec());
+        worker.initialize_copy_sources(&roots).unwrap();
+
+        assert_eq!(worker.source_roots.len(), 1);
+        assert_eq!(
+            worker.source_root_identity(roots[0].selection.root()),
+            source_control.source_root_identity(roots[0].selection.root())
+        );
+        let response = worker.handle(&Request::FileHash {
+            path: b"file".to_vec(),
+            source: None,
+            guard: None,
+        });
+        assert!(
+            matches!(response, Response::FileHash { size: 11, hash } if hash == content_digest(b"destination"))
         );
     }
 

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -58,6 +58,12 @@ struct CopyLocalPolicy {
     allow_sequential_nfs_fallback: bool,
 }
 
+#[derive(Clone, Copy)]
+enum CopyLocalOutcome {
+    Copied,
+    Unsupported,
+}
+
 #[cfg(target_os = "linux")]
 fn discard_rooted_copy_partial(
     root: &Root,
@@ -3544,7 +3550,8 @@ impl FsOps {
     /// Copy a whole same-machine file without routing its bytes through the
     /// transport. Prefer copy_file_range; when a cross-mount copy into NFS
     /// cannot be offloaded, use one sequential userspace writer instead. Other
-    /// unsupported filesystems return "EXDEV" for the parallel streaming path.
+    /// unsupported filesystems return `CopyLocalOutcome::Unsupported` for the
+    /// parallel streaming path.
     #[cfg(target_os = "linux")]
     fn copy_local(
         &mut self,
@@ -3554,7 +3561,7 @@ impl FsOps {
         partial_id: &PartialId,
         size: u64,
         mode: u32,
-    ) -> Result<()> {
+    ) -> Result<CopyLocalOutcome> {
         let CopyLocalPolicy {
             inplace,
             allow_sequential_nfs_fallback,
@@ -3713,7 +3720,7 @@ impl FsOps {
                         partial_metadata.ino(),
                     )?;
                 }
-                bail!("EXDEV");
+                return Ok(CopyLocalOutcome::Unsupported);
             }
         }
         let mut off: i64 = 0;
@@ -3757,7 +3764,7 @@ impl FsOps {
                             partial_metadata.ino(),
                         )?;
                     }
-                    bail!("EXDEV");
+                    return Ok(CopyLocalOutcome::Unsupported);
                 }
                 if raw == libc::EINTR {
                     continue;
@@ -3797,7 +3804,7 @@ impl FsOps {
             }
             d.set_len(size)?;
         }
-        Ok(())
+        Ok(CopyLocalOutcome::Copied)
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -3809,8 +3816,8 @@ impl FsOps {
         _partial_id: &PartialId,
         _size: u64,
         _mode: u32,
-    ) -> Result<()> {
-        bail!("EXDEV")
+    ) -> Result<CopyLocalOutcome> {
+        Ok(CopyLocalOutcome::Unsupported)
     }
 
     /// Write a whole small file through its deterministic sidecar and atomically
@@ -4348,7 +4355,10 @@ impl FsOps {
                     *size,
                     *mode,
                 )
-                .map(|_| Response::Ok),
+                .map(|outcome| match outcome {
+                    CopyLocalOutcome::Copied => Response::Ok,
+                    CopyLocalOutcome::Unsupported => Response::CopyLocalUnsupported,
+                }),
             Request::PutSmallBatch(puts) => Ok(Response::Applied(
                 puts.iter()
                     .map(|put| {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -447,8 +447,11 @@ pub enum ConnectionRole {
     /// A data connection used to mutate a destination endpoint. Unrestricted
     /// receivers require an exact registered root; restricted receivers derive
     /// their confinement from the signed grant and reject a supplied ticket.
+    /// A same-machine worker may additionally receive source capabilities for
+    /// `CopyLocal`; no other destination request may use them.
     DestinationWorker {
         destination: Option<DestinationRoot>,
+        copy_sources: Vec<RegisteredSourceRoot>,
     },
 }
 
@@ -612,7 +615,7 @@ pub enum Request {
     /// source and asynchronous NFS destination). Err("EXDEV") tells the
     /// caller to use the normal streaming path.
     CopyLocal {
-        src: PathBytes,
+        source: RegisteredPath,
         dst: PathBytes,
         inplace: bool,
         allow_sequential_nfs_fallback: bool,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -612,8 +612,8 @@ pub enum Request {
     },
     /// Receiver-side copy of a same-machine file (copy_file_range when
     /// possible, optionally a sequential userspace fallback for a local
-    /// source and asynchronous NFS destination). Err("EXDEV") tells the
-    /// caller to use the normal streaming path.
+    /// source and asynchronous NFS destination). `CopyLocalUnsupported`
+    /// tells the caller to use the normal streaming path.
     CopyLocal {
         source: RegisteredPath,
         dst: PathBytes,
@@ -773,6 +773,10 @@ pub enum Response {
     Receipt(#[serde(with = "serde_bytes")] Vec<u8>),
     Ok,
     Err(String),
+    /// `CopyLocal` could not use the receiver-side direct-copy path. This is
+    /// deliberately distinct from `Err`: filenames and other diagnostics are
+    /// untrusted text and must never select a recovery path.
+    CopyLocalUnsupported,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -1045,5 +1049,19 @@ mod tests {
             let encoded = postcard::to_allocvec(&invalid).unwrap();
             assert!(postcard::from_bytes::<RegisteredPath>(&encoded).is_err());
         }
+    }
+
+    #[test]
+    fn copy_local_fallback_has_a_structured_wire_response() {
+        let mut frame = Vec::new();
+        FrameWriter::new(&mut frame, false)
+            .write_msg(&Response::CopyLocalUnsupported)
+            .unwrap();
+        assert!(matches!(
+            FrameReader::new(frame.as_slice())
+                .read_msg::<Response>()
+                .unwrap(),
+            Response::CopyLocalUnsupported
+        ));
     }
 }

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -9,8 +9,9 @@ use std::sync::{Arc, Condvar, Mutex};
 #[derive(Clone, Debug)]
 pub struct FileJob {
     pub src: PathBytes,
-    /// Descriptor-session authority corresponding to `src`. Source workers
-    /// claim its root during Hello; reads switch to it in the next slice.
+    /// Descriptor-session authority corresponding to `src`. Source workers,
+    /// and Linux destination workers using CopyLocal, claim its root during
+    /// authenticated initialization and use it for content opens.
     pub source: RegisteredPath,
     pub dst: PathBytes,
     pub rel: String,

--- a/src/server.rs
+++ b/src/server.rs
@@ -190,15 +190,26 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 return Err(error).context("initialize source worker");
             }
         }
+        ConnectionRole::DestinationWorker { copy_sources, .. }
+            if authority.is_some() && !copy_sources.is_empty() =>
+        {
+            w.write_msg(&Response::Err(
+                "a command-restricted receiver does not accept caller-supplied copy sources".into(),
+            ))?;
+            bail!("command-restricted receiver rejected supplied copy sources");
+        }
         ConnectionRole::DestinationWorker {
             destination: Some(_),
+            ..
         } if authority.is_some() => {
             w.write_msg(&Response::Err(
                 "a command-restricted destination derives its root from the signed grant".into(),
             ))?;
             bail!("command-restricted receiver rejected a supplied destination root");
         }
-        ConnectionRole::DestinationWorker { destination: None } if authority.is_none() => {
+        ConnectionRole::DestinationWorker {
+            destination: None, ..
+        } if authority.is_none() => {
             w.write_msg(&Response::Err(
                 "unrestricted destination worker requires a registered root".into(),
             ))?;
@@ -206,6 +217,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
         }
         ConnectionRole::DestinationWorker {
             destination: Some(destination),
+            copy_sources,
         } => {
             if let Err(error) = ops.initialize_destination(destination) {
                 w.write_msg(&Response::Err(format!(
@@ -213,8 +225,19 @@ fn serve<R: Read + Send + 'static, W: Write>(
                 )))?;
                 return Err(error).context("initialize destination worker");
             }
+            if !copy_sources.is_empty() {
+                if let Err(error) = ops.initialize_copy_sources(copy_sources) {
+                    w.write_msg(&Response::Err(format!(
+                        "initialize local copy sources: {error:#}"
+                    )))?;
+                    return Err(error).context("initialize local copy sources");
+                }
+            }
         }
-        ConnectionRole::Control | ConnectionRole::DestinationWorker { destination: None } => {}
+        ConnectionRole::Control
+        | ConnectionRole::DestinationWorker {
+            destination: None, ..
+        } => {}
     }
     w.write_msg(&Response::HelloOk {
         identity: crate::identity::build().to_string(),
@@ -1039,6 +1062,7 @@ mod tests {
                         ticket,
                         request_prefix: b"destination".to_vec(),
                     }),
+                    copy_sources: Vec::new(),
                 },
             })
             .unwrap();

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1155,11 +1155,20 @@ pub fn run(args: Args) -> Result<i32> {
                     let conns = src_ep
                         .connect_with_sources(compress, initial_sources.clone())
                         .and_then(|src| {
+                            let copy_sources = if cfg!(target_os = "linux")
+                                && opts.same_host
+                                && !opts.insecure_links
+                            {
+                                initial_sources.clone()
+                            } else {
+                                Vec::new()
+                            };
                             Ok((
                                 src,
-                                dst_ep.connect_with_destination(
+                                dst_ep.connect_with_copy_capabilities(
                                     compress,
                                     initial_destination.clone(),
+                                    copy_sources,
                                 )?,
                             ))
                         });
@@ -1333,6 +1342,19 @@ pub fn run(args: Args) -> Result<i32> {
         Endpoint::Local { .. } => 0,
         Endpoint::Remote(_) => maximum_workers.min(crate::conn::MAX_CONCURRENT_CONNECTS),
     };
+    // On Linux, each same-machine destination worker also claims the exact
+    // source capabilities from the source endpoint's broker before reporting
+    // ready. These are foreign-session claims even when both logical endpoints
+    // are local to the coordinator process.
+    let copy_local_claim_workers =
+        if cfg!(target_os = "linux") && opts.same_host && !opts.insecure_links {
+            maximum_workers
+        } else {
+            0
+        };
+    let source_independent_claim_workers = source_independent_claim_workers
+        .checked_add(copy_local_claim_workers)
+        .context("source worker count overflow")?;
     let registered_sources = register_source_roots(
         &mut *src_ctl,
         srcs,
@@ -5943,6 +5965,7 @@ impl Worker {
         // copy_file_range cannot be paced, so a limited same-machine transfer
         // uses the regular userspace path (also useful for mounted NFS paths).
         if self.opts.same_host
+            && !self.opts.insecure_links
             && !self.opts.checksum
             && self.bwlimit.is_none()
             && job.entry.size > 0
@@ -6142,7 +6165,7 @@ impl Worker {
         self.set_inplace(idx, inplace);
         let mode = self.create_mode(job);
         let resp = self.dst.call(Request::CopyLocal {
-            src: job.src.clone(),
+            source: job.source.clone(),
             dst: job.dst.clone(),
             inplace,
             allow_sequential_nfs_fallback: self.opts.allow_sequential_nfs_fallback,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -6193,7 +6193,7 @@ impl Worker {
                 }
                 Ok(true)
             }
-            Response::Err(e) if e.contains("EXDEV") => Ok(false),
+            Response::CopyLocalUnsupported => Ok(false),
             Response::Err(e) => bail!("{e}"),
             other => bail!("unexpected response {other:?}"),
         }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -92,11 +92,12 @@ fn source_fd_preflight_rejects_shared_worker_boundary_before_destination_creatio
         &t.s("destination"),
     ]);
     // Local and remote-TCP sources feed the same shared-worker count into FD
-    // admission. At 64 workers the conservative exact-leaf model requires
-    // current_open + 1572 slots. Use a portable low limit here to verify that
-    // admission fails before destination creation; the exact per-worker
-    // arithmetic, including the uncached hash descriptor, is asserted in the
-    // FsOps unit test. The child must retain the lowered hard limit because syq
+    // admission. At 64 workers the conservative exact-leaf model plus the 64
+    // cross-session destination claims requires current_open + 1764 slots. Use
+    // a portable low limit here to verify that admission fails before
+    // destination creation; the exact per-worker arithmetic, including the
+    // uncached hash descriptor, is asserted in the FsOps unit test. The child
+    // must retain the lowered hard limit because syq
     // normally raises a
     // low soft limit to the inherited hard limit during startup. Never try to
     // raise an inherited hard limit: supported environments commonly cap it
@@ -141,7 +142,7 @@ fn source_fd_preflight_rejects_shared_worker_boundary_before_destination_creatio
         .unwrap();
     // Conservatively budget every selector as parent + exact object for the
     // registry, control, and all 64 shared workers, plus worker/cache reserve.
-    assert_eq!(required, current_open + 1572, "{stderr}");
+    assert_eq!(required, current_open + 1764, "{stderr}");
     assert!(
         !t.path("destination").exists(),
         "source FD admission failed after destination creation"
@@ -410,6 +411,181 @@ fn source_small_and_range_reads_use_registered_root_after_path_replacement() {
     assert_output_ok(&output);
     assert_eq!(read(&t.path("dst/small")), b"original");
     assert_eq!(read(&t.path("dst/large")), original_large);
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_uses_registered_source_after_path_replacement() {
+    let t = Tmp::new();
+    let original = vec![b'o'; 8 << 20];
+    write(&t.path("src/file"), &original);
+    write(&t.path("outside/file"), &vec![b'r'; original.len()]);
+    let ready = t.path("source-capability-ready");
+
+    let mut child = compat_command()
+        .args([
+            "-a",
+            "--syq-connections",
+            "1",
+            &t.s("src/"),
+            &t.s("dst/"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
+        .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
+        // A pathname fallback would read through the replacement below. A
+        // streaming fallback fails instead of hiding that CopyLocal was not
+        // exercised.
+        .env("SYQ_TEST_FAIL_READ_RANGE", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !ready.exists() && std::time::Instant::now() < deadline {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "syq exited before registering the source root"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(
+        ready.exists(),
+        "source root was not registered before timeout"
+    );
+
+    fs::rename(t.path("src"), t.path("selected-and-moved")).unwrap();
+    std::os::unix::fs::symlink(t.path("outside"), t.path("src")).unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("dst/file")), original);
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_refuses_a_replaced_destination_parent() {
+    let t = Tmp::new();
+    write(&t.path("src/tree/file"), &vec![b's'; 8 << 20]);
+    fs::create_dir_all(t.path("dst/tree")).unwrap();
+    write(&t.path("outside/sentinel"), b"unchanged");
+    let ready = t.path("copy-local-ready");
+
+    let mut child = compat_command()
+        .args([
+            "-a",
+            "--syq-connections",
+            "1",
+            &t.s("src/"),
+            &t.s("dst/"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_COPY_LOCAL_READY_FILE", &ready)
+        .env("SYQ_TEST_HOLD_COPY_LOCAL_MS", "750")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !ready.exists() && std::time::Instant::now() < deadline {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "syq exited before reaching the local-copy destination open"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(ready.exists(), "local copy did not reach the test hook");
+
+    fs::rename(t.path("dst/tree"), t.path("dst/tree-original")).unwrap();
+    std::os::unix::fs::symlink(t.path("outside"), t.path("dst/tree")).unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert!(!output.status.success(), "unexpected success: {output:?}");
+    assert_eq!(read(&t.path("outside/sentinel")), b"unchanged");
+    assert!(!t.path("outside/file").exists());
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn inplace_copy_local_replaces_a_raced_destination_symlink() {
+    let t = Tmp::new();
+    let contents = vec![b's'; 8 << 20];
+    write(&t.path("src"), &contents);
+    write(&t.path("dst"), &vec![b'd'; contents.len()]);
+    write(&t.path("outside"), b"unchanged");
+    set_mtime(&t.path("src"), 1_700_000_000);
+    set_mtime(&t.path("dst"), 1_600_000_000);
+    let ready = t.path("copy-local-ready");
+
+    let mut child = compat_command()
+        .args([
+            "-a",
+            "--inplace",
+            "--syq-connections",
+            "1",
+            &t.s("src"),
+            &t.s("dst"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_COPY_LOCAL_READY_FILE", &ready)
+        .env("SYQ_TEST_HOLD_COPY_LOCAL_MS", "750")
+        .env("SYQ_TEST_FAIL_READ_RANGE", "1")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !ready.exists() && std::time::Instant::now() < deadline {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "syq exited before reaching the local-copy destination open"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(ready.exists(), "local copy did not reach the test hook");
+
+    fs::remove_file(t.path("dst")).unwrap();
+    std::os::unix::fs::symlink("outside", t.path("dst")).unwrap();
+
+    let output = child.wait_with_output().unwrap();
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("outside")), b"unchanged");
+    assert!(fs::symlink_metadata(t.path("dst")).unwrap().is_file());
+    assert_eq!(read(&t.path("dst")), contents);
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn insecure_links_does_not_delegate_unconfined_names_to_copy_local() {
+    let t = Tmp::new();
+    let contents = vec![b'u'; 8 << 20];
+    fs::create_dir_all(t.path("src")).unwrap();
+    write(&t.path("outside/secret"), &contents);
+    std::os::unix::fs::symlink("../outside", t.path("src/link")).unwrap();
+    write(&t.path("list"), b"link/secret\n");
+    let copy_local_ready = t.path("copy-local-ready");
+
+    let output = compat_command()
+        .args([
+            "-a",
+            "-r",
+            "--insecure-links",
+            "--files-from",
+            &t.s("list"),
+            &t.s("src"),
+            &t.s("dst"),
+            "--no-progress",
+        ])
+        .env("SYQ_TEST_COPY_LOCAL_READY_FILE", &copy_local_ready)
+        .run()
+        .unwrap();
+
+    assert_output_ok(&output);
+    assert!(!copy_local_ready.exists());
+    assert_eq!(read(&t.path("dst/link/secret")), contents);
 }
 
 fn run_native_ok(args: &[&str]) -> String {


### PR DESCRIPTION
## Summary
- replace `CopyLocal`'s raw source pathname with a registered source capability
- initialize Linux same-machine destination workers with exact cross-session source descriptors before readiness
- open both the source and destination through retained roots, including no-follow in-place replacement and descriptor-relative sidecar cleanup
- skip the optimization for rsync `--insecure-links`, whose explicit unconfined source names cannot be represented by the capability-only request
- account for destination-worker broker claims during pre-mutation source FD admission

## Security properties
- replacing the registered source spelling cannot redirect `CopyLocal`
- replacing a destination parent with an outside symlink fails visibly without touching the outside tree
- a raced final destination symlink is replaced rather than followed for `--inplace`
- dormant copy-source capabilities do not reclassify destination hashing or verification requests as source reads
- command-restricted receivers reject caller-supplied copy-source capabilities

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (306 unit, 295 integration, 7 updater)

Stacked on #130 (`source-reads-rooted` at `9db40c5`).
