### PR TITLE
Require attached values for hyphen-prefixed native paths

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -36,6 +36,12 @@ syq rm --root /srv --src-dir cache
 syq rm --cwd /srv --follow-src --src-dir current-release
 ```
 
+Native path and pattern option values that begin with `-` use the attached
+`--option=value` spelling, for example `--src=--archive`, `--src-dir=-`, or
+`--into=-target`. This keeps a following option recognizable. `--mapping -`
+is the intentional exception: there, `-` means to read the mapping from
+standard input.
+
 `--from [USER@]HOST[:PORT]` selects one source endpoint and `--to
 [USER@]HOST[:PORT]` selects one target endpoint; omission means local. Enclose
 an IPv6 address in brackets, for example `alice@[2001:db8::1]:2222`. The port
@@ -62,8 +68,8 @@ the target container. `--srcs PATH...`, `--src-srcs DIR...`, `--src-files
 PATH...`, and `--src-dirs DIR...` are bulk conveniences for the corresponding
 singular selectors. Symlinks found while traversing a selected directory are
 copied as symlinks and are never followed. Singular selector options consume
-their next argument even when it begins with `-`, so every Unix filename is
-expressible without losing raw path bytes.
+an ordinary next argument; the attached spelling above works for singular and
+bulk selectors and preserves every Unix filename and its raw path bytes.
 
 All native commands use one link-resolution rule for filesystem paths supplied
 directly by the operator. By default, SYQ refuses a symlink in any component

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -86,9 +86,10 @@ syq.cp(src=["a", "b"], src_dir=["assets", "fonts"], into="archive")
 ```
 
 The implementation serializes this as repeated `--src` and `--src-dir`
-options. A keyword accepts either one path or an iterable of paths; `str`,
-`bytes`, and path-like objects are always treated as scalar paths rather than
-iterables.
+options. When a path begins with `-`, it uses the native attached spelling such
+as `--src-dir=-`; callers still pass the path itself. A keyword accepts either
+one path or an iterable of paths; `str`, `bytes`, and path-like objects are
+always treated as scalar paths rather than iterables.
 
 ## Scope
 

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -776,7 +776,9 @@ def _rm_arguments(
     if syq_path is not None and no_bootstrap:
         raise SyqInvocationError("syq_path and no_bootstrap conflict")
     if syq_path is not None:
-        argv.extend(("--syq-path", _text_arg(syq_path, label="syq_path")))
+        _append_path_option(
+            argv, "--syq-path", _text_arg(syq_path, label="syq_path")
+        )
     if no_bootstrap:
         argv.append("--no-bootstrap")
     return argv, source_count

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -481,8 +481,19 @@ def _append_paths(
 ) -> int:
     values = _values(value, label=option)
     for item in values:
-        argv.extend((option, item))
+        _append_path_option(argv, option, item)
     return len(values)
+
+
+def _append_path_option(
+    argv: list[Argument], option: str, value: Argument
+) -> None:
+    if isinstance(value, bytes) and value.startswith(b"-"):
+        argv.append(os.fsencode(option) + b"=" + value)
+    elif isinstance(value, str) and value.startswith("-"):
+        argv.append(f"{option}={value}")
+    else:
+        argv.extend((option, value))
 
 
 def _append_text(argv: list[Argument], option: str, value: object | None) -> None:
@@ -516,7 +527,9 @@ def _append_remote_arguments(
     if rsh is not None:
         argv.extend(("--rsh", _text_arg(rsh, label="rsh")))
     if syq_path is not None:
-        argv.extend(("--syq-path", _text_arg(syq_path, label="syq_path")))
+        _append_path_option(
+            argv, "--syq-path", _text_arg(syq_path, label="syq_path")
+        )
     for enabled, option in (
         (no_bootstrap, "--no-bootstrap"),
         (tcp_plain, "--tcp-plain"),
@@ -616,9 +629,9 @@ def _copy_arguments(
     if cwd is not None and root is not None:
         raise SyqInvocationError("cwd and root are mutually exclusive")
     if cwd is not None:
-        argv.extend(("--cwd", _argument(cwd, label="cwd")))
+        _append_path_option(argv, "--cwd", _argument(cwd, label="cwd"))
     if root is not None:
-        argv.extend(("--root", _argument(root, label="root")))
+        _append_path_option(argv, "--root", _argument(root, label="root"))
     if follow:
         argv.append("--follow")
     if follow_src:
@@ -647,7 +660,7 @@ def _copy_arguments(
         raise SyqInvocationError("mapping placement options conflict")
     for option, value in selected_placements:
         assert value is not None
-        argv.extend((option, _argument(value, label=option)))
+        _append_path_option(argv, option, _argument(value, label=option))
         if option.startswith("--as") and source_count and (
             source_count != 1 or contents_count
         ):
@@ -676,11 +689,13 @@ def _copy_arguments(
         rules = (ignore,) if isinstance(ignore, (str, IgnoreFrom)) else tuple(ignore)
         for rule in rules:
             if isinstance(rule, IgnoreFrom):
-                argv.extend(
-                    ("--ignore-from", _argument(rule.path, label="--ignore-from"))
+                _append_path_option(
+                    argv,
+                    "--ignore-from",
+                    _argument(rule.path, label="--ignore-from"),
                 )
             elif isinstance(rule, str):
-                argv.extend(("--ignore", rule))
+                _append_path_option(argv, "--ignore", rule)
             else:
                 raise SyqInvocationError(
                     "--ignore entries must be text or syq.IgnoreFrom"
@@ -742,9 +757,9 @@ def _rm_arguments(
     if cwd is not None and root is not None:
         raise SyqInvocationError("cwd and root are mutually exclusive")
     if cwd is not None:
-        argv.extend(("--cwd", _argument(cwd, label="cwd")))
+        _append_path_option(argv, "--cwd", _argument(cwd, label="cwd"))
     if root is not None:
-        argv.extend(("--root", _argument(root, label="root")))
+        _append_path_option(argv, "--root", _argument(root, label="root"))
     if follow:
         argv.append("--follow")
     if follow_src:
@@ -1090,7 +1105,9 @@ class Client:
         if any(value is not None for value in (as_, as_new, as_existing)):
             raise SyqInvocationError("--mapping conflicts with --as")
         if isinstance(mapping, (str, bytes, os.PathLike)):
-            argv.extend(("--mapping", _argument(mapping, label="mapping")))
+            _append_path_option(
+                argv, "--mapping", _argument(mapping, label="mapping")
+            )
             return self._typed(
                 argv,
                 mode="cp",

--- a/sdk/python/tests/test_native.py
+++ b/sdk/python/tests/test_native.py
@@ -342,6 +342,13 @@ class NativeClientTests(unittest.TestCase):
         self.assertNotIn("-base", argv)
         self.assertNotIn("-destination", argv)
 
+    def test_rm_hyphen_prefixed_syq_path_uses_an_attached_value(self) -> None:
+        self.client.rm("victim", from_="host", syq_path="-helper")
+
+        argv = self.argv()
+        self.assertIn("--syq-path=-helper", argv)
+        self.assertNotIn("-helper", argv)
+
     def test_rm_uses_native_names_and_returns_structured_outcomes(self) -> None:
         events: list[syq.AutomationEvent] = []
         output = io.BytesIO()

--- a/sdk/python/tests/test_native.py
+++ b/sdk/python/tests/test_native.py
@@ -331,6 +331,17 @@ class NativeClientTests(unittest.TestCase):
         self.assertNotIn("--quiet", argv)
         self.assertEqual(argv.count("--src"), 2)
 
+    def test_hyphen_prefixed_paths_use_attached_option_values(self) -> None:
+        self.client.cp(src_dir="-", cwd="-base", into="-destination")
+
+        argv = self.argv()
+        self.assertIn("--src-dir=-", argv)
+        self.assertIn("--cwd=-base", argv)
+        self.assertIn("--into=-destination", argv)
+        self.assertNotIn("-", argv)
+        self.assertNotIn("-base", argv)
+        self.assertNotIn("-destination", argv)
+
     def test_rm_uses_native_names_and_returns_structured_outcomes(self) -> None:
         events: list[syq.AutomationEvent] = []
         output = io.BytesIO()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1047,27 +1047,48 @@ fn reject_detached_dash_native_values(argv: &[OsString]) -> Result<()> {
         b"--pscope",
         b"--syq-path",
     ];
+    const VARIADIC_VALUE_OPTIONS: &[&[u8]] =
+        &[b"--srcs", b"--src-srcs", b"--src-files", b"--src-dirs"];
 
-    for pair in argv
+    let arguments = argv
         .split(|argument| argument.as_bytes() == b"--")
         .next()
-        .unwrap_or_default()
-        .windows(2)
-    {
+        .unwrap_or_default();
+
+    for pair in arguments.windows(2) {
         let option = pair[0].as_bytes();
         if ATTACHED_VALUE_OPTIONS.contains(&option) && pair[1].as_bytes() == b"-" {
-            let option = String::from_utf8_lossy(option);
-            let attached = if option == "-C" {
-                "--cwd=-".to_string()
-            } else {
-                format!("{option}=-")
-            };
-            bail!(
-                "a native path or pattern value beginning with `-` must be attached with `=`; use {attached}"
-            );
+            reject_detached_dash(option)?;
+        }
+    }
+
+    let mut variadic_option = None;
+    for argument in arguments {
+        let argument = argument.as_bytes();
+        if argument == b"-" {
+            if let Some(option) = variadic_option {
+                reject_detached_dash(option)?;
+            }
+        } else if argument.starts_with(b"-") {
+            variadic_option = VARIADIC_VALUE_OPTIONS.iter().copied().find(|option| {
+                argument == *option
+                    || (argument.starts_with(option) && argument.get(option.len()) == Some(&b'='))
+            });
         }
     }
     Ok(())
+}
+
+fn reject_detached_dash(option: &[u8]) -> Result<()> {
+    let option = String::from_utf8_lossy(option);
+    let attached = if option == "-C" {
+        "--cwd=-".to_string()
+    } else {
+        format!("{option}=-")
+    };
+    bail!(
+        "a native path or pattern value beginning with `-` must be attached with `=`; use {attached}"
+    )
 }
 
 /// Decode the base64 path operands of a delegated remote-to-remote argv

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -640,16 +640,10 @@ pub(crate) fn command_for_completion(name: &str) -> Option<clap::Command> {
 #[derive(clap::Args, Debug)]
 struct NativeSourceArgs {
     /// Resolve relative source selectors from DIR
-    #[arg(
-        short = 'C',
-        long,
-        value_name = "DIR",
-        allow_hyphen_values = true,
-        conflicts_with = "root"
-    )]
+    #[arg(short = 'C', long, value_name = "DIR", conflicts_with = "root")]
     cwd: Option<OsString>,
     /// Resolve source selectors beneath DIR and refuse any escape
-    #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
+    #[arg(long, value_name = "DIR")]
     root: Option<OsString>,
     /// Follow symlinks in all directly supplied filesystem paths
     #[arg(long)]
@@ -657,17 +651,17 @@ struct NativeSourceArgs {
     /// Follow symlinks in directly supplied source paths
     #[arg(long)]
     follow_src: bool,
-    /// Select a named source object (repeatable)
-    #[arg(long, value_name = "PATH", allow_hyphen_values = true)]
+    /// Select a named source object; attach =PATH when it begins with `-` (repeatable)
+    #[arg(long, value_name = "PATH")]
     src: Vec<OsString>,
-    /// Select a directory's contents (repeatable)
-    #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
+    /// Select a directory's contents; attach =DIR when it begins with `-` (repeatable)
+    #[arg(long, value_name = "DIR")]
     src_src: Vec<OsString>,
-    /// Select a named non-directory source object (repeatable)
-    #[arg(long, value_name = "PATH", allow_hyphen_values = true)]
+    /// Select a named non-directory source object; attach =PATH when it begins with `-` (repeatable)
+    #[arg(long, value_name = "PATH")]
     src_file: Vec<OsString>,
-    /// Select a named source directory (repeatable)
-    #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
+    /// Select a named source directory; attach =DIR when it begins with `-` (repeatable)
+    #[arg(long, value_name = "DIR")]
     src_dir: Vec<OsString>,
     /// Select several named non-directory source objects
     #[arg(long, value_name = "PATH", num_args = 1..)]
@@ -701,16 +695,10 @@ struct NativeRmSelectionArgs {
     #[arg(long, value_name = "ENDPOINT")]
     from: Option<String>,
     /// Resolve relative selectors from DIR at the source endpoint
-    #[arg(
-        short = 'C',
-        long,
-        value_name = "DIR",
-        allow_hyphen_values = true,
-        conflicts_with = "root"
-    )]
+    #[arg(short = 'C', long, value_name = "DIR", conflicts_with = "root")]
     cwd: Option<OsString>,
     /// Confine resolution and removal beneath DIR
-    #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
+    #[arg(long, value_name = "DIR")]
     root: Option<OsString>,
     /// Follow symlinks in all directly supplied filesystem paths
     #[arg(long)]
@@ -718,17 +706,17 @@ struct NativeRmSelectionArgs {
     /// Follow symlinks in directly supplied source paths
     #[arg(long)]
     follow_src: bool,
-    /// Select an object without constraining the selected object's type (repeatable)
-    #[arg(long, value_name = "PATH", allow_hyphen_values = true)]
+    /// Select an object without constraining its type; attach =PATH when it begins with `-` (repeatable)
+    #[arg(long, value_name = "PATH")]
     src: Vec<OsString>,
-    /// Select a directory's contents, retaining the directory (repeatable)
-    #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
+    /// Select a directory's contents; attach =DIR when it begins with `-` (repeatable)
+    #[arg(long, value_name = "DIR")]
     src_src: Vec<OsString>,
-    /// Select a non-directory object (repeatable)
-    #[arg(long, value_name = "PATH", allow_hyphen_values = true)]
+    /// Select a non-directory object; attach =PATH when it begins with `-` (repeatable)
+    #[arg(long, value_name = "PATH")]
     src_file: Vec<OsString>,
-    /// Select a directory tree (repeatable)
-    #[arg(long, value_name = "DIR", allow_hyphen_values = true)]
+    /// Select a directory tree; attach =DIR when it begins with `-` (repeatable)
+    #[arg(long, value_name = "DIR")]
     src_dir: Vec<OsString>,
     /// Select several non-directory objects
     #[arg(long, value_name = "PATH", num_args = 1..)]
@@ -776,7 +764,7 @@ struct NativeOperationalArgs {
 struct NativeResultsArgs {
     /// Write the machine-readable NDJSON result stream to FILE (created
     /// fresh; an existing file is refused). Automation schema version 1
-    #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
+    #[arg(long, value_name = "FILE")]
     results: Option<OsString>,
     /// Write the result stream to an inherited file descriptor the caller
     /// opened (e.g. `--results-fd 3 3>run.ndjson`); must be above 2
@@ -801,7 +789,7 @@ struct NativeCopyOperationalArgs {
     #[arg(long)]
     stats: bool,
     /// Skip paths matching a gitignore-style pattern (repeatable)
-    #[arg(long = "ignore", value_name = "PATTERN", allow_hyphen_values = true)]
+    #[arg(long = "ignore", value_name = "PATTERN")]
     ignore: Vec<String>,
     /// Securely open and read gitignore-style patterns from raw-byte FILE (repeatable; stacks in command-line order)
     #[arg(long, value_name = "FILE")]
@@ -916,57 +904,27 @@ struct NativeCopyFields {
     #[arg(long)]
     follow_dest: bool,
     /// Put selected names inside DIR, creating it if necessary
-    #[arg(
-        long,
-        value_name = "DIR",
-        group = "placement",
-        allow_hyphen_values = true
-    )]
+    #[arg(long, value_name = "DIR", group = "placement")]
     into: Option<OsString>,
     /// Put selected names inside DIR, which must not exist
-    #[arg(
-        long,
-        value_name = "DIR",
-        group = "placement",
-        allow_hyphen_values = true
-    )]
+    #[arg(long, value_name = "DIR", group = "placement")]
     into_new: Option<OsString>,
     /// Put selected names inside an existing directory
-    #[arg(
-        long,
-        value_name = "DIR",
-        group = "placement",
-        allow_hyphen_values = true
-    )]
+    #[arg(long, value_name = "DIR", group = "placement")]
     into_existing: Option<OsString>,
     /// Map one named source exactly to PATH; never follow its final entry
-    #[arg(
-        long,
-        value_name = "PATH",
-        group = "placement",
-        allow_hyphen_values = true
-    )]
+    #[arg(long, value_name = "PATH", group = "placement")]
     r#as: Option<OsString>,
     /// Map one named source exactly to PATH; its final entry must not exist and is never followed
-    #[arg(
-        long,
-        value_name = "PATH",
-        group = "placement",
-        allow_hyphen_values = true
-    )]
+    #[arg(long, value_name = "PATH", group = "placement")]
     as_new: Option<OsString>,
     /// Map one named source exactly to PATH; its final entry must exist and is never followed
-    #[arg(
-        long,
-        value_name = "PATH",
-        group = "placement",
-        allow_hyphen_values = true
-    )]
+    #[arg(long, value_name = "PATH", group = "placement")]
     as_existing: Option<OsString>,
     /// Copy the entries of an NDJSON mapping manifest (`-` reads stdin), acquired before
     /// destination changes, instead of selecting sources; entry src paths are relative to
     /// -C and dst paths are relative to the --into container
-    #[arg(long, value_name = "FILE", allow_hyphen_values = true)]
+    #[arg(long, value_name = "FILE")]
     mapping: Option<OsString>,
     #[command(flatten)]
     results_output: NativeResultsArgs,
@@ -989,7 +947,7 @@ struct NativeSizeSelectionArgs {
     name = "syq cp",
     version,
     about = "Copy selected objects with explicit endpoint and placement syntax",
-    long_about = "Copy selected objects with explicit endpoint and placement syntax.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files. By default, destination-only objects remain in place. --prune removes them from mapped directory scopes after copying, while protecting ignored and size-excluded paths.",
+    long_about = "Copy selected objects with explicit endpoint and placement syntax.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files. By default, destination-only objects remain in place. --prune removes them from mapped directory scopes after copying, while protecting ignored and size-excluded paths. Attach path and pattern option values beginning with `-` by using `=`, for example --src-dir=-. The spelling --mapping - retains its conventional stdin meaning.",
     override_usage = "syq cp [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]... PLACEMENT"
 )]
 struct NativeCopyCommand {
@@ -1016,14 +974,14 @@ struct NativeCopyCommand {
     name = "syq map",
     version,
     about = "Print a local source selection as an NDJSON mapping",
-    long_about = "Print a local source selection as an NDJSON mapping.\n\nOne JSON object per line: tagged src and dst paths (src relative to the source base, dst relative to a future target container), the object kind, and size/mtime for regular files. Emission is local and read-only. Names must be valid UTF-8.",
+    long_about = "Print a local source selection as an NDJSON mapping.\n\nOne JSON object per line: tagged src and dst paths (src relative to the source base, dst relative to a future target container), the object kind, and size/mtime for regular files. Emission is local and read-only. Names must be valid UTF-8. Attach path option values beginning with `-` by using `=`, for example --src-dir=-.",
     override_usage = "syq map [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]..."
 )]
 struct NativeMapCommand {
     #[command(flatten)]
     source: NativeSourceArgs,
     /// Rename the single selected root in the emitted mapping
-    #[arg(long, value_name = "PATH", allow_hyphen_values = true)]
+    #[arg(long, value_name = "PATH")]
     r#as: Option<OsString>,
 }
 
@@ -1032,6 +990,7 @@ struct NativeMapCommand {
     name = "syq rm",
     version,
     about = "Remove endpoint-resolved object trees without following symlinks by default",
+    long_about = "Remove endpoint-resolved object trees without following symlinks by default.\n\nAttach path option values beginning with `-` by using `=`, for example --src-dir=-.",
     override_usage = "syq rm [OPTIONS] [--src PATH | --src-src DIR | --src-file PATH | --src-dir DIR | PATH]..."
 )]
 struct NativeRmCommand {
@@ -1049,12 +1008,66 @@ struct NativeRmCommand {
 }
 
 fn parse_native(argv: &[OsString], interface: Interface) -> Result<Args> {
+    reject_detached_dash_native_values(argv)?;
     match interface {
         Interface::NativeCp => parse_native_copy(argv),
         Interface::NativeMap => parse_native_map(argv),
         Interface::NativeRm => parse_native_rm(argv),
         Interface::Rsync => unreachable!(),
     }
+}
+
+/// Clap normally treats option-looking tokens as new options, but deliberately
+/// treats a lone `-` as an ordinary detached value. Keep native path and
+/// pattern arguments consistent: a hyphen-prefixed value uses the attached
+/// `--option=value` spelling. `--mapping -` remains the conventional stdin
+/// spelling and is intentionally not in this list.
+fn reject_detached_dash_native_values(argv: &[OsString]) -> Result<()> {
+    const ATTACHED_VALUE_OPTIONS: &[&[u8]] = &[
+        b"-C",
+        b"--cwd",
+        b"--root",
+        b"--src",
+        b"--src-src",
+        b"--src-file",
+        b"--src-dir",
+        b"--srcs",
+        b"--src-srcs",
+        b"--src-files",
+        b"--src-dirs",
+        b"--into",
+        b"--into-new",
+        b"--into-existing",
+        b"--as",
+        b"--as-new",
+        b"--as-existing",
+        b"--results",
+        b"--ignore",
+        b"--ignore-from",
+        b"--pscope",
+        b"--syq-path",
+    ];
+
+    for pair in argv
+        .split(|argument| argument.as_bytes() == b"--")
+        .next()
+        .unwrap_or_default()
+        .windows(2)
+    {
+        let option = pair[0].as_bytes();
+        if ATTACHED_VALUE_OPTIONS.contains(&option) && pair[1].as_bytes() == b"-" {
+            let option = String::from_utf8_lossy(option);
+            let attached = if option == "-C" {
+                "--cwd=-".to_string()
+            } else {
+                format!("{option}=-")
+            };
+            bail!(
+                "a native path or pattern value beginning with `-` must be attached with `=`; use {attached}"
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Decode the base64 path operands of a delegated remote-to-remote argv

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -765,7 +765,9 @@ fn filesystem_command_candidates(
         }
         if let Some(previous) = args.last() {
             if let Some(kind) = value_completion(command, previous, &command_meta) {
-                return complete_value(command, args, current, kind);
+                if command == "rsync" || !current.starts_with(b"-") {
+                    return complete_value(command, args, current, kind);
+                }
             }
         }
         if current.starts_with(b"-") {
@@ -1806,6 +1808,14 @@ mod tests {
         let command = crate::cli::command_for_completion("cp").unwrap();
         let options = values(option_candidates(&command, b"--coor"));
         assert_eq!(options, vec![b"--coordinate-at".to_vec()]);
+    }
+
+    #[test]
+    fn native_option_looking_values_are_completed_as_options_unless_attached() {
+        let options =
+            values(filesystem_command_candidates("cp", &[b"--src-dir".to_vec()], b"--i").unwrap());
+        assert!(options.contains(&b"--ignore".to_vec()));
+        assert!(options.contains(&b"--into".to_vec()));
     }
 
     #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1413,6 +1413,7 @@ fn native_copy_uses_explicit_endpoints_cwd_and_attached_option_like_selectors() 
 fn native_hyphen_prefixed_selector_values_require_equals() {
     let t = Tmp::new();
     write(&t.path("base/-/file"), b"literal hyphen directory");
+    write(&t.path("base/foo"), b"ordinary source");
 
     let option_looking = native_syq(&[
         "cp",
@@ -1448,6 +1449,25 @@ fn native_hyphen_prefixed_selector_values_require_equals() {
     );
     assert!(!t.path("detached").exists());
 
+    for (selector_args, destination) in [
+        (&["--srcs", "foo", "-"][..], "detached-bulk"),
+        (&["--srcs=foo", "-"][..], "detached-inline-bulk"),
+    ] {
+        let base = t.s("base");
+        let destination_path = t.s(destination);
+        let mut args = vec!["cp", "--cwd", base.as_str()];
+        args.extend_from_slice(selector_args);
+        args.extend_from_slice(&["--into", destination_path.as_str()]);
+        let detached_bulk = native_syq(&args);
+        assert!(!detached_bulk.status.success());
+        assert!(
+            stderr_of(&detached_bulk).contains("use --srcs=-"),
+            "{}",
+            stderr_of(&detached_bulk)
+        );
+        assert!(!t.path(destination).exists());
+    }
+
     run_native_ok(&[
         "cp",
         "--cwd",
@@ -1458,6 +1478,22 @@ fn native_hyphen_prefixed_selector_values_require_equals() {
     ]);
     assert_eq!(
         read(&t.path("attached/-/file")),
+        b"literal hyphen directory"
+    );
+
+    run_native_ok(&[
+        "cp",
+        "--cwd",
+        &t.s("base"),
+        "--srcs",
+        "foo",
+        "--srcs=-",
+        "--into",
+        &t.s("attached-bulk"),
+    ]);
+    assert_eq!(read(&t.path("attached-bulk/foo")), b"ordinary source");
+    assert_eq!(
+        read(&t.path("attached-bulk/-/file")),
         b"literal hyphen directory"
     );
 }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1370,7 +1370,7 @@ fn native_as_existing_updates_a_same_type_symlink() {
 }
 
 #[test]
-fn native_copy_uses_explicit_endpoints_cwd_and_option_safe_selectors() {
+fn native_copy_uses_explicit_endpoints_cwd_and_attached_option_like_selectors() {
     let t = Tmp::new();
     write(&t.path("base/foo"), b"cwd");
     write(&t.path("base/--into"), b"option-looking");
@@ -1382,8 +1382,7 @@ fn native_copy_uses_explicit_endpoints_cwd_and_option_safe_selectors() {
         &t.s("base"),
         "--src",
         "foo",
-        "--src",
-        "--into",
+        "--src=--into",
         "host:path",
         "--into",
         &t.s("dst"),
@@ -1408,6 +1407,59 @@ fn native_copy_uses_explicit_endpoints_cwd_and_option_safe_selectors() {
     assert!(!no_basename.status.success());
     assert!(String::from_utf8_lossy(&no_basename.stderr).contains("no target basename"));
     assert!(!t.path("no-basename").exists());
+}
+
+#[test]
+fn native_hyphen_prefixed_selector_values_require_equals() {
+    let t = Tmp::new();
+    write(&t.path("base/-/file"), b"literal hyphen directory");
+
+    let option_looking = native_syq(&[
+        "cp",
+        "--cwd",
+        &t.s("base"),
+        "--src-dir",
+        "--dry-run",
+        "--into",
+        &t.s("option-looking"),
+    ]);
+    assert!(!option_looking.status.success());
+    assert!(
+        stderr_of(&option_looking).contains("a value is required for '--src-dir <DIR>'"),
+        "{}",
+        stderr_of(&option_looking)
+    );
+    assert!(!t.path("option-looking").exists());
+
+    let detached = native_syq(&[
+        "cp",
+        "--cwd",
+        &t.s("base"),
+        "--src-dir",
+        "-",
+        "--into",
+        &t.s("detached"),
+    ]);
+    assert!(!detached.status.success());
+    assert!(
+        stderr_of(&detached).contains("use --src-dir=-"),
+        "{}",
+        stderr_of(&detached)
+    );
+    assert!(!t.path("detached").exists());
+
+    run_native_ok(&[
+        "cp",
+        "--cwd",
+        &t.s("base"),
+        "--src-dir=-",
+        "--into",
+        &t.s("attached"),
+    ]);
+    assert_eq!(
+        read(&t.path("attached/-/file")),
+        b"literal hyphen directory"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Summary

- stop native path and pattern options from consuming option-looking following arguments
- require attached --option=value spelling for literal hyphen-prefixed values, while retaining --mapping - for stdin
- align help, completion, reference docs, and Python SDK serialization

Testing

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --bin syq
- cargo test --test local native_
- cargo test --all-targets
- uv run --project sdk/python --frozen python -m unittest discover -s sdk/python/tests
- python3 scripts/check-doc-links.py