### PR TITLE
Add a build-identified wire preamble

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -132,7 +132,7 @@ fn is_non_retryable_connect_error(error: &anyhow::Error) -> bool {
     let message = format!("{error:#}");
     is_worker_initialization_error(error)
         || message.contains("build identity mismatch")
-        || message.contains("wire preamble")
+        || message.contains(WIRE_PREAMBLE_PROTOCOL_ERROR)
         || message.contains("unexpected handshake response")
         || message.contains("exit status: 127")
         || message.contains(&format!(
@@ -646,17 +646,20 @@ impl RemoteConn {
         if let Some(child) = &mut self.child {
             for _ in 0..20 {
                 if let Ok(Some(status)) = child.try_wait() {
-                    if self.multiplexed_ssh && status.code() == Some(255) {
-                        return MultiplexedSshSessionError(format!(
-                            "{}: multiplexed SSH session was rejected ({status})",
-                            self.label
-                        ))
-                        .into();
+                    if status.code() == Some(255) {
+                        if self.multiplexed_ssh {
+                            return MultiplexedSshSessionError(format!(
+                                "{}: multiplexed SSH session was rejected ({status})",
+                                self.label
+                            ))
+                            .into();
+                        }
+                        return anyhow!("{}: remote syq exited ({status})", self.label);
                     }
                     // For other early exits, a preamble failure is the
                     // actionable version-skew diagnosis; the exit status is
                     // commonly just the old helper rejecting unknown bytes.
-                    if detail.contains("wire preamble")
+                    if detail.contains(WIRE_PREAMBLE_PROTOCOL_ERROR)
                         || detail.contains("build identity mismatch")
                     {
                         return anyhow!("{}: {detail}", self.label);
@@ -666,7 +669,9 @@ impl RemoteConn {
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
         }
-        if detail.contains("wire preamble") || detail.contains("build identity mismatch") {
+        if detail.contains(WIRE_PREAMBLE_PROTOCOL_ERROR)
+            || detail.contains("build identity mismatch")
+        {
             return anyhow!("{}: {detail}", self.label);
         }
         let msg = if e
@@ -1616,7 +1621,7 @@ fn helper_needs_install(e: &anyhow::Error) -> bool {
         "exit status: {}",
         remote_helper::HELPER_NOT_EXECUTABLE_EXIT
     )) || message.contains("build identity mismatch")
-        || message.contains("wire preamble")
+        || message.contains(WIRE_PREAMBLE_PROTOCOL_ERROR)
 }
 
 /// Concurrently probe which (addr, speed) entries accept a TCP connection on
@@ -2724,12 +2729,42 @@ mod tests {
     }
 
     #[test]
-    fn missing_wire_preamble_is_non_retryable_and_refreshes_a_managed_helper() {
-        let error = anyhow!(
-            "wire preamble magic mismatch; remote syq may predate the build-identified preamble"
-        );
+    fn malformed_wire_preamble_is_non_retryable_and_refreshes_a_managed_helper() {
+        let error =
+            anyhow!("{WIRE_PREAMBLE_PROTOCOL_ERROR}: remote syq sent an invalid build identity");
         assert!(is_non_retryable_connect_error(&error));
         assert!(helper_needs_install(&error));
+    }
+
+    #[test]
+    fn ssh_exit_255_wins_over_a_missing_wire_preamble() {
+        let child = Command::new("/bin/sh")
+            .args(["-c", "exit 255"])
+            .spawn()
+            .unwrap();
+        let mut conn = RemoteConn {
+            child: Some(child),
+            w: FrameWriter::new(Box::new(std::io::sink()), false),
+            rx: None,
+            reader: None,
+            label: "retryable SSH test".into(),
+            dead: false,
+            peer: None,
+            tcp_socket: None,
+            multiplexed_ssh: false,
+        };
+        let error = conn.io_err(
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                format!("{WIRE_PREAMBLE_PROTOCOL_ERROR}: read header from remote syq"),
+            )
+            .into(),
+        );
+        let diagnostic = format!("{error:#}");
+        assert!(diagnostic.contains("exit status: 255"), "{diagnostic}");
+        assert!(!diagnostic.contains(WIRE_PREAMBLE_PROTOCOL_ERROR));
+        assert!(!is_non_retryable_connect_error(&error));
+        assert!(!helper_needs_install(&error));
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -132,6 +132,7 @@ fn is_non_retryable_connect_error(error: &anyhow::Error) -> bool {
     let message = format!("{error:#}");
     is_worker_initialization_error(error)
         || message.contains("build identity mismatch")
+        || message.contains("wire preamble")
         || message.contains("unexpected handshake response")
         || message.contains("exit status: 127")
         || message.contains(&format!(
@@ -638,7 +639,10 @@ impl RemoteConn {
 
     fn io_err(&mut self, e: anyhow::Error) -> anyhow::Error {
         self.dead = true;
-        // If the child has exited (or does so shortly), that's the more useful error.
+        let detail = format!("{e:#}");
+        // If the child has exited (or does so shortly), that's usually the
+        // more useful error. A multiplexed SSH refusal in particular must win
+        // over the missing-preamble EOF so the caller can retry independently.
         if let Some(child) = &mut self.child {
             for _ in 0..20 {
                 if let Ok(Some(status)) = child.try_wait() {
@@ -649,10 +653,21 @@ impl RemoteConn {
                         ))
                         .into();
                     }
+                    // For other early exits, a preamble failure is the
+                    // actionable version-skew diagnosis; the exit status is
+                    // commonly just the old helper rejecting unknown bytes.
+                    if detail.contains("wire preamble")
+                        || detail.contains("build identity mismatch")
+                    {
+                        return anyhow!("{}: {detail}", self.label);
+                    }
                     return anyhow!("{}: remote syq exited ({status})", self.label);
                 }
                 std::thread::sleep(std::time::Duration::from_millis(10));
             }
+        }
+        if detail.contains("wire preamble") || detail.contains("build identity mismatch") {
+            return anyhow!("{}: {detail}", self.label);
         }
         let msg = if e
             .downcast_ref::<std::io::Error>()
@@ -660,7 +675,7 @@ impl RemoteConn {
         {
             "connection closed by remote".to_string()
         } else {
-            format!("{e:#}")
+            detail
         };
         anyhow!("{}: {msg}", self.label)
     }
@@ -1601,6 +1616,7 @@ fn helper_needs_install(e: &anyhow::Error) -> bool {
         "exit status: {}",
         remote_helper::HELPER_NOT_EXECUTABLE_EXIT
     )) || message.contains("build identity mismatch")
+        || message.contains("wire preamble")
 }
 
 /// Concurrently probe which (addr, speed) entries accept a TCP connection on
@@ -2705,6 +2721,15 @@ mod tests {
         );
         assert!(is_non_retryable_connect_error(&error));
         server.join().unwrap();
+    }
+
+    #[test]
+    fn missing_wire_preamble_is_non_retryable_and_refreshes_a_managed_helper() {
+        let error = anyhow!(
+            "wire preamble magic mismatch; remote syq may predate the build-identified preamble"
+        );
+        assert!(is_non_retryable_connect_error(&error));
+        assert!(helper_needs_install(&error));
     }
 
     #[test]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -22,6 +22,7 @@ const COMPRESS_LEVEL: i32 = 1;
 const WIRE_PREAMBLE_MAGIC: &[u8; 8] = b"SYQWIRE\0";
 const WIRE_PREAMBLE_FIXED_LEN: usize = WIRE_PREAMBLE_MAGIC.len() + 2;
 const MAX_BUILD_IDENTITY_BYTES: usize = 512;
+pub(crate) const WIRE_PREAMBLE_PROTOCOL_ERROR: &str = "wire preamble protocol error";
 #[cfg(target_os = "linux")]
 const MODE_SYMLINK: u32 = libc::S_IFLNK;
 #[cfg(not(target_os = "linux"))]
@@ -1056,7 +1057,9 @@ impl<W: Write> FrameWriter<W> {
             .ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
-                    "local build identity exceeds the wire preamble limit",
+                    format!(
+                        "{WIRE_PREAMBLE_PROTOCOL_ERROR}: local build identity exceeds the supported limit"
+                    ),
                 )
             })?;
         self.w.write_all(WIRE_PREAMBLE_MAGIC)?;
@@ -1118,7 +1121,7 @@ impl<R: Read> FrameReader<R> {
             io::Error::new(
                 error.kind(),
                 format!(
-                    "read wire preamble from remote syq: {error}; remote may be incompatible with local build {}",
+                    "{WIRE_PREAMBLE_PROTOCOL_ERROR}: read header from remote syq: {error}; remote may be incompatible with local build {}",
                     crate::identity::build()
                 ),
             )
@@ -1127,7 +1130,7 @@ impl<R: Read> FrameReader<R> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "wire preamble magic mismatch; remote syq may predate the build-identified preamble (local {})",
+                    "{WIRE_PREAMBLE_PROTOCOL_ERROR}: magic mismatch; remote syq may predate the build-identified preamble (local {})",
                     crate::identity::build()
                 ),
             ));
@@ -1140,27 +1143,31 @@ impl<R: Read> FrameReader<R> {
         if identity_len == 0 || identity_len > MAX_BUILD_IDENTITY_BYTES {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("remote syq build identity length {identity_len} is invalid"),
+                format!(
+                    "{WIRE_PREAMBLE_PROTOCOL_ERROR}: remote syq build identity length {identity_len} is invalid"
+                ),
             ));
         }
         let mut identity = vec![0u8; identity_len];
         self.r.read_exact(&mut identity).map_err(|error| {
             io::Error::new(
                 error.kind(),
-                format!("read remote syq build identity: {error}"),
+                format!("{WIRE_PREAMBLE_PROTOCOL_ERROR}: read remote syq build identity: {error}"),
             )
         })?;
         let identity = std::str::from_utf8(&identity).map_err(|error| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("remote syq build identity is not UTF-8: {error}"),
+                format!(
+                    "{WIRE_PREAMBLE_PROTOCOL_ERROR}: remote syq build identity is not UTF-8: {error}"
+                ),
             )
         })?;
         if identity != crate::identity::build() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "build identity mismatch (remote {identity}, local {})",
+                    "{WIRE_PREAMBLE_PROTOCOL_ERROR}: build identity mismatch (remote {identity}, local {})",
                     crate::identity::build()
                 ),
             ));
@@ -1293,8 +1300,41 @@ mod tests {
             .read_msg::<Request>()
             .unwrap_err();
         let diagnostic = error.to_string();
-        assert!(diagnostic.contains("wire preamble magic mismatch"));
+        assert!(diagnostic.contains(WIRE_PREAMBLE_PROTOCOL_ERROR));
+        assert!(diagnostic.contains("magic mismatch"));
         assert!(diagnostic.contains("may predate"));
+    }
+
+    #[test]
+    fn every_malformed_build_identity_is_a_preamble_protocol_error() {
+        let preamble = |length: u16, identity: &[u8]| {
+            let mut input = Vec::new();
+            input.extend_from_slice(WIRE_PREAMBLE_MAGIC);
+            input.extend_from_slice(&length.to_be_bytes());
+            input.extend_from_slice(identity);
+            input
+        };
+        let cases = [
+            (preamble(0, b""), "length 0 is invalid"),
+            (
+                preamble((MAX_BUILD_IDENTITY_BYTES + 1) as u16, b""),
+                "length 513 is invalid",
+            ),
+            (preamble(4, b"ab"), "read remote syq build identity"),
+            (preamble(1, &[0xff]), "not UTF-8"),
+        ];
+
+        for (input, expected) in cases {
+            let error = FrameReader::new(input.as_slice())
+                .read_msg::<Response>()
+                .unwrap_err();
+            let diagnostic = error.to_string();
+            assert!(
+                diagnostic.contains(WIRE_PREAMBLE_PROTOCOL_ERROR),
+                "{diagnostic}"
+            );
+            assert!(diagnostic.contains(expected), "{diagnostic}");
+        }
     }
 
     #[test]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,9 +1,11 @@
-//! Wire protocol: message types and length-prefixed framing.
+//! Wire protocol: build-identified preambles, message types, and framing.
 //!
-//! Every connection (control or data) speaks the same request/response
-//! protocol. Frames are `u32 len | u8 flags | payload`, payload is postcard;
-//! flag bit 0 means the payload is zstd-compressed. Each writer decides
-//! independently whether to compress, readers always accept both.
+//! Every connection (control or data) begins each direction with a plain-byte
+//! preamble containing a fixed magic string and the sender's build identity.
+//! Only after that identity matches do frames begin. Frames are
+//! `u32 len | u8 flags | payload`, payload is postcard; flag bit 0 means the
+//! payload is zstd-compressed. Each writer decides independently whether to
+//! compress, readers always accept both.
 
 use crate::descriptor_broker::{DescriptorTicket, RegisteredRootId};
 use anyhow::{bail, Result};
@@ -17,6 +19,9 @@ const HASH_RESPONSE_BYTES_PER_ENTRY: u64 = 32;
 const HASH_RESPONSE_OVERHEAD: u64 = 24;
 const COMPRESS_MIN: usize = 512;
 const COMPRESS_LEVEL: i32 = 1;
+const WIRE_PREAMBLE_MAGIC: &[u8; 8] = b"SYQWIRE\0";
+const WIRE_PREAMBLE_FIXED_LEN: usize = WIRE_PREAMBLE_MAGIC.len() + 2;
+const MAX_BUILD_IDENTITY_BYTES: usize = 512;
 #[cfg(target_os = "linux")]
 const MODE_SYMLINK: u32 = libc::S_IFLNK;
 #[cfg(not(target_os = "linux"))]
@@ -1028,6 +1033,7 @@ impl SizeHint for Response {
 pub struct FrameWriter<W: Write> {
     w: BufWriter<W>,
     pub compress: bool,
+    preamble_written: bool,
 }
 
 impl<W: Write> FrameWriter<W> {
@@ -1035,10 +1041,34 @@ impl<W: Write> FrameWriter<W> {
         FrameWriter {
             w: BufWriter::with_capacity(1 << 20, w),
             compress,
+            preamble_written: false,
         }
     }
 
+    pub fn write_preamble(&mut self) -> io::Result<()> {
+        if self.preamble_written {
+            return Ok(());
+        }
+        let identity = crate::identity::build().as_bytes();
+        let identity_len = u16::try_from(identity.len())
+            .ok()
+            .filter(|length| usize::from(*length) <= MAX_BUILD_IDENTITY_BYTES)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "local build identity exceeds the wire preamble limit",
+                )
+            })?;
+        self.w.write_all(WIRE_PREAMBLE_MAGIC)?;
+        self.w.write_all(&identity_len.to_be_bytes())?;
+        self.w.write_all(identity)?;
+        self.w.flush()?;
+        self.preamble_written = true;
+        Ok(())
+    }
+
     pub fn write_msg<T: Serialize + SizeHint>(&mut self, msg: &T) -> io::Result<()> {
+        self.write_preamble()?;
         let payload = postcard::to_extend(msg, Vec::with_capacity(msg.size_hint()))
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let mut flag = 0u8;
@@ -1068,16 +1098,79 @@ impl<W: Write> FrameWriter<W> {
 
 pub struct FrameReader<R: Read> {
     r: BufReader<R>,
+    preamble_read: bool,
 }
 
 impl<R: Read> FrameReader<R> {
     pub fn new(r: R) -> Self {
         FrameReader {
             r: BufReader::with_capacity(1 << 20, r),
+            preamble_read: false,
         }
     }
 
+    fn read_preamble(&mut self) -> io::Result<()> {
+        if self.preamble_read {
+            return Ok(());
+        }
+        let mut fixed = [0u8; WIRE_PREAMBLE_FIXED_LEN];
+        self.r.read_exact(&mut fixed).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!(
+                    "read wire preamble from remote syq: {error}; remote may be incompatible with local build {}",
+                    crate::identity::build()
+                ),
+            )
+        })?;
+        if &fixed[..WIRE_PREAMBLE_MAGIC.len()] != WIRE_PREAMBLE_MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "wire preamble magic mismatch; remote syq may predate the build-identified preamble (local {})",
+                    crate::identity::build()
+                ),
+            ));
+        }
+        let identity_len = u16::from_be_bytes(
+            fixed[WIRE_PREAMBLE_MAGIC.len()..]
+                .try_into()
+                .expect("fixed preamble length"),
+        ) as usize;
+        if identity_len == 0 || identity_len > MAX_BUILD_IDENTITY_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("remote syq build identity length {identity_len} is invalid"),
+            ));
+        }
+        let mut identity = vec![0u8; identity_len];
+        self.r.read_exact(&mut identity).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("read remote syq build identity: {error}"),
+            )
+        })?;
+        let identity = std::str::from_utf8(&identity).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("remote syq build identity is not UTF-8: {error}"),
+            )
+        })?;
+        if identity != crate::identity::build() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "build identity mismatch (remote {identity}, local {})",
+                    crate::identity::build()
+                ),
+            ));
+        }
+        self.preamble_read = true;
+        Ok(())
+    }
+
     pub fn read_msg<T: for<'de> Deserialize<'de>>(&mut self) -> io::Result<T> {
+        self.read_preamble()?;
         let mut hdr = [0u8; 4];
         self.r.read_exact(&mut hdr)?;
         let len = u32::from_le_bytes(hdr) as usize;
@@ -1118,6 +1211,10 @@ impl<R: Read> FrameReader<R> {
 mod tests {
     use super::*;
 
+    fn local_preamble_len() -> usize {
+        WIRE_PREAMBLE_FIXED_LEN + crate::identity::build().len()
+    }
+
     fn block_frame(data: Vec<u8>, compress: bool) -> Vec<u8> {
         let mut frame = Vec::new();
         FrameWriter::new(&mut frame, compress)
@@ -1134,7 +1231,11 @@ mod tests {
     fn compression_is_per_frame_and_never_expands_the_wire_payload() {
         let data = vec![b'a'; 64 * 1024];
         let compressed = block_frame(data.clone(), true);
-        assert_eq!(compressed[4], 1, "compressible frame was not compressed");
+        assert_eq!(
+            compressed[local_preamble_len() + 4],
+            1,
+            "compressible frame was not compressed"
+        );
 
         let decoded = FrameReader::new(compressed.as_slice())
             .read_msg::<Response>()
@@ -1152,7 +1253,11 @@ mod tests {
         }
 
         let disabled = block_frame(data, false);
-        assert_eq!(disabled[4], 0, "disabled compression changed the frame");
+        assert_eq!(
+            disabled[local_preamble_len() + 4],
+            0,
+            "disabled compression changed the frame"
+        );
 
         let mut random = vec![0u8; 64 * 1024];
         let mut state = 0x9e37_79b9_7f4a_7c15u64;
@@ -1164,9 +1269,50 @@ mod tests {
         }
         let incompressible = block_frame(random, true);
         assert_eq!(
-            incompressible[4], 0,
+            incompressible[local_preamble_len() + 4],
+            0,
             "an expanded compressed representation was selected"
         );
+    }
+
+    #[test]
+    fn captured_old_format_handshake_is_rejected_before_postcard_decode() {
+        // Captured pre-preamble frame for Request::Hello { identity: "v0.1.8",
+        // compress: false, debug: false, token: [], role: Control }.
+        const OLD_FORMAT_HELLO: &[u8] = &[
+            0x0d, 0x00, 0x00, 0x00, // frame length
+            0x00, // frame flags
+            0x00, // Request::Hello
+            0x06, b'v', b'0', b'.', b'1', b'.', b'8', // identity
+            0x00, 0x00, // compress, debug
+            0x00, // empty token
+            0x00, // ConnectionRole::Control
+        ];
+
+        let error = FrameReader::new(OLD_FORMAT_HELLO)
+            .read_msg::<Request>()
+            .unwrap_err();
+        let diagnostic = error.to_string();
+        assert!(diagnostic.contains("wire preamble magic mismatch"));
+        assert!(diagnostic.contains("may predate"));
+    }
+
+    #[test]
+    fn build_identity_mismatch_is_reported_before_frame_decode() {
+        let remote_identity = b"v0.0.0+different-build";
+        let mut input = Vec::new();
+        input.extend_from_slice(WIRE_PREAMBLE_MAGIC);
+        input.extend_from_slice(&(remote_identity.len() as u16).to_be_bytes());
+        input.extend_from_slice(remote_identity);
+        input.extend_from_slice(b"not a postcard frame");
+
+        let error = FrameReader::new(input.as_slice())
+            .read_msg::<Response>()
+            .unwrap_err();
+        let diagnostic = error.to_string();
+        assert!(diagnostic.contains("build identity mismatch"));
+        assert!(diagnostic.contains("remote v0.0.0+different-build"));
+        assert!(diagnostic.contains(crate::identity::build()));
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -143,6 +143,10 @@ fn serve<R: Read + Send + 'static, W: Write>(
     } = session;
     let mut r = FrameReader::new(r);
     let mut w = FrameWriter::new(w, false);
+    // Send our build identity before waiting for the client's first postcard
+    // frame. Both peers can therefore diagnose version skew even when their
+    // Request or Response enum layouts no longer agree.
+    w.write_preamble().context("write wire preamble")?;
 
     let debug;
     let role;
@@ -1224,7 +1228,8 @@ mod tests {
         }
         // Give the accept loop (which polls every 25ms) time to take every
         // pending socket, then confirm each is being served rather than
-        // dropped: a served socket stays silent, a dropped one reads EOF.
+        // dropped. A socket with no connection id stays silent; the one that
+        // supplied an id receives the server's proactive wire preamble.
         std::thread::sleep(Duration::from_millis(200));
         for socket in &pending {
             socket
@@ -1234,6 +1239,7 @@ mod tests {
             match (&*socket).read(&mut byte) {
                 Err(error)
                     if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {}
+                Ok(1) => {}
                 other => panic!("pending socket was not held open: {other:?}"),
             }
         }


### PR DESCRIPTION
## Summary

- send a fixed plain-byte SYQWIRE magic and bounded build identity in each direction before the first postcard frame on every control or data connection
- have the server send its preamble proactively, so either side can diagnose version skew before decoding Request or Response enum layouts
- classify preamble and build-identity failures as non-retryable protocol errors while refreshing managed helpers, without breaking the independent-SSH retry for a multiplexed connection refusal
- add captured old-format handshake coverage and prove build mismatch wins before postcard decoding

This is intentionally separate from the restricted-receiver safety changes so the wire-format transition can be reviewed and landed independently before release.

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --bin syq (372 passed)
- cargo test --all-targets (372 unit, 352 local integration, and 7 update tests passed)
- scripts/test-real-ssh.sh