### PR TITLE
Preserve restricted root mode policy errors

### DIFF
--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -6330,6 +6330,19 @@ mod tests {
         let mut source_modes = test_authority(&root, DeletionPolicy::Forbid, 1024);
         source_modes.copy.options.preserve_permissions = true;
         source_modes.copy.options.receiver_managed_modes = false;
+        let mut source_mkdir = Request::Apply {
+            ops: vec![Op::Mkdir {
+                path: target.clone(),
+                mode: 0o750,
+                condition: proto::TargetCondition::Any,
+            }],
+            guard: None,
+        };
+        source_modes.authorize(&mut source_mkdir, false).unwrap();
+        let Request::Apply { ops, .. } = source_mkdir else {
+            unreachable!()
+        };
+        assert!(matches!(ops[0], Op::Mkdir { mode: 0o750, .. }));
         let mut source_mode = metadata(proto::flags::MODE);
         source_modes.authorize(&mut source_mode, false).unwrap();
         let mut receiver_mode = metadata(proto::flags::RECEIVER_MODE);
@@ -6574,19 +6587,18 @@ mod tests {
     }
 
     #[test]
-    fn receiver_managed_new_directory_preserves_receiver_inherited_setgid() {
+    fn receiver_managed_missing_root_preserves_receiver_umask_and_inherited_setgid() {
         let temporary = tempfile::tempdir().unwrap();
         let root = temporary.path().join("root");
-        let parent = root.join("target/inheriting-parent");
-        let child = parent.join("child");
-        fs::create_dir_all(&parent).unwrap();
-        fs::set_permissions(&parent, fs::Permissions::from_mode(0o2755)).unwrap();
+        let target = root.join("target");
+        fs::create_dir(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o2755)).unwrap();
         let mut authority = test_authority(&root, DeletionPolicy::Forbid, 1024);
         authority.receiver_umask = 0o022;
 
         let mut mkdir = Request::Apply {
             ops: vec![Op::Mkdir {
-                path: child.as_os_str().as_bytes().to_vec(),
+                path: target.as_os_str().as_bytes().to_vec(),
                 mode: 0o7777,
                 condition: proto::TargetCondition::Any,
             }],
@@ -6605,11 +6617,11 @@ mod tests {
             .apply(ops, Some(guard))
             .into_iter()
             .all(|error| error.is_none()));
-        assert_eq!(fs::metadata(&child).unwrap().mode() & 0o7777, 0o2700);
+        assert_eq!(fs::metadata(&target).unwrap().mode() & 0o7777, 0o2700);
 
         let mut metadata = Request::Apply {
             ops: vec![Op::SetMeta {
-                path: child.as_os_str().as_bytes().to_vec(),
+                path: target.as_os_str().as_bytes().to_vec(),
                 meta: proto::Meta {
                     // None of these source-proposed special bits are trusted.
                     mode: 0o7777,
@@ -6644,7 +6656,7 @@ mod tests {
             .apply(ops, Some(guard))
             .into_iter()
             .all(|error| error.is_none()));
-        assert_eq!(fs::metadata(&child).unwrap().mode() & 0o7777, 0o2755);
+        assert_eq!(fs::metadata(&target).unwrap().mode() & 0o7777, 0o2755);
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -2036,6 +2036,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             &dst_root,
             root_create_condition,
             opts.restricted_receiver,
+            opts.perms,
         )?;
         mutation_root_condition = target_identity(&created);
         if guard_containers {
@@ -2828,14 +2829,16 @@ fn mkdir_root(
     dst_root: &[u8],
     condition: TargetCondition,
     restricted_receiver: bool,
+    preserve_permissions: bool,
 ) -> Result<Entry> {
-    for ops in mkdir_root_batches(dst_root, condition, restricted_receiver) {
+    for ops in mkdir_root_batches(
+        dst_root,
+        condition,
+        restricted_receiver,
+        preserve_permissions,
+    ) {
         match ok(conn.call(Request::Apply { ops, guard: None })?, "mkdir")? {
-            Response::Applied(errs) => {
-                if let Some(e) = errs.into_iter().flatten().next() {
-                    bail!("{e}");
-                }
-            }
+            Response::Applied(errs) => mkdir_apply_result(errs)?,
             other => bail!("unexpected response {other:?}"),
         }
     }
@@ -2844,17 +2847,25 @@ fn mkdir_root(
         .with_context(|| format!("created target {} is not a directory", display(dst_root)))
 }
 
+fn mkdir_apply_result(errors: Vec<Option<WireError>>) -> Result<()> {
+    if let Some(error) = errors.into_iter().flatten().next() {
+        return Err(endpoint_error(error)).context("mkdir");
+    }
+    Ok(())
+}
+
 fn mkdir_root_batches(
     dst_root: &[u8],
     condition: TargetCondition,
     restricted_receiver: bool,
+    preserve_permissions: bool,
 ) -> Vec<Vec<Op>> {
     let mut batches = vec![vec![Op::Mkdir {
         path: dst_root.to_vec(),
         mode: 0o755,
         condition,
     }]];
-    if restricted_receiver {
+    if restricted_receiver && !preserve_permissions {
         // Keep this in a later receiver call. The restricted authority must
         // observe the directory after Mkdir so it can distinguish HostB's
         // kernel-inherited setgid bit from HostA's untrusted mode proposal.
@@ -4716,8 +4727,13 @@ impl Planner<'_> {
                     .expect("destination anchor set once");
             } else {
                 debug_assert!(is_destination_root);
-                let created =
-                    mkdir_root(self.dst, &root, condition, self.opts.restricted_receiver)?;
+                let created = mkdir_root(
+                    self.dst,
+                    &root,
+                    condition,
+                    self.opts.restricted_receiver,
+                    self.opts.perms,
+                )?;
                 self.mutation_root_condition = target_identity(&created);
                 if self.guard_containers {
                     self.container_guard = Some(target_container(&root, &created));
@@ -7671,6 +7687,18 @@ mod tests {
     }
 
     #[test]
+    fn mkdir_apply_error_preserves_endpoint_os_kind() {
+        let error = WireError {
+            message: "destination is full".into(),
+            io_kind: Some(WireIoKind::NoSpace),
+            raw_os_error: Some(libc::ENOSPC),
+        };
+        let error = mkdir_apply_result(vec![None, Some(error)]).unwrap_err();
+        assert_eq!(os_kind_of(&error), Some("no_space"));
+        assert_eq!(format!("{error:#}"), "mkdir: destination is full");
+    }
+
+    #[test]
     fn raw_path_identity_is_lossless_without_changing_utf8_identity() {
         use std::os::unix::ffi::OsStrExt as _;
 
@@ -7799,19 +7827,27 @@ mod tests {
     }
 
     #[test]
-    fn restricted_root_creation_includes_receiver_managed_final_mode() {
-        let ordinary = mkdir_root_batches(b"/destination", TargetCondition::Absent, false);
+    fn restricted_root_creation_uses_only_the_authorized_mode_policy() {
+        let ordinary = mkdir_root_batches(b"/destination", TargetCondition::Absent, false, false);
         assert_eq!(ordinary.len(), 1);
         assert!(matches!(ordinary[0].as_slice(), [Op::Mkdir { .. }]));
 
-        let restricted = mkdir_root_batches(b"/destination", TargetCondition::Absent, true);
-        assert_eq!(restricted.len(), 2);
+        let preserving = mkdir_root_batches(b"/destination", TargetCondition::Absent, true, true);
+        assert_eq!(preserving.len(), 1);
         assert!(matches!(
-            restricted[0].as_slice(),
+            preserving[0].as_slice(),
+            [Op::Mkdir { mode: 0o755, .. }]
+        ));
+
+        let receiver_managed =
+            mkdir_root_batches(b"/destination", TargetCondition::Absent, true, false);
+        assert_eq!(receiver_managed.len(), 2);
+        assert!(matches!(
+            receiver_managed[0].as_slice(),
             [Op::Mkdir { mode: 0o755, .. }]
         ));
         assert!(matches!(
-            restricted[1].as_slice(),
+            receiver_managed[1].as_slice(),
             [Op::SetMeta {
                 meta: Meta { mode: 0o755, .. },
                 flags: flags::RECEIVER_MODE,

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -71,10 +71,6 @@ under `target/real-ssh.*`; the ephemeral private key is always removed.
 
 ## Known findings from bringing up the suite
 
-- A restricted copy to a missing directory with `--preserve=permissions` is
-  currently rejected because root creation requests a receiver-managed mode
-  that the grant does not authorize. The passing restricted case pre-creates
-  its root and uses `--into-existing`; descendant modes are still compared.
 - The first signed TCP worker can currently receive a connection reset and
   recover on its built-in retry. The suite requires final success and leaves
   this diagnostic visible rather than treating the recovered run as clean.

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -100,10 +100,9 @@ printf 'real-SSH environment: profile %s; %s; %s\n' \
 
 printf 'case: source coordinator with constrained agent and restricted destination\n'
 make_tree source /tmp/syq-real-ssh/direct-source direct
-ssh destination 'install -d -m 0755 /tmp/syq-real-ssh/direct-destination'
 syq cp --no-progress -j 2 --preserve=permissions \
     --from source --src-src /tmp/syq-real-ssh/direct-source \
-    --to destination --into-existing /tmp/syq-real-ssh/direct-destination
+    --to destination --into /tmp/syq-real-ssh/direct-destination
 assert_same_tree \
     source /tmp/syq-real-ssh/direct-source \
     destination /tmp/syq-real-ssh/direct-destination \


### PR DESCRIPTION
## Summary

- preserve typed endpoint errors returned while creating a destination root
- request receiver-managed root metadata only when permission preservation is disabled
- exercise preserved-permission and receiver-managed missing roots, including live restricted SSH creation through `--into`

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq`
- `scripts/test-real-ssh.sh`