### PR TITLE
Fix restricted enrollment follow-up issues

### DIFF
--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -50,9 +50,10 @@ read-only or identify root, the target user, or its verified user-private
 group. A default ACL does not make its existing directory writable, and every
 new directory or file syq creates is validated before use. Group-write from the
 conventional umask 002 is accepted only when account and group database lookups
-prove that the group is user-private (same name and no other member or non-root
+check that the group is user-private (same name and no other member or non-root
 primary-group user). Otherwise group-write still fails closed. Private
-enrollment directories and secret files remain exactly 0700 and 0600. A
+enrollment directories require exactly 0700 access bits; directory special bits
+do not affect this check. Secret files remain exactly mode 0600. A
 failure names the machine and reports every unsafe component of the path that
 syq could securely inspect.
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -128,6 +128,22 @@ pub(crate) fn is_worker_initialization_error(error: &anyhow::Error) -> bool {
         .any(|cause| cause.is::<WorkerInitializationError>())
 }
 
+fn is_non_retryable_connect_error(error: &anyhow::Error) -> bool {
+    let message = format!("{error:#}");
+    is_worker_initialization_error(error)
+        || message.contains("build identity mismatch")
+        || message.contains("unexpected handshake response")
+        || message.contains("exit status: 127")
+        || message.contains(&format!(
+            "exit status: {}",
+            remote_helper::HELPER_MISSING_EXIT
+        ))
+        || message.contains(&format!(
+            "exit status: {}",
+            remote_helper::HELPER_NOT_EXECUTABLE_EXIT
+        ))
+}
+
 /// OpenSSH accepted the control connection but rejected a multiplexed worker
 /// session. Independent SSH connections may still be permitted (for example,
 /// with `MaxSessions 1`), so callers can safely disable reuse and retry.
@@ -1197,24 +1213,9 @@ impl RemoteSpec {
                     last = Some(e);
                     continue;
                 }
-                // Don't retry what won't change: a missing binary (127) or a
-                // build identity mismatch.
-                Err(e)
-                    if attempt == 5
-                        || format!("{e:#}").contains("build identity mismatch")
-                        || is_worker_initialization_error(&e)
-                        || format!("{e:#}").contains("exit status: 127")
-                        || format!("{e:#}").contains(&format!(
-                            "exit status: {}",
-                            remote_helper::HELPER_MISSING_EXIT
-                        ))
-                        || format!("{e:#}").contains(&format!(
-                            "exit status: {}",
-                            remote_helper::HELPER_NOT_EXECUTABLE_EXIT
-                        )) =>
-                {
-                    return Err(e)
-                }
+                // Don't retry what won't change: a missing binary or an
+                // incompatible protocol/build identity.
+                Err(e) if attempt == 5 || is_non_retryable_connect_error(&e) => return Err(e),
                 Err(e) => {
                     let limit = if limited {
                         Some(tighten_connect_limit())
@@ -1727,12 +1728,15 @@ fn hello(
         Ok(Response::Err(error)) => bail!("{}: {error}", conn.label),
         Ok(other) if worker => {
             return Err(WorkerInitializationError(format!(
-                "{}: unexpected handshake response {other:?}",
-                conn.label
-            ))
+            "{}: unexpected handshake response {other:?}; remote syq may be a different version",
+            conn.label
+        ))
             .into())
         }
-        Ok(other) => bail!("{}: unexpected handshake response {other:?}", conn.label),
+        Ok(other) => bail!(
+            "{}: unexpected handshake response {other:?}; remote syq may be a different version",
+            conn.label
+        ),
         Err(e) => {
             return Err(e)
                 .with_context(|| format!("could not start the remote syq on {}", conn.label))
@@ -2654,6 +2658,51 @@ mod tests {
         drop(conn);
         server.join().unwrap();
         descriptor_session.close();
+    }
+
+    #[test]
+    fn unexpected_hello_response_reports_version_skew_without_retry() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (socket, _) = listener.accept().unwrap();
+            let mut reader = FrameReader::new(socket.try_clone().unwrap());
+            assert!(matches!(
+                reader.read_msg::<Request>().unwrap(),
+                Request::Hello { .. }
+            ));
+            FrameWriter::new(socket, false)
+                .write_msg(&Response::Ok)
+                .unwrap();
+        });
+
+        let socket = TcpStream::connect(address).unwrap();
+        let (rx, reader) = spawn_reader(Box::new(socket.try_clone().unwrap()));
+        let conn = RemoteConn {
+            child: None,
+            w: FrameWriter::new(Box::new(socket), false),
+            rx: Some(rx),
+            reader: Some(reader),
+            label: "version-skew test".into(),
+            dead: false,
+            peer: None,
+            tcp_socket: None,
+            multiplexed_ssh: false,
+        };
+        let error = hello(conn, false, Vec::new(), ConnectionRole::Control)
+            .err()
+            .expect("an operation response is not a valid handshake");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("unexpected handshake response"),
+            "{message}"
+        );
+        assert!(
+            message.contains("remote syq may be a different version"),
+            "{message}"
+        );
+        assert!(is_non_retryable_connect_error(&error));
+        server.join().unwrap();
     }
 
     #[test]

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -1406,7 +1406,7 @@ fn validate_private_directory(directory: &File, path: &Path) -> Result<()> {
             path.display()
         );
     }
-    let mode = metadata.permissions().mode() & 0o7777;
+    let mode = metadata.permissions().mode() & 0o777;
     if mode != 0o700 {
         bail!(
             "private directory {} must have mode 0700 (found {:04o})",
@@ -3216,6 +3216,18 @@ mod tests {
         let link = directory.join("state-link");
         std::os::unix::fs::symlink(&private, &link).expect("create state symlink");
         assert!(ReplayStore::open(&link).is_err());
+    }
+
+    #[test]
+    fn replay_store_accepts_a_setgid_private_directory() {
+        let directory = TestDir::new("setgid-private");
+        let state = directory.join("state");
+        provision_test_replay_directory(&state);
+        fs::set_permissions(&state, fs::Permissions::from_mode(0o2700))
+            .expect("set setgid on private state directory");
+        assert_eq!(fs::metadata(&state).unwrap().mode() & 0o2000, 0o2000);
+
+        ReplayStore::open(&state).expect("setgid does not grant another principal access");
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -3018,6 +3018,10 @@ pub(crate) fn remote_revoke() -> Result<()> {
     }
     request.id.validate()?;
     let (account, home) = current_account()?;
+    revoke_for_account(&request, &account, &home)
+}
+
+fn revoke_for_account(request: &RevokeRequest, account: &str, home: &Path) -> Result<()> {
     if account != request.target_login {
         bail!("revocation target login does not match the remote account");
     }
@@ -3025,6 +3029,7 @@ pub(crate) fn remote_revoke() -> Result<()> {
     let state = state_base.join(request.id.to_string());
     let (receiver_path, remove_state) = match fs::symlink_metadata(&state) {
         Ok(_) => {
+            delegation::validate_private_directory_path(&state)?;
             let (config, allowed_signers, _) = receiver_config(request.id)?;
             if config.target_login != request.target_login {
                 bail!("revocation target login does not match receiver state");
@@ -3038,13 +3043,16 @@ pub(crate) fn remote_revoke() -> Result<()> {
             )
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            (receiver_install_path(&home), None)
+            (receiver_install_path(home), None)
         }
         Err(error) => return Err(error).context("inspect restricted receiver state"),
     };
     let transport = TransportPublicKey::parse(&request.public_key)?;
     let entry = AuthorizedKeyEntry::new(request.id, &receiver_path, &transport)?;
-    let ssh = ensure_private_chain(&home, &[".ssh"])?;
+    // Validate the shared state chain before removing the credential. The
+    // second check below determines whether the now-updated state is empty.
+    let _ = directory_is_empty(&state_base)?;
+    let ssh = ensure_private_chain(home, &[".ssh"])?;
     let directory = open_directory(&ssh)?;
     lock_directory(&directory)?;
     let original =
@@ -3053,21 +3061,20 @@ pub(crate) fn remote_revoke() -> Result<()> {
     let (updated, _) = enrollment::revoke_authorized_key(&normalized, &entry)?;
     atomic_write_locked(&directory, "authorized_keys", &updated, 0o600, false)?;
     if let Some(state) = remove_state {
-        delegation::validate_private_directory_path(&state)?;
         fs::remove_dir_all(&state)
             .with_context(|| format!("remove revoked receiver state {}", state.display()))?;
     }
     let last_enrollment =
         !contains_managed_enrollment(&updated) && directory_is_empty(&state_base)?;
     if last_enrollment {
-        let installed_receiver = receiver_install_path(&home);
+        let installed_receiver = receiver_install_path(home);
         if receiver_path != installed_receiver {
             bail!(
                 "refusing to remove unexpected restricted receiver path {}",
                 receiver_path.display()
             );
         }
-        remove_final_enrollment_state_directories(&home)?;
+        remove_final_enrollment_state_directories(home)?;
         match fs::symlink_metadata(&installed_receiver) {
             Ok(_) => {
                 delegation::validate_secure_executable(&installed_receiver, "restricted receiver")?;
@@ -4231,6 +4238,56 @@ mod tests {
         assert!(contains_managed_enrollment(
             b"restrict,command=\"syq\" ssh-ed25519 key syq-enrollment:id\n"
         ));
+    }
+
+    #[test]
+    fn revoke_validates_all_state_before_rewriting_authorized_keys() {
+        for unsafe_enrollment in [false, true] {
+            let (account, account_home) = current_account().unwrap();
+            let temporary = tempfile::Builder::new()
+                .prefix("syq-revoke-order-")
+                .tempdir_in(account_home)
+                .unwrap();
+            let home = temporary.path();
+            fs::set_permissions(home, fs::Permissions::from_mode(0o700)).unwrap();
+
+            let id = EnrollmentId::test_v4(41);
+            let state_base = home.join(".local/share/syq/restricted");
+            fs::create_dir_all(&state_base).unwrap();
+            fs::set_permissions(
+                &state_base,
+                fs::Permissions::from_mode(if unsafe_enrollment { 0o700 } else { 0o755 }),
+            )
+            .unwrap();
+            if unsafe_enrollment {
+                let state = state_base.join(id.to_string());
+                fs::create_dir(&state).unwrap();
+                fs::set_permissions(&state, fs::Permissions::from_mode(0o755)).unwrap();
+            }
+            let ssh = home.join(".ssh");
+            fs::create_dir(&ssh).unwrap();
+            fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+
+            let key = generate_transport_key(id).unwrap();
+            let public_key = key.public_key().to_openssh().unwrap();
+            let transport = TransportPublicKey::parse(&public_key).unwrap();
+            let entry =
+                AuthorizedKeyEntry::new(id, &receiver_install_path(home), &transport).unwrap();
+            let original = format!("{}\n", entry.line()).into_bytes();
+            let authorized_keys = ssh.join("authorized_keys");
+            fs::write(&authorized_keys, &original).unwrap();
+            fs::set_permissions(&authorized_keys, fs::Permissions::from_mode(0o600)).unwrap();
+
+            let request = RevokeRequest {
+                version: CONFIG_VERSION,
+                id,
+                target_login: account.clone(),
+                public_key,
+            };
+            let error = revoke_for_account(&request, &account, home).unwrap_err();
+            assert!(error.to_string().contains("must have mode 0700"));
+            assert_eq!(fs::read(authorized_keys).unwrap(), original);
+        }
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -258,6 +258,28 @@ fn interface_option<'a>(args: &Args, native: &'a str, rsync: &'a str) -> &'a str
     }
 }
 
+fn remote_helper_mode(spec: &RemoteSpec, interface: Interface) -> &'static str {
+    if spec.auto_helper {
+        if *spec.helper_install.lock().unwrap() {
+            "managed; installed now"
+        } else {
+            "managed helper cache"
+        }
+    } else if spec.restricted_grant.is_some() {
+        "restricted grant"
+    } else if spec.syq_path.is_some() {
+        match interface {
+            Interface::Rsync => "--rsync-path",
+            _ => "--syq-path",
+        }
+    } else {
+        match interface {
+            Interface::Rsync => "remote PATH (--syq-no-bootstrap)",
+            _ => "remote PATH (--no-bootstrap)",
+        }
+    }
+}
+
 fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
     let diagnostics = spec.diagnostics();
     eprintln!("syq: {}:", spec.label());
@@ -267,21 +289,7 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
             spec.remote_shell_name(),
             peer.platform
         );
-        let helper_mode = if spec.auto_helper {
-            if *spec.helper_install.lock().unwrap() {
-                "managed; installed now"
-            } else {
-                "managed helper cache"
-            }
-        } else if spec.syq_path.is_some() {
-            interface_option(args, "--syq-path", "--rsync-path")
-        } else {
-            interface_option(
-                args,
-                "remote PATH (--no-bootstrap)",
-                "remote PATH (--syq-no-bootstrap)",
-            )
-        };
+        let helper_mode = remote_helper_mode(spec, args.interface);
         eprintln!("  helper: {} ({helper_mode})", peer.identity);
     }
 
@@ -7654,6 +7662,17 @@ impl Worker {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn restricted_remote_diagnostics_name_the_grant_helper() {
+        let mut spec = RemoteSpec::local_receiver(false);
+        spec.restricted_grant = Some("signed-grant".into());
+
+        assert_eq!(
+            remote_helper_mode(&spec, Interface::NativeCp),
+            "restricted grant"
+        );
+    }
 
     #[test]
     fn endpoint_semantic_error_kind_wins_over_numeric_errno() {


### PR DESCRIPTION
## Summary

- accept setgid/sticky bits on otherwise mode-0700 private directories
- validate both shared and per-enrollment restricted state before rewriting authorized_keys during revocation
- fail fast on unexpected handshake responses with a version-skew diagnostic
- label restricted-grant helpers correctly in -vv output and clarify the relocated permissions contract

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --bin syq
- cargo test --test local double_verbose_dry_run_reports_tcp_without_extra_connection -- --exact
- cargo test --test local managed_remote_helper_install_is_cached -- --exact
- python3 scripts/check-doc-links.py