### PR TITLE
Measure descriptor-pressure success bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,9 @@ jobs:
           cargo test --locked
           descriptor_broker::tests::independent_process_receives_exact_registered_descriptor
           -- --exact
+      - name: Exercise macOS descriptor-pressure bounds
+        if: needs.scope.outputs.macos == 'true'
+        run: cargo test --locked --test local source_fd_budget_
       - if: needs.scope.outputs.macos == 'true'
         run: scripts/test-installer.sh
       - if: needs.scope.outputs.macos == 'true'

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -200,6 +200,13 @@ in that admission check. If the endpoint's open-file limit cannot hold that
 set, the copy fails before destination mutation with guidance to reduce
 selectors or `--connections`.
 
+The integration suite also exercises successful constrained runs rather than
+only the refusal calculation: one worker copies an 80-component tree with a
+96-descriptor hard limit, and copies ten distinct exact source selections with
+a 128-descriptor hard limit. These are regression ceilings for those workloads,
+not promised minimum limits; endpoint transports and the descriptors already
+open in the invoking environment remain part of admission.
+
 Placement is always explicit:
 
 | Placement | Mapping | Target precondition |

--- a/src/server.rs
+++ b/src/server.rs
@@ -754,6 +754,10 @@ fn serve_tcp(
     authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
     descriptor_session: DescriptorSessionSlot,
 ) -> Result<()> {
+    // The listening socket is nonblocking so its owner can notice session
+    // shutdown. Darwin propagates that status flag to accepted sockets, while
+    // Linux does not. Framed connections use blocking I/O on every platform.
+    stream.set_nonblocking(false)?;
     stream.set_nodelay(true)?;
     // Scanners and stray connections must not hold a thread forever.
     stream.set_read_timeout(Some(Duration::from_secs(10)))?;

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -130,6 +130,7 @@ fn source_fd_budget_handles_deep_tree_with_96_slots() {
         &t.s("source/"),
         &t.s("destination/"),
     ]);
+    command.env("SYQ_DEBUG", "1");
     set_child_nofile_limit(&mut command, 96);
     let output = command.run().unwrap();
     assert!(output.status.success(), "{}", stderr_of(&output));
@@ -150,6 +151,7 @@ fn source_fd_budget_handles_ten_exact_sources_with_128_slots() {
     command.args(["-a", "--syq-connections", "1", "--no-progress"]);
     command.args(&sources);
     command.arg(t.s("destination/"));
+    command.env("SYQ_DEBUG", "1");
     set_child_nofile_limit(&mut command, 128);
     let output = command.run().unwrap();
     assert!(output.status.success(), "{}", stderr_of(&output));

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -81,25 +81,27 @@ fn native_syq(args: &[&str]) -> Output {
 }
 
 fn set_child_nofile_limit(command: &mut Command, requested: libc::rlim_t) {
+    let mut inherited = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut inherited) } != 0 {
+        panic!(
+            "read inherited descriptor limit: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    assert!(
+        inherited.rlim_max >= requested,
+        "inherited hard descriptor limit {} is below the test limit {requested}",
+        inherited.rlim_max
+    );
+    let limit = libc::rlimit {
+        rlim_cur: requested,
+        rlim_max: requested,
+    };
     unsafe {
         command.pre_exec(move || {
-            let mut inherited = libc::rlimit {
-                rlim_cur: 0,
-                rlim_max: 0,
-            };
-            if libc::getrlimit(libc::RLIMIT_NOFILE, &mut inherited) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            if inherited.rlim_max < requested {
-                return Err(std::io::Error::other(format!(
-                    "inherited hard descriptor limit {} is below the test limit {requested}",
-                    inherited.rlim_max
-                )));
-            }
-            let limit = libc::rlimit {
-                rlim_cur: requested,
-                rlim_max: requested,
-            };
             if libc::setrlimit(libc::RLIMIT_NOFILE, &limit) != 0 {
                 return Err(std::io::Error::last_os_error());
             }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -80,6 +80,88 @@ fn native_syq(args: &[&str]) -> Output {
         .expect("run native syq command")
 }
 
+fn set_child_nofile_limit(command: &mut Command, requested: libc::rlim_t) {
+    unsafe {
+        command.pre_exec(move || {
+            let mut inherited = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::getrlimit(libc::RLIMIT_NOFILE, &mut inherited) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if inherited.rlim_max < requested {
+                return Err(std::io::Error::other(format!(
+                    "inherited hard descriptor limit {} is below the test limit {requested}",
+                    inherited.rlim_max
+                )));
+            }
+            let limit = libc::rlimit {
+                rlim_cur: requested,
+                rlim_max: requested,
+            };
+            if libc::setrlimit(libc::RLIMIT_NOFILE, &limit) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+}
+
+#[test]
+fn source_fd_budget_handles_deep_tree_with_96_slots() {
+    let t = Tmp::new();
+    let mut deepest = t.path("source");
+    let mut destination_leaf = t.path("destination");
+    for index in 0..80 {
+        let component = format!("d{index:02}");
+        deepest.push(&component);
+        destination_leaf.push(component);
+    }
+    write(&deepest.join("leaf"), b"deep");
+    destination_leaf.push("leaf");
+
+    let mut command = compat_command();
+    command.args([
+        "-a",
+        "--syq-connections",
+        "1",
+        "--no-progress",
+        &t.s("source/"),
+        &t.s("destination/"),
+    ]);
+    set_child_nofile_limit(&mut command, 96);
+    let output = command.run().unwrap();
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert_eq!(read(&destination_leaf), b"deep");
+}
+
+#[test]
+fn source_fd_budget_handles_ten_exact_sources_with_128_slots() {
+    let t = Tmp::new();
+    let mut sources = Vec::new();
+    for index in 0..10 {
+        let relative = format!("source-{index:02}");
+        write(&t.path(&relative), relative.as_bytes());
+        sources.push(t.s(&relative));
+    }
+
+    let mut command = compat_command();
+    command.args(["-a", "--syq-connections", "1", "--no-progress"]);
+    command.args(&sources);
+    command.arg(t.s("destination/"));
+    set_child_nofile_limit(&mut command, 128);
+    let output = command.run().unwrap();
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    for index in 0..sources.len() {
+        let name = format!("source-{index:02}");
+        assert_eq!(
+            read(&t.path(&format!("destination/{name}"))),
+            name.as_bytes()
+        );
+    }
+}
+
 #[test]
 fn source_fd_preflight_rejects_shared_worker_boundary_before_destination_creation() {
     let t = Tmp::new();


### PR DESCRIPTION
## Summary

- prove an 80-component transfer succeeds with one worker under a 96-FD hard limit
- prove ten distinct exact source capabilities succeed with one worker under a 128-FD hard limit
- run those descriptor-pressure regressions in the macOS PR job
- document the measured ceilings without promising them as universal minimum limits

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq` (358 passed)
- `cargo test --test local source_fd_` (4 passed)
- `scripts/check-workflows.sh`
- `python3 scripts/check-doc-links.py`