### PR TITLE
Fix live restricted SSH workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ cargo install --locked --path . # or: put it on your PATH
 
 Managed remote bootstrap is available only from official release builds.
 For Cargo and checkout builds, install a compatible `syq` on the remote and
-select it explicitly. Native `syq cp` uses `--syq-path PATH`, or
-`--no-bootstrap` when the binary is on the remote `PATH`; `syq rsync` uses the
-rsync-compatible `--rsync-path PATH`, or `--syq-no-bootstrap` for the same
-`PATH` lookup.
+select it explicitly. Native `syq cp` and remote `syq rm` use `--syq-path
+PATH`, or `--no-bootstrap` when the binary is on the remote `PATH`; `syq
+rsync` uses the rsync-compatible `--rsync-path PATH`, or
+`--syq-no-bootstrap` for the same `PATH` lookup.
 
 Standalone installs download and verify one signed release manifest at most
 once a day after a successful interactive command. When a newer release is
@@ -82,8 +82,8 @@ usually produce Gatekeeper prompts. A binary downloaded through a browser may;
 browser-oriented distribution would need Apple Developer ID signing and
 notarization in addition to this terminal-first path.
 
-The remote side runs `syq --server`, but it does not need to be installed or
-configured first. An official syq uses its exact release helper under
+An ordinary remote side runs `syq --server`, but it does not need to be
+installed or configured first. An official syq uses its exact release helper under
 `~/.cache/syq/helpers/`. On first use of a version it detects the remote
 platform and checks for a downloader, SHA-256 implementation, and `gzip`. When
 that complete toolchain is available, the remote downloads the matching
@@ -108,10 +108,10 @@ discarded and produces an integrity warning even if the verified upload then
 succeeds.
 
 The managed cache accepts only a verified release binary. To opt out of
-managed bootstrap, install a compatible binary yourself. Native `syq cp` uses
-`--syq-path /path/to/syq`, or `--no-bootstrap` when the binary is on the
-non-interactive remote `PATH`; `syq rsync` uses `--rsync-path /path/to/syq` or
-`--syq-no-bootstrap`.
+managed bootstrap, install a compatible binary yourself. Native `syq cp` and
+remote `syq rm` use `--syq-path /path/to/syq`, or `--no-bootstrap` when the
+binary is on the non-interactive remote `PATH`; `syq rsync` uses `--rsync-path
+/path/to/syq` or `--syq-no-bootstrap`.
 
 The local client verifies the manifest's embedded Ed25519 signature over its
 RFC 8785 canonical JSON. Direct remote download uses `curl` or `wget`, `gzip`,
@@ -156,6 +156,7 @@ syq cp --inplace disk.img --to server --as-existing /images/disk.img
 syq cp --prune --src-src build --to server --into-existing /srv/app
 syq rm cache old-output
 syq rm --from server --cwd /srv --src old-output
+syq rm --from server --syq-path /opt/syq-dev --src old-output
 syq rm --root /srv --src-dir cache
 syq rm --cwd /srv --follow-src --src-dir current-release
 ```
@@ -383,6 +384,9 @@ explicit `--rsh` is the complete SSH and agent policy and bypasses automatic
 broker/receiver setup. A port in native endpoint syntax can be combined with
 the default SSH command or an explicit command whose executable is `ssh`; an
 arbitrary remote-shell wrapper must carry its own port option.
+Remote `rm` accepts the same `--syq-path PATH` and `--no-bootstrap` helper
+selection; those options are mutually exclusive and are rejected for a local
+removal.
 
 For two remote endpoints, `--coordinate-at auto` (the default) places the coordinator
 at the source. Path operands travel base64-encoded inside the delegated
@@ -597,6 +601,10 @@ data does not traverse the invoking machine; path operands travel encoded in
 the delegated command, so any filename works. Matching helpers are installed
 automatically on both hosts and output is streamed back. When both endpoints
 name the same host and user, syq runs a local copy on that host.
+For a source build, `--syq-path` or `--no-bootstrap` selects the ordinary hostA
+coordinator, including on the command-restricted path. It is not forwarded as
+authority to choose hostB's receiver: that executable is the separately
+enrolled forced command and is refreshed by enrollment.
 
 With implicit OpenSSH, the default combines a pre-enrolled forced receiver on
 hostB with a temporary local agent broker. The first transfer to a destination
@@ -610,10 +618,18 @@ under `~/.local/share/syq/restricted/`; the receipt key's public half is
 returned to the local machine and recorded with the enrollment. Before
 publishing the forced key, syq verifies that the installed receiver is a
 regular executable and that it and every path ancestor are trusted-owner- or
-root-owned, non-writable by other users, and free of non-owner ACL grants.
+root-owned, non-writable by other users, and free of extended ACLs. On Linux,
+group-write from the conventional umask 002 is accepted only when account and
+group database lookups prove that the group is user-private (same name and no
+other member or non-root primary-group user). Otherwise group-write still
+fails closed. Private enrollment directories and secret files remain exactly
+0700 and 0600. A failure names the machine and reports every unsafe component
+of the path that syq could securely inspect.
 
-Enrollment first tries local→hostB directly. If that network path is
-unavailable, it retries through hostA with OpenSSH `ProxyJump`; hostA gets only
+Enrollment first tries local→hostB directly. If SSH reports a transport
+failure, it retries through hostA with OpenSSH `ProxyJump`; a remote validation
+or installation error is reported against hostB without repeating it through
+the proxy. HostA gets only
 `ssh -W` byte forwarding and cannot see the encrypted hostB session, an agent
 socket, or the enrollment key. The destination parent must already exist.
 Enrollment is durable, is reused for later destination leaves sharing that
@@ -793,8 +809,11 @@ also refreshes the installed
 receiver to the exact local syq binary; the receipt key is kept for the life
 of the enrollment, so a refresh, or a retry after a lost reply, never leaves
 the two sides holding different keys. To rotate it, revoke and enroll again.
-Revocation leaves that shared binary because other enrollments may use it. It
-prevents new receiver sessions. A
+Revocation keeps the shared receiver while another enrollment or managed
+forced-key entry may use it. The final revoke removes the shared receiver and
+empty syq-owned state directories on hostB. Install and revoke serialize that
+lifecycle, so a concurrent enrollment recreates the receiver before publishing
+its forced key. Revocation prevents new receiver sessions. A
 session that already claimed its signed request can finish an operation already
 in progress; later protocol requests are rejected once the signed execution
 deadline expires rather than forcibly interrupting a filesystem syscall.

--- a/README.md
+++ b/README.md
@@ -618,13 +618,17 @@ under `~/.local/share/syq/restricted/`; the receipt key's public half is
 returned to the local machine and recorded with the enrollment. Before
 publishing the forced key, syq verifies that the installed receiver is a
 regular executable and that it and every path ancestor are trusted-owner- or
-root-owned, non-writable by other users, and free of extended ACLs. On Linux,
-group-write from the conventional umask 002 is accepted only when account and
-group database lookups prove that the group is user-private (same name and no
-other member or non-root primary-group user). Otherwise group-write still
-fails closed. Private enrollment directories and secret files remain exactly
-0700 and 0600. A failure names the machine and reports every unsafe component
-of the path that syq could securely inspect.
+root-owned and non-writable by other users. On Linux, access ACLs are evaluated
+by their effective permissions: named entries are accepted when they are
+read-only or identify root, the target user, or its verified user-private
+group. A default ACL does not make its existing directory writable, and every
+new directory or file syq creates is validated before use. Group-write from the
+conventional umask 002 is accepted only when account and group database lookups
+prove that the group is user-private (same name and no other member or non-root
+primary-group user). Otherwise group-write still fails closed. Private
+enrollment directories and secret files remain exactly 0700 and 0600. A
+failure names the machine and reports every unsafe component of the path that
+syq could securely inspect.
 
 Enrollment first tries local→hostB directly. If SSH reports a transport
 failure, it retries through hostA with OpenSSH `ProxyJump`; a remote validation
@@ -811,9 +815,13 @@ of the enrollment, so a refresh, or a retry after a lost reply, never leaves
 the two sides holding different keys. To rotate it, revoke and enroll again.
 Revocation keeps the shared receiver while another enrollment or managed
 forced-key entry may use it. The final revoke removes the shared receiver and
-empty syq-owned state directories on hostB. Install and revoke serialize that
-lifecycle, so a concurrent enrollment recreates the receiver before publishing
-its forced key. Revocation prevents new receiver sessions. A
+empty `syq/restricted` state namespace on hostB. General account directories
+such as `.local`, `share`, and `libexec` are preserved even when empty because
+syq does not assume it created them. Each installer or revoker uploads and runs
+its temporary management helper within one SSH session whose cleanup trap owns
+the stage. Install and revoke serialize the shared receiver lifecycle, so a
+concurrent enrollment recreates the receiver before publishing its forced key.
+Revocation prevents new receiver sessions. A
 session that already claimed its signed request can finish an operation already
 in progress; later protocol requests are rejected once the signed execution
 deadline expires rather than forcibly interrupting a filesystem syscall.

--- a/sdk/python/native-api.json
+++ b/sdk/python/native-api.json
@@ -101,7 +101,9 @@
         "connections",
         "progress",
         "no-progress",
-        "progress-json"
+        "progress-json",
+        "syq-path",
+        "no-bootstrap"
       ],
       "follow_up": [
         "pscope"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -776,6 +776,16 @@ enum ReceiptMode {
 }
 
 #[derive(clap::Args, Debug, Default)]
+struct NativeRemoteHelperArgs {
+    /// Use this exact syq executable for ordinary remote helpers, including an r2r coordinator
+    #[arg(long, value_name = "PATH", conflicts_with = "no_bootstrap")]
+    syq_path: Option<String>,
+    /// Require ordinary remote helpers on PATH instead of installing a versioned helper
+    #[arg(long)]
+    no_bootstrap: bool,
+}
+
+#[derive(clap::Args, Debug, Default)]
 struct NativeRemoteArgs {
     /// Choose the endpoint that runs the coordinator
     #[arg(long, value_enum, default_value_t = CoordinateAt::Auto)]
@@ -783,12 +793,8 @@ struct NativeRemoteArgs {
     /// Remote shell command (default: ssh); the command owns SSH and agent policy when set
     #[arg(long = "rsh", value_name = "COMMAND")]
     rsh: Option<String>,
-    /// Use this exact syq executable on remote endpoints instead of the managed helper
-    #[arg(long, value_name = "PATH")]
-    syq_path: Option<String>,
-    /// Require syq on each remote PATH instead of installing a versioned helper
-    #[arg(long)]
-    no_bootstrap: bool,
+    #[command(flatten)]
+    helper: NativeRemoteHelperArgs,
     /// Use TCP data connections without encryption (trusted networks only)
     #[arg(long)]
     tcp_plain: bool,
@@ -982,6 +988,8 @@ struct NativeRmCommand {
     selection: NativeRmSelectionArgs,
     #[command(flatten)]
     operational: NativeOperationalArgs,
+    #[command(flatten)]
+    helper: NativeRemoteHelperArgs,
     /// Use an isolated SSH persistence scope created by `syq persist on --ephemeral`
     #[arg(long, value_name = "PATH")]
     pscope: Option<PathBuf>,
@@ -1377,6 +1385,9 @@ fn parse_native_rm(argv: &[OsString]) -> Result<Args> {
         bail!("syq rm needs at least one source selector");
     }
     let endpoint = parse_native_endpoint(parsed.selection.from.as_deref())?;
+    if endpoint.is_none() && (parsed.helper.syq_path.is_some() || parsed.helper.no_bootstrap) {
+        bail!("--syq-path and --no-bootstrap apply only to a remote removal endpoint");
+    }
     let locations = ordered
         .into_iter()
         .map(|(_, selection, path)| {
@@ -1393,6 +1404,8 @@ fn parse_native_rm(argv: &[OsString]) -> Result<Args> {
     args.native_follow = parsed.selection.follow;
     args.native_follow_src = parsed.selection.follow_src;
     args.pscope = parsed.pscope;
+    args.syq_path = parsed.helper.syq_path;
+    args.no_bootstrap = parsed.helper.no_bootstrap;
     args.rm = true;
     apply_native_operational(&mut args, parsed.operational);
     Ok(args)
@@ -1613,8 +1626,8 @@ fn apply_native_copy_operational(
 fn apply_native_remote(args: &mut Args, remote: NativeRemoteArgs) -> Result<()> {
     args.coordinate_at = remote.coordinate_at;
     args.rsh = remote.rsh;
-    args.syq_path = remote.syq_path;
-    args.no_bootstrap = remote.no_bootstrap;
+    args.syq_path = remote.helper.syq_path;
+    args.no_bootstrap = remote.helper.no_bootstrap;
     args.tcp_plain = remote.tcp_plain;
     args.no_tcp = remote.no_tcp;
     crate::transfer::parse_ports(&remote.tcp_ports)?;
@@ -2061,7 +2074,7 @@ pub fn parse_size(s: &str) -> Result<u64> {
 mod tests {
     use super::{
         native_engine_defaults, parse_duration_secs, parse_native_copy, parse_native_endpoint,
-        parse_size, read_files_from_reader, Args, Placement, SourceSelection,
+        parse_native_rm, parse_size, read_files_from_reader, Args, Placement, SourceSelection,
     };
     use anyhow::{bail, Result};
     use clap::Parser;
@@ -2304,7 +2317,6 @@ mod tests {
             "--coordinate-at=dest",
             "--rsh=ssh -J jump",
             "--syq-path=/opt/syq",
-            "--no-bootstrap",
             "--no-tcp",
             "--tcp-ports=49000-49010",
             "--detach",
@@ -2317,10 +2329,32 @@ mod tests {
         assert_eq!(args.coordinate_at, super::CoordinateAt::Dest);
         assert_eq!(args.rsh.as_deref(), Some("ssh -J jump"));
         assert_eq!(args.syq_path.as_deref(), Some("/opt/syq"));
-        assert!(args.no_bootstrap);
+        assert!(!args.no_bootstrap);
         assert!(args.no_tcp);
         assert_eq!(args.tcp_ports, "49000-49010");
         assert!(args.detach);
+    }
+
+    #[test]
+    fn native_rm_lowers_remote_helper_selection() {
+        let argv = ["--from=backup", "--syq-path=/opt/syq", "old"].map(std::ffi::OsString::from);
+        let args = parse_native_rm(&argv).unwrap();
+        assert_eq!(args.syq_path.as_deref(), Some("/opt/syq"));
+        assert!(!args.no_bootstrap);
+
+        let argv = ["--from=backup", "--no-bootstrap", "old"].map(std::ffi::OsString::from);
+        let args = parse_native_rm(&argv).unwrap();
+        assert!(args.syq_path.is_none());
+        assert!(args.no_bootstrap);
+    }
+
+    #[test]
+    fn native_rm_rejects_remote_helper_selection_for_local_removal() {
+        let argv = ["--syq-path=/opt/syq", "old"].map(std::ffi::OsString::from);
+        let error = parse_native_rm(&argv).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("apply only to a remote removal endpoint"));
     }
 
     #[test]

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -28,16 +28,18 @@
 //! missing or replaced namespace is a security failure that requires explicit
 //! repair or re-enrollment; [`ReplayStore::open`] never creates it.
 //! Every path component including `/` must be root/effective-user owned and
-//! not group/world writable. On macOS this core additionally rejects any
-//! extended ACL on trusted directories, verifier inputs, the verifier binary,
-//! and replay files; enrollment must therefore provision an ACL-free chain.
+//! not writable by another principal. Linux user-private-group write bits are
+//! accepted only after the account database proves that the owner is the
+//! group's sole non-root member. Linux and macOS both reject extended ACLs on
+//! trusted directories, verifier inputs, the verifier binary, and replay
+//! files; enrollment must therefore provision an ACL-free chain.
 
 use anyhow::{anyhow, bail, Context, Result};
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use ssh_key::{HashAlg, LineEnding, PrivateKey};
-use std::ffi::{CString, OsStr};
+use std::ffi::{CStr, CString, OsStr};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
@@ -46,7 +48,7 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -1397,13 +1399,20 @@ fn validate_private_directory(directory: &File, path: &Path) -> Result<()> {
         .metadata()
         .with_context(|| format!("inspect replay state directory {}", path.display()))?;
     if !metadata.is_dir() || metadata.uid() != unsafe { libc::geteuid() } {
-        bail!("replay state directory must be target-owned and not a symlink");
+        bail!(
+            "private directory {} must be target-owned and not a symlink",
+            path.display()
+        );
     }
-    let mode = metadata.permissions().mode() & 0o777;
-    if mode & 0o077 != 0 || mode & 0o700 != 0o700 {
-        bail!("replay state directory must have private mode 0700");
+    let mode = metadata.permissions().mode() & 0o7777;
+    if mode != 0o700 {
+        bail!(
+            "private directory {} must have mode 0700 (found {:04o})",
+            path.display(),
+            mode
+        );
     }
-    reject_extended_acl(directory, "replay state directory")?;
+    reject_extended_acl(directory, &format!("private directory {}", path.display()))?;
     Ok(())
 }
 
@@ -1413,26 +1422,28 @@ pub(crate) fn validate_private_directory_path(path: &Path) -> Result<()> {
 }
 
 pub(crate) fn validate_trusted_directory_path(path: &Path) -> Result<()> {
-    let directory = open_trusted_directory_path(path, "trusted directory")?;
-    validate_trusted_directory(&directory, "trusted directory")
+    open_trusted_directory_path(path, "trusted directory").map(|_| ())
 }
 
 fn open_trusted_directory_path(path: &Path, label: &str) -> Result<File> {
     validate_canonical_trusted_path(path, label)?;
+    let mut violations = Vec::new();
     let mut directory = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
         .open("/")
         .with_context(|| format!("open filesystem root for {label}"))?;
-    validate_trusted_directory(&directory, label)?;
-    let mut components = path.components().peekable();
+    collect_trusted_directory_violation(&directory, label, Path::new("/"), &mut violations)?;
+    let mut components = path.components();
     if !matches!(components.next(), Some(std::path::Component::RootDir)) {
         bail!("{label} path must start at the filesystem root");
     }
-    while let Some(component) = components.next() {
+    let mut current = PathBuf::from("/");
+    for component in components {
         let std::path::Component::Normal(name) = component else {
             bail!("{label} path contains a noncanonical component");
         };
+        current.push(name);
         directory = openat_os_file(
             directory.as_raw_fd(),
             name,
@@ -1440,60 +1451,185 @@ fn open_trusted_directory_path(path: &Path, label: &str) -> Result<File> {
             0,
         )
         .with_context(|| format!("securely open {label} {}", path.display()))?;
-        if components.peek().is_some() {
-            validate_trusted_directory(&directory, label)?;
-        }
+        collect_trusted_directory_violation(&directory, label, &current, &mut violations)?;
+    }
+    if !violations.is_empty() {
+        bail!(
+            "unsafe {label} path components in {}:\n  - {}",
+            path.display(),
+            violations.join("\n  - ")
+        );
     }
     Ok(directory)
 }
 
 fn open_existing_replay_directory(path: &Path) -> Result<File> {
-    validate_canonical_trusted_path(path, "replay state directory")?;
-    let mut directory = OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        .open("/")
-        .context("open filesystem root for replay-state validation")?;
-    validate_trusted_directory(&directory, "replay-state ancestor")?;
-
-    let mut components = path.components().peekable();
-    if !matches!(components.next(), Some(std::path::Component::RootDir)) {
-        bail!("replay state path must start at the filesystem root");
-    }
-    while let Some(component) = components.next() {
-        let std::path::Component::Normal(name) = component else {
-            bail!("replay state path contains a noncanonical component");
-        };
-        let next = openat_os_file(
-            directory.as_raw_fd(),
-            name,
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-            0,
-        )
-        .with_context(|| format!("securely open replay state path {}", path.display()))?;
-        if components.peek().is_some() {
-            validate_trusted_directory(&next, "replay-state ancestor")?;
-            directory = next;
-        } else {
-            validate_private_directory(&next, path)?;
-            return Ok(next);
-        }
-    }
-    bail!("replay state path has no private leaf directory")
+    let directory = open_trusted_directory_path(path, "replay state directory")?;
+    validate_private_directory(&directory, path)?;
+    Ok(directory)
 }
 
-fn validate_trusted_directory(directory: &File, label: &str) -> Result<()> {
+fn trusted_owner_mode(
+    owner: libc::uid_t,
+    group: libc::gid_t,
+    mode: u32,
+    effective_uid: libc::uid_t,
+    private_group: Option<libc::gid_t>,
+) -> bool {
+    (owner == 0 || owner == effective_uid)
+        && mode & 0o002 == 0
+        && (mode & 0o020 == 0 || private_group == Some(group))
+}
+
+/// A Linux user-private group does not add a second writer even when the
+/// conventional umask 002 leaves group-write set. Prove the convention from
+/// NSS instead of assuming that equal numeric uid/gid values imply privacy.
+#[cfg(target_os = "linux")]
+fn lookup_account_uid(name: &CStr) -> Result<Option<libc::uid_t>> {
+    const MAX_ACCOUNT_BUFFER: usize = 1024 * 1024;
+    let mut passwd: libc::passwd = unsafe { std::mem::zeroed() };
+    let mut result = std::ptr::null_mut();
+    let mut buffer = vec![0u8; MAX_ACCOUNT_BUFFER];
+    let status = unsafe {
+        libc::getpwnam_r(
+            name.as_ptr(),
+            &mut passwd,
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            &mut result,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status)).context("look up private-group member");
+    }
+    Ok((!result.is_null()).then_some(passwd.pw_uid))
+}
+
+#[cfg(target_os = "linux")]
+fn discover_private_group() -> Result<Option<libc::gid_t>> {
+    const MAX_ACCOUNT_BUFFER: usize = 1024 * 1024;
+    let uid = unsafe { libc::geteuid() };
+    let mut passwd: libc::passwd = unsafe { std::mem::zeroed() };
+    let mut passwd_result = std::ptr::null_mut();
+    let mut passwd_buffer = vec![0u8; MAX_ACCOUNT_BUFFER];
+    let status = unsafe {
+        libc::getpwuid_r(
+            uid,
+            &mut passwd,
+            passwd_buffer.as_mut_ptr().cast(),
+            passwd_buffer.len(),
+            &mut passwd_result,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status)).context("look up private-group owner");
+    }
+    if passwd_result.is_null() || passwd.pw_name.is_null() {
+        return Ok(None);
+    }
+    let username = unsafe { CStr::from_ptr(passwd.pw_name) }
+        .to_bytes()
+        .to_vec();
+    let gid = passwd.pw_gid;
+
+    let mut group: libc::group = unsafe { std::mem::zeroed() };
+    let mut group_result = std::ptr::null_mut();
+    let mut group_buffer = vec![0u8; MAX_ACCOUNT_BUFFER];
+    let status = unsafe {
+        libc::getgrgid_r(
+            gid,
+            &mut group,
+            group_buffer.as_mut_ptr().cast(),
+            group_buffer.len(),
+            &mut group_result,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status)).context("look up private group");
+    }
+    if group_result.is_null()
+        || group.gr_name.is_null()
+        || unsafe { CStr::from_ptr(group.gr_name) }.to_bytes() != username
+    {
+        return Ok(None);
+    }
+    let mut member = group.gr_mem;
+    while !member.is_null() && unsafe { !(*member).is_null() } {
+        let member_name = unsafe { CStr::from_ptr(*member) };
+        if member_name.to_bytes() != username && lookup_account_uid(member_name)? != Some(0) {
+            return Ok(None);
+        }
+        member = unsafe { member.add(1) };
+    }
+
+    // Supplementary members appear in gr_mem, but users whose primary group
+    // is this gid do not. Enumerate passwd entries so a reused primary gid is
+    // not mistaken for a user-private group.
+    unsafe { libc::setpwent() };
+    let enumeration = (|| -> Result<bool> {
+        loop {
+            unsafe { *libc::__errno_location() = 0 };
+            let entry = unsafe { libc::getpwent() };
+            if entry.is_null() {
+                let error = unsafe { *libc::__errno_location() };
+                return if error == 0 {
+                    Ok(true)
+                } else {
+                    Err(io::Error::from_raw_os_error(error))
+                        .context("enumerate private-group accounts")
+                };
+            }
+            let entry = unsafe { &*entry };
+            if entry.pw_gid == gid && entry.pw_uid != uid && entry.pw_uid != 0 {
+                return Ok(false);
+            }
+        }
+    })();
+    unsafe { libc::endpwent() };
+    Ok(enumeration?.then_some(gid))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn discover_private_group() -> Result<Option<libc::gid_t>> {
+    Ok(None)
+}
+
+fn private_group() -> Option<libc::gid_t> {
+    static PRIVATE_GROUP: OnceLock<Option<libc::gid_t>> = OnceLock::new();
+    *PRIVATE_GROUP.get_or_init(|| discover_private_group().unwrap_or(None))
+}
+
+pub(crate) fn metadata_has_trusted_writers(metadata: &std::fs::Metadata) -> bool {
+    trusted_owner_mode(
+        metadata.uid(),
+        metadata.gid(),
+        metadata.permissions().mode(),
+        unsafe { libc::geteuid() },
+        private_group(),
+    )
+}
+
+fn collect_trusted_directory_violation(
+    directory: &File,
+    label: &str,
+    path: &Path,
+    violations: &mut Vec<String>,
+) -> Result<()> {
     let metadata = directory
         .metadata()
         .with_context(|| format!("inspect {label}"))?;
-    let effective_uid = unsafe { libc::geteuid() };
-    if !metadata.is_dir()
-        || (metadata.uid() != 0 && metadata.uid() != effective_uid)
-        || metadata.permissions().mode() & 0o022 != 0
-    {
-        bail!("{label} must be root/target-owned and not group/world writable");
+    if !metadata.is_dir() || !metadata_has_trusted_writers(&metadata) {
+        violations.push(format!(
+            "{}: must be a root/target-owned directory not writable by another principal (mode {:04o}, uid {}, gid {})",
+            path.display(),
+            metadata.permissions().mode() & 0o7777,
+            metadata.uid(),
+            metadata.gid()
+        ));
     }
-    reject_extended_acl(directory, label)?;
+    if let Err(error) = reject_extended_acl(directory, &format!("{label} {}", path.display())) {
+        violations.push(format!("{}: {error:#}", path.display()));
+    }
     Ok(())
 }
 
@@ -1503,7 +1639,7 @@ fn validate_private_file(file: &File, label: &str) -> Result<()> {
         .with_context(|| format!("inspect {label}"))?;
     if !metadata.is_file()
         || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.permissions().mode() & 0o777 != 0o600
+        || metadata.permissions().mode() & 0o7777 != 0o600
     {
         bail!("{label} must be a target-owned private regular file");
     }
@@ -1513,20 +1649,28 @@ fn validate_private_file(file: &File, label: &str) -> Result<()> {
 
 pub(crate) fn validate_secure_executable(path: &Path, label: &str) -> Result<()> {
     validate_canonical_trusted_path(path, label)?;
+    let mut violations = Vec::new();
     let mut directory = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
         .open("/")
         .with_context(|| format!("open filesystem root for {label} validation"))?;
-    validate_trusted_directory(&directory, &format!("{label} ancestor"))?;
+    collect_trusted_directory_violation(
+        &directory,
+        &format!("{label} ancestor"),
+        Path::new("/"),
+        &mut violations,
+    )?;
     let mut components = path.components().peekable();
     if !matches!(components.next(), Some(std::path::Component::RootDir)) {
         bail!("{label} path must start at the filesystem root");
     }
+    let mut current = PathBuf::from("/");
     while let Some(component) = components.next() {
         let std::path::Component::Normal(name) = component else {
             bail!("{label} path contains a noncanonical component");
         };
+        current.push(name);
         if components.peek().is_some() {
             let next = openat_os_file(
                 directory.as_raw_fd(),
@@ -1535,7 +1679,12 @@ pub(crate) fn validate_secure_executable(path: &Path, label: &str) -> Result<()>
                 0,
             )
             .with_context(|| format!("securely open {label} ancestor in {}", path.display()))?;
-            validate_trusted_directory(&next, &format!("{label} ancestor"))?;
+            collect_trusted_directory_violation(
+                &next,
+                &format!("{label} ancestor"),
+                &current,
+                &mut violations,
+            )?;
             directory = next;
             continue;
         }
@@ -1548,15 +1697,28 @@ pub(crate) fn validate_secure_executable(path: &Path, label: &str) -> Result<()>
         )
         .with_context(|| format!("open trusted {label} {}", path.display()))?;
         let metadata = file.metadata()?;
-        let effective_uid = unsafe { libc::geteuid() };
         if !metadata.is_file()
-            || (metadata.uid() != 0 && metadata.uid() != effective_uid)
-            || metadata.permissions().mode() & 0o022 != 0
+            || !metadata_has_trusted_writers(&metadata)
             || metadata.permissions().mode() & 0o111 == 0
         {
-            bail!("{label} must be a trusted non-writable executable");
+            violations.push(format!(
+                "{}: {label} must be a trusted executable not writable by another principal (mode {:04o}, uid {}, gid {})",
+                current.display(),
+                metadata.permissions().mode() & 0o7777,
+                metadata.uid(),
+                metadata.gid()
+            ));
         }
-        reject_extended_acl(&file, label)?;
+        if let Err(error) = reject_extended_acl(&file, &format!("{label} {}", current.display())) {
+            violations.push(format!("{}: {error:#}", current.display()));
+        }
+        if !violations.is_empty() {
+            bail!(
+                "unsafe {label} path components in {}:\n  - {}",
+                path.display(),
+                violations.join("\n  - ")
+            );
+        }
         // The validated ancestor chain cannot be replaced by an untrusted OS
         // user, so Command's subsequent path resolution cannot be redirected.
         // The receiver's own effective uid is part of the trusted boundary.
@@ -1567,17 +1729,24 @@ pub(crate) fn validate_secure_executable(path: &Path, label: &str) -> Result<()>
 
 pub(crate) fn read_secure_regular(path: &Path, label: &str, maximum: usize) -> Result<Vec<u8>> {
     validate_canonical_trusted_path(path, label)?;
+    let mut violations = Vec::new();
     let mut directory = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
         .open("/")
         .with_context(|| format!("open filesystem root for {label} validation"))?;
-    validate_trusted_directory(&directory, &format!("{label} ancestor"))?;
+    collect_trusted_directory_violation(
+        &directory,
+        &format!("{label} ancestor"),
+        Path::new("/"),
+        &mut violations,
+    )?;
 
     let mut components = path.components().peekable();
     if !matches!(components.next(), Some(std::path::Component::RootDir)) {
         bail!("{label} path must start at the filesystem root");
     }
+    let mut current = PathBuf::from("/");
     let mut file = loop {
         let Some(component) = components.next() else {
             bail!("{label} path has no regular-file component");
@@ -1585,6 +1754,7 @@ pub(crate) fn read_secure_regular(path: &Path, label: &str, maximum: usize) -> R
         let std::path::Component::Normal(name) = component else {
             bail!("{label} path contains a noncanonical component");
         };
+        current.push(name);
         if components.peek().is_some() {
             let next = openat_os_file(
                 directory.as_raw_fd(),
@@ -1593,7 +1763,12 @@ pub(crate) fn read_secure_regular(path: &Path, label: &str, maximum: usize) -> R
                 0,
             )
             .with_context(|| format!("securely open {label} ancestor in {}", path.display()))?;
-            validate_trusted_directory(&next, &format!("{label} ancestor"))?;
+            collect_trusted_directory_violation(
+                &next,
+                &format!("{label} ancestor"),
+                &current,
+                &mut violations,
+            )?;
             directory = next;
             continue;
         }
@@ -1607,16 +1782,29 @@ pub(crate) fn read_secure_regular(path: &Path, label: &str, maximum: usize) -> R
         .with_context(|| format!("open trusted {label} {}", path.display()))?;
     };
     let metadata = file.metadata()?;
-    let effective_uid = unsafe { libc::geteuid() };
     if !metadata.file_type().is_file()
         || metadata.file_type().is_symlink()
         || metadata.file_type().is_socket()
-        || (metadata.uid() != 0 && metadata.uid() != effective_uid)
-        || metadata.permissions().mode() & 0o022 != 0
+        || !metadata_has_trusted_writers(&metadata)
     {
-        bail!("{label} must be a trusted non-writable regular file");
+        violations.push(format!(
+            "{}: {label} must be a trusted regular file not writable by another principal (mode {:04o}, uid {}, gid {})",
+            current.display(),
+            metadata.permissions().mode() & 0o7777,
+            metadata.uid(),
+            metadata.gid()
+        ));
     }
-    reject_extended_acl(&file, label)?;
+    if let Err(error) = reject_extended_acl(&file, &format!("{label} {}", current.display())) {
+        violations.push(format!("{}: {error:#}", current.display()));
+    }
+    if !violations.is_empty() {
+        bail!(
+            "unsafe {label} path components in {}:\n  - {}",
+            path.display(),
+            violations.join("\n  - ")
+        );
+    }
     let mut contents = Vec::new();
     Read::by_ref(&mut file)
         .take(maximum as u64 + 1)
@@ -1643,8 +1831,36 @@ fn validate_canonical_trusted_path(path: &Path, label: &str) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 fn reject_extended_acl(_file: &File, _label: &str) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn reject_extended_acl(file: &File, label: &str) -> Result<()> {
+    for (name, description) in [
+        (
+            b"system.posix_acl_access\0".as_slice(),
+            "an extended access ACL",
+        ),
+        (b"system.posix_acl_default\0".as_slice(), "a default ACL"),
+    ] {
+        let result = unsafe {
+            libc::fgetxattr(
+                file.as_raw_fd(),
+                name.as_ptr().cast(),
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if result >= 0 {
+            bail!("{label} must not have {description}");
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::ENODATA) {
+            return Err(error).with_context(|| format!("inspect {label} ACLs"));
+        }
+    }
     Ok(())
 }
 
@@ -2833,14 +3049,90 @@ mod tests {
             .claim(request, [0x44; 32], NOW)
             .expect("claim request before rollback");
 
-        fs::set_permissions(&directory.0, fs::Permissions::from_mode(0o770))
-            .expect("make replay ancestor group writable");
+        fs::set_permissions(&directory.0, fs::Permissions::from_mode(0o702))
+            .expect("make replay ancestor writable by another principal");
         fs::rename(&state, &retained).expect("roll back replay namespace");
         provision_test_replay_directory(&state);
         assert!(ReplayStore::open(&state).is_err());
         assert!(retained
             .join(format!("claim-{}", request.file_component()))
             .is_file());
+    }
+
+    #[test]
+    fn trusted_writer_policy_accepts_only_a_proven_private_group() {
+        let uid = 1000;
+        let private_gid = 2000;
+        assert!(trusted_owner_mode(
+            uid,
+            private_gid,
+            0o770,
+            uid,
+            Some(private_gid)
+        ));
+        assert!(!trusted_owner_mode(uid, private_gid, 0o770, uid, None));
+        assert!(!trusted_owner_mode(
+            uid,
+            private_gid + 1,
+            0o770,
+            uid,
+            Some(private_gid)
+        ));
+        assert!(!trusted_owner_mode(
+            uid,
+            private_gid,
+            0o707,
+            uid,
+            Some(private_gid)
+        ));
+        assert!(!trusted_owner_mode(
+            uid + 1,
+            private_gid,
+            0o700,
+            uid,
+            Some(private_gid)
+        ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_trusted_paths_reject_extended_posix_acls() {
+        fn entry(encoded: &mut Vec<u8>, tag: u16, permissions: u16, id: u32) {
+            encoded.extend_from_slice(&tag.to_le_bytes());
+            encoded.extend_from_slice(&permissions.to_le_bytes());
+            encoded.extend_from_slice(&id.to_le_bytes());
+        }
+
+        let directory = TestDir::new("posix-acl");
+        let guarded = directory.join("guarded");
+        fs::DirBuilder::new().mode(0o700).create(&guarded).unwrap();
+        let opened = File::open(&guarded).unwrap();
+        let mut acl = 2u32.to_le_bytes().to_vec();
+        entry(&mut acl, 0x01, 0o7, u32::MAX); // ACL_USER_OBJ
+        entry(
+            &mut acl,
+            0x02,
+            0o4,
+            unsafe { libc::geteuid() }.saturating_add(1),
+        ); // ACL_USER
+        entry(&mut acl, 0x04, 0, u32::MAX); // ACL_GROUP_OBJ
+        entry(&mut acl, 0x10, 0o4, u32::MAX); // ACL_MASK
+        entry(&mut acl, 0x20, 0, u32::MAX); // ACL_OTHER
+        let result = unsafe {
+            libc::fsetxattr(
+                opened.as_raw_fd(),
+                c"system.posix_acl_access".as_ptr().cast(),
+                acl.as_ptr().cast(),
+                acl.len(),
+                0,
+            )
+        };
+        assert_eq!(result, 0, "set test ACL: {}", io::Error::last_os_error());
+
+        let error = validate_trusted_directory_path(&guarded).unwrap_err();
+        let diagnostic = error.to_string();
+        assert!(diagnostic.contains("extended access ACL"), "{diagnostic}");
+        assert!(diagnostic.contains(&guarded.display().to_string()));
     }
 
     #[cfg(target_os = "macos")]
@@ -2893,10 +3185,34 @@ mod tests {
         write_private(&executable, b"test executable");
         fs::set_permissions(&executable, fs::Permissions::from_mode(0o500))
             .expect("make test verifier executable");
-        fs::set_permissions(&ancestor, fs::Permissions::from_mode(0o770))
-            .expect("make verifier ancestor group writable");
+        fs::set_permissions(&ancestor, fs::Permissions::from_mode(0o702))
+            .expect("make verifier ancestor writable by another principal");
 
         assert!(validate_secure_executable(&executable, "test verifier").is_err());
+    }
+
+    #[test]
+    fn verifier_reports_every_unsafe_ancestor_with_its_path() {
+        let directory = TestDir::new("verifier-ancestor-report");
+        let first = directory.join("first");
+        let second = first.join("second");
+        fs::create_dir_all(&second).unwrap();
+        let executable = second.join("ssh-keygen");
+        write_private(&executable, b"test executable");
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o500)).unwrap();
+        fs::set_permissions(&first, fs::Permissions::from_mode(0o702)).unwrap();
+        fs::set_permissions(&second, fs::Permissions::from_mode(0o702)).unwrap();
+
+        let error = validate_secure_executable(&executable, "test verifier").unwrap_err();
+        let diagnostic = error.to_string();
+        assert!(
+            diagnostic.contains(&first.display().to_string()),
+            "{diagnostic}"
+        );
+        assert!(
+            diagnostic.contains(&second.display().to_string()),
+            "{diagnostic}"
+        );
     }
 
     #[test]
@@ -2915,8 +3231,8 @@ mod tests {
                 b"retained policy\n",
             );
         }
-        fs::set_permissions(&ancestor, fs::Permissions::from_mode(0o770))
-            .expect("make policy ancestor group writable");
+        fs::set_permissions(&ancestor, fs::Permissions::from_mode(0o702))
+            .expect("make policy ancestor writable by another principal");
 
         for name in ["allowed-signers", "revocations"] {
             let active = ancestor.join(name);

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -30,9 +30,11 @@
 //! Every path component including `/` must be root/effective-user owned and
 //! not writable by another principal. Linux user-private-group write bits are
 //! accepted only after the account database proves that the owner is the
-//! group's sole non-root member. Linux and macOS both reject extended ACLs on
-//! trusted directories, verifier inputs, the verifier binary, and replay
-//! files; enrollment must therefore provision an ACL-free chain.
+//! group's sole non-root member. Linux accepts access ACLs only when their
+//! effective write grants are confined to those same trusted principals;
+//! default ACLs do not authorize changes to an existing ancestor, and every
+//! newly created component is revalidated before use. macOS conservatively
+//! rejects extended ACLs on trusted paths.
 
 use anyhow::{anyhow, bail, Context, Result};
 use base64::Engine as _;
@@ -1412,7 +1414,16 @@ fn validate_private_directory(directory: &File, path: &Path) -> Result<()> {
             mode
         );
     }
-    reject_extended_acl(directory, &format!("private directory {}", path.display()))?;
+    if !file_has_trusted_writers(
+        directory,
+        &metadata,
+        &format!("private directory {}", path.display()),
+    )? {
+        bail!(
+            "private directory {} must not grant write access to another principal",
+            path.display()
+        );
+    }
     Ok(())
 }
 
@@ -1599,16 +1610,6 @@ fn private_group() -> Option<libc::gid_t> {
     *PRIVATE_GROUP.get_or_init(|| discover_private_group().unwrap_or(None))
 }
 
-pub(crate) fn metadata_has_trusted_writers(metadata: &std::fs::Metadata) -> bool {
-    trusted_owner_mode(
-        metadata.uid(),
-        metadata.gid(),
-        metadata.permissions().mode(),
-        unsafe { libc::geteuid() },
-        private_group(),
-    )
-}
-
 fn collect_trusted_directory_violation(
     directory: &File,
     label: &str,
@@ -1618,7 +1619,19 @@ fn collect_trusted_directory_violation(
     let metadata = directory
         .metadata()
         .with_context(|| format!("inspect {label}"))?;
-    if !metadata.is_dir() || !metadata_has_trusted_writers(&metadata) {
+    let trusted_writers = if metadata.is_dir() {
+        match file_has_trusted_writers(directory, &metadata, &format!("{label} {}", path.display()))
+        {
+            Ok(trusted) => trusted,
+            Err(error) => {
+                violations.push(format!("{}: {error:#}", path.display()));
+                true
+            }
+        }
+    } else {
+        false
+    };
+    if !metadata.is_dir() || !trusted_writers {
         violations.push(format!(
             "{}: must be a root/target-owned directory not writable by another principal (mode {:04o}, uid {}, gid {})",
             path.display(),
@@ -1626,9 +1639,6 @@ fn collect_trusted_directory_violation(
             metadata.uid(),
             metadata.gid()
         ));
-    }
-    if let Err(error) = reject_extended_acl(directory, &format!("{label} {}", path.display())) {
-        violations.push(format!("{}: {error:#}", path.display()));
     }
     Ok(())
 }
@@ -1643,7 +1653,9 @@ fn validate_private_file(file: &File, label: &str) -> Result<()> {
     {
         bail!("{label} must be a target-owned private regular file");
     }
-    reject_extended_acl(file, label)?;
+    if !file_has_trusted_writers(file, &metadata, label)? {
+        bail!("{label} must not grant write access to another principal");
+    }
     Ok(())
 }
 
@@ -1697,10 +1709,18 @@ pub(crate) fn validate_secure_executable(path: &Path, label: &str) -> Result<()>
         )
         .with_context(|| format!("open trusted {label} {}", path.display()))?;
         let metadata = file.metadata()?;
-        if !metadata.is_file()
-            || !metadata_has_trusted_writers(&metadata)
-            || metadata.permissions().mode() & 0o111 == 0
-        {
+        let trusted_writers = match file_has_trusted_writers(
+            &file,
+            &metadata,
+            &format!("{label} {}", current.display()),
+        ) {
+            Ok(trusted) => trusted,
+            Err(error) => {
+                violations.push(format!("{}: {error:#}", current.display()));
+                true
+            }
+        };
+        if !metadata.is_file() || !trusted_writers || metadata.permissions().mode() & 0o111 == 0 {
             violations.push(format!(
                 "{}: {label} must be a trusted executable not writable by another principal (mode {:04o}, uid {}, gid {})",
                 current.display(),
@@ -1708,9 +1728,6 @@ pub(crate) fn validate_secure_executable(path: &Path, label: &str) -> Result<()>
                 metadata.uid(),
                 metadata.gid()
             ));
-        }
-        if let Err(error) = reject_extended_acl(&file, &format!("{label} {}", current.display())) {
-            violations.push(format!("{}: {error:#}", current.display()));
         }
         if !violations.is_empty() {
             bail!(
@@ -1782,10 +1799,19 @@ pub(crate) fn read_secure_regular(path: &Path, label: &str, maximum: usize) -> R
         .with_context(|| format!("open trusted {label} {}", path.display()))?;
     };
     let metadata = file.metadata()?;
+    let trusted_writers =
+        match file_has_trusted_writers(&file, &metadata, &format!("{label} {}", current.display()))
+        {
+            Ok(trusted) => trusted,
+            Err(error) => {
+                violations.push(format!("{}: {error:#}", current.display()));
+                true
+            }
+        };
     if !metadata.file_type().is_file()
         || metadata.file_type().is_symlink()
         || metadata.file_type().is_socket()
-        || !metadata_has_trusted_writers(&metadata)
+        || !trusted_writers
     {
         violations.push(format!(
             "{}: {label} must be a trusted regular file not writable by another principal (mode {:04o}, uid {}, gid {})",
@@ -1794,9 +1820,6 @@ pub(crate) fn read_secure_regular(path: &Path, label: &str, maximum: usize) -> R
             metadata.uid(),
             metadata.gid()
         ));
-    }
-    if let Err(error) = reject_extended_acl(&file, &format!("{label} {}", current.display())) {
-        violations.push(format!("{}: {error:#}", current.display()));
     }
     if !violations.is_empty() {
         bail!(
@@ -1832,40 +1855,192 @@ fn validate_canonical_trusted_path(path: &Path, label: &str) -> Result<()> {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn reject_extended_acl(_file: &File, _label: &str) -> Result<()> {
-    Ok(())
+fn file_has_trusted_writers(
+    _file: &File,
+    metadata: &std::fs::Metadata,
+    _label: &str,
+) -> Result<bool> {
+    Ok(trusted_owner_mode(
+        metadata.uid(),
+        metadata.gid(),
+        metadata.permissions().mode(),
+        unsafe { libc::geteuid() },
+        private_group(),
+    ))
 }
 
 #[cfg(target_os = "linux")]
-fn reject_extended_acl(file: &File, label: &str) -> Result<()> {
-    for (name, description) in [
-        (
-            b"system.posix_acl_access\0".as_slice(),
-            "an extended access ACL",
-        ),
-        (b"system.posix_acl_default\0".as_slice(), "a default ACL"),
-    ] {
-        let result = unsafe {
+fn read_fd_xattr(file: &File, name: &CStr, label: &str) -> Result<Option<Vec<u8>>> {
+    const MAX_ACL_XATTR: usize = 1024 * 1024;
+    for _ in 0..3 {
+        let size =
+            unsafe { libc::fgetxattr(file.as_raw_fd(), name.as_ptr(), std::ptr::null_mut(), 0) };
+        if size < 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::ENODATA) {
+                return Ok(None);
+            }
+            return Err(error).with_context(|| format!("inspect {label} ACL"));
+        }
+        let size = usize::try_from(size).context("ACL size is not representable")?;
+        if size > MAX_ACL_XATTR {
+            bail!("{label} ACL exceeds the supported size");
+        }
+        let mut encoded = vec![0u8; size];
+        let read = unsafe {
             libc::fgetxattr(
                 file.as_raw_fd(),
-                name.as_ptr().cast(),
-                std::ptr::null_mut(),
-                0,
+                name.as_ptr(),
+                encoded.as_mut_ptr().cast(),
+                encoded.len(),
             )
         };
-        if result >= 0 {
-            bail!("{label} must not have {description}");
+        if read >= 0 {
+            encoded.truncate(usize::try_from(read).context("ACL size is not representable")?);
+            return Ok(Some(encoded));
         }
         let error = io::Error::last_os_error();
-        if error.raw_os_error() != Some(libc::ENODATA) {
-            return Err(error).with_context(|| format!("inspect {label} ACLs"));
+        if error.raw_os_error() == Some(libc::ENODATA) {
+            return Ok(None);
+        }
+        if error.raw_os_error() != Some(libc::ERANGE) {
+            return Err(error).with_context(|| format!("read {label} ACL"));
         }
     }
-    Ok(())
+    bail!("{label} ACL changed repeatedly while it was inspected")
+}
+
+#[cfg(target_os = "linux")]
+fn posix_acl_has_only_trusted_writers(
+    encoded: &[u8],
+    metadata: &std::fs::Metadata,
+    effective_uid: libc::uid_t,
+    private_group: Option<libc::gid_t>,
+    label: &str,
+) -> Result<bool> {
+    const VERSION: u32 = 2;
+    const USER_OBJ: u16 = 0x01;
+    const USER: u16 = 0x02;
+    const GROUP_OBJ: u16 = 0x04;
+    const GROUP: u16 = 0x08;
+    const MASK: u16 = 0x10;
+    const OTHER: u16 = 0x20;
+    const WRITE: u16 = 0x02;
+    const UNDEFINED_ID: u32 = u32::MAX;
+
+    if encoded.len() < 4 || !(encoded.len() - 4).is_multiple_of(8) {
+        bail!("{label} has a malformed POSIX access ACL");
+    }
+    let version = u32::from_le_bytes(encoded[..4].try_into().unwrap());
+    if version != VERSION {
+        bail!("{label} has an unsupported POSIX access ACL version {version}");
+    }
+    let entries = encoded[4..]
+        .chunks_exact(8)
+        .map(|entry| {
+            (
+                u16::from_le_bytes(entry[..2].try_into().unwrap()),
+                u16::from_le_bytes(entry[2..4].try_into().unwrap()),
+                u32::from_le_bytes(entry[4..].try_into().unwrap()),
+            )
+        })
+        .collect::<Vec<_>>();
+    let masks = entries
+        .iter()
+        .filter(|(tag, _, _)| *tag == MASK)
+        .map(|(_, permissions, _)| *permissions)
+        .collect::<Vec<_>>();
+    if masks.len() != 1 {
+        bail!("{label} has a malformed POSIX access ACL mask");
+    }
+    let mask = masks[0];
+    let mut user_objects = 0;
+    let mut group_objects = 0;
+    let mut others = 0;
+    for &(tag, permissions, id) in &entries {
+        if permissions & !0o7 != 0 {
+            bail!("{label} has malformed POSIX access ACL permissions");
+        }
+        let (effective_permissions, trusted) = match tag {
+            USER_OBJ => {
+                user_objects += 1;
+                if id != UNDEFINED_ID {
+                    bail!("{label} has a malformed POSIX owner ACL entry");
+                }
+                (permissions, true)
+            }
+            USER => {
+                if id == UNDEFINED_ID {
+                    bail!("{label} has a malformed POSIX named-user ACL entry");
+                }
+                (permissions & mask, id == effective_uid || id == 0)
+            }
+            GROUP_OBJ => {
+                group_objects += 1;
+                if id != UNDEFINED_ID {
+                    bail!("{label} has a malformed POSIX owner-group ACL entry");
+                }
+                (permissions & mask, private_group == Some(metadata.gid()))
+            }
+            GROUP => {
+                if id == UNDEFINED_ID {
+                    bail!("{label} has a malformed POSIX named-group ACL entry");
+                }
+                (permissions & mask, private_group == Some(id))
+            }
+            MASK => {
+                if id != UNDEFINED_ID {
+                    bail!("{label} has a malformed POSIX mask ACL entry");
+                }
+                (0, true)
+            }
+            OTHER => {
+                others += 1;
+                if id != UNDEFINED_ID {
+                    bail!("{label} has a malformed POSIX other ACL entry");
+                }
+                (permissions, false)
+            }
+            _ => bail!("{label} has an unknown POSIX access ACL entry"),
+        };
+        if effective_permissions & WRITE != 0 && !trusted {
+            return Ok(false);
+        }
+    }
+    if user_objects != 1 || group_objects != 1 || others != 1 {
+        bail!("{label} has malformed POSIX access ACL base entries");
+    }
+    Ok(true)
+}
+
+#[cfg(target_os = "linux")]
+fn file_has_trusted_writers(
+    file: &File,
+    metadata: &std::fs::Metadata,
+    label: &str,
+) -> Result<bool> {
+    let effective_uid = unsafe { libc::geteuid() };
+    if metadata.uid() != 0 && metadata.uid() != effective_uid {
+        return Ok(false);
+    }
+    let Some(acl) = read_fd_xattr(file, c"system.posix_acl_access", label)? else {
+        return Ok(trusted_owner_mode(
+            metadata.uid(),
+            metadata.gid(),
+            metadata.permissions().mode(),
+            effective_uid,
+            private_group(),
+        ));
+    };
+    posix_acl_has_only_trusted_writers(&acl, metadata, effective_uid, private_group(), label)
 }
 
 #[cfg(target_os = "macos")]
-fn reject_extended_acl(file: &File, label: &str) -> Result<()> {
+fn file_has_trusted_writers(
+    file: &File,
+    metadata: &std::fs::Metadata,
+    label: &str,
+) -> Result<bool> {
     const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
 
     unsafe extern "C" {
@@ -1882,7 +2057,13 @@ fn reject_extended_acl(file: &File, label: &str) -> Result<()> {
     if acl.is_null() {
         let error = io::Error::last_os_error();
         if error.raw_os_error() == Some(libc::ENOENT) {
-            return Ok(());
+            return Ok(trusted_owner_mode(
+                metadata.uid(),
+                metadata.gid(),
+                metadata.permissions().mode(),
+                unsafe { libc::geteuid() },
+                private_group(),
+            ));
         }
         return Err(error).with_context(|| format!("inspect {label} extended ACL"));
     }
@@ -3096,7 +3277,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn linux_trusted_paths_reject_extended_posix_acls() {
+    fn linux_trusted_paths_reject_only_effective_untrusted_acl_writers() {
         fn entry(encoded: &mut Vec<u8>, tag: u16, permissions: u16, id: u32) {
             encoded.extend_from_slice(&tag.to_le_bytes());
             encoded.extend_from_slice(&permissions.to_le_bytes());
@@ -3104,35 +3285,66 @@ mod tests {
         }
 
         let directory = TestDir::new("posix-acl");
-        let guarded = directory.join("guarded");
-        fs::DirBuilder::new().mode(0o700).create(&guarded).unwrap();
-        let opened = File::open(&guarded).unwrap();
-        let mut acl = 2u32.to_le_bytes().to_vec();
-        entry(&mut acl, 0x01, 0o7, u32::MAX); // ACL_USER_OBJ
-        entry(
-            &mut acl,
-            0x02,
-            0o4,
-            unsafe { libc::geteuid() }.saturating_add(1),
-        ); // ACL_USER
-        entry(&mut acl, 0x04, 0, u32::MAX); // ACL_GROUP_OBJ
-        entry(&mut acl, 0x10, 0o4, u32::MAX); // ACL_MASK
-        entry(&mut acl, 0x20, 0, u32::MAX); // ACL_OTHER
-        let result = unsafe {
-            libc::fsetxattr(
-                opened.as_raw_fd(),
-                c"system.posix_acl_access".as_ptr().cast(),
-                acl.as_ptr().cast(),
-                acl.len(),
-                0,
-            )
+        let set_acl = |path: &Path, name: &CStr, named_uid, permissions| {
+            let opened = File::open(path).unwrap();
+            let mut acl = 2u32.to_le_bytes().to_vec();
+            entry(&mut acl, 0x01, 0o7, u32::MAX); // ACL_USER_OBJ
+            entry(&mut acl, 0x02, permissions, named_uid); // ACL_USER
+            entry(&mut acl, 0x04, 0, u32::MAX); // ACL_GROUP_OBJ
+            entry(&mut acl, 0x10, permissions, u32::MAX); // ACL_MASK
+            entry(&mut acl, 0x20, 0, u32::MAX); // ACL_OTHER
+            let result = unsafe {
+                libc::fsetxattr(
+                    opened.as_raw_fd(),
+                    name.as_ptr(),
+                    acl.as_ptr().cast(),
+                    acl.len(),
+                    0,
+                )
+            };
+            assert_eq!(result, 0, "set test ACL: {}", io::Error::last_os_error());
         };
-        assert_eq!(result, 0, "set test ACL: {}", io::Error::last_os_error());
+        let make_directory = |name| {
+            let path = directory.join(name);
+            fs::DirBuilder::new().mode(0o700).create(&path).unwrap();
+            path
+        };
+        let effective_uid = unsafe { libc::geteuid() };
+        let other_uid = effective_uid.saturating_add(1);
 
-        let error = validate_trusted_directory_path(&guarded).unwrap_err();
+        let default_parent = make_directory("default-parent");
+        let guarded = default_parent.join("guarded");
+        fs::DirBuilder::new().mode(0o700).create(&guarded).unwrap();
+        set_acl(&default_parent, c"system.posix_acl_default", other_uid, 0o7);
+        validate_trusted_directory_path(&guarded)
+            .expect("a default ACL does not authorize writes to its existing directory");
+        let inherited_private = default_parent.join("inherited-private");
+        fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&inherited_private)
+            .unwrap();
+        validate_private_directory_path(&inherited_private)
+            .expect("a mode-0700 child masks inherited access grants before validation");
+
+        let named_reader = make_directory("named-reader");
+        set_acl(&named_reader, c"system.posix_acl_access", other_uid, 0o4);
+        validate_trusted_directory_path(&named_reader)
+            .expect("a named read-only ACL entry is not a writer");
+
+        let owner_alias = make_directory("owner-alias");
+        set_acl(&owner_alias, c"system.posix_acl_access", effective_uid, 0o7);
+        validate_trusted_directory_path(&owner_alias)
+            .expect("an ACL entry naming the effective user is not another writer");
+
+        let named_writer = make_directory("named-writer");
+        set_acl(&named_writer, c"system.posix_acl_access", other_uid, 0o6);
+        let error = validate_trusted_directory_path(&named_writer).unwrap_err();
         let diagnostic = error.to_string();
-        assert!(diagnostic.contains("extended access ACL"), "{diagnostic}");
-        assert!(diagnostic.contains(&guarded.display().to_string()));
+        assert!(
+            diagnostic.contains("not writable by another principal"),
+            "{diagnostic}"
+        );
+        assert!(diagnostic.contains(&named_writer.display().to_string()));
     }
 
     #[cfg(target_os = "macos")]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -599,6 +599,8 @@ fn constrained_destination_rsh(port: u16, host_key_algorithms: &str) -> String {
         "-o".to_owned(),
         "StrictHostKeyChecking=no".to_owned(),
         "-o".to_owned(),
+        "LogLevel=ERROR".to_owned(),
+        "-o".to_owned(),
         "UserKnownHostsFile=/dev/null".to_owned(),
         "-o".to_owned(),
         "GlobalKnownHostsFile=/dev/null".to_owned(),
@@ -627,6 +629,23 @@ fn broker_connection_limit(connections_opt: Option<usize>, connections: usize) -
 
 fn automatic_enrollment_allowed(dry_run: bool, verify_only: bool) -> bool {
     !(dry_run || verify_only)
+}
+
+fn append_delegated_helper_selection(
+    command: &mut Vec<String>,
+    syq_path: Option<&str>,
+    no_bootstrap: bool,
+    restricted_receiver: bool,
+) {
+    if restricted_receiver {
+        return;
+    }
+    if no_bootstrap {
+        command.push("--no-bootstrap".into());
+    }
+    if let Some(path) = syq_path {
+        command.push(format!("--syq-path={path}"));
+    }
 }
 
 /// Encode a delegated path operand: standard unpadded base64 of the raw
@@ -942,9 +961,15 @@ fn run_remote(
             "--results with a direct remote-to-remote copy needs a command-restricted receiver enrollment (its verified receipt is the stream) or --coordinate-at local to route the transfer through this machine"
         );
     }
-    if args.no_bootstrap {
-        remote.push("--no-bootstrap".into());
-    }
+    // Helper selection applies to ordinary remote syq processes. The local
+    // launcher already used it for this coordinator; an enrolled destination
+    // is selected by its forced authorized_keys command instead.
+    append_delegated_helper_selection(
+        &mut remote,
+        args.syq_path.as_deref(),
+        args.no_bootstrap,
+        receipt_expectation.is_some(),
+    );
     if args.no_tcp {
         remote.push("--no-tcp".into());
     }
@@ -955,9 +980,6 @@ fn run_remote(
         remote.push(format!("--tcp-congestion={algorithm}"));
     }
     remote.push(format!("--tcp-ports={}", args.tcp_ports));
-    if let Some(path) = &args.syq_path {
-        remote.push(format!("--syq-path={path}"));
-    }
     if let Some(remote_shell) = destination_rsh(
         args.rsh.as_deref(),
         same_host,
@@ -1236,6 +1258,20 @@ mod tests {
         command.get_args().collect()
     }
 
+    #[test]
+    fn helper_selection_stops_at_a_command_restricted_receiver() {
+        let mut ordinary = Vec::new();
+        append_delegated_helper_selection(&mut ordinary, Some("/opt/syq-dev"), false, false);
+        assert_eq!(ordinary, ["--syq-path=/opt/syq-dev"]);
+
+        let mut restricted = Vec::new();
+        append_delegated_helper_selection(&mut restricted, Some("/opt/syq-dev"), false, true);
+        assert!(restricted.is_empty());
+
+        append_delegated_helper_selection(&mut restricted, None, true, true);
+        assert!(restricted.is_empty());
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn detached_timeout_terminates_the_complete_process_group() {
@@ -1355,6 +1391,7 @@ mod tests {
             "BatchMode=yes",
             "ProxyJump=none",
             "ProxyCommand=none",
+            "LogLevel=ERROR",
             "HostKeyAlgorithms=ssh-ed25519",
             "2222",
         ] {

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -2374,11 +2374,9 @@ fn ensure_directory(path: &Path, mode: u32) -> Result<()> {
             if !metadata.is_dir() || metadata.file_type().is_symlink() {
                 bail!("{} is not a real directory", path.display());
             }
-            if metadata.uid() != unsafe { libc::geteuid() }
-                || !delegation::metadata_has_trusted_writers(&metadata)
-            {
+            if metadata.uid() != unsafe { libc::geteuid() } {
                 bail!(
-                    "{} is not an owner-controlled directory (mode {:04o}, uid {}, gid {})",
+                    "{} is not a target-owned directory (mode {:04o}, uid {}, gid {})",
                     path.display(),
                     metadata.mode() & 0o7777,
                     metadata.uid(),
@@ -2811,6 +2809,11 @@ fn remove_empty_directory(path: &Path) -> Result<()> {
     }
 }
 
+fn remove_final_enrollment_state_directories(home: &Path) -> Result<()> {
+    remove_empty_directory(&home.join(".local/share/syq/restricted"))?;
+    remove_empty_directory(&home.join(".local/share/syq"))
+}
+
 fn contains_managed_enrollment(contents: &[u8]) -> bool {
     const MARKER: &[u8] = b"syq-enrollment:";
     contents.split(|byte| *byte == b'\n').any(|line| {
@@ -3042,9 +3045,7 @@ pub(crate) fn remote_revoke() -> Result<()> {
                 receiver_path.display()
             );
         }
-        remove_empty_directory(&state_base)?;
-        remove_empty_directory(&home.join(".local/share/syq"))?;
-        remove_empty_directory(&home.join(".local/share"))?;
+        remove_final_enrollment_state_directories(&home)?;
         match fs::symlink_metadata(&installed_receiver) {
             Ok(_) => {
                 delegation::validate_secure_executable(&installed_receiver, "restricted receiver")?;
@@ -3061,11 +3062,9 @@ pub(crate) fn remote_revoke() -> Result<()> {
                     .with_context(|| format!("inspect {}", installed_receiver.display()))
             }
         }
-        // These are cleanup-only ancestors. Once the receiver and state are
-        // gone, a non-empty directory is legitimate and any other failure
-        // does not make the revocation incomplete.
-        let _ = remove_empty_directory(&home.join(".local/libexec"));
-        let _ = remove_empty_directory(&home.join(".local"));
+        // `.local`, `share`, and `libexec` are general account directories.
+        // Without a durable record proving syq created them, preserve them
+        // even when the final enrollment leaves them empty.
     }
     drop(directory);
     println!("revoked {}", request.id);
@@ -3313,6 +3312,19 @@ impl ManagementAction {
     }
 }
 
+fn management_remote_command(
+    stage: &str,
+    action: ManagementAction,
+    request: &[u8],
+) -> Result<String> {
+    let request = std::str::from_utf8(request).context("management request is not UTF-8")?;
+    Ok(format!(
+        "set -eu; d=\"$HOME/.local/libexec\"; p=\"$d/{stage}\"; umask 077; mkdir -p -- \"$d\"; trap 'rm -f -- \"$p\"' EXIT; trap 'exit 129' HUP; trap 'exit 130' INT; trap 'exit 143' TERM; cat >\"$p\"; chmod 700 \"$p\"; printf '%s' {} | \"$p\" {}",
+        shell_words::quote(request),
+        action.argument()
+    ))
+}
+
 fn run_management_over_route(
     target: &SshEndpoint,
     route: EnrollmentRoute<'_>,
@@ -3330,29 +3342,12 @@ fn run_management_over_route(
     let mut nonce = [0u8; 8];
     getrandom::fill(&mut nonce).context("generate receiver staging filename")?;
     let stage = format!(".syq-receiver-{}-{:016x}", id, u64::from_le_bytes(nonce));
-    let upload = format!(
-        "set -eu; d=\"$HOME/.local/libexec\"; p=\"$d/{stage}\"; umask 077; mkdir -p -- \"$d\"; trap 'rm -f -- \"$p\"' EXIT HUP INT TERM; cat >\"$p\"; chmod 700 \"$p\"; trap - EXIT HUP INT TERM"
-    );
-    run_ssh(target, route.clone(), &upload, &bytes)?;
-    let cleanup_ancestors = match action {
-        ManagementAction::Install => "",
-        ManagementAction::Revoke => {
-            "; rmdir -- \"$HOME/.local/libexec\" \"$HOME/.local\" 2>/dev/null || :"
-        }
-    };
-    let invoke = format!(
-        "p=\"$HOME/.local/libexec/{stage}\"; \"$p\" {}; s=$?; rm -f -- \"$p\"{cleanup_ancestors}; exit \"$s\"",
-        action.argument()
-    );
-    let output = match run_ssh(target, route.clone(), &invoke, input) {
-        Ok(output) => output,
-        Err(error) => {
-            let cleanup = format!("rm -f -- \"$HOME/.local/libexec/{stage}\"{cleanup_ancestors}");
-            let _ = run_ssh(target, route, &cleanup, &[]);
-            return Err(error);
-        }
-    };
-    Ok(output)
+    let command = management_remote_command(&stage, action, input)?;
+    // Upload and invocation share one SSH session. The remote shell installs
+    // its cleanup trap before reading the binary and retains it until the
+    // management helper exits, so there is no inter-session orphan window or
+    // cleanup request that depends on a route which has already failed.
+    run_ssh(target, route, &command, &bytes)
 }
 
 fn install_over_route(
@@ -4214,6 +4209,81 @@ mod tests {
         assert!(contains_managed_enrollment(
             b"restrict,command=\"syq\" ssh-ed25519 key syq-enrollment:id\n"
         ));
+    }
+
+    #[test]
+    fn final_enrollment_cleanup_preserves_general_account_directories() {
+        let temporary = tempfile::tempdir().unwrap();
+        let home = temporary.path();
+        let local = home.join(".local");
+        let share = local.join("share");
+        let syq = share.join("syq");
+        let restricted = syq.join("restricted");
+        let libexec = local.join("libexec");
+        fs::create_dir_all(&restricted).unwrap();
+        fs::create_dir(&libexec).unwrap();
+        fs::set_permissions(&local, fs::Permissions::from_mode(0o750)).unwrap();
+        fs::set_permissions(&share, fs::Permissions::from_mode(0o751)).unwrap();
+        fs::set_permissions(&libexec, fs::Permissions::from_mode(0o710)).unwrap();
+
+        remove_final_enrollment_state_directories(home).unwrap();
+
+        assert!(!restricted.exists());
+        assert!(!syq.exists());
+        assert_eq!(fs::metadata(&local).unwrap().mode() & 0o7777, 0o750);
+        assert_eq!(fs::metadata(&share).unwrap().mode() & 0o7777, 0o751);
+        assert_eq!(fs::metadata(&libexec).unwrap().mode() & 0o7777, 0o710);
+    }
+
+    #[test]
+    fn management_stage_is_scoped_to_one_shell_session() {
+        fn invoke(home: &Path, stage: &str, script: &[u8], request: &[u8]) -> std::process::Output {
+            let remote = management_remote_command(stage, ManagementAction::Install, request)
+                .expect("build management command");
+            let mut child = Command::new("/bin/sh")
+                .arg("-c")
+                .arg(remote)
+                .env("HOME", home)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap();
+            child.stdin.take().unwrap().write_all(script).unwrap();
+            child.wait_with_output().unwrap()
+        }
+
+        let temporary = tempfile::tempdir().unwrap();
+        let request = br#"{"value":"' ; exit 91; #"}"#;
+        let output = invoke(
+            temporary.path(),
+            ".syq-receiver-test-success",
+            b"#!/bin/sh\ncat\n",
+            request,
+        );
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(output.stdout, request);
+        assert!(!temporary
+            .path()
+            .join(".local/libexec/.syq-receiver-test-success")
+            .exists());
+        assert!(temporary.path().join(".local/libexec").is_dir());
+
+        let output = invoke(
+            temporary.path(),
+            ".syq-receiver-test-failure",
+            b"#!/bin/sh\nexit 23\n",
+            b"failure request",
+        );
+        assert_eq!(output.status.code(), Some(23));
+        assert!(!temporary
+            .path()
+            .join(".local/libexec/.syq-receiver-test-failure")
+            .exists());
     }
 
     fn test_authority(

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -19,11 +19,12 @@ use ssh_key::private::Ed25519Keypair;
 use ssh_key::{LineEnding, PrivateKey};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ffi::{CStr, CString, OsStr, OsString};
+use std::fmt;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
-use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -2373,10 +2374,15 @@ fn ensure_directory(path: &Path, mode: u32) -> Result<()> {
             if !metadata.is_dir() || metadata.file_type().is_symlink() {
                 bail!("{} is not a real directory", path.display());
             }
-            if metadata.uid() != unsafe { libc::geteuid() } || metadata.mode() & 0o022 != 0 {
+            if metadata.uid() != unsafe { libc::geteuid() }
+                || !delegation::metadata_has_trusted_writers(&metadata)
+            {
                 bail!(
-                    "{} is not a private owner-controlled directory",
-                    path.display()
+                    "{} is not an owner-controlled directory (mode {:04o}, uid {}, gid {})",
+                    path.display(),
+                    metadata.mode() & 0o7777,
+                    metadata.uid(),
+                    metadata.gid()
                 );
             }
         }
@@ -2394,8 +2400,29 @@ fn ensure_directory(path: &Path, mode: u32) -> Result<()> {
 }
 
 fn ensure_private_chain(home: &Path, components: &[&str]) -> Result<PathBuf> {
-    delegation::validate_trusted_directory_path(home)
-        .with_context(|| format!("validate account home {}", home.display()))?;
+    let mut deepest_existing = home.to_path_buf();
+    for component in components {
+        let candidate = deepest_existing.join(component);
+        match fs::symlink_metadata(&candidate) {
+            Ok(metadata) => {
+                if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                    bail!("{} is not a real directory", candidate.display());
+                }
+                deepest_existing = candidate;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("inspect directory {}", candidate.display()))
+            }
+        }
+    }
+    delegation::validate_trusted_directory_path(&deepest_existing).with_context(|| {
+        format!(
+            "validate existing account directory chain through {}",
+            deepest_existing.display()
+        )
+    })?;
     let mut path = home.to_path_buf();
     for component in components {
         path.push(component);
@@ -2464,10 +2491,12 @@ fn read_leaf(
     };
     let mut file = unsafe { File::from_raw_fd(fd) };
     let metadata = file.metadata()?;
-    if !metadata.is_file()
-        || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.mode() & if private { 0o077 } else { 0o022 } != 0
-    {
+    let unsafe_mode = if private {
+        metadata.mode() & 0o7777 != 0o600
+    } else {
+        metadata.mode() & 0o022 != 0
+    };
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } || unsafe_mode {
         bail!("private state file has unsafe type, owner, or permissions");
     }
     let mut contents = Vec::new();
@@ -2547,6 +2576,69 @@ fn atomic_write_locked(
             let error = std::io::Error::last_os_error();
             if error.kind() != std::io::ErrorKind::Interrupted {
                 return Err(error).context("publish atomic private state file");
+            }
+        }
+        directory.sync_all()?;
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = unsafe { libc::unlinkat(directory.as_raw_fd(), temporary.as_ptr(), 0) };
+    }
+    write_result
+}
+
+fn atomic_replace_executable_locked(directory: &File, name: &str, contents: &[u8]) -> Result<()> {
+    let destination = leaf_name(name)?;
+    let mut random = [0u8; 8];
+    getrandom::fill(&mut random).context("generate atomic receiver filename")?;
+    let temporary_name = format!(
+        ".syq-receiver-write-{}-{}",
+        std::process::id(),
+        u64::from_le_bytes(random)
+    );
+    let temporary = leaf_name(&temporary_name)?;
+    let fd = loop {
+        let fd = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                temporary.as_ptr(),
+                libc::O_WRONLY
+                    | libc::O_CREAT
+                    | libc::O_EXCL
+                    | libc::O_NOFOLLOW
+                    | libc::O_NOCTTY
+                    | libc::O_CLOEXEC,
+                0o700,
+            )
+        };
+        if fd >= 0 {
+            break fd;
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error).context("create atomic restricted receiver");
+        }
+    };
+    let mut file = unsafe { File::from_raw_fd(fd) };
+    let write_result = (|| -> Result<()> {
+        file.set_permissions(fs::Permissions::from_mode(0o700))?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+        loop {
+            let result = unsafe {
+                libc::renameat(
+                    directory.as_raw_fd(),
+                    temporary.as_ptr(),
+                    directory.as_raw_fd(),
+                    destination.as_ptr(),
+                )
+            };
+            if result == 0 {
+                break;
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::Interrupted {
+                return Err(error).context("publish restricted receiver");
             }
         }
         directory.sync_all()?;
@@ -2678,6 +2770,63 @@ fn install_state_paths(home: &Path, id: EnrollmentId) -> Result<(PathBuf, PathBu
     ))
 }
 
+fn receiver_install_path(home: &Path) -> PathBuf {
+    home.join(".local/libexec/syq-receiver")
+}
+
+fn materialize_receiver(home: &Path, contents: &[u8]) -> Result<PathBuf> {
+    let directory_path = ensure_private_chain(home, &[".local", "libexec"])?;
+    let directory = open_directory(&directory_path)?;
+    atomic_replace_executable_locked(&directory, "syq-receiver", contents)?;
+    let receiver = receiver_install_path(home);
+    delegation::validate_secure_executable(&receiver, "restricted receiver")?;
+    Ok(receiver)
+}
+
+fn directory_is_empty(path: &Path) -> Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => delegation::validate_private_directory_path(path)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(true),
+        Err(error) => return Err(error).with_context(|| format!("inspect {}", path.display())),
+    }
+    Ok(fs::read_dir(path)
+        .with_context(|| format!("list {}", path.display()))?
+        .next()
+        .transpose()?
+        .is_none())
+}
+
+fn remove_empty_directory(path: &Path) -> Result<()> {
+    match fs::remove_dir(path) {
+        Ok(()) => Ok(()),
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+            ) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(error).with_context(|| format!("remove empty {}", path.display())),
+    }
+}
+
+fn contains_managed_enrollment(contents: &[u8]) -> bool {
+    const MARKER: &[u8] = b"syq-enrollment:";
+    contents.split(|byte| *byte == b'\n').any(|line| {
+        let trimmed = line
+            .iter()
+            .copied()
+            .skip_while(u8::is_ascii_whitespace)
+            .collect::<Vec<_>>();
+        !trimmed.starts_with(b"#")
+            && line
+                .rsplit(|byte| byte.is_ascii_whitespace())
+                .find(|word| !word.is_empty())
+                .is_some_and(|word| word.starts_with(MARKER))
+    })
+}
+
 fn resolve_ssh_keygen() -> Result<PathBuf> {
     let candidates = std::iter::once(PathBuf::from("/usr/bin/ssh-keygen")).chain(
         std::env::var_os("PATH")
@@ -2741,12 +2890,19 @@ pub(crate) fn remote_install() -> Result<()> {
     if public_words.len() < 2 {
         bail!("transport public key is malformed");
     }
-    let receiver_path = std::env::current_exe().context("resolve restricted receiver path")?;
-    delegation::validate_secure_executable(&receiver_path, "restricted receiver")?;
-    let entry = AuthorizedKeyEntry::new(request.id, &receiver_path, &transport)?;
+    let running_receiver = std::env::current_exe().context("resolve restricted receiver path")?;
+    delegation::validate_secure_executable(&running_receiver, "restricted receiver")?;
+    let receiver_contents = fs::read(&running_receiver)
+        .with_context(|| format!("read restricted receiver {}", running_receiver.display()))?;
     let ssh = ensure_private_chain(&home, &[".ssh"])?;
     let directory = open_directory(&ssh)?;
     lock_directory(&directory)?;
+    // The authorized-keys directory lock is the receiver lifecycle lock too.
+    // A concurrent final revoke may unlink the shared executable, but an
+    // installer that already started has its bytes and recreates it before
+    // publishing the new forced authorization.
+    let receiver_path = materialize_receiver(&home, &receiver_contents)?;
+    let entry = AuthorizedKeyEntry::new(request.id, &receiver_path, &transport)?;
     let original =
         read_leaf(&directory, "authorized_keys", MAX_AUTHORIZED_KEYS, false)?.unwrap_or_default();
     let normalized = normalize_managed_authorized_keys(&original, &entry.marker());
@@ -2840,9 +2996,8 @@ pub(crate) fn remote_revoke() -> Result<()> {
     if account != request.target_login {
         bail!("revocation target login does not match the remote account");
     }
-    let state = home
-        .join(".local/share/syq/restricted")
-        .join(request.id.to_string());
+    let state_base = home.join(".local/share/syq/restricted");
+    let state = state_base.join(request.id.to_string());
     let (receiver_path, remove_state) = match fs::symlink_metadata(&state) {
         Ok(_) => {
             let (config, allowed_signers, _) = receiver_config(request.id)?;
@@ -2857,10 +3012,9 @@ pub(crate) fn remote_revoke() -> Result<()> {
                 Some(state.to_path_buf()),
             )
         }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => (
-            std::env::current_exe().context("resolve restricted receiver path")?,
-            None,
-        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            (receiver_install_path(&home), None)
+        }
         Err(error) => return Err(error).context("inspect restricted receiver state"),
     };
     let transport = TransportPublicKey::parse(&request.public_key)?;
@@ -2873,12 +3027,47 @@ pub(crate) fn remote_revoke() -> Result<()> {
     let normalized = normalize_managed_authorized_keys(&original, &entry.marker());
     let (updated, _) = enrollment::revoke_authorized_key(&normalized, &entry)?;
     atomic_write_locked(&directory, "authorized_keys", &updated, 0o600, false)?;
-    drop(directory);
     if let Some(state) = remove_state {
         delegation::validate_private_directory_path(&state)?;
         fs::remove_dir_all(&state)
             .with_context(|| format!("remove revoked receiver state {}", state.display()))?;
     }
+    let last_enrollment =
+        !contains_managed_enrollment(&updated) && directory_is_empty(&state_base)?;
+    if last_enrollment {
+        let installed_receiver = receiver_install_path(&home);
+        if receiver_path != installed_receiver {
+            bail!(
+                "refusing to remove unexpected restricted receiver path {}",
+                receiver_path.display()
+            );
+        }
+        remove_empty_directory(&state_base)?;
+        remove_empty_directory(&home.join(".local/share/syq"))?;
+        remove_empty_directory(&home.join(".local/share"))?;
+        match fs::symlink_metadata(&installed_receiver) {
+            Ok(_) => {
+                delegation::validate_secure_executable(&installed_receiver, "restricted receiver")?;
+                fs::remove_file(&installed_receiver).with_context(|| {
+                    format!(
+                        "remove final restricted receiver {}",
+                        installed_receiver.display()
+                    )
+                })?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("inspect {}", installed_receiver.display()))
+            }
+        }
+        // These are cleanup-only ancestors. Once the receiver and state are
+        // gone, a non-empty directory is legitimate and any other failure
+        // does not make the revocation incomplete.
+        let _ = remove_empty_directory(&home.join(".local/libexec"));
+        let _ = remove_empty_directory(&home.join(".local"));
+    }
+    drop(directory);
     println!("revoked {}", request.id);
     Ok(())
 }
@@ -2909,6 +3098,7 @@ fn normalize_managed_authorized_keys(original: &[u8], marker: &str) -> Vec<u8> {
 fn local_state_base() -> Result<PathBuf> {
     let (_, home) = current_account()?;
     ensure_private_chain(&home, &[".local", "state", "syq", "restricted"])
+        .context("validate restricted enrollment state on the invoking machine")
 }
 
 fn store_pending_enrollment(
@@ -3025,6 +3215,42 @@ fn load_private_key(directory: &Path) -> Result<PrivateKey> {
     PrivateKey::from_openssh(&encoded).context("parse restricted transport private key")
 }
 
+#[derive(Debug)]
+struct EnrollmentSshError {
+    message: String,
+    transport: bool,
+}
+
+impl fmt::Display for EnrollmentSshError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for EnrollmentSshError {}
+
+fn enrollment_ssh_error(
+    target: &SshEndpoint,
+    transport: bool,
+    message: impl fmt::Display,
+) -> anyhow::Error {
+    anyhow::Error::new(EnrollmentSshError {
+        message: format!(
+            "restricted enrollment SSH to {} failed: {message}",
+            target.label()
+        ),
+        transport,
+    })
+}
+
+fn is_enrollment_transport_failure(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<EnrollmentSshError>()
+            .is_some_and(|failure| failure.transport)
+    })
+}
+
 fn run_ssh(
     target: &SshEndpoint,
     route: EnrollmentRoute<'_>,
@@ -3038,27 +3264,95 @@ fn run_ssh(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let mut child = command.spawn().context("start restricted enrollment SSH")?;
+    let mut child = command
+        .spawn()
+        .map_err(|error| enrollment_ssh_error(target, true, error))?;
     let mut stdin = child
         .stdin
         .take()
-        .context("enrollment SSH stdin unavailable")?;
-    stdin.write_all(input)?;
+        .ok_or_else(|| enrollment_ssh_error(target, true, "stdin unavailable"))?;
+    let write_error = stdin.write_all(input).err();
     drop(stdin);
-    let output = child.wait_with_output()?;
+    let output = child
+        .wait_with_output()
+        .map_err(|error| enrollment_ssh_error(target, true, error))?;
     if !output.status.success() {
         let diagnostic = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-        bail!(
-            "restricted enrollment SSH failed ({}): {}",
-            output.status,
-            if diagnostic.is_empty() {
-                "no diagnostic"
-            } else {
-                &diagnostic
-            }
-        );
+        return Err(enrollment_ssh_error(
+            target,
+            output.status.code() == Some(255),
+            format_args!(
+                "{}: {}",
+                output.status,
+                if diagnostic.is_empty() {
+                    "no diagnostic"
+                } else {
+                    &diagnostic
+                }
+            ),
+        ));
+    }
+    if let Some(error) = write_error {
+        return Err(enrollment_ssh_error(target, true, error));
     }
     Ok(output.stdout)
+}
+
+#[derive(Clone, Copy)]
+enum ManagementAction {
+    Install,
+    Revoke,
+}
+
+impl ManagementAction {
+    fn argument(self) -> &'static str {
+        match self {
+            Self::Install => "--restricted-install",
+            Self::Revoke => "--restricted-revoke",
+        }
+    }
+}
+
+fn run_management_over_route(
+    target: &SshEndpoint,
+    route: EnrollmentRoute<'_>,
+    id: EnrollmentId,
+    action: ManagementAction,
+    input: &[u8],
+) -> Result<Vec<u8>> {
+    let executable = std::env::current_exe().context("resolve local syq executable")?;
+    delegation::validate_secure_executable(&executable, "local syq executable")
+        .context("validate syq executable on the invoking machine")?;
+    let mut binary = File::open(&executable)
+        .with_context(|| format!("open local syq executable {}", executable.display()))?;
+    let mut bytes = Vec::new();
+    binary.read_to_end(&mut bytes)?;
+    let mut nonce = [0u8; 8];
+    getrandom::fill(&mut nonce).context("generate receiver staging filename")?;
+    let stage = format!(".syq-receiver-{}-{:016x}", id, u64::from_le_bytes(nonce));
+    let upload = format!(
+        "set -eu; d=\"$HOME/.local/libexec\"; p=\"$d/{stage}\"; umask 077; mkdir -p -- \"$d\"; trap 'rm -f -- \"$p\"' EXIT HUP INT TERM; cat >\"$p\"; chmod 700 \"$p\"; trap - EXIT HUP INT TERM"
+    );
+    run_ssh(target, route.clone(), &upload, &bytes)?;
+    let cleanup_ancestors = match action {
+        ManagementAction::Install => "",
+        ManagementAction::Revoke => {
+            "; rmdir -- \"$HOME/.local/libexec\" \"$HOME/.local\" 2>/dev/null || :"
+        }
+    };
+    let invoke = format!(
+        "p=\"$HOME/.local/libexec/{stage}\"; \"$p\" {}; s=$?; rm -f -- \"$p\"{cleanup_ancestors}; exit \"$s\"",
+        action.argument()
+    );
+    let output = match run_ssh(target, route.clone(), &invoke, input) {
+        Ok(output) => output,
+        Err(error) => {
+            let cleanup = format!("rm -f -- \"$HOME/.local/libexec/{stage}\"{cleanup_ancestors}");
+            let _ = run_ssh(target, route, &cleanup, &[]);
+            return Err(error);
+        }
+    };
+    Ok(output)
 }
 
 fn install_over_route(
@@ -3066,24 +3360,14 @@ fn install_over_route(
     route: EnrollmentRoute<'_>,
     request: &InstallRequest,
 ) -> Result<InstallResponse> {
-    let executable = std::env::current_exe().context("resolve local syq executable")?;
-    let mut binary = File::open(&executable)
-        .with_context(|| format!("open local syq executable {}", executable.display()))?;
-    let metadata = binary.metadata()?;
-    if !metadata.is_file() || metadata.mode() & 0o022 != 0 {
-        bail!("local syq executable is not a trusted regular file");
-    }
-    let mut bytes = Vec::new();
-    binary.read_to_end(&mut bytes)?;
-    let upload = "set -eu; d=\"$HOME/.local/libexec\"; umask 077; mkdir -p -- \"$d\"; t=\"$d/.syq-receiver.$$\"; trap 'rm -f -- \"$t\"' EXIT HUP INT TERM; cat >\"$t\"; chmod 700 \"$t\"; mv -f -- \"$t\" \"$d/syq-receiver\"; trap - EXIT HUP INT TERM";
-    run_ssh(target, route.clone(), upload, &bytes)?;
     let expected_id = request.id;
     let expected_login = request.target_login.clone();
     let request = serde_json::to_vec(request)?;
-    let output = run_ssh(
+    let output = run_management_over_route(
         target,
         route,
-        "exec \"$HOME/.local/libexec/syq-receiver\" --restricted-install",
+        expected_id,
+        ManagementAction::Install,
         &request,
     )?;
     let response: InstallResponse =
@@ -3191,7 +3475,7 @@ fn enroll(
     let direct = install_over_route(&target, EnrollmentRoute::Direct, &request);
     let response = match (direct, jump) {
         (Ok(response), _) => response,
-        (Err(direct_error), Some(jump)) => {
+        (Err(direct_error), Some(jump)) if is_enrollment_transport_failure(&direct_error) => {
             install_over_route(&target, EnrollmentRoute::ProxyJump { jump }, &request)
                 .with_context(|| {
                     format!(
@@ -3200,7 +3484,7 @@ fn enroll(
             )
                 })?
         }
-        (Err(error), None) => {
+        (Err(error), _) => {
             return Err(error).with_context(|| format!("enrollment {} {retry_state}", pending.id,))
         }
     };
@@ -3326,11 +3610,6 @@ fn validate_restricted_args(args: &Args) -> Result<()> {
     {
         bail!(
             "--files-from, --mapping, and --min-size are not yet independently enforceable by the command-restricted receiver"
-        );
-    }
-    if args.syq_path.is_some() || args.no_bootstrap {
-        bail!(
-            "--syq-path and --no-bootstrap cannot select the pre-enrolled command-restricted receiver"
         );
     }
     if args.pscope_explicit {
@@ -3835,32 +4114,19 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
             let active = load_local_enrollments()?
                 .into_iter()
                 .find(|(metadata, _)| metadata.id == id);
-            let (target_login, host, port, remote_command, directory) = match active {
-                Some((metadata, directory)) => {
-                    let command = enrollment::EnrollmentRemoteCommand::new(
-                        Path::new(&metadata.receiver_path),
-                        &["--restricted-revoke".into()],
-                    )?;
-                    (
-                        metadata.target_login,
-                        metadata.host,
-                        metadata.port,
-                        command.as_str().to_owned(),
-                        directory,
-                    )
-                }
+            let (target_login, host, port, directory) = match active {
+                Some((metadata, directory)) => (
+                    metadata.target_login,
+                    metadata.host,
+                    metadata.port,
+                    directory,
+                ),
                 None => {
                     let (pending, directory) = load_pending_enrollments()?
                         .into_iter()
                         .find(|(pending, _)| pending.id == id)
                         .context("no local enrollment has that ID")?;
-                    (
-                        pending.target_login,
-                        pending.host,
-                        pending.port,
-                        "exec \"$HOME/.local/libexec/syq-receiver\" --restricted-revoke".to_owned(),
-                        directory,
-                    )
+                    (pending.target_login, pending.host, pending.port, directory)
                 }
             };
             let private_key = load_private_key(&directory)?;
@@ -3872,19 +4138,28 @@ pub(crate) fn dispatch_management(argv: &[OsString]) -> Option<Result<i32>> {
             };
             let target = endpoint(&target_login, &host, port)?;
             let encoded = serde_json::to_vec(&request)?;
-            let direct = run_ssh(&target, EnrollmentRoute::Direct, &remote_command, &encoded);
+            let direct = run_management_over_route(
+                &target,
+                EnrollmentRoute::Direct,
+                id,
+                ManagementAction::Revoke,
+                &encoded,
+            );
             match (direct, via.as_ref()) {
                 (Ok(_), _) => {}
-                (Err(direct_error), Some(via)) => {
-                    run_ssh(
+                (Err(direct_error), Some(via))
+                    if is_enrollment_transport_failure(&direct_error) =>
+                {
+                    run_management_over_route(
                         &target,
                         EnrollmentRoute::ProxyJump { jump: via },
-                        &remote_command,
+                        id,
+                        ManagementAction::Revoke,
                         &encoded,
                     )
                     .with_context(|| format!("direct revocation also failed: {direct_error:#}"))?;
                 }
-                (Err(error), None) => return Err(error),
+                (Err(error), _) => return Err(error),
             }
             delegation::validate_private_directory_path(&directory)?;
             fs::remove_dir_all(&directory)
@@ -3903,6 +4178,43 @@ mod tests {
     use super::*;
     use clap::Parser;
     use std::os::unix::fs::{symlink, PermissionsExt};
+
+    #[test]
+    fn enrollment_ssh_failures_distinguish_transport_from_remote_rejection() {
+        let target = SshEndpoint::from_parts("backup", "host-b", Some(2222)).unwrap();
+        let transport = enrollment_ssh_error(&target, true, "connection refused");
+        assert!(is_enrollment_transport_failure(&transport));
+        assert!(transport.to_string().contains("backup@host-b:2222"));
+
+        let rejection = enrollment_ssh_error(&target, false, "remote exit status: 1");
+        assert!(!is_enrollment_transport_failure(&rejection));
+        assert!(rejection.to_string().contains("backup@host-b:2222"));
+    }
+
+    #[test]
+    fn receiver_publication_is_atomic_private_and_executable() {
+        let temporary = tempfile::tempdir().unwrap();
+        fs::set_permissions(temporary.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let directory = open_directory(temporary.path()).unwrap();
+        atomic_replace_executable_locked(&directory, "syq-receiver", b"receiver-v1").unwrap();
+        atomic_replace_executable_locked(&directory, "syq-receiver", b"receiver-v2").unwrap();
+
+        let path = temporary.path().join("syq-receiver");
+        assert_eq!(fs::read(&path).unwrap(), b"receiver-v2");
+        assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o700);
+        assert_eq!(fs::read_dir(temporary.path()).unwrap().count(), 1);
+    }
+
+    #[test]
+    fn receiver_gc_detects_any_remaining_managed_enrollment() {
+        assert!(!contains_managed_enrollment(b"ssh-ed25519 unrelated\n"));
+        assert!(!contains_managed_enrollment(
+            b"  # revoked key syq-enrollment:old\n"
+        ));
+        assert!(contains_managed_enrollment(
+            b"restrict,command=\"syq\" ssh-ed25519 key syq-enrollment:id\n"
+        ));
+    }
 
     fn test_authority(
         root: &Path,
@@ -6331,6 +6643,17 @@ mod tests {
         let mut args = Args::try_parse_from(["syq", "source", "destination"]).unwrap();
         args.normalize();
         args.bwlimit_bytes = 1024;
+        validate_restricted_args(&args).unwrap();
+    }
+
+    #[test]
+    fn ordinary_helper_selection_does_not_change_the_restricted_grant() {
+        let mut args = Args::try_parse_from(["syq", "source", "destination"]).unwrap();
+        args.normalize();
+        args.syq_path = Some("/tmp/development-syq".to_owned());
+        validate_restricted_args(&args).unwrap();
+        args.syq_path = None;
+        args.no_bootstrap = true;
         validate_restricted_args(&args).unwrap();
     }
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -4890,6 +4890,69 @@ fn native_rm_removes_named_tree_and_contents_keeps_root() {
 }
 
 #[test]
+fn native_remote_rm_uses_explicit_or_path_selected_helpers() {
+    let t = Tmp::new();
+    let ssh = fake_ssh(&t);
+    for name in ["explicit", "path"] {
+        write(&t.path(&format!("{name}/file")), b"remove");
+    }
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+
+    let run = |helper: &[&str], selected: &str| {
+        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .arg("rm")
+            .args(helper)
+            .args(["--from", "fake", "--cwd", &t.s(""), "--src", selected, "-q"])
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", ssh.parent().unwrap().to_string_lossy()),
+            )
+            .run()
+            .expect("run native remote removal");
+        assert_output_ok(&output);
+        assert!(!t.path(selected).exists());
+    };
+    run(&["--syq-path", env!("CARGO_BIN_EXE_syq")], "explicit");
+    run(&["--no-bootstrap"], "path");
+
+    let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    assert!(log.contains(env!("CARGO_BIN_EXE_syq")), "{log}");
+    assert!(log.contains("syq --server"), "{log}");
+}
+
+#[test]
+fn native_rm_rejects_conflicting_or_local_remote_helper_selection() {
+    let t = Tmp::new();
+    write(&t.path("keep"), b"keep");
+    let conflict = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "rm",
+            "--from",
+            "fake",
+            "--syq-path",
+            "/opt/syq",
+            "--no-bootstrap",
+            "keep",
+        ])
+        .run()
+        .unwrap();
+    assert_eq!(conflict.status.code(), Some(2));
+    assert!(stderr_of(&conflict).contains("cannot be used with"));
+
+    let local = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["rm", "--cwd", &t.s(""), "--syq-path", "/opt/syq", "keep"])
+        .run()
+        .unwrap();
+    assert_eq!(local.status.code(), Some(2));
+    assert!(stderr_of(&local).contains("only to a remote removal endpoint"));
+    assert_eq!(read(&t.path("keep")), b"keep");
+}
+
+#[test]
 fn native_rm_contents_requires_a_directory() {
     let t = Tmp::new();
     write(&t.path("file"), b"keep");


### PR DESCRIPTION
## Summary

- evaluate Linux access ACLs by effective write grants, allow harmless default ACLs on existing ancestors, retain conservative macOS ACL rejection, and report unsafe components with host context
- let --syq-path and --no-bootstrap select the ordinary hostA helper for restricted remote-to-remote copies, and expose the same controls for remote rm
- upload and invoke each temporary management receiver in one SSH session with session-scoped cleanup
- serialize receiver installation and revocation, remove only syq-owned state on final revoke, and preserve general account directories
- suppress repeated pinned-host-key warnings and limit ProxyJump retries to transport failures
- update the README, CLI coverage, and Python native API inventory

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets: 292 unit, 316 local integration, and 7 update tests
- real-SSH Compose default profile
- real-SSH Compose max-sessions-1 profile

The Compose profiles ran against product commit c9b5ace using the separately owned infrastructure from PR #145 at d9325d6 in a disposable validation worktree.