### PR TITLE
Close rsync descendant-link option boundary

### DIFF
--- a/docs/rsync-compat.md
+++ b/docs/rsync-compat.md
@@ -226,7 +226,13 @@ command says what to change.
   divergences" 1; these are refused rather than pending.
 - `-H`/`--hard-links` — needs cross-file ordering in a scheduler that has
   none today.
-- `-L`/`--copy-links`, `-k`/`--copy-dirlinks`, `-K`/`--keep-dirlinks`.
+- `-L`/`--copy-links`, `--copy-unsafe-links`, `-k`/`--copy-dirlinks`,
+  `-K`/`--keep-dirlinks`. The first three expand source authority by
+  traversing descendant links; the last follows an existing destination
+  directory link. They are rejected explicitly and are not enabled by
+  `--insecure-links`.
+- `--safe-links` and `--munge-links`; syq currently preserves selected
+  symlink target bytes without filtering or rewriting them.
 - `--backup`/`--backup-dir`/`--suffix`.
 - `--link-dest`/`--compare-dest`/`--copy-dest`.
 - `--relative` (`-R`), `--partial-dir`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -96,7 +96,11 @@ What is different from rsync, or weaker:
 - **The rsync-mode escape hatch.** `syq rsync --insecure-links` restores the
   unconfined, name-based source traversal, including through symlinked
   `--files-from` parents. It exists for compatibility and is never selected
-  automatically.
+  automatically. It does not enable rsync's separate descendant-link modes:
+  `-L`/`--copy-links`, `--copy-unsafe-links`, `-k`/`--copy-dirlinks`, and
+  `-K`/`--keep-dirlinks` remain unsupported and are rejected before either
+  endpoint is contacted. `--safe-links` and `--munge-links` are likewise not
+  implemented; selected symlink target bytes are preserved unchanged.
 - **Older macOS.** The descriptor-bound symlink read that source registration
   relies on needs macOS 13 or newer; older releases fail registration instead
   of falling back to a name-based read.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1963,6 +1963,8 @@ fn unsupported_message(tok: &str) -> Option<String> {
 const FILTER_MSG: &str = "syq has no --exclude/--include/--filter. The SYQ extension --syq-ignore (or --syq-ignore-from) takes gitignore-style patterns: e.g. `--exclude node_modules` becomes `--syq-ignore node_modules`. See \"Ignoring paths\" in docs/reference.md.";
 const ITEMIZE_MSG: &str = "syq does not implement rsync's -i/--itemize-changes. --syq-verify-only can compare contents without mutation, but it does not produce rsync's itemized output.";
 const DELETE_MSG: &str = "syq deletes only after the transfer (--delete; --delete-after and --delete-delay are synonyms); --delete-before, --delete-during and --force are not supported.";
+const SOURCE_LINK_TRAVERSAL_MSG: &str = "syq does not implement rsync's source descendant-link traversal (-L/--copy-links, --copy-unsafe-links, or -k/--copy-dirlinks); -l copies symlinks as symlinks, and --insecure-links does not enable these modes.";
+const DESTINATION_LINK_TRAVERSAL_MSG: &str = "syq does not implement -K/--keep-dirlinks because it follows existing destination directory symlinks; syq replaces destination symlink conflicts instead.";
 
 fn message_for_long(base: &str) -> Option<&'static str> {
     Some(match base {
@@ -1979,8 +1981,13 @@ fn message_for_long(base: &str) -> Option<&'static str> {
         "hard-links" => "syq does not preserve hard links (-H/--hard-links).",
         "acls" => "syq does not preserve ACLs (-A/--acls).",
         "xattrs" => "syq does not preserve extended attributes (-X/--xattrs).",
-        "copy-links" | "copy-unsafe-links" | "copy-dirlinks" => {
-            "syq does not implement -L/--copy-links; it copies symlinks as symlinks (-l)."
+        "copy-links" | "copy-unsafe-links" | "copy-dirlinks" => SOURCE_LINK_TRAVERSAL_MSG,
+        "keep-dirlinks" => DESTINATION_LINK_TRAVERSAL_MSG,
+        "safe-links" => {
+            "syq does not implement --safe-links; selected symlinks are preserved without classifying whether their targets leave the transfer tree."
+        }
+        "munge-links" => {
+            "syq does not implement --munge-links; selected symlink target bytes are preserved unchanged."
         }
         "link-dest" | "compare-dest" | "copy-dest" => {
             "syq does not implement --link-dest/--compare-dest/--copy-dest."
@@ -1997,6 +2004,8 @@ fn message_for_short(c: char) -> Option<&'static str> {
         'S' => "sparse",
         'x' => "one-file-system",
         'L' => "copy-links",
+        'k' => "copy-dirlinks",
+        'K' => "keep-dirlinks",
         'i' => "itemize-changes",
         _ => return None,
     })

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -9124,6 +9124,40 @@ fn unsupported_rsync_flags_explain_themselves() {
         "bundled -H should be explained: {}",
         String::from_utf8_lossy(&out.stderr)
     );
+
+    // Every rsync mode that would traverse a descendant source or destination
+    // symlink is classified explicitly. In particular, --insecure-links is an
+    // operator-path/race-safety opt-out, not an alias for any of these modes.
+    for (flag, expected) in [
+        ("-aL", "source descendant-link traversal"),
+        ("-ak", "source descendant-link traversal"),
+        ("--copy-unsafe-links", "source descendant-link traversal"),
+        ("-aK", "existing destination directory symlinks"),
+        ("--keep-dirlinks", "existing destination directory symlinks"),
+    ] {
+        let out = syq(&[flag, "--insecure-links", &t.s("src/"), &t.s("link-dst/")]);
+        assert!(!out.status.success(), "{flag} unexpectedly succeeded");
+        let err = String::from_utf8_lossy(&out.stderr);
+        assert!(err.contains(expected), "{flag}: {err}");
+        assert!(
+            !t.path("link-dst").exists(),
+            "{flag} mutated its destination"
+        );
+    }
+
+    for (flag, expected) in [
+        ("--safe-links", "without classifying"),
+        ("--munge-links", "preserved unchanged"),
+    ] {
+        let out = syq(&["-a", flag, &t.s("src/"), &t.s("link-dst/")]);
+        assert!(!out.status.success(), "{flag} unexpectedly succeeded");
+        let err = String::from_utf8_lossy(&out.stderr);
+        assert!(err.contains(expected), "{flag}: {err}");
+        assert!(
+            !t.path("link-dst").exists(),
+            "{flag} mutated its destination"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- classify every rsync source and destination descendant-link traversal option explicitly
- keep `--insecure-links` distinct from `-L`, `-k`, and `-K`
- document unsupported safe-link filtering and target munging
- verify unsupported modes fail before destination mutation

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq` (358 passed)
- focused local unsupported-option regression
- `python3 scripts/check-doc-links.py`
- rsync 3.5 compatibility harness: recorded baseline reproduced (33 pass, 1 policy-open expected failure)