### PR TITLE
Reword the Python package's PyPI description and readme lead

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,18 +1,19 @@
 # syq for Python
 
-`syq` is the official Python client for the
-[syq parallel file copier](https://github.com/greaber/syq). It invokes syq with
-an argument array and never constructs a shell command. The typed API mirrors
-native `cp`, including `cp --prune`, and `map`. Commands without an automation
-result stream, including `rm`, remain available through `run`.
+The official Python client for [syq](https://github.com/greaber/syq), a fast
+file transfer tool. Call `syq.cp(...)` (including `cp --prune`) and
+`syq.map(...)` and get typed results back; anything else syq can do, such as
+`rm`, is one `syq.run([...])` away.
 
 ```sh
 python -m pip install syq
 ```
 
-Package installation does not download an executable. The first call that
-needs syq downloads the exact release pinned by this SDK into the user cache.
-For Python package `0.0.3`, that release is syq `0.1.8`.
+Installing the package does not install syq itself. The first call downloads
+the syq release this package was tested with into your user cache, checks it
+against the signed release manifest, and uses that binary from then on.
+For Python package `0.0.3`, that release is syq `0.1.8`. syq always runs as a
+subprocess with an argument list, never through a shell.
 
 ```python
 import syq

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -9,9 +9,10 @@ file transfer tool. Call `syq.cp(...)` (including `cp --prune`) and
 python -m pip install syq
 ```
 
-Installing the package does not install syq itself. The first call downloads
-the syq release this package was tested with into your user cache, checks it
-against the signed release manifest, and uses that binary from then on.
+Installing the package does not install syq itself. The first default call that
+needs syq downloads the syq release this package was tested with if it is not
+already cached, checks it against the signed release manifest, and uses that
+managed binary for subsequent default calls.
 For Python package `0.0.3`, that release is syq `0.1.8`. syq always runs as a
 subprocess with an argument list, never through a shell.
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "syq"
 version = "0.0.3"
-description = "Typed, version-pinned Python client for the syq parallel file copier"
+description = "Official client for the syq file transfer tool"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## Summary

- PyPI short description: "Official client for the syq file transfer tool" (was "Typed, version-pinned Python client for the syq parallel file copier"). PyPI already says it is Python; pinning is a mechanism, not the headline.
- The readme lead now says what the package is for and how to call it, and moves the subprocess and no-shell facts below the install command. The rest of the readme is unchanged.
- The sentence `scripts/prepare-python-sdk-release.py` rewrites ("For Python package `0.0.3`, that release is syq `0.1.8`.") and the two cache-path mentions are kept verbatim.

The text on PyPI changes with the next SDK release; published release metadata cannot be edited.

## Verification

- `scripts/test-python-sdk-release-tools.sh` passes
- `pyproject.toml` parses; the readme keeps exactly two `syq/sdk/python/v0.1.8/` markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HQ25vBNy9n8i9YPkVmjcf
