### PR TITLE
Listen and advertise TCP data paths over IPv6

### DIFF
--- a/docs/server-tuning.md
+++ b/docs/server-tuning.md
@@ -40,8 +40,10 @@ This is usually the most useful server-side change. syq authenticates over ssh,
 then asks the remote helper to listen on one available port in
 `47600-47699` (or the range given with `--syq-tcp-ports`) for the duration of that
 transfer. The default TCP records are encrypted with a key exchanged through
-ssh. If no advertised address and port is reachable, syq reports the fallback
-once and carries data over separate ssh sessions instead.
+ssh. The helper listens on that port over both IPv4 and IPv6, so a firewall
+rule must allow whichever family the client will use. If no advertised
+address and port is reachable, syq reports the fallback once and carries data
+over separate ssh sessions instead.
 
 Allow the chosen port range only from clients or trusted networks that need it.
 For example, an administrator using ufw could adapt one of these rules:

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -30,8 +30,8 @@ table](reference.md#compatibility-options)).
    process at a few hundred MB/s of cipher work. Syq keeps ssh for
    authentication and control and moves data over separate TCP connections
    carrying AES-256-GCM records keyed through the ssh session. It advertises
-   every address the remote has, prefers the fastest that answers, and spreads
-   connections across NICs of comparable speed. If no port is reachable it says
+   every IPv4 and IPv6 address the remote has, prefers the fastest that
+   answers, and spreads connections across NICs of comparable speed. If no port is reachable it says
    so once and falls back to ssh data connections. See [TCP data
    connections](#tcp-data-connections).
 3. **Kernel and server-side copies on one machine.** Same-machine copies use
@@ -247,6 +247,17 @@ AES-256-GCM records keyed by a secret exchanged over the ssh session
 (`--syq-tcp-plain` skips the encryption on trusted networks; `--syq-no-tcp` sends data over the ssh connection instead). If the port can't be
 reached — a firewall, typically — syq says so once and falls back to ssh data
 connections, so the default is always safe.
+
+The listener accepts IPv4 and IPv6 on the same port, and the remote advertises
+its global addresses of both families: the address your ssh session arrived
+on first, then private-network addresses, then public ones, then overlay
+addresses such as Tailscale, with faster NICs first within each group.
+Link-local IPv6 addresses (`fe80::`) and addresses on virtual interfaces such
+as docker bridges are not advertised. syq also tries the name you gave ssh,
+which is what works when the remote sits behind NAT or port forwarding. Every
+distinct address is probed once, in parallel, for one second; on an IPv6-only
+private network such as a cloud provider's internal mesh the IPv6 address is
+the one that answers.
 
 On Linux, `--syq-tcp-congestion ALGO` requests a congestion-control algorithm for
 both ends of every direct TCP data connection. The connecting socket is

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1607,7 +1607,9 @@ impl RemoteSpec {
                             )
                         })
                     }
-                    Err(e) => last = anyhow!("{addr}:{}: {e}", info.port),
+                    Err(e) => {
+                        last = anyhow!("{}: {e}", crate::transfer::data_address(addr, info.port))
+                    }
                 }
             }
             let stream = match got {
@@ -1685,7 +1687,7 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
         });
     }
     drop(resolved_tx);
-    let mut resolved = vec![Vec::new(); candidates.len()];
+    let mut resolved: Vec<Vec<SocketAddr>> = vec![Vec::new(); candidates.len()];
     for _ in 0..candidates.len() {
         let Ok((i, addrs)) = resolved_rx.recv() else {
             break;
@@ -1693,18 +1695,37 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
         resolved[i] = addrs;
     }
 
+    // Probe each distinct socket address once. An advertised literal and the
+    // ssh target name commonly resolve to the same address; one probe answers
+    // for every candidate that led there.
+    let mut targets: Vec<(SocketAddr, Vec<usize>)> = Vec::new();
+    let mut remaining: Vec<usize> = vec![0; candidates.len()];
+    for (i, addrs) in resolved.iter().enumerate() {
+        for &addr in addrs {
+            let owners = match targets.iter_mut().find(|(target, _)| *target == addr) {
+                Some((_, owners)) => owners,
+                None => {
+                    targets.push((addr, Vec::new()));
+                    &mut targets.last_mut().unwrap().1
+                }
+            };
+            if !owners.contains(&i) {
+                owners.push(i);
+                remaining[i] += 1;
+            }
+        }
+    }
+
     let timeout = std::time::Duration::from_millis(1000);
     let (tx, rx) = std::sync::mpsc::channel();
-    let mut remaining: Vec<usize> = resolved.iter().map(Vec::len).collect();
     let mut undetermined = remaining.iter().filter(|&&count| count > 0).count();
     let mut determined = vec![false; candidates.len()];
-    for (i, addrs) in resolved.into_iter().enumerate() {
-        for addr in addrs {
-            let tx = tx.clone();
-            std::thread::spawn(move || {
-                let _ = tx.send((i, TcpStream::connect_timeout(&addr, timeout).is_ok()));
-            });
-        }
+    for (t, (addr, _)) in targets.iter().enumerate() {
+        let tx = tx.clone();
+        let addr = *addr;
+        std::thread::spawn(move || {
+            let _ = tx.send((t, TcpStream::connect_timeout(&addr, timeout).is_ok()));
+        });
     }
     drop(tx);
 
@@ -1716,17 +1737,19 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
         let Some(wait) = deadline.checked_duration_since(std::time::Instant::now()) else {
             break;
         };
-        let Ok((i, reachable)) = rx.recv_timeout(wait) else {
+        let Ok((t, reachable)) = rx.recv_timeout(wait) else {
             break;
         };
-        if determined[i] {
-            continue;
-        }
-        remaining[i] -= 1;
-        if reachable || remaining[i] == 0 {
-            candidates[i].reachable = reachable;
-            determined[i] = true;
-            undetermined -= 1;
+        for &i in &targets[t].1 {
+            if determined[i] {
+                continue;
+            }
+            remaining[i] -= 1;
+            if reachable || remaining[i] == 0 {
+                candidates[i].reachable = reachable;
+                determined[i] = true;
+                undetermined -= 1;
+            }
         }
     }
 }
@@ -3158,5 +3181,40 @@ mod tests {
             args[control_index + 1].as_bytes(),
             b"/tmp/scope with space/%%h/non-utf8-\xff/socket"
         );
+    }
+
+    #[test]
+    fn probe_reachable_probes_each_socket_address_once() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let via_localhost = ("localhost", port)
+            .to_socket_addrs()
+            .map(|mut it| it.any(|a| a.ip() == std::net::Ipv4Addr::LOCALHOST))
+            .unwrap_or(false);
+        let accepted = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = accepted.clone();
+        std::thread::spawn(move || {
+            while let Ok((_stream, _)) = listener.accept() {
+                counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        });
+        let candidate = |address: &str| TcpCandidate {
+            address: address.to_string(),
+            speed_mbps: 0,
+            source: DataAddressSource::RemoteInterface,
+            reachable: false,
+            selected: false,
+        };
+        let mut candidates = vec![
+            candidate("127.0.0.1"),
+            candidate("localhost"),
+            candidate("127.0.0.1"),
+        ];
+        probe_reachable(&mut candidates, port);
+        assert!(candidates[0].reachable);
+        assert!(candidates[2].reachable);
+        assert_eq!(candidates[1].reachable, via_localhost);
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(accepted.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -854,6 +854,26 @@ impl Drop for ConnectSlot {
 
 pub const CIPHERS: &str = "Ciphers=aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-ctr,aes256-ctr,chacha20-poly1305@openssh.com";
 
+/// Whether an advertised address belongs to an overlay network (CGNAT /
+/// Tailscale). Such routes are last in priority on both ends: the server
+/// buckets them last, and the client inserts the direct ssh target before
+/// them, so an overlay never wins over the public address ssh reached.
+/// Tailscale uses `100.64.0.0/10` and `fd7a:115c:a1e0::/48`; any other IPv6
+/// unique-local address is an ordinary private network.
+pub(crate) fn is_overlay_address(address: &str) -> bool {
+    match address.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(v4)) => {
+            let [a, b, _, _] = v4.octets();
+            a == 100 && (b & 0xc0) == 64
+        }
+        Ok(std::net::IpAddr::V6(v6)) => {
+            let s = v6.segments();
+            s[0] == 0xfd7a && s[1] == 0x115c && s[2] == 0xa1e0
+        }
+        Err(_) => false,
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DataAddressSource {
     RemoteInterface,
@@ -1441,7 +1461,7 @@ impl RemoteSpec {
             if !candidates.iter().any(|candidate| candidate.address == h) {
                 let at = candidates
                     .iter()
-                    .position(|candidate| candidate.address.starts_with("100."))
+                    .position(|candidate| is_overlay_address(&candidate.address))
                     .unwrap_or(candidates.len());
                 candidates.insert(
                     at,
@@ -3216,5 +3236,15 @@ mod tests {
         assert_eq!(candidates[1].reachable, via_localhost);
         std::thread::sleep(std::time::Duration::from_millis(100));
         assert_eq!(accepted.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn overlay_addresses_are_recognized_in_both_families() {
+        assert!(is_overlay_address("100.101.102.103"));
+        assert!(is_overlay_address("fd7a:115c:a1e0::1234"));
+        assert!(!is_overlay_address("100.1.2.3"));
+        assert!(!is_overlay_address("fdaa:0:1:a7b::2"));
+        assert!(!is_overlay_address("192.168.1.2"));
+        assert!(!is_overlay_address("gpu01.example.net"));
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use crate::fsops::{self, FsOps};
 use crate::proto::*;
 use anyhow::{bail, Context, Result};
 use std::io::{self, ErrorKind, Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
 use std::sync::Arc;
 use std::time::Duration;
@@ -377,11 +377,13 @@ fn serve<R: Read + Send + 'static, W: Write>(
                     authority.clone(),
                     descriptor_session.clone(),
                 ) {
-                    Ok((port, congestion_control)) => w.write_msg(&Response::TcpListening {
-                        port,
-                        addrs: local_addrs(),
-                        congestion_control,
-                    })?,
+                    Ok((port, families, congestion_control)) => {
+                        w.write_msg(&Response::TcpListening {
+                            port,
+                            addrs: local_addrs(families),
+                            congestion_control,
+                        })?
+                    }
                     Err(e) if crate::conn::is_tcp_congestion_error(&e) => {
                         w.write_msg(&Response::TcpCongestionRejected(format!("{e:#}")))?
                     }
@@ -605,49 +607,206 @@ fn iface_speed(name: &str) -> u32 {
         .unwrap_or(0)
 }
 
-/// (ip, speed_mbps) for each real NIC the client might reach us on. The ssh
-/// session's own server-IP is first; virtual interfaces (docker/bridges/etc.)
-/// are skipped so multipath never fans out onto a dead bridge.
-fn local_addrs() -> Vec<(String, u32)> {
-    let ssh_ip = std::env::var("SSH_CONNECTION")
-        .ok()
-        .and_then(|c| c.split_whitespace().nth(2).map(str::to_string));
+/// Which address families the data listener bound, and so which advertised
+/// addresses a client could possibly connect to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct BoundFamilies {
+    v4: bool,
+    v6: bool,
+}
+
+impl BoundFamilies {
+    fn accepts(self, ip: IpAddr) -> bool {
+        match ip {
+            IpAddr::V4(_) => self.v4,
+            IpAddr::V6(_) => self.v6,
+        }
+    }
+}
+
+/// (ip, speed_mbps) for each real NIC the client might reach us on, over
+/// both IPv4 and IPv6. The ssh session's own server address is first (and is
+/// included even when the interface listing is unavailable); virtual
+/// interfaces (docker/bridges/etc.) are skipped so multipath never fans out
+/// onto a dead bridge.
+fn local_addrs(families: BoundFamilies) -> Vec<(String, u32)> {
+    let ssh_ip = std::env::var("SSH_CONNECTION").ok().and_then(|c| {
+        c.split_whitespace()
+            .nth(2)
+            .and_then(|ip| ip.parse::<IpAddr>().ok())
+    });
     let out = std::process::Command::new("ip")
-        .args(["-o", "-4", "addr", "show"])
+        .args(["-o", "addr", "show"])
         .output();
     let text = out
         .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
         .unwrap_or_default();
-    let mut addrs: Vec<(String, u32, u8)> = Vec::new(); // (ip, speed, priority-bucket)
+    advertised_addrs(&text, ssh_ip, families, iface_speed)
+}
+
+/// Priority bucket for an advertised address: lower sorts first. The address
+/// ssh arrived on is bucket 0 (handled by the caller); this classifies the
+/// rest so that LAN addresses are tried before public ones and overlay
+/// (CGNAT / Tailscale) addresses last.
+fn addr_bucket(ip: IpAddr) -> u8 {
+    match ip {
+        IpAddr::V4(v4) => {
+            let [a, b, _, _] = v4.octets();
+            if v4.is_private() {
+                1
+            } else if a == 100 && (b & 0xc0) == 64 {
+                3 // CGNAT / Tailscale (100.64.0.0/10)
+            } else {
+                2 // public
+            }
+        }
+        IpAddr::V6(v6) => {
+            if (v6.segments()[0] & 0xfe00) == 0xfc00 {
+                1 // unique local (fc00::/7), e.g. a private cloud network
+            } else {
+                2
+            }
+        }
+    }
+}
+
+/// Parse `ip -o addr show` output into the addresses worth advertising, in
+/// priority order: the ssh arrival address, then by bucket, then by NIC speed
+/// (fastest first). Only `scope global` addresses of a bound family count,
+/// which drops loopback and link-local addresses (a client cannot use an
+/// `fe80::` address without the interface scope, which syq does not carry).
+fn advertised_addrs(
+    text: &str,
+    ssh_ip: Option<IpAddr>,
+    families: BoundFamilies,
+    iface_speed: impl Fn(&str) -> u32,
+) -> Vec<(String, u32)> {
+    let mut addrs: Vec<(IpAddr, u32, u8)> = Vec::new(); // (ip, speed, priority-bucket)
     for line in text.lines() {
-        // "3: bond0    inet 10.2.201.45/24 brd ... scope global bond0"
+        // "3: bond0    inet 10.2.201.45/24 brd ... scope global bond0\ ..."
+        // "3: bond0    inet6 fdaa:0:1::2/112 scope global \ ..."
         let f: Vec<&str> = line.split_whitespace().collect();
-        let (Some(iface), Some(ipcidr)) = (f.get(1), f.iter().skip_while(|w| **w != "inet").nth(1))
-        else {
+        let Some(iface) = f.get(1) else {
             continue;
         };
+        let Some(family_at) = f.iter().position(|w| *w == "inet" || *w == "inet6") else {
+            continue;
+        };
+        let Some(ipcidr) = f.get(family_at + 1) else {
+            continue;
+        };
+        let scope = f
+            .iter()
+            .position(|w| *w == "scope")
+            .and_then(|at| f.get(at + 1))
+            .copied();
+        if scope != Some("global") {
+            continue;
+        }
+        // An address the kernel is still checking, or is retiring, is not a
+        // reliable route to advertise.
+        if f.iter().any(|w| *w == "tentative" || *w == "deprecated") {
+            continue;
+        }
         if is_virtual_iface(iface) {
             continue;
         }
-        let ip = ipcidr.split('/').next().unwrap_or("").to_string();
-        if ip.is_empty() || ip.starts_with("127.") {
+        let Some(ip) = ipcidr
+            .split('/')
+            .next()
+            .and_then(|ip| ip.parse::<IpAddr>().ok())
+        else {
+            continue;
+        };
+        if !families.accepts(ip) || ip.is_loopback() {
             continue;
         }
-        let bucket = if ssh_ip.as_deref() == Some(&ip) {
+        let bucket = if ssh_ip == Some(ip) {
             0
-        } else if ip.starts_with("10.") || ip.starts_with("192.168.") || ip.starts_with("172.") {
-            1
-        } else if ip.starts_with("100.") {
-            3 // CGNAT / Tailscale
         } else {
-            2 // public
+            addr_bucket(ip)
         };
         addrs.push((ip, iface_speed(iface), bucket));
+    }
+    // The address ssh arrived on is reachable by construction (loopback
+    // included: the client is then on this host). Advertise it even when the
+    // listing did not name it (no `ip` tool, or an address on an interface
+    // the listing filtered out).
+    if let Some(ip) = ssh_ip {
+        if families.accepts(ip) && !addrs.iter().any(|a| a.0 == ip) {
+            addrs.push((ip, 0, 0));
+        }
     }
     // ssh-arrival ip first, then by bucket, then by speed (fastest first).
     addrs.sort_by(|a, b| a.2.cmp(&b.2).then(b.1.cmp(&a.1)));
     addrs.dedup_by(|a, b| a.0 == b.0);
-    addrs.into_iter().map(|(ip, sp, _)| (ip, sp)).collect()
+    addrs
+        .into_iter()
+        .map(|(ip, sp, _)| (ip.to_string(), sp))
+        .collect()
+}
+
+/// Bind the data listener on the first free port in `lo..=hi`, on both
+/// address families when the host supports both. IPv6 is bound `V6ONLY` so the
+/// two sockets never contend for the same wildcard address, whatever the
+/// platform default. A port where either family is already taken is skipped
+/// so the two listeners always share one port number; a family the host cannot
+/// bind at all (no IPv6, say) is simply left out.
+fn bind_data_listeners(lo: u16, hi: u16) -> Result<(u16, Vec<TcpListener>)> {
+    use socket2::{Domain, Protocol, SockAddr, Socket, Type};
+    let mut last_error = None;
+    // Port 0 asks the kernel for an ephemeral port: the first family's bind
+    // chooses it and the second must follow. Retry a few times if the second
+    // family finds that port taken.
+    let attempts: Vec<u16> = if lo == 0 && hi == 0 {
+        vec![0; 8]
+    } else {
+        (lo..=hi.max(lo)).collect()
+    };
+    for requested in attempts {
+        let mut port = requested;
+        let mut listeners: Vec<TcpListener> = Vec::new();
+        let mut in_use = false;
+        for domain in [Domain::IPV4, Domain::IPV6] {
+            let bound = (|| -> std::io::Result<TcpListener> {
+                let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
+                // As std's TcpListener::bind does: a port with lingering
+                // TIME_WAIT sockets from an earlier transfer stays usable.
+                #[cfg(unix)]
+                socket.set_reuse_address(true)?;
+                let address: SocketAddr = if domain == Domain::IPV4 {
+                    (Ipv4Addr::UNSPECIFIED, port).into()
+                } else {
+                    socket.set_only_v6(true)?;
+                    (Ipv6Addr::UNSPECIFIED, port).into()
+                };
+                socket.bind(&SockAddr::from(address))?;
+                socket.listen(128)?;
+                Ok(socket.into())
+            })();
+            match bound {
+                Ok(listener) => {
+                    if port == 0 {
+                        port = listener.local_addr()?.port();
+                    }
+                    listeners.push(listener);
+                }
+                Err(error) if error.kind() == ErrorKind::AddrInUse => {
+                    in_use = true;
+                    break;
+                }
+                Err(error) => last_error = Some(error),
+            }
+        }
+        if in_use || listeners.is_empty() {
+            continue;
+        }
+        return Ok((port, listeners));
+    }
+    match last_error {
+        Some(error) => bail!("no free port in {lo}-{hi} ({error})"),
+        None => bail!("no free port in {lo}-{hi}"),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -661,22 +820,24 @@ fn tcp_listen(
     congestion_control: Option<&str>,
     authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
     descriptor_session: DescriptorSessionSlot,
-) -> Result<(u16, Option<String>)> {
-    let mut listener = None;
-    for port in lo..=hi.max(lo) {
-        if let Ok(l) = TcpListener::bind(("0.0.0.0", port)) {
-            listener = Some(l);
-            break;
-        }
-    }
-    let Some(listener) = listener else {
-        bail!("no free port in {lo}-{hi}");
-    };
+) -> Result<(u16, BoundFamilies, Option<String>)> {
+    let (port, listeners) = bind_data_listeners(lo, hi)?;
     // Passive connections inherit the listener's congestion controller. Set
-    // and verify it before advertising the port so even handshake-time
-    // behavior uses the requested algorithm.
-    let congestion_control = crate::conn::configure_tcp_congestion(&listener, congestion_control)?;
-    let port = listener.local_addr()?.port();
+    // and verify it on every listener before advertising the port so even
+    // handshake-time behavior uses the requested algorithm.
+    let mut effective_congestion_control = None;
+    for listener in &listeners {
+        let effective = crate::conn::configure_tcp_congestion(listener, congestion_control)?;
+        effective_congestion_control = effective_congestion_control.or(effective);
+    }
+    let families = BoundFamilies {
+        v4: listeners
+            .iter()
+            .any(|l| l.local_addr().is_ok_and(|a| a.is_ipv4())),
+        v6: listeners
+            .iter()
+            .any(|l| l.local_addr().is_ok_and(|a| a.is_ipv6())),
+    };
     let next_id = Arc::new(AtomicU32::new(1));
     // Bound in-flight data connections (a peer shouldn't be able to spawn
     // unbounded threads), and remember which client connection ids we've seen
@@ -690,61 +851,104 @@ fn tcp_listen(
     let seen: Arc<std::sync::Mutex<std::collections::HashSet<u32>>> =
         Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
     let max_live = MAX_LIVE_TCP_CONNECTIONS;
-    listener.set_nonblocking(true)?;
-    std::thread::spawn(move || {
-        loop {
-            if descriptor_session.is_closed()
-                || authority
-                    .as_ref()
-                    .is_some_and(|authority| !authority.control_is_open())
-            {
-                break;
-            }
-            let stream = match listener.accept() {
-                Ok((stream, _)) => stream,
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                    std::thread::sleep(Duration::from_millis(25));
-                    continue;
-                }
-                Err(_) => continue,
-            };
-            let id = next_id.fetch_add(1, Relaxed);
-            if live.load(Relaxed) >= max_live {
-                if debug {
-                    eprintln!("syq server (tcp): refusing connection, {max_live} already live");
-                }
-                continue; // drop; stream closes
-            }
-            live.fetch_add(1, Relaxed);
-            let (key, token, live, seen, authority, descriptor_session) = (
-                key.clone(),
-                token.clone(),
-                live.clone(),
-                seen.clone(),
-                authority.clone(),
-                descriptor_session.clone(),
-            );
-            std::thread::spawn(move || {
-                if let Err(e) = serve_tcp(
-                    stream,
-                    id,
-                    key,
-                    token,
-                    debug,
-                    compress,
-                    &seen,
-                    authority.clone(),
-                    descriptor_session,
-                ) {
-                    if debug {
-                        eprintln!("syq server (tcp {id}): {e:#}");
-                    }
-                }
-                live.fetch_sub(1, Relaxed);
-            });
+    // One accept thread per bound family; every listener feeds the same
+    // token, connection limit, replay set, and id sequence.
+    for listener in listeners {
+        listener.set_nonblocking(true)?;
+        let (key, token, next_id, live, seen, authority, descriptor_session) = (
+            key.clone(),
+            token.clone(),
+            next_id.clone(),
+            live.clone(),
+            seen.clone(),
+            authority.clone(),
+            descriptor_session.clone(),
+        );
+        std::thread::spawn(move || {
+            accept_data_connections(
+                listener,
+                key,
+                token,
+                debug,
+                compress,
+                next_id,
+                live,
+                max_live,
+                seen,
+                authority,
+                descriptor_session,
+            )
+        });
+    }
+    Ok((port, families, effective_congestion_control))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn accept_data_connections(
+    listener: TcpListener,
+    key: Option<Vec<u8>>,
+    token: Vec<u8>,
+    debug: bool,
+    compress: bool,
+    next_id: Arc<AtomicU32>,
+    live: Arc<AtomicU32>,
+    max_live: u32,
+    seen: Arc<std::sync::Mutex<std::collections::HashSet<u32>>>,
+    authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
+    descriptor_session: DescriptorSessionSlot,
+) {
+    loop {
+        if descriptor_session.is_closed()
+            || authority
+                .as_ref()
+                .is_some_and(|authority| !authority.control_is_open())
+        {
+            break;
         }
-    });
-    Ok((port, congestion_control))
+        let stream = match listener.accept() {
+            Ok((stream, _)) => stream,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(25));
+                continue;
+            }
+            Err(_) => continue,
+        };
+        let id = next_id.fetch_add(1, Relaxed);
+        // Reserve a slot atomically: both family listeners charge one bound.
+        if live.fetch_add(1, Relaxed) >= max_live {
+            live.fetch_sub(1, Relaxed);
+            if debug {
+                eprintln!("syq server (tcp): refusing connection, {max_live} already live");
+            }
+            continue; // drop; stream closes
+        }
+        let (key, token, live, seen, authority, descriptor_session) = (
+            key.clone(),
+            token.clone(),
+            live.clone(),
+            seen.clone(),
+            authority.clone(),
+            descriptor_session.clone(),
+        );
+        std::thread::spawn(move || {
+            if let Err(e) = serve_tcp(
+                stream,
+                id,
+                key,
+                token,
+                debug,
+                compress,
+                &seen,
+                authority.clone(),
+                descriptor_session,
+            ) {
+                if debug {
+                    eprintln!("syq server (tcp {id}): {e:#}");
+                }
+            }
+            live.fetch_sub(1, Relaxed);
+        });
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -875,6 +1079,93 @@ mod tests {
     use super::*;
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::MetadataExt;
+
+    const IP_ADDR_SHOW: &str = "\
+1: lo    inet 127.0.0.1/8 scope host lo\\       valid_lft forever preferred_lft forever
+1: lo    inet6 ::1/128 scope host noprefixroute \\       valid_lft forever preferred_lft forever
+2: eth0    inet 172.19.3.10/29 brd 172.19.3.15 scope global eth0\\       valid_lft forever preferred_lft forever
+2: eth0    inet6 fdaa:0:1:a7b::2/112 scope global \\       valid_lft forever preferred_lft forever
+2: eth0    inet6 2001:db8::2/64 scope global \\       valid_lft forever preferred_lft forever
+2: eth0    inet6 2001:db8::3/64 scope global tentative \\       valid_lft forever preferred_lft forever
+2: eth0    inet6 fe80::9e6b:ff:fe4e:89ad/64 scope link \\       valid_lft forever preferred_lft forever
+3: bond0    inet 10.2.201.45/24 brd 10.2.201.255 scope global bond0\\       valid_lft forever preferred_lft forever
+4: tailscale0    inet 100.101.102.103/32 scope global tailscale0\\       valid_lft forever preferred_lft forever
+5: docker0    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0\\       valid_lft forever preferred_lft forever
+";
+
+    fn speeds(name: &str) -> u32 {
+        match name {
+            "bond0" => 25000,
+            "eth0" => 1000,
+            _ => 0,
+        }
+    }
+
+    #[test]
+    fn advertised_addrs_lists_both_families_with_ssh_arrival_first() {
+        let ssh = "fdaa:0:1:a7b::2".parse().ok();
+        let both = BoundFamilies { v4: true, v6: true };
+        let got = advertised_addrs(IP_ADDR_SHOW, ssh, both, speeds);
+        assert_eq!(
+            got,
+            vec![
+                ("fdaa:0:1:a7b::2".to_string(), 1000),
+                ("10.2.201.45".to_string(), 25000),
+                ("172.19.3.10".to_string(), 1000),
+                ("2001:db8::2".to_string(), 1000),
+                ("100.101.102.103".to_string(), 0),
+            ]
+        );
+    }
+
+    #[test]
+    fn advertised_addrs_only_names_families_the_listener_bound() {
+        let v4 = BoundFamilies {
+            v4: true,
+            v6: false,
+        };
+        let got = advertised_addrs(IP_ADDR_SHOW, None, v4, speeds);
+        assert!(got
+            .iter()
+            .all(|(ip, _)| ip.parse::<IpAddr>().unwrap().is_ipv4()));
+        assert_eq!(got[0].0, "10.2.201.45");
+        // The ssh arrival address is still advertised first, but only when a
+        // listener of its family exists.
+        let ssh = "fdaa:0:1:a7b::2".parse().ok();
+        let got = advertised_addrs(IP_ADDR_SHOW, ssh, v4, speeds);
+        assert!(!got.iter().any(|(ip, _)| ip.starts_with("fdaa")));
+    }
+
+    #[test]
+    fn advertised_addrs_includes_ssh_arrival_address_without_a_listing() {
+        let ssh = "203.0.113.7".parse().ok();
+        let both = BoundFamilies { v4: true, v6: true };
+        assert_eq!(
+            advertised_addrs("", ssh, both, speeds),
+            vec![("203.0.113.7".to_string(), 0)]
+        );
+    }
+
+    #[test]
+    fn data_listeners_share_one_port_across_families() {
+        let (port, listeners) = bind_data_listeners(0, 0).unwrap();
+        assert_ne!(port, 0);
+        let ports: Vec<u16> = listeners
+            .iter()
+            .map(|l| l.local_addr().unwrap().port())
+            .collect();
+        assert!(ports.iter().all(|p| *p == port), "{ports:?} != {port}");
+        for listener in &listeners {
+            let local = listener.local_addr().unwrap();
+            let target: SocketAddr = if local.is_ipv4() {
+                (Ipv4Addr::LOCALHOST, port).into()
+            } else {
+                (Ipv6Addr::LOCALHOST, port).into()
+            };
+            TcpStream::connect_timeout(&target, Duration::from_secs(2))
+                .unwrap_or_else(|e| panic!("connect {target}: {e}"));
+        }
+    }
 
     struct ExitObserved<R> {
         inner: R,
@@ -1204,7 +1495,7 @@ mod tests {
         let max_workers = usize::from(crate::restricted::tests::TEST_AUTHORITY_MAX_CONNECTIONS);
         let token = b"data-token".to_vec();
         let descriptor_session = DescriptorSessionSlot::default();
-        let (port, _) = tcp_listen(
+        let (port, _, _) = tcp_listen(
             None,
             token.clone(),
             0,

--- a/src/server.rs
+++ b/src/server.rs
@@ -649,24 +649,14 @@ fn local_addrs(families: BoundFamilies) -> Vec<(String, u32)> {
 /// rest so that LAN addresses are tried before public ones and overlay
 /// (CGNAT / Tailscale) addresses last.
 fn addr_bucket(ip: IpAddr) -> u8 {
+    if crate::conn::is_overlay_address(&ip.to_string()) {
+        return 3; // CGNAT / Tailscale
+    }
     match ip {
-        IpAddr::V4(v4) => {
-            let [a, b, _, _] = v4.octets();
-            if v4.is_private() {
-                1
-            } else if a == 100 && (b & 0xc0) == 64 {
-                3 // CGNAT / Tailscale (100.64.0.0/10)
-            } else {
-                2 // public
-            }
-        }
-        IpAddr::V6(v6) => {
-            if (v6.segments()[0] & 0xfe00) == 0xfc00 {
-                1 // unique local (fc00::/7), e.g. a private cloud network
-            } else {
-                2
-            }
-        }
+        IpAddr::V4(v4) if v4.is_private() => 1,
+        // Unique local (fc00::/7), e.g. a private cloud network.
+        IpAddr::V6(v6) if (v6.segments()[0] & 0xfe00) == 0xfc00 => 1,
+        _ => 2, // public
     }
 }
 
@@ -1090,6 +1080,7 @@ mod tests {
 2: eth0    inet6 fe80::9e6b:ff:fe4e:89ad/64 scope link \\       valid_lft forever preferred_lft forever
 3: bond0    inet 10.2.201.45/24 brd 10.2.201.255 scope global bond0\\       valid_lft forever preferred_lft forever
 4: tailscale0    inet 100.101.102.103/32 scope global tailscale0\\       valid_lft forever preferred_lft forever
+4: tailscale0    inet6 fd7a:115c:a1e0::1234/128 scope global \\       valid_lft forever preferred_lft forever
 5: docker0    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0\\       valid_lft forever preferred_lft forever
 ";
 
@@ -1114,6 +1105,7 @@ mod tests {
                 ("172.19.3.10".to_string(), 1000),
                 ("2001:db8::2".to_string(), 1000),
                 ("100.101.102.103".to_string(), 0),
+                ("fd7a:115c:a1e0::1234".to_string(), 0),
             ]
         );
     }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -215,7 +215,7 @@ pub(crate) fn parse_ports(s: &str) -> Result<(u16, u16)> {
     Ok((lo, hi))
 }
 
-fn data_address(address: &str, port: u16) -> String {
+pub(crate) fn data_address(address: &str, port: u16) -> String {
     if address.contains(':') {
         format!("[{address}]:{port}")
     } else {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3424,6 +3424,14 @@ else
     PATH="$FAKE_REMOTE_BIN:/usr/bin:/bin"
 fi
 export HOME PATH
+# The remote helper advertises the address ssh arrived on; never leak the
+# developer's own session into the fixture.
+if [ -n "${FAKE_SSH_CONNECTION:-}" ]; then
+    SSH_CONNECTION="$FAKE_SSH_CONNECTION"
+    export SSH_CONNECTION
+else
+    unset SSH_CONNECTION
+fi
 printf '%s\n' "$1" >> "$FAKE_RSH_LOG"
 exec /bin/sh -c "$1"
 "#,
@@ -3453,6 +3461,12 @@ shift
 HOME="$FAKE_REMOTE_HOME"
 PATH="$FAKE_REMOTE_BIN:/usr/bin:/bin"
 export HOME PATH
+if [ -n "${FAKE_SSH_CONNECTION:-}" ]; then
+    SSH_CONNECTION="$FAKE_SSH_CONNECTION"
+    export SSH_CONNECTION
+else
+    unset SSH_CONNECTION
+fi
 exec /bin/sh -c "$1"
 "#,
     );
@@ -3503,6 +3517,12 @@ fi
 HOME="$FAKE_REMOTE_HOME"
 PATH=/usr/bin:/bin
 export HOME PATH
+if [ -n "${FAKE_SSH_CONNECTION:-}" ]; then
+    SSH_CONNECTION="$FAKE_SSH_CONNECTION"
+    export SSH_CONNECTION
+else
+    unset SSH_CONNECTION
+fi
 exec /bin/sh -c "$1"
 "#,
     );
@@ -4302,6 +4322,49 @@ fn double_verbose_dry_run_reports_ssh_fallback_without_extra_connection() {
             .count(),
         1,
         "-vv must not verify fallback with an extra connection"
+    );
+}
+
+#[test]
+fn double_verbose_dry_run_reports_ipv6_arrival_address_as_reachable() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    // No usable interface listing: only the address ssh arrived on, an IPv6
+    // loopback here, can be advertised. It must be listened on and selected.
+    executable(&t.path("remote-bin/ip"), b"#!/bin/sh\nexit 1\n");
+    write(&t.path("src"), b"v6");
+    let remote = format!("diagnostic.invalid:{}", t.s("dst"));
+
+    let out = compat_command()
+        .arg("-e")
+        .arg(&rsh)
+        .arg("--rsync-path")
+        .arg(env!("CARGO_BIN_EXE_syq"))
+        .args(["--syq-tcp-ports", EPHEMERAL_TCP_PORTS])
+        .args(["--dry-run", "-vv", "-a"])
+        .arg(t.s("src"))
+        .arg(&remote)
+        .arg("--no-progress")
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("FAKE_SSH_CONNECTION", "::1 40000 ::1 22")
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .run()
+        .expect("run double-verbose dry-run over IPv6");
+
+    assert_output_ok(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("TCP [::1]:")
+            && stderr.contains(": reachable, link speed unknown, selected by preflight"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "transport: encrypted TCP planned for a real transfer (reachability preflight passed)"
+        ),
+        "{stderr}"
     );
 }
 


### PR DESCRIPTION
## Why

On an IPv6-only private network such as Fly's internal mesh, syq never got a direct TCP data path. The remote helper bound only the IPv4 wildcard and advertised only IPv4 addresses, so the per-machine IPv4 address timed out, the ssh target name resolved to an IPv6 address nothing listened on, and every transfer burned the full probe window before falling back to ssh data connections.

## What changes

- **Dual-family listener.** `tcp_listen` binds `0.0.0.0` and `[::]` (with `IPV6_V6ONLY`) on one port. A port where either family is already taken is skipped; a family the host cannot bind at all is left out and never advertised. Each listener runs its own accept thread sharing the token, live-connection bound, replay set, and id sequence.
- **IPv6 advertisement.** The helper reads `ip -o addr show` for `scope global` addresses of both bound families, groups IPv6 unique-local (`fc00::/7`) with the private IPv4 ranges, skips link-local, `tentative`, and `deprecated` addresses, and always advertises the address the ssh session arrived on, even when the interface listing is unavailable. No wire change: the advertised list simply gains IPv6 literals.
- **Probe dedup.** The client probes each distinct resolved socket address once, so an advertised literal and the ssh target name that resolves to it share one probe.
- **Test fixtures.** The fake ssh/rsh fixtures now pin `SSH_CONNECTION` (override with `FAKE_SSH_CONNECTION`) so the developer's own session does not leak into what the fake remote advertises.

Docs: `docs/speed.md` describes the advertised address order and both families; `docs/server-tuning.md` notes the listener accepts both families.

Not in this PR: stopping the probe wait as soon as one route answers (the dynamic route pool). That changes a documented invariant and is planned as a separate PR.

## Verification (at 269220f)

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --bin syq`: 392 passed
- `cargo test --all-targets`: all passed (run before two small follow-up edits: `SO_REUSEADDR` on the manual bind and an atomic live-slot reservation; the unit tests and the focused `local` TCP tests below were rerun on the final build)
- `cargo test --test local -- tcp double_verbose`: 13 passed, including the new `double_verbose_dry_run_reports_ipv6_arrival_address_as_reachable`
- `scripts/test-real-ssh.sh`: passed (default profile, 7 cases, including the firewall-triggered TCP fallback)
- `scripts/check-doc-links.py`: 0 problems

Not verified: behavior on an actual Fly machine, macOS/BSD hosts (no `ip` tool; they now advertise the ssh arrival address), and hosts with IPv6 disabled at the kernel level (the IPv6 bind should fail non-fatally and be left out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TifPzn1RLMUS7iNfBtBvNo
