### PR TITLE
Fix unsafe-audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,12 @@ jobs:
           cargo test --locked
           descriptor_broker::tests::independent_process_receives_exact_registered_descriptor
           -- --exact
+      - name: Exercise macOS descriptor soft-limit raise and umask read
+        if: needs.scope.outputs.macos == 'true'
+        run: >-
+          cargo test --locked --bin syq --
+          --exact tests::raise_nofile_lifts_the_soft_limit_to_a_usable_value
+          fsops::tests::process_umask_matches_file_creation
       - name: Exercise macOS descriptor-pressure bounds
         if: needs.scope.outputs.macos == 'true'
         run: cargo test --locked --test local source_fd_budget_

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
         if: needs.scope.outputs.macos == 'true'
         run: >-
           cargo test --locked --bin syq --
-          --exact tests::raise_nofile_lifts_the_soft_limit_to_a_usable_value
+          --exact tests::raise_nofile_reaches_its_target
           fsops::tests::process_umask_matches_file_creation
       - name: Exercise macOS descriptor-pressure bounds
         if: needs.scope.outputs.macos == 'true'

--- a/src/descriptor_broker.rs
+++ b/src/descriptor_broker.rs
@@ -652,6 +652,10 @@ fn receive_descriptor(socket: RawFd) -> io::Result<(u8, Option<File>)> {
 
     let mut descriptors = Vec::new();
     let mut malformed = message.msg_flags & libc::MSG_CTRUNC != 0;
+    // SAFETY: recvmsg filled `control` through `message` and set
+    // `msg_controllen` to the bytes it wrote, which bounds the header walk.
+    // Every SCM_RIGHTS payload holds descriptors this process now owns; each
+    // is wrapped exactly once so a later rejection closes all of them.
     unsafe {
         let mut header = libc::CMSG_FIRSTHDR(&message);
         while !header.is_null() {
@@ -667,9 +671,7 @@ fn receive_descriptor(socket: RawFd) -> io::Result<(u8, Option<File>)> {
                     let raw = std::ptr::read_unaligned(
                         libc::CMSG_DATA(header).cast::<RawFd>().add(index),
                     );
-                    let file = File::from_raw_fd(raw);
-                    set_close_on_exec(&file)?;
-                    descriptors.push(file);
+                    descriptors.push(File::from_raw_fd(raw));
                 }
             } else {
                 malformed = true;
@@ -684,7 +686,11 @@ fn receive_descriptor(socket: RawFd) -> io::Result<(u8, Option<File>)> {
             "descriptor broker returned malformed ancillary data",
         ));
     }
-    Ok((status[0], descriptors.pop()))
+    let descriptor = descriptors.pop();
+    if let Some(file) = &descriptor {
+        set_close_on_exec(file)?;
+    }
+    Ok((status[0], descriptor))
 }
 
 fn set_close_on_exec(file: &File) -> io::Result<()> {

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1229,6 +1229,42 @@ fn is_root() -> bool {
     unsafe { libc::geteuid() == 0 }
 }
 
+/// The process file-creation mask. Linux publishes it in `/proc/self/status`
+/// (kernel 4.7 and later), which avoids the umask(2) set-and-restore window
+/// during which another thread would create files with the probe mask. The
+/// portable probe is used elsewhere; callers read the mask before starting
+/// any thread that creates files.
+pub(crate) fn process_umask() -> u32 {
+    #[cfg(target_os = "linux")]
+    if let Some(mask) = fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|status| parse_proc_status_umask(&status))
+    {
+        return mask;
+    }
+    probe_umask()
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_status_umask(status: &str) -> Option<u32> {
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix("Umask:"))
+        .and_then(|value| u32::from_str_radix(value.trim(), 8).ok())
+        .filter(|mask| *mask <= 0o777)
+}
+
+fn probe_umask() -> u32 {
+    // SAFETY: umask(2) only exchanges the process mask and the original is
+    // restored at once; the callers guarantee no other thread creates files
+    // in between.
+    unsafe {
+        let mask = libc::umask(0o022);
+        libc::umask(mask);
+        mask as u32
+    }
+}
+
 fn source_descriptor_requirement(
     current_open: usize,
     root_count: usize,
@@ -4782,15 +4818,18 @@ impl FsOps {
                 return Ok(CopyLocalOutcome::Unsupported);
             }
         }
-        let mut off: i64 = 0;
+        let mut source_offset: libc::off64_t = 0;
+        let mut destination_offset: libc::off64_t = 0;
         let mut remaining = size;
         while remaining > 0 && !userspace_fallback {
+            // SAFETY: each offset is its own local that outlives the call, so
+            // the kernel reads and advances the two through distinct pointers.
             let n = unsafe {
                 libc::copy_file_range(
                     s.as_raw_fd(),
-                    &mut off as *mut i64 as *mut _,
+                    &mut source_offset,
                     d.as_raw_fd(),
-                    &mut off as *mut i64 as *mut _,
+                    &mut destination_offset,
                     remaining as usize,
                     0,
                 )
@@ -9109,5 +9148,31 @@ mod tests {
         if limits.rlim_cur != libc::RLIM_INFINITY {
             assert!(current_open_descriptor_count(limits.rlim_cur).unwrap() >= 3);
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn proc_status_umask_parses_only_the_kernel_line() {
+        assert_eq!(
+            parse_proc_status_umask("Name:\tsyq\nUmask:\t0022\nState:\tR (running)\n"),
+            Some(0o022)
+        );
+        assert_eq!(parse_proc_status_umask("Umask:\t0077\n"), Some(0o077));
+        assert_eq!(parse_proc_status_umask("Name:\tsyq\n"), None);
+        assert_eq!(parse_proc_status_umask("Umask:\t8\n"), None);
+        assert_eq!(parse_proc_status_umask("Umask:\t01777\n"), None);
+    }
+
+    #[test]
+    fn process_umask_matches_file_creation() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o777)
+            .open(temp.path().join("probe"))
+            .unwrap();
+        let created = file.metadata().unwrap().mode() & 0o777;
+        assert_eq!(created, 0o777 & !process_umask());
     }
 }

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1229,12 +1229,26 @@ fn is_root() -> bool {
     unsafe { libc::geteuid() == 0 }
 }
 
-/// The process file-creation mask. Linux publishes it in `/proc/self/status`
-/// (kernel 4.7 and later), which avoids the umask(2) set-and-restore window
-/// during which another thread would create files with the probe mask. The
-/// portable probe is used elsewhere; callers read the mask before starting
-/// any thread that creates files.
+static PROCESS_UMASK: OnceLock<u32> = OnceLock::new();
+
+/// Record the file-creation mask while the process is still single-threaded.
+/// `main` calls this before anything can spawn a thread, so the portable
+/// probe in `read_process_umask` never races another file creation.
+pub(crate) fn capture_process_umask() {
+    PROCESS_UMASK.get_or_init(read_process_umask);
+}
+
+/// The process file-creation mask captured at startup. A caller that runs
+/// without `main`, such as a unit test, reads it lazily instead.
 pub(crate) fn process_umask() -> u32 {
+    *PROCESS_UMASK.get_or_init(read_process_umask)
+}
+
+/// Linux publishes the mask in `/proc/self/status` (kernel 4.7 and later),
+/// which avoids the umask(2) set-and-restore window during which another
+/// thread would create files with the probe mask. Elsewhere the probe is the
+/// only option, so it must run while the process is single-threaded.
+fn read_process_umask() -> u32 {
     #[cfg(target_os = "linux")]
     if let Some(mask) = fs::read_to_string("/proc/self/status")
         .ok()
@@ -1256,13 +1270,35 @@ fn parse_proc_status_umask(status: &str) -> Option<u32> {
 
 fn probe_umask() -> u32 {
     // SAFETY: umask(2) only exchanges the process mask and the original is
-    // restored at once; the callers guarantee no other thread creates files
-    // in between.
+    // restored at once; `capture_process_umask` runs this before any thread
+    // exists, so no other file creation can observe the probe value.
     unsafe {
         let mask = libc::umask(0o022);
         libc::umask(mask);
         mask as u32
     }
+}
+
+/// Read this process's open-file limits.
+pub(crate) fn nofile_limits() -> io::Result<libc::rlimit> {
+    let mut limits = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: getrlimit writes only into the local struct passed by pointer.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(limits)
+}
+
+/// Replace this process's open-file limits.
+pub(crate) fn set_nofile_limits(limits: &libc::rlimit) -> io::Result<()> {
+    // SAFETY: setrlimit only reads the struct behind the pointer.
+    if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, limits) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 fn source_descriptor_requirement(
@@ -1341,13 +1377,7 @@ fn require_source_descriptor_capacity(
     shared_workers: usize,
     independent_workers: usize,
 ) -> Result<()> {
-    let mut limit = libc::rlimit {
-        rlim_cur: 0,
-        rlim_max: 0,
-    };
-    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) } != 0 {
-        return Err(io::Error::last_os_error()).context("read source endpoint file limit");
-    }
+    let limit = nofile_limits().context("read source endpoint file limit")?;
     if limit.rlim_cur == libc::RLIM_INFINITY {
         return Ok(());
     }
@@ -9137,14 +9167,7 @@ mod tests {
 
     #[test]
     fn live_descriptor_snapshot_includes_this_process() {
-        let mut limits = libc::rlimit {
-            rlim_cur: 0,
-            rlim_max: 0,
-        };
-        assert_eq!(
-            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) },
-            0
-        );
+        let limits = nofile_limits().unwrap();
         if limits.rlim_cur != libc::RLIM_INFINITY {
             assert!(current_open_descriptor_count(limits.rlim_cur).unwrap() >= 3);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,19 +48,74 @@ fn tune_allocator() {
 #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 fn tune_allocator() {}
 
-/// Many workers each keep a few files open; the default soft limit (1024) is
-/// too small for -j32, so use whatever the hard limit allows.
+/// Many workers each keep a few files open; the default soft limit (1024 on
+/// Linux, 256 on macOS) is too small for -j32, so use whatever the hard limit
+/// allows. Best effort: the source descriptor budget later reports what the
+/// endpoint actually permits.
 fn raise_nofile() {
-    unsafe {
-        let mut rl = libc::rlimit {
-            rlim_cur: 0,
-            rlim_max: 0,
+    let mut limits = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: getrlimit writes only into the local struct passed by pointer.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) } != 0
+        || limits.rlim_cur >= limits.rlim_max
+    {
+        return;
+    }
+    for candidate in nofile_candidates(limits.rlim_max) {
+        let wanted = candidate.min(limits.rlim_max);
+        if wanted <= limits.rlim_cur {
+            continue;
+        }
+        let raised = libc::rlimit {
+            rlim_cur: wanted,
+            rlim_max: limits.rlim_max,
         };
-        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut rl) == 0 && rl.rlim_cur < rl.rlim_max {
-            rl.rlim_cur = rl.rlim_max.min(1 << 20);
-            libc::setrlimit(libc::RLIMIT_NOFILE, &rl);
+        // SAFETY: setrlimit reads only the local struct. A rejected value
+        // leaves the limit unchanged, so the next candidate can be tried.
+        if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &raised) } == 0 {
+            return;
         }
     }
+}
+
+/// Soft limits to try, highest first. Linux accepts anything up to the hard
+/// limit, so one candidate suffices. macOS usually reports an unlimited hard
+/// limit but rejects a soft limit above `kern.maxfilesperproc` with EINVAL
+/// instead of clamping it, so that ceiling and then `OPEN_MAX` follow.
+fn nofile_candidates(hard_limit: libc::rlim_t) -> Vec<libc::rlim_t> {
+    let ceiling = hard_limit.min(1 << 20);
+    #[cfg(target_os = "macos")]
+    {
+        let mut candidates = vec![ceiling];
+        candidates.extend(max_files_per_process());
+        candidates.push(10240);
+        candidates
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        vec![ceiling]
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn max_files_per_process() -> Option<libc::rlim_t> {
+    let mut value: libc::c_int = 0;
+    let mut length = std::mem::size_of::<libc::c_int>();
+    // SAFETY: sysctlbyname writes at most `length` bytes into `value` and
+    // stores the bytes written back through `length`; no new value is set.
+    let result = unsafe {
+        libc::sysctlbyname(
+            c"kern.maxfilesperproc".as_ptr(),
+            (&mut value as *mut libc::c_int).cast(),
+            &mut length,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    (result == 0 && length == std::mem::size_of::<libc::c_int>() && value > 0)
+        .then(|| value as libc::rlim_t)
 }
 
 fn main() {
@@ -200,5 +255,29 @@ fn main() {
             eprintln!("syq: {e:#}");
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn raise_nofile_lifts_the_soft_limit_to_a_usable_value() {
+        super::raise_nofile();
+        let mut limits = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: getrlimit writes only into the local struct.
+        assert_eq!(
+            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) },
+            0
+        );
+        // A rejected raise would leave macOS at its default soft limit of 256.
+        assert!(
+            limits.rlim_cur >= limits.rlim_max.min(1024),
+            "soft descriptor limit {} was not raised toward hard limit {}",
+            limits.rlim_cur,
+            limits.rlim_max
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,50 +53,40 @@ fn tune_allocator() {}
 /// allows. Best effort: the source descriptor budget later reports what the
 /// endpoint actually permits.
 fn raise_nofile() {
-    let mut limits = libc::rlimit {
-        rlim_cur: 0,
-        rlim_max: 0,
-    };
-    // SAFETY: getrlimit writes only into the local struct passed by pointer.
-    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) } != 0
-        || limits.rlim_cur >= limits.rlim_max
-    {
+    let Some((limits, wanted)) = nofile_raise_target() else {
         return;
-    }
-    for candidate in nofile_candidates(limits.rlim_max) {
-        let wanted = candidate.min(limits.rlim_max);
-        if wanted <= limits.rlim_cur {
-            continue;
-        }
-        let raised = libc::rlimit {
-            rlim_cur: wanted,
-            rlim_max: limits.rlim_max,
-        };
-        // SAFETY: setrlimit reads only the local struct. A rejected value
-        // leaves the limit unchanged, so the next candidate can be tried.
-        if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &raised) } == 0 {
-            return;
-        }
-    }
+    };
+    let _ = fsops::set_nofile_limits(&libc::rlimit {
+        rlim_cur: wanted,
+        rlim_max: limits.rlim_max,
+    });
 }
 
-/// Soft limits to try, highest first. Linux accepts anything up to the hard
-/// limit, so one candidate suffices. macOS usually reports an unlimited hard
-/// limit but rejects a soft limit above `kern.maxfilesperproc` with EINVAL
-/// instead of clamping it, so that ceiling and then `OPEN_MAX` follow.
-fn nofile_candidates(hard_limit: libc::rlim_t) -> Vec<libc::rlim_t> {
-    let ceiling = hard_limit.min(1 << 20);
-    #[cfg(target_os = "macos")]
-    {
-        let mut candidates = vec![ceiling];
-        candidates.extend(max_files_per_process());
-        candidates.push(10240);
-        candidates
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        vec![ceiling]
-    }
+/// The current limits and the soft limit worth requesting, or `None` when the
+/// soft limit is already as high as it can usefully go. The request stays at
+/// or below one million descriptors and the platform ceiling.
+fn nofile_raise_target() -> Option<(libc::rlimit, libc::rlim_t)> {
+    let limits = fsops::nofile_limits().ok()?;
+    let wanted = platform_nofile_ceiling(limits.rlim_max.min(1 << 20));
+    (wanted > limits.rlim_cur).then_some((limits, wanted))
+}
+
+/// macOS usually reports an unlimited hard limit but enforces
+/// `kern.maxfilesperproc` as the real per-process ceiling. macOS 11 and later
+/// store a higher soft limit and apply the ceiling internally; macOS 10.15 and
+/// earlier rejected such a request with EINVAL instead of clamping it, which
+/// left the default soft limit of 256 in place. Requesting at most the ceiling
+/// behaves the same on both. `OPEN_MAX` is the kernel's initial value for the
+/// ceiling and stands in when the sysctl is unavailable.
+#[cfg(target_os = "macos")]
+fn platform_nofile_ceiling(wanted: libc::rlim_t) -> libc::rlim_t {
+    const OPEN_MAX: libc::rlim_t = 10240;
+    wanted.min(max_files_per_process().unwrap_or(OPEN_MAX))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_nofile_ceiling(wanted: libc::rlim_t) -> libc::rlim_t {
+    wanted
 }
 
 #[cfg(target_os = "macos")]
@@ -121,6 +111,7 @@ fn max_files_per_process() -> Option<libc::rlim_t> {
 fn main() {
     tune_allocator();
     raise_nofile();
+    fsops::capture_process_umask();
     let argv: Vec<std::ffi::OsString> = std::env::args_os().collect();
     if argv.get(1).and_then(|arg| arg.to_str()) == Some("--build-identity") {
         println!("{}", identity::build());
@@ -261,23 +252,23 @@ fn main() {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn raise_nofile_lifts_the_soft_limit_to_a_usable_value() {
+    fn raise_nofile_reaches_its_target() {
+        let target = super::nofile_raise_target();
         super::raise_nofile();
-        let mut limits = libc::rlimit {
-            rlim_cur: 0,
-            rlim_max: 0,
-        };
-        // SAFETY: getrlimit writes only into the local struct.
-        assert_eq!(
-            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) },
-            0
-        );
-        // A rejected raise would leave macOS at its default soft limit of 256.
+        let after = crate::fsops::nofile_limits().unwrap();
+        if let Some((before, wanted)) = target {
+            assert!(wanted > before.rlim_cur);
+            assert_eq!(
+                after.rlim_cur, wanted,
+                "soft descriptor limit {} did not reach {wanted} under hard limit {}",
+                after.rlim_cur, before.rlim_max
+            );
+        }
         assert!(
-            limits.rlim_cur >= limits.rlim_max.min(1024),
-            "soft descriptor limit {} was not raised toward hard limit {}",
-            limits.rlim_cur,
-            limits.rlim_max
+            super::nofile_raise_target().is_none(),
+            "soft descriptor limit {} can still be raised under hard limit {}",
+            after.rlim_cur,
+            after.rlim_max
         );
     }
 }

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -331,12 +331,9 @@ fn reject_control_plane_scopes(
 #[cfg(not(test))]
 fn read_process_umask() -> u32 {
     // RestrictedAuthority is constructed by the forced receiver before it
-    // starts any protocol worker threads.
-    unsafe {
-        let mask = libc::umask(0o022);
-        libc::umask(mask);
-        mask as u32
-    }
+    // starts any protocol worker threads, which the portable fallback in
+    // `process_umask` relies on.
+    crate::fsops::process_umask()
 }
 
 #[cfg(test)]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -330,9 +330,7 @@ fn reject_control_plane_scopes(
 
 #[cfg(not(test))]
 fn read_process_umask() -> u32 {
-    // RestrictedAuthority is constructed by the forced receiver before it
-    // starts any protocol worker threads, which the portable fallback in
-    // `process_umask` relies on.
+    // main captured the mask before any thread existed.
     crate::fsops::process_umask()
 }
 

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -2871,17 +2871,13 @@ mod tests {
         fs::create_dir_all(tree.path().join(&path)).unwrap();
         let base = File::open(tree.path()).unwrap();
 
-        let mut limits: libc::rlimit = unsafe { std::mem::zeroed() };
-        assert_eq!(
-            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) },
-            0
-        );
+        let mut limits = crate::fsops::nofile_limits().unwrap();
         assert!(
             limits.rlim_max >= 64,
             "hard file-descriptor limit is below 64"
         );
         limits.rlim_cur = 64;
-        assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limits) }, 0);
+        crate::fsops::set_nofile_limits(&limits).unwrap();
 
         let resolver =
             OperatorResolver::beneath(&base, true, OperatorSymlinkPolicy::Refuse).unwrap();

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -2229,26 +2229,18 @@ fn rename_exchange(
     new_parent: RawFd,
     new_name: &CString,
 ) -> io::Result<()> {
-    let result = loop {
-        let result = unsafe {
-            libc::syscall(
-                libc::SYS_renameat2,
-                old_parent,
-                old_name.as_ptr(),
-                new_parent,
-                new_name.as_ptr(),
-                libc::RENAME_EXCHANGE,
-            )
-        };
-        if result == 0 || io::Error::last_os_error().kind() != io::ErrorKind::Interrupted {
-            break result;
-        }
-    };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
+    // SAFETY: both names are NUL-terminated and outlive the call; the
+    // descriptors are only read. The typed wrapper avoids passing `c_int`
+    // arguments through `syscall(2)`'s `long` varargs.
+    retry_zero(|| unsafe {
+        libc::renameat2(
+            old_parent,
+            old_name.as_ptr(),
+            new_parent,
+            new_name.as_ptr(),
+            libc::RENAME_EXCHANGE,
+        )
+    })
 }
 
 #[cfg(target_os = "macos")]

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -871,14 +871,10 @@ mod tests {
         }
         let root = Arc::new(Root::from_directory(File::open(temp.path()).unwrap()).unwrap());
 
-        let mut limits: libc::rlimit = unsafe { std::mem::zeroed() };
-        assert_eq!(
-            unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) },
-            0
-        );
+        let mut limits = crate::fsops::nofile_limits().unwrap();
         assert!(limits.rlim_max >= 64, "hard descriptor limit is below 64");
         limits.rlim_cur = 64;
-        assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limits) }, 0);
+        crate::fsops::set_nofile_limits(&limits).unwrap();
 
         let (entries, ignored, warnings) = descriptor_entries(root);
         assert!(

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -787,14 +787,6 @@ pub fn debug() -> bool {
     std::env::var_os("SYQ_DEBUG").is_some()
 }
 
-fn read_umask() -> u32 {
-    unsafe {
-        let m = libc::umask(0o022);
-        libc::umask(m);
-        m as u32
-    }
-}
-
 fn handle_tcp_setup_error(
     args: &Args,
     spec: &RemoteSpec,
@@ -1195,7 +1187,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         dry_run: args.dry_run,
         quiet: args.quiet,
         verbose: if args.quiet { 0 } else { args.verbose },
-        umask: read_umask(),
+        umask: crate::fsops::process_umask(),
         partial_id: std::sync::OnceLock::new(),
         ignore: args.ignore_lines.clone(),
         delete: args.delete,


### PR DESCRIPTION
Follow-up to an audit of every `unsafe` block in the tree. No memory-safety bug was found; these are the functional and hygiene fixes that came out of it, revised after review.

## Changes

- **macOS descriptor soft limit.** `raise_nofile` now makes one `setrlimit` call for the minimum of the hard limit, one million, and on macOS `kern.maxfilesperproc` (falling back to `OPEN_MAX` when the sysctl is unavailable). macOS 11 and later store a higher request and enforce that ceiling internally, so the old code already worked there. macOS 10.15 and earlier rejected such a request with EINVAL instead of clamping, which left the default soft limit of 256; the ignored return value hid that. The XNU sources for both releases were checked. A unit test asserts the soft limit equals the computed target and that nothing remains raisable, so a no-op body fails it.
- **Shared rlimit helpers.** `fsops::nofile_limits` and `set_nofile_limits` replace six open-coded `getrlimit`/`setrlimit` blocks in `main`, `fsops`, `rooted`, and `scan`.
- **Umask captured once at startup.** `main` records the file-creation mask into a `OnceLock` before any thread exists. On Linux the value comes from the `Umask` line of `/proc/self/status` (kernel 4.7+), which is race-free; elsewhere the `umask(2)` set-and-restore probe runs only inside that single-threaded capture, so the precondition is structural rather than a comment. `transfer.rs` and `restricted.rs` read the captured value. Unit tests cover the parser and compare the result against a real file creation.
- **`copy_file_range` offsets.** The source and destination offsets shared one `&mut` local reborrowed twice in the same call. The kernel wrote equal values back, so the result was correct, but two live raw pointers from the same `&mut` violate Stacked Borrows. They are now distinct locals.
- **`renameat2` through the typed libc wrapper** instead of `syscall(2)` varargs, which read `c_int` arguments as `long`. glibc 2.28 is already the floor because `statx` is used, so no new symbol requirement.
- **Descriptor broker receive path.** Every received SCM_RIGHTS descriptor is wrapped in `File` before any check can fail, so a `fcntl` failure can no longer leak descriptors from later control headers. Only reachable on macOS, where `MSG_CMSG_CLOEXEC` is unavailable.
- **CI.** The macOS job runs a fixed list of targeted tests, so one step now runs the `raise_nofile` and `process_umask` unit tests there.
- SAFETY comments on every block touched.

## Verification at `a9a8560`

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --bin syq` (376 passed).
- `cargo test --test local -- copy_local results_fd fd_budget perms special_files symlink_swap replaces_a_raced` (16 passed).
- `scripts/test-real-ssh.sh` (default profile), because the restricted receiver's umask source changed: passed (`real-SSH integration tests passed for syq a9a8560`).
- Pull request CI, including the real `macos-14` job with the new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PZT33EUCj3x1oti7JaDv1
