### PR TITLE
Match Python SDK and syq release versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,8 +176,8 @@ jobs:
             exit 1
           }
           pinned_version=${pinned_tag#v}
-          python_version=$(python -c \
-            'import tomllib; print(tomllib.load(open("sdk/python/pyproject.toml", "rb"))["project"]["version"])')
+          python_version=$(sed -n 's/^version = "\(.*\)"/\1/p' \
+            sdk/python/pyproject.toml)
           test "$python_version" = "$pinned_version" || {
             echo "Python SDK $python_version pins syq $pinned_version; versions must match" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Install pinned Python tooling
         if: needs.scope.outputs.sdks == 'true'
         run: python -m pip install --disable-pip-version-check --no-deps uv==0.11.6
-      - name: Require the SDK mapping for the latest syq release
+      - name: Require the matching Python SDK for the latest syq release
         if: needs.scope.outputs.sdks == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -173,6 +173,13 @@ jobs:
           pinned_tag=$(jq -er .tag sdk/python/src/syq/syq-release-manifest.json)
           test "$pinned_tag" = "$latest_tag" || {
             echo "Python SDK pins $pinned_tag, but the latest syq release is $latest_tag" >&2
+            exit 1
+          }
+          pinned_version=${pinned_tag#v}
+          python_version=$(python -c \
+            'import tomllib; print(tomllib.load(open("sdk/python/pyproject.toml", "rb"))["project"]["version"])')
+          test "$python_version" = "$pinned_version" || {
+            echo "Python SDK $python_version pins syq $pinned_version; versions must match" >&2
             exit 1
           }
       - name: Build the candidate syq executable

--- a/.github/workflows/prepare-python-sdk.yml
+++ b/.github/workflows/prepare-python-sdk.yml
@@ -51,7 +51,7 @@ jobs:
           test "$(jq -er .tag \
             "$RUNNER_TEMP/syq-release/syq-release-manifest.json")" = \
             "$RELEASE_TAG"
-      - name: Prepare the next Python SDK mapping
+      - name: Prepare the matching Python SDK release
         id: prepare
         env:
           RELEASE_MANIFEST: ${{ runner.temp }}/syq-release/syq-release-manifest.json
@@ -72,6 +72,7 @@ jobs:
           python_version=$(python3 -c \
             'import tomllib; print(tomllib.load(open("sdk/python/pyproject.toml", "rb"))["project"]["version"])')
           syq_version=$(jq -er .version "$RELEASE_MANIFEST")
+          test "$python_version" = "$syq_version"
           {
             echo 'changed=true'
             echo "python_version=$python_version"
@@ -104,20 +105,20 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git switch -c "$branch"
-          git add sdk/README.md sdk/python sdk/RELEASING.md
+          git add sdk/python
           git diff --cached --check
-          git commit -m "Pin Python SDK $PYTHON_VERSION to syq $SYQ_VERSION"
+          git commit -m "Prepare Python SDK $PYTHON_VERSION"
           git push origin "$branch"
           body=$(printf '%s\n\n%s\n%s\n%s\n\n%s' \
             "Automated follow-up to the immutable syq v$SYQ_VERSION release." \
-            "- bumps the Python SDK to $PYTHON_VERSION" \
+            "- sets the Python SDK version to match syq $SYQ_VERSION" \
             "- embeds the exact signed v$SYQ_VERSION release manifest" \
-            "- updates the documented SDK-to-syq mapping" \
+            "- updates the managed executable cache documentation" \
             "The native pull-request checks are approved explicitly because GitHub puts workflow runs caused by GITHUB_TOKEN into an approval-required state. Auto-merge is requested only after the substantive sdks check succeeds on this exact commit; publication still requires the maintainer-signed tag sdk-python-v$PYTHON_VERSION and approval of the protected pypi environment.")
           pr_url=$(gh pr create \
             --base master \
             --head "$branch" \
-            --title "Pin Python SDK $PYTHON_VERSION to syq $SYQ_VERSION" \
+            --title "Prepare Python SDK $PYTHON_VERSION" \
             --body "$body")
           echo "Created $pr_url"
           head_sha=$(git rev-parse HEAD)

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -51,6 +51,12 @@ jobs:
           version=$(python -c \
             'import tomllib; print(tomllib.load(open("sdk/python/pyproject.toml", "rb"))["project"]["version"])')
           test "$GITHUB_REF_NAME" = "sdk-python-v$version"
+          pinned_version=$(jq -er .version \
+            sdk/python/src/syq/syq-release-manifest.json)
+          test "$version" = "$pinned_version" || {
+            echo "Python SDK $version pins syq $pinned_version; versions must match" >&2
+            exit 1
+          }
           uv run --project sdk/python --frozen python -m unittest discover -s sdk/python/tests
       - name: Build distributions with pinned tooling
         env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,8 +6,9 @@ before a tag can publish anything. The workflow uses a draft until every file
 is uploaded and checked, then publishes it once. Enable GitHub's immutable
 releases setting so published assets and tags cannot be changed afterward.
 
-Python, JavaScript, and Go SDKs have independent versions and tag conventions.
-Their registry setup and release procedure live in [`sdk/RELEASING.md`](sdk/RELEASING.md).
+The Python SDK shares the version of the syq release it pins. JavaScript and Go
+SDKs have independent versions, and every SDK has its own tag convention. Their
+registry setup and release procedure live in [`sdk/RELEASING.md`](sdk/RELEASING.md).
 
 ## One-time repository setup
 
@@ -191,7 +192,7 @@ connection, so enable it only for a trusted release host rather than globally.
    every uploaded byte, publishes it, publishes the matching source package to
    crates.io with a short-lived OIDC credential, and finally updates the tap.
    Once the entire release workflow succeeds, the Python SDK preparation
-   workflow opens a pull request for the next SDK patch release using this
+   workflow opens a pull request for the matching SDK release using this
    immutable syq manifest. PyPI publication remains a separate signed-tag and
    protected-environment action, so a registry outage cannot block syq.
    Track the complete state at any time with:
@@ -202,7 +203,7 @@ connection, so enable it only for a trusted release host rather than globally.
    ```
 
    The report correlates the exact tag commit, release runs and pending
-   environments, GitHub release state, crates.io, the mapped PyPI SDK version,
+   environments, GitHub release state, crates.io, the matching PyPI SDK version,
    and the Homebrew formula without modifying any of them.
 4. Verify one or more downloaded artifacts and exercise all install paths:
 

--- a/scripts/prepare-python-sdk-release.py
+++ b/scripts/prepare-python-sdk-release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prepare a Python SDK patch release for one immutable syq manifest."""
+"""Prepare a matching Python SDK release for one immutable syq manifest."""
 
 from __future__ import annotations
 
@@ -109,14 +109,9 @@ def prepare(root: Path, manifest_path: Path) -> bool:
     packaged_manifest = root / "sdk/python/src/syq/syq-release-manifest.json"
     current_manifest = json.loads(packaged_manifest.read_bytes())
     current_syq_version = str(current_manifest["version"])
-    if version_tuple(new_syq_version, label="new syq release") <= version_tuple(
+    current_syq_version_tuple = version_tuple(
         current_syq_version, label="current syq release"
-    ):
-        print(
-            f"Python SDK already pins syq {current_syq_version}; "
-            f"not preparing {new_syq_version}"
-        )
-        return False
+    )
 
     pyproject_path = root / "sdk/python/pyproject.toml"
     pyproject = pyproject_path.read_text(encoding="utf-8")
@@ -124,10 +119,25 @@ def prepare(root: Path, manifest_path: Path) -> bool:
     if version_match is None:
         raise ValueError("could not find the Python package version")
     current_python_version = version_match.group(1)
-    major, minor, patch = version_tuple(
+    current_python_version_tuple = version_tuple(
         current_python_version, label="current Python SDK"
     )
-    new_python_version = f"{major}.{minor}.{patch + 1}"
+    if current_python_version_tuple != current_syq_version_tuple:
+        raise ValueError(
+            f"current Python SDK {current_python_version} does not match "
+            f"pinned syq {current_syq_version}"
+        )
+
+    if version_tuple(
+        new_syq_version, label="new syq release"
+    ) <= current_syq_version_tuple:
+        print(
+            f"Python SDK already pins syq {current_syq_version}; "
+            f"not preparing {new_syq_version}"
+        )
+        return False
+
+    new_python_version = new_syq_version
     pyproject = replace_once(
         pyproject,
         f'version = "{current_python_version}"',
@@ -139,10 +149,8 @@ def prepare(root: Path, manifest_path: Path) -> bool:
     python_readme = python_readme_path.read_text(encoding="utf-8")
     python_readme = replace_once(
         python_readme,
-        f"For Python package `{current_python_version}`, that release is syq "
-        f"`{current_syq_version}`.",
-        f"For Python package `{new_python_version}`, that release is syq "
-        f"`{new_syq_version}`.",
+        f"package `{current_python_version}`\nmanages syq `{current_syq_version}`.",
+        f"package `{new_python_version}`\nmanages syq `{new_syq_version}`.",
         label="Python README release mapping",
     )
     old_cache_path = f"syq/sdk/python/v{current_syq_version}/"
@@ -155,20 +163,8 @@ def prepare(root: Path, manifest_path: Path) -> bool:
     if old_cache_path in python_readme:
         raise ValueError("the Python README retained the old cache version")
 
-    sdk_readme_path = root / "sdk/README.md"
-    sdk_readme = sdk_readme_path.read_text(encoding="utf-8")
-    current_row = f"| `{current_python_version}` | `{current_syq_version}` |"
-    new_row = f"| `{new_python_version}` | `{new_syq_version}` |"
-    sdk_readme = replace_once(
-        sdk_readme,
-        current_row,
-        f"{current_row}\n{new_row}",
-        label="SDK mapping table row",
-    )
-
     pyproject_path.write_text(pyproject, encoding="utf-8")
     python_readme_path.write_text(python_readme, encoding="utf-8")
-    sdk_readme_path.write_text(sdk_readme, encoding="utf-8")
     packaged_manifest.write_bytes(raw_manifest)
     print(
         f"prepared Python SDK {new_python_version} for syq {new_syq_version}"

--- a/scripts/test-python-sdk-release-tools.sh
+++ b/scripts/test-python-sdk-release-tools.sh
@@ -8,7 +8,6 @@ cleanup() { rm -rf "$work"; }
 trap cleanup EXIT HUP INT TERM
 
 mkdir -p "$work/sdk/python/src/syq"
-cp "$repo_dir/sdk/README.md" "$work/sdk/README.md"
 cp "$repo_dir/sdk/python/README.md" "$work/sdk/python/README.md"
 cp "$repo_dir/sdk/python/pyproject.toml" "$work/sdk/python/pyproject.toml"
 cp "$repo_dir/sdk/python/src/syq/syq-release-manifest.json" \
@@ -18,10 +17,12 @@ current_manifest="$repo_dir/sdk/python/src/syq/syq-release-manifest.json"
 current_syq_version=$(jq -er .version "$current_manifest")
 current_python_version=$(sed -n 's/^version = "\(.*\)"/\1/p' \
   "$repo_dir/sdk/python/pyproject.toml")
-IFS=. read -r syq_major syq_minor syq_patch <<<"$current_syq_version"
-IFS=. read -r python_major python_minor python_patch <<<"$current_python_version"
-next_syq_version="$syq_major.$syq_minor.$((syq_patch + 1))"
-next_python_version="$python_major.$python_minor.$((python_patch + 1))"
+test "$current_python_version" = "$current_syq_version"
+IFS=. read -r syq_major syq_minor _ <<<"$current_syq_version"
+# Use a non-patch increment so the test proves that the incoming syq version is
+# copied instead of independently incrementing the Python patch component.
+next_syq_version="$syq_major.$((syq_minor + 1)).0"
+next_python_version=$next_syq_version
 candidate="$work/candidate.json"
 jq --arg version "$next_syq_version" \
   '{
@@ -41,12 +42,12 @@ python3 "$script_dir/prepare-python-sdk-release.py" \
 
 grep -Fx "version = \"$next_python_version\"" \
   "$work/sdk/python/pyproject.toml" >/dev/null
-grep -F "For Python package \`$next_python_version\`, that release is syq \`$next_syq_version\`." \
+grep -F "package \`$next_python_version\`" \
+  "$work/sdk/python/README.md" >/dev/null
+grep -F "manages syq \`$next_syq_version\`." \
   "$work/sdk/python/README.md" >/dev/null
 test "$(grep -Fc "syq/sdk/python/v$next_syq_version/" \
   "$work/sdk/python/README.md")" -eq 2
-grep -Fx "| \`$next_python_version\` | \`$next_syq_version\` |" \
-  "$work/sdk/README.md" >/dev/null
 cmp "$candidate" "$work/sdk/python/src/syq/syq-release-manifest.json"
 
 before=$(find "$work/sdk" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)
@@ -54,6 +55,23 @@ python3 "$script_dir/prepare-python-sdk-release.py" \
   --root "$work" --manifest "$candidate"
 after=$(find "$work/sdk" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum)
 test "$before" = "$after"
+
+misaligned="$work/misaligned"
+mkdir -p "$misaligned/sdk/python/src/syq"
+cp "$repo_dir/sdk/python/README.md" "$misaligned/sdk/python/README.md"
+cp "$repo_dir/sdk/python/pyproject.toml" "$misaligned/sdk/python/pyproject.toml"
+cp "$repo_dir/sdk/python/src/syq/syq-release-manifest.json" \
+  "$misaligned/sdk/python/src/syq/syq-release-manifest.json"
+sed -i 's/^version = ".*"/version = "0.0.0"/' \
+  "$misaligned/sdk/python/pyproject.toml"
+if python3 "$script_dir/prepare-python-sdk-release.py" \
+  --root "$misaligned" --manifest "$candidate" \
+  > "$work/misaligned.out" 2>&1; then
+  echo 'misaligned Python and syq versions unexpectedly succeeded' >&2
+  exit 1
+fi
+grep -F "current Python SDK 0.0.0 does not match pinned syq $current_syq_version" \
+  "$work/misaligned.out" >/dev/null
 
 invalid="$work/invalid.json"
 jq 'del(.signature)' "$candidate" > "$invalid"

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -398,7 +398,7 @@ cat >"$status_bin/curl" <<'EOF'
 #!/usr/bin/env bash
 case " $* " in
   *'crates.io/'*) printf '{"versions":[{"num":"0.1.8"}]}\n' ;;
-  *'pypi.org/'*) printf '{"info":{"version":"0.0.3"},"releases":{"0.0.3":[{}]}}\n' ;;
+  *'pypi.org/'*) printf '{"info":{"version":"0.1.8"},"releases":{"0.1.8":[{}]}}\n' ;;
   *) exit 2 ;;
 esac
 EOF

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -31,20 +31,12 @@ verifies its archive and decompressed bytes against the release manifest
 embedded in the package, checks its version and release identity, and then
 always invokes that cached binary.
 
-The current mapping is:
-
-| Python SDK | syq executable |
-|---|---|
-| `0.0.1` | `0.1.5` |
-| `0.0.2` | `0.1.7` |
-| `0.0.3` | `0.1.8` |
-
-The two version numbers do not need to match, but the mapping is immutable for
-a published SDK release. Multiple SDK releases may pin the same syq release.
-Moving to another syq release requires a new SDK release and its compatibility
-tests. Every successful official syq release automatically prepares a Python
-SDK patch-release pull request that pins its exact signed manifest. Maintainers
-review and merge that mapping before creating the signed Python SDK tag.
+The Python package uses the same version as the syq release it manages. Its
+package version, `syq.__version__`, and `syq.PINNED_SYQ_VERSION` therefore agree.
+The embedded mapping remains immutable for a published package. Every
+successful official syq release automatically prepares the matching Python SDK
+release pull request with its exact signed manifest. Maintainers review and
+merge that release before creating the signed Python SDK tag.
 
 Callers that need a local build, a newer syq, or an offline-provisioned binary
 may pass `executable=` explicitly. That opts out of the tested pairing; the
@@ -52,9 +44,8 @@ caller owns compatibility and provenance for the override.
 
 This makes the supported SDK/runtime combination hermetic. SDK consumers can
 pin the Python package version in their own lockfile and choose when to adopt a
-new SDK-plus-syq pair. The SDK still versions changes to its Python API normally,
-but its supported subprocess behavior is never exposed to untested executable
-drift.
+new SDK-plus-syq release. The supported subprocess behavior is never exposed
+to untested executable drift.
 
 The Python package implements this model. The JavaScript and Go preview
 packages must adopt it before their first registry releases.

--- a/sdk/RELEASING.md
+++ b/sdk/RELEASING.md
@@ -1,11 +1,12 @@
 # Releasing the language SDKs
 
-SDK releases use independent versions and tags. Published versions are
-immutable: never move or delete their release tags or attempt to replace an
-uploaded package. A Python or JavaScript tag whose publication is abandoned
-before any permanent release or registry state exists remains provisional;
-audit all destinations, clean any recoverable draft, and delete that tag rather
-than burning an unpublished SDK version.
+The Python SDK shares the version of the exact syq release it pins. JavaScript
+and Go SDKs use independent versions, and every SDK uses its own tag convention.
+Published versions are immutable: never move or delete their release tags or
+attempt to replace an uploaded package. A Python or JavaScript tag whose
+publication is abandoned before any permanent release or registry state exists
+remains provisional; audit all destinations, clean any recoverable draft, and
+delete that tag rather than burning an unpublished SDK version.
 
 A Go module tag such as `sdk/go/v*` is permanent as soon as it is pushed. The
 tag itself publishes the version: a client or arbitrary module proxy may fetch
@@ -81,26 +82,24 @@ branch workflow, and run all SDK checks. Create a signed annotated tag that
 directly targets the commit on `master`.
 
 For a Python release, first choose the exact immutable syq release the SDK will
-use. Replace `python/src/syq/syq-release-manifest.json` with that release's
-complete signed manifest; do not edit its artifact hashes by hand. Update the
-mapping table in `README.md`. The packaged manifest is the SDK's immutable
-executable-version mapping and runtime trust root for downloaded bytes. Tests
-and the release workflow must build the wheel in a clean cache, perform its
-managed first-use download, and require `syq.version()` to equal
-`syq.PINNED_SYQ_VERSION`.
+use. Set `python/pyproject.toml` to that syq version and replace
+`python/src/syq/syq-release-manifest.json` with the release's complete signed
+manifest; do not edit its artifact hashes by hand. The packaged manifest is the
+SDK's immutable executable-version mapping and runtime trust root for downloaded
+bytes. Tests and the release workflow must build the wheel in a clean cache,
+perform its managed first-use download, and require the package version,
+`syq.PINNED_SYQ_VERSION`, and `syq.version()` to agree.
 
 Python tags use the version in `python/pyproject.toml`:
 
 ```sh
-git tag -s sdk-python-v0.0.1 -m 'Python SDK 0.0.1'
-git push origin sdk-python-v0.0.1
+version=$(sed -n 's/^version = "\(.*\)"/\1/p' python/pyproject.toml)
+git tag -s "sdk-python-v$version" -m "Python SDK $version"
+git push origin "sdk-python-v$version"
 ```
 
-The first Python tag uses the pending trusted publisher configured above; do
-not upload `0.0.1` locally. The protected workflow creates the PyPI project and
-publishes the already-tested distributions with OIDC. PyPI does not reserve the
-name until that workflow successfully publishes, so create the pending
-publisher immediately before the tag.
+Do not upload the package locally. The protected workflow publishes the
+already-tested distributions through PyPI trusted publishing with OIDC.
 
 JavaScript `0.0.1` is the package that requires the manual bootstrap publish.
 After those exact bytes are verified and its trusted publisher is configured,
@@ -123,16 +122,16 @@ the Python adapter's candidate compatibility tests against it. These exercise
 the reported version, a real disposable local copy, argument boundaries, and
 failure retention. The syq release tag verifier requires `sdks` alongside the
 Rust and platform checks, so a failing adapter blocks publication of the syq
-release itself. The same job requires the packaged Python manifest to match the
-latest immutable syq release. Until the generated mapping pull request lands,
-subsequent development therefore cannot acquire a green release-eligible
-`sdks` check or consume the same next Python patch version.
+release itself. The same job requires the Python package version and packaged
+manifest to match the latest immutable syq release. Until the generated release
+pull request lands, subsequent development therefore cannot acquire a green
+release-eligible `sdks` check or consume the matching Python version.
 
 After `.github/workflows/release.yml` completes successfully and the GitHub
 release is immutable, `.github/workflows/prepare-python-sdk.yml` downloads its
-exact signed manifest and prepares the next Python patch version. It opens an
+exact signed manifest and prepares the same Python package version. It opens an
 `automation/python-sdk-vX.Y.Z` pull request containing the version, manifest,
-cache-path documentation, lockfile, and mapping-table updates. GitHub places
+cache-path documentation, and lockfile updates. GitHub places
 pull-request workflow runs caused by its own token into an approval-required
 state. The preparation workflow waits until GitHub has registered both native
 runs for the exact generated commit, verifies that the pull request and native

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -622,9 +622,10 @@ file.
 
 ## Compatibility and versioning
 
-Every published Python package pins one exact syq release. That is the tested
-default pairing. Several Python releases may pin the same syq release, but one
-published Python version never changes its pin.
+Every published Python package has the same version as the exact syq release it
+pins. That is the tested default pairing, and a published Python version never
+changes its pin. Python-only changes ship with the next syq release rather than
+creating an independently numbered package.
 
 The automation schema has its own version. The Python package supports stated
 schema major versions rather than guessing compatibility from the executable's
@@ -634,8 +635,10 @@ schema's compatibility policy.
 Mapping entries are supported at the exact SDK/binary pairing. A separately
 versioned mapping schema can broaden that compatibility boundary later.
 
-Python API changes follow Python package semantic versioning. Adding support
-for a new syq release does not by itself justify a breaking Python API change.
+The Python package does not maintain a compatibility version separate from the
+syq product release. Python API and native changes still follow their documented
+compatibility contracts; sharing a release number does not make the executable
+version a substitute for the automation schema version.
 
 The naming rule is part of compatibility. A new native command `foo-bar`
 reserves `foo_bar`; a new semantic `--some-option` reserves `some_option`.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -10,11 +10,12 @@ python -m pip install syq
 ```
 
 Installing the package does not install syq itself. The first default call that
-needs syq downloads the syq release this package was tested with if it is not
+needs syq downloads the matching syq release if it is not
 already cached, checks it against the signed release manifest, and uses that
 managed binary for subsequent default calls.
-For Python package `0.0.3`, that release is syq `0.1.8`. syq always runs as a
-subprocess with an argument list, never through a shell.
+The Python package and its managed syq executable share one version: package `0.1.8`
+manages syq `0.1.8`.
+syq always runs as a subprocess with an argument list, never through a shell.
 
 ```python
 import syq

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "syq"
-version = "0.0.3"
+version = "0.1.8"
 description = "Official client for the syq file transfer tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/tests/test_bootstrap.py
+++ b/sdk/python/tests/test_bootstrap.py
@@ -77,9 +77,10 @@ class BootstrapTests(unittest.TestCase):
             mock.patch.object(bootstrap, "_host_target", return_value="linux-x86_64"),
         )
 
-    def test_package_pin_matches_embedded_manifest(self) -> None:
+    def test_package_version_and_pin_match_embedded_manifest(self) -> None:
         manifest_path = Path(bootstrap.__file__).with_name("syq-release-manifest.json")
         manifest = json.loads(manifest_path.read_bytes())
+        self.assertEqual(syq.__version__, manifest["version"])
         self.assertEqual(syq.PINNED_SYQ_VERSION, manifest["version"])
 
     def test_downloads_validates_and_reuses_the_exact_binary(self) -> None:

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "syq"
-version = "0.0.3"
+version = "0.1.8"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
The official Python package should identify the syq product release it manages instead of maintaining an unrelated patch counter.

- set the current Python package version to 0.1.8, matching its embedded syq release
- make the post-release preparation workflow copy the incoming syq version verbatim
- enforce package/manifest version equality in CI, Python tests, and PyPI publication
- simplify the SDK compatibility and release documentation around the shared version

The release-helper fixture uses a non-patch jump to prove that it copies the incoming version rather than incrementing the Python patch component independently.