### PR TITLE
Check the OpenSSH client version before constrained agent forwarding

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -159,9 +159,11 @@ Debian 11 do not. On such hosts pass `--no-forward-agent` and keep credentials
 on the coordinator host, or choose `--unrestricted-agent-forwarding` or an
 explicit `--rsh` policy. `syq cp -vv` prints the client version it found.
 
-On macOS, Apple's `ssh` is built without FIDO support, so hardware-backed
-`sk-` keys do not work with it. Install `openssh` with Homebrew and put its
-`bin` directory first on `PATH`; syq picks up whichever `ssh` that resolves to.
+On macOS, Apple's `ssh` ships without a built-in FIDO provider, so a
+hardware-backed `sk-` key works only with an external `SecurityKeyProvider`
+library configured in `ssh_config`. The simplest route is to install `openssh`
+with Homebrew, which has the provider built in, and put its `bin` directory
+first on `PATH`; syq picks up whichever `ssh` that resolves to.
 
 ## Platform notes
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -145,6 +145,24 @@ recreates the helper it needs on the next connection. After launch, both peers
 require the same build identity: the release tag for official binaries, or the
 Git-derived identity when an explicit source-built helper is used.
 
+## SSH requirements
+
+Syq runs your own `ssh`, so your configuration, keys, agent, and known hosts
+apply unchanged. Two ordinary copies need nothing special. A copy between two
+remote machines forwards a constrained agent to the coordinator host by
+default, and that relies on OpenSSH features from release 8.9 (February 2022):
+the client on your machine and on the coordinator host must be 8.9 or newer,
+and so must the `sshd` on the other remote. Syq checks the two clients it runs
+and stops with a message naming the older one. Ubuntu 22.04, Debian 12, RHEL 9
+with current updates, and macOS 13 or newer qualify; RHEL 8, Ubuntu 20.04, and
+Debian 11 do not. On such hosts pass `--no-forward-agent` and keep credentials
+on the coordinator host, or choose `--unrestricted-agent-forwarding` or an
+explicit `--rsh` policy. `syq cp -vv` prints the client version it found.
+
+On macOS, Apple's `ssh` is built without FIDO support, so hardware-backed
+`sk-` keys do not work with it. Install `openssh` with Homebrew and put its
+`bin` directory first on `PATH`; syq picks up whichever `ssh` that resolves to.
+
 ## Platform notes
 
 - **macOS (Apple Silicon / Intel):** build natively on the Mac with

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -365,7 +365,10 @@ no read-restricted receiver, and syq never silently downgrades to
 authentication-only confinement. Pull is available with an explicit `--rsh`, `--no-forward-agent` when the target owns source
 credentials, `--agent-broker-only`, or
 `--unrestricted-agent-forwarding`. The authentication options and `--detach`
-apply only to a direct copy between distinct remote endpoints. A detached
+apply only to a direct copy between distinct remote endpoints. Constrained forwarding
+needs OpenSSH 8.9 or newer for the client on the local machine, the client on
+the coordinator host, and the peer's server; syq checks both clients before
+connecting and names the older one together with these alternatives. A detached
 launch requires coordinator-owned credentials (`--no-forward-agent`) or an
 explicit remote-shell policy, and the coordinator host needs `/bin/kill` plus
 either `setsid` or `perl` to start the new session (macOS has no `setsid`);

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -991,6 +991,82 @@ pub(crate) struct SshMultiplexer {
 /// no-reauthentication window stays comparable to sudo's credential cache.
 const REUSE_PERSIST_SECONDS: &str = "300";
 
+/// The oldest OpenSSH release whose client speaks the agent session-bind
+/// extension and host-bound public-key authentication. Constrained agent
+/// forwarding relies on both, on the local machine and on the coordinator
+/// host, and the peer's `sshd` must be at least this new as well.
+pub(crate) const CONSTRAINED_OPENSSH_MINIMUM: OpenSshVersion =
+    OpenSshVersion { major: 8, minor: 9 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct OpenSshVersion {
+    pub major: u32,
+    pub minor: u32,
+}
+
+impl std::fmt::Display for OpenSshVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "OpenSSH {}.{}", self.major, self.minor)
+    }
+}
+
+/// Read the release number out of an `ssh -V` banner such as
+/// `OpenSSH_9.6p1 Ubuntu-3ubuntu13.19, OpenSSL 3.0.13 30 Jan 2024`. Other
+/// clients report nothing recognizable and yield `None`.
+pub(crate) fn parse_openssh_version(banner: &[u8]) -> Option<OpenSshVersion> {
+    let text = String::from_utf8_lossy(banner);
+    let rest = text.split("OpenSSH_").nth(1)?;
+    let mut numbers = rest
+        .split(|c: char| !c.is_ascii_digit())
+        .take(2)
+        .map(|digits| digits.parse::<u32>().ok());
+    let major = numbers.next()??;
+    let minor = numbers.next()??;
+    Some(OpenSshVersion { major, minor })
+}
+
+/// Ask `program -V` for its version once per program name. Only programs
+/// whose name ends in `ssh` are probed: an arbitrary `--rsh` command is a
+/// complete user policy and might do anything with a `-V` argument.
+pub(crate) fn openssh_version(program: &str) -> Option<OpenSshVersion> {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    static CACHE: Mutex<Option<HashMap<String, Option<OpenSshVersion>>>> = Mutex::new(None);
+    if !program.ends_with("ssh") {
+        return None;
+    }
+    let mut cache = CACHE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let cache = cache.get_or_insert_with(HashMap::new);
+    if let Some(version) = cache.get(program) {
+        return *version;
+    }
+    let version = Command::new(program)
+        .arg("-V")
+        .stdin(Stdio::null())
+        .output()
+        .ok()
+        .and_then(|output| {
+            parse_openssh_version(&output.stderr).or_else(|| parse_openssh_version(&output.stdout))
+        });
+    cache.insert(program.to_owned(), version);
+    version
+}
+
+/// Refuse constrained agent forwarding through an OpenSSH client that
+/// predates session binding. A client whose version cannot be read is left to
+/// fail on its own, so this only turns a confusing authentication failure
+/// into a direct explanation.
+pub(crate) fn require_constrained_openssh(program: &str, location: &str) -> Result<()> {
+    match openssh_version(program) {
+        Some(version) if version < CONSTRAINED_OPENSSH_MINIMUM => bail!(
+            "constrained agent forwarding needs {CONSTRAINED_OPENSSH_MINIMUM} or newer {location}, but {program} is {version}; use --no-forward-agent with credentials on the coordinator host, --unrestricted-agent-forwarding, or an explicit --rsh policy"
+        ),
+        _ => Ok(()),
+    }
+}
+
 impl SshMultiplexer {
     pub(crate) fn new() -> Result<Self> {
         let directory = tempfile::Builder::new()
@@ -1369,6 +1445,13 @@ impl RemoteSpec {
             command.args(&server_args);
             command
         } else {
+            if self
+                .rsh
+                .iter()
+                .any(|argument| argument == "PubkeyAuthentication=host-bound")
+            {
+                require_constrained_openssh(&self.rsh[0], "on the coordinator host")?;
+            }
             let mut command = self.ssh_command(ssh_connection);
             let remote_command = if self.restricted_grant.is_some() {
                 // This text is inspected by the forced receiver through
@@ -2633,6 +2716,43 @@ mod tests {
             self.dropped
                 .store(true, std::sync::atomic::Ordering::SeqCst);
         }
+    }
+
+    #[test]
+    fn openssh_version_banners_parse_and_compare() {
+        let parse = |banner: &str| parse_openssh_version(banner.as_bytes());
+        assert_eq!(
+            parse("OpenSSH_9.6p1 Ubuntu-3ubuntu13.19, OpenSSL 3.0.13 30 Jan 2024\n"),
+            Some(OpenSshVersion { major: 9, minor: 6 })
+        );
+        assert_eq!(
+            parse("OpenSSH_8.9p1, LibreSSL 3.3.6"),
+            Some(CONSTRAINED_OPENSSH_MINIMUM)
+        );
+        assert_eq!(
+            parse("OpenSSH_10.0p2"),
+            Some(OpenSshVersion {
+                major: 10,
+                minor: 0
+            })
+        );
+        assert_eq!(parse("Dropbear v2024.85"), None);
+        assert_eq!(parse("OpenSSH_"), None);
+        assert!(OpenSshVersion { major: 8, minor: 2 } < CONSTRAINED_OPENSSH_MINIMUM);
+        assert!(
+            OpenSshVersion {
+                major: 8,
+                minor: 10
+            } > CONSTRAINED_OPENSSH_MINIMUM
+        );
+        assert!(OpenSshVersion { major: 9, minor: 0 } > CONSTRAINED_OPENSSH_MINIMUM);
+        assert_eq!(CONSTRAINED_OPENSSH_MINIMUM.to_string(), "OpenSSH 8.9");
+    }
+
+    #[test]
+    fn only_ssh_named_programs_are_probed_for_a_version() {
+        assert_eq!(openssh_version("fake-rsh"), None);
+        assert_eq!(openssh_version("/definitely/missing/ssh"), None);
     }
 
     #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -131,6 +131,7 @@ pub(crate) fn is_worker_initialization_error(error: &anyhow::Error) -> bool {
 fn is_non_retryable_connect_error(error: &anyhow::Error) -> bool {
     let message = format!("{error:#}");
     is_worker_initialization_error(error)
+        || error.chain().any(|cause| cause.is::<OpenSshVersionError>())
         || message.contains("build identity mismatch")
         || message.contains(WIRE_PREAMBLE_PROTOCOL_ERROR)
         || message.contains("unexpected handshake response")
@@ -1054,15 +1055,32 @@ pub(crate) fn openssh_version(program: &str) -> Option<OpenSshVersion> {
     version
 }
 
+/// An installed OpenSSH client is too old for constrained agent forwarding.
+/// Nothing about a retry changes that, so the connection loop gives up on it
+/// immediately.
+#[derive(Debug)]
+pub(crate) struct OpenSshVersionError(String);
+
+impl std::fmt::Display for OpenSshVersionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for OpenSshVersionError {}
+
 /// Refuse constrained agent forwarding through an OpenSSH client that
 /// predates session binding. A client whose version cannot be read is left to
 /// fail on its own, so this only turns a confusing authentication failure
 /// into a direct explanation.
 pub(crate) fn require_constrained_openssh(program: &str, location: &str) -> Result<()> {
     match openssh_version(program) {
-        Some(version) if version < CONSTRAINED_OPENSSH_MINIMUM => bail!(
-            "constrained agent forwarding needs {CONSTRAINED_OPENSSH_MINIMUM} or newer {location}, but {program} is {version}; use --no-forward-agent with credentials on the coordinator host, --unrestricted-agent-forwarding, or an explicit --rsh policy"
-        ),
+        Some(version) if version < CONSTRAINED_OPENSSH_MINIMUM => {
+            Err(OpenSshVersionError(format!(
+                "constrained agent forwarding needs {CONSTRAINED_OPENSSH_MINIMUM} or newer {location}, but {program} is {version}; use --no-forward-agent with credentials on the coordinator host, --unrestricted-agent-forwarding, or an explicit --rsh policy"
+            ))
+            .into())
+        }
         _ => Ok(()),
     }
 }
@@ -2747,6 +2765,18 @@ mod tests {
         );
         assert!(OpenSshVersion { major: 9, minor: 0 } > CONSTRAINED_OPENSSH_MINIMUM);
         assert_eq!(CONSTRAINED_OPENSSH_MINIMUM.to_string(), "OpenSSH 8.9");
+    }
+
+    #[test]
+    fn an_old_client_is_not_retried() {
+        let error: anyhow::Error = OpenSshVersionError("too old".to_owned()).into();
+        assert!(is_non_retryable_connect_error(&error));
+        assert!(is_non_retryable_connect_error(
+            &error.context("connect to the coordinator")
+        ));
+        assert!(!is_non_retryable_connect_error(&anyhow!(
+            "connection reset"
+        )));
     }
 
     #[test]

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -773,6 +773,7 @@ fn run_remote(
     } else if args.unrestricted_agent_forwarding {
         Some(AgentForwarding::Unrestricted)
     } else {
+        crate::conn::require_constrained_openssh(&rsh[0], "on this machine")?;
         let coordinator_policy = crate::agent_broker::resolve_host_policy_at(
             &rsh[0],
             coordinator.user.as_deref(),

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -298,6 +298,9 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
             spec.remote_shell_name(),
             peer.platform
         );
+        if let Some(version) = crate::conn::openssh_version(&spec.rsh[0]) {
+            eprintln!("  ssh client: {version}");
+        }
         let helper_mode = remote_helper_mode(spec, args.interface);
         eprintln!("  helper: {} ({helper_mode})", peer.identity);
     }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3506,6 +3506,10 @@ fn fake_ssh(t: &Tmp) -> PathBuf {
     executable(
         &path,
         br#"#!/bin/sh
+if [ "$1" = -V ]; then
+    printf 'OpenSSH_%s, fake\n' "${FAKE_SSH_VERSION:-9.9p1}" >&2
+    exit 0
+fi
 printf '%s\n' "$*" >> "$FAKE_RSH_LOG"
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -3540,6 +3544,10 @@ fn fake_ssh_rejecting_multiplexed_workers(t: &Tmp) -> PathBuf {
     executable(
         &path,
         br#"#!/bin/sh
+if [ "$1" = -V ]; then
+    printf 'OpenSSH_9.9p1, fake\n' >&2
+    exit 0
+fi
 control_master=unset
 control_path=unset
 while [ "$#" -gt 0 ]; do
@@ -10636,6 +10644,53 @@ fn files_from_leaves_unlisted_destination_root_metadata_alone() {
         &t.s("dst2"),
     ]);
     assert!(t.path("dst2").is_dir());
+}
+
+#[test]
+fn constrained_agent_forwarding_requires_openssh_8_9() {
+    let t = Tmp::new();
+    let ssh = fake_ssh(&t);
+    write(&t.path("src/file"), b"data");
+    let run = |version: &str| {
+        Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "cp",
+                "--src-src",
+                "/src",
+                "--from",
+                "hosta",
+                "--to",
+                "hostb",
+                "--into",
+                "/dst",
+            ])
+            .env("FAKE_SSH_VERSION", version)
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", ssh.parent().unwrap().to_string_lossy()),
+            )
+            .run()
+            .unwrap()
+    };
+    let old = run("8.2p1");
+    assert!(!old.status.success());
+    let stderr = String::from_utf8_lossy(&old.stderr);
+    assert!(
+        stderr.contains("needs OpenSSH 8.9 or newer on this machine, but ssh is OpenSSH 8.2"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("--no-forward-agent"), "{stderr}");
+    // The version probe must not have been mistaken for a connection.
+    assert!(!t.path("rsh.log").exists(), "{stderr}");
+
+    // A new enough client proceeds to the next step, which is reading the
+    // real OpenSSH configuration that this fake cannot answer.
+    let new = run("8.9p1");
+    let stderr = String::from_utf8_lossy(&new.stderr);
+    assert!(!stderr.contains("needs OpenSSH 8.9"), "{stderr}");
 }
 
 #[test]

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -97,6 +97,15 @@ EOF
 
 printf 'real-SSH environment: profile %s; %s; %s\n' \
     "${SYQ_REAL_SSH_PROFILE:-default}" "$(syq --build-identity)" "$(ssh -V 2>&1)"
+# The suite exercises constrained agent forwarding, which docs/install.md
+# supports from OpenSSH 8.9. Fail loudly if the image ever drifts below it.
+ssh_release=$(ssh -V 2>&1 | sed -n 's/^OpenSSH_\([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1 \2/p')
+ssh_major=${ssh_release%% *}
+ssh_minor=${ssh_release#* }
+if [ -z "$ssh_release" ] || [ "$ssh_major" -lt 8 ] || { [ "$ssh_major" -eq 8 ] && [ "$ssh_minor" -lt 9 ]; }; then
+    echo "real-SSH suite needs OpenSSH 8.9 or newer in the container image; found: $(ssh -V 2>&1)" >&2
+    exit 1
+fi
 
 printf 'case: remote filename completion reuses a persistent ordinary SSH login\n'
 ssh source 'rm -rf /tmp/syq-real-ssh/completion; mkdir -p /tmp/syq-real-ssh/completion/alpine; : > "/tmp/syq-real-ssh/completion/alpha file"'


### PR DESCRIPTION
## Summary

Follow-up to #167. syq's default for a copy between two remote machines forwards a constrained agent to the coordinator host, which relies on two OpenSSH 8.9 features: the agent session-bind extension (local client) and `PubkeyAuthentication=host-bound` (client on the coordinator host, and the peer's `sshd`). Nothing checked for that before, so an older client failed with whatever `ssh` printed.

- `conn.rs` gains a small `ssh -V` probe, cached per program name and only run for programs whose name ends in `ssh` (an arbitrary `--rsh` command is left alone), plus `require_constrained_openssh`, which stops with the alternatives (`--no-forward-agent`, `--unrestricted-agent-forwarding`, explicit `--rsh`) when a client is older than 8.9. The shortfall is a typed `OpenSshVersionError` that the connection retry loop treats as permanent, so an old coordinator client fails on the first attempt. A client whose version cannot be read is left to fail on its own.
- The check runs on the local machine just before `ssh -G` resolution when the constrained policy is selected, and on the coordinator host inside the helper whenever the remote-shell command carries `PubkeyAuthentication=host-bound`.
- `-vv` prints `ssh client: OpenSSH x.y` after the control line when known.
- `docs/install.md` gains an "SSH requirements" section naming the 8.9 floor, which distributions meet it, the alternatives, and the macOS FIDO caveat (Apple's `ssh` has no built-in FIDO provider; an external `SecurityKeyProvider` works, Homebrew's build is the simplest route). `docs/reference.md` states the floor in the constrained-authentication paragraph.
- The real-SSH suite already prints the container's `ssh -V`; it now refuses an image below 8.9 so the pinned client version is an explicit baseline (currently OpenSSH 9.2 from Debian 12).
- Tests: banner parsing and ordering; the probe ignores non-`ssh` programs; an integration test with a fake `ssh` answering `-V` as 8.2 gets the message without any connection attempt, and 8.9 proceeds to the next step.

Not in scope: vendoring or downloading a pinned client. See `current-plans/active/macos-portability.md` for that discussion.

## Verification

At `3786f93`, worktree clean.

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo test --all-targets` on Linux.
- `scripts/test-real-ssh.sh` passed (three-container OpenSSH 9.2 suite, exercises the constrained path with the new check on both hosts).
- shellcheck on `tests/real-ssh/scenarios.sh`, `scripts/check-doc-links.py`.

Not verified: behavior against a genuinely old OpenSSH client end to end; the floor is exercised only through the fake `ssh` in the integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPohRhyNQ1xoWq3J6aTTns
