### PR TITLE
Keep rsync-mode --insecure-links local only

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -183,7 +183,9 @@ source, destination, and control paths, and uses the legacy unconfined source
 discovery and content-read paths. As in rsync, the flag is local only. It
 applies to the source or destination on the machine where you run syq and to
 the control files syq reads there; it is never passed to a remote endpoint,
-which keeps the default trusted-owner policy and confined source paths. Native
+which keeps the default trusted-owner policy and confined source paths. Rsync
+lets the remote side opt out through `--rsync-path`; syq's `--rsync-path` is
+an executable path only, so a remote endpoint cannot opt out. Native
 mapping/generated names never inherit native `--follow`; they remain strict
 descendants of the registered source root. Rsync-compatible operator control
 paths retain rsync's implicit policy of following a symlink owned by root or

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -180,7 +180,10 @@ spelling cannot redirect that decision.
 Rsync-mode `--insecure-links` is the explicit compatibility opt-out: that
 session follows symlinks regardless of ownership in its operator-supplied
 source, destination, and control paths, and uses the legacy unconfined source
-discovery and content-read paths. Native
+discovery and content-read paths. As in rsync, the flag is local only. It
+applies to the source or destination on the machine where you run syq and to
+the control files syq reads there; it is never passed to a remote endpoint,
+which keeps the default trusted-owner policy and confined source paths. Native
 mapping/generated names never inherit native `--follow`; they remain strict
 descendants of the registered source root. Rsync-compatible operator control
 paths retain rsync's implicit policy of following a symlink owned by root or
@@ -588,7 +591,7 @@ accept them.
 | `--max-size SIZE`, `--min-size SIZE` | Don't transfer regular files larger / smaller than SIZE |
 | `--files-from FILE` | Copy only the listed paths (relative to the one source directory; see below) |
 | `--from0` | `--files-from` entries are NUL-separated |
-| `--insecure-links` | Permit legacy traversal through symlinks in rsync operator paths and source descendants, regardless of ownership |
+| `--insecure-links` | Follow symlinks in this machine's operator paths regardless of ownership, and use legacy traversal through symlinked source parents; never applied to a remote endpoint, as in rsync |
 | `-h` | No-op for rsync compatibility; sizes are always human-readable. Use `--help` for help |
 
 Like rsync, `-q` suppresses ordinary non-error output: progress, summaries,
@@ -1051,9 +1054,10 @@ source is not traversed and that listed path fails. This is deliberately
 stricter than hardened rsync 3.5.0: rsync may first emit the implied destination
 directory and then fail the content open, while SYQ refuses the path before
 emitting that implied parent. Both report a partial-transfer error (exit 23).
-`--insecure-links` opts the whole source session into the legacy unconfined
+`--insecure-links` opts a local source session into the legacy unconfined
 pathname behavior: such a parent is followed and becomes a real directory on
-the destination. A parent that resolves to a file or dangles is an error. A
+the destination. A remote source keeps the confined behavior, because the flag
+is never sent to the remote side. A parent that resolves to a file or dangles is an error. A
 listed directory is copied *without*
 its contents unless `-r` is given on the command line itself — `-a` alone
 does not count, as in rsync — so `-a -r --files-from` walks the directories

--- a/docs/security.md
+++ b/docs/security.md
@@ -118,7 +118,9 @@ What is different from rsync, or weaker:
   automatically; do not reach for it to satisfy a source-side need without
   accepting that destination and control paths lose the same check. Like
   rsync's flag, it is local only: it never reaches a remote endpoint, which
-  keeps the default ownership check and confined source paths. It does
+  keeps the default ownership check and confined source paths. Rsync lets
+  the remote side opt out through `--rsync-path`; syq's `--rsync-path` names
+  an executable only, so a remote endpoint cannot opt out. It does
   not enable rsync's separate descendant-link modes:
   `-L`/`--copy-links`, `--copy-unsafe-links`, `-k`/`--copy-dirlinks`, and
   `-K`/`--keep-dirlinks` remain unsupported and are rejected before either
@@ -392,11 +394,16 @@ verified:
 - **Source builds are honest about identity.** A checkout build carries its Git
   revision, is not an immutable release, and cannot populate the managed
   helper cache; peers must present matching build identities to connect.
-- **Both sides always run the same build.** Every connection starts by
+- **Peers must have matching build identities.** Every connection starts by
   exchanging build identities in plain bytes, and any mismatch is refused
-  before either side decodes a protocol message. There is no protocol version
-  number and no negotiation between versions: the wire format is free to
-  change between releases because two different builds never talk to each
-  other. The managed helper install is what makes this practical; the local
-  client puts its own verified release on the remote side rather than
-  adapting to whatever is installed there.
+  before either side decodes a protocol message. The identity is the release
+  version for an official binary and the Git revision (plus a hash of any
+  uncommitted changes) for a source build, so it names the source the binary
+  was built from, not the exact executable: release artifacts for different
+  platforms share one identity, and so do clean builds of the same commit.
+  There is no protocol version number and no negotiation between versions;
+  the wire format is free to change between releases because peers built
+  from different source never talk to each other. The managed helper install
+  is what makes this practical, and it separately guarantees that the remote
+  side runs a verified release artifact rather than whatever is installed
+  there.

--- a/docs/security.md
+++ b/docs/security.md
@@ -116,7 +116,9 @@ What is different from rsync, or weaker:
   the unconfined, name-based source traversal, including through symlinked
   `--files-from` parents. It exists for compatibility and is never selected
   automatically; do not reach for it to satisfy a source-side need without
-  accepting that destination and control paths lose the same check. It does
+  accepting that destination and control paths lose the same check. Like
+  rsync's flag, it is local only: it never reaches a remote endpoint, which
+  keeps the default ownership check and confined source paths. It does
   not enable rsync's separate descendant-link modes:
   `-L`/`--copy-links`, `--copy-unsafe-links`, `-k`/`--copy-dirlinks`, and
   `-K`/`--keep-dirlinks` remain unsupported and are rejected before either
@@ -390,3 +392,11 @@ verified:
 - **Source builds are honest about identity.** A checkout build carries its Git
   revision, is not an immutable release, and cannot populate the managed
   helper cache; peers must present matching build identities to connect.
+- **Both sides always run the same build.** Every connection starts by
+  exchanging build identities in plain bytes, and any mismatch is refused
+  before either side decodes a protocol message. There is no protocol version
+  number and no negotiation between versions: the wire format is free to
+  change between releases because two different builds never talk to each
+  other. The managed helper install is what makes this practical; the local
+  client puts its own verified release on the remote side rather than
+  adapting to whatever is installed there.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,7 +166,7 @@ pub struct Args {
     /// Copy symlinks as symlinks
     #[arg(short = 'l', long)]
     pub links: bool,
-    /// Permit legacy traversal through symlinks in rsync operator paths and source descendants
+    /// Follow symlinks in this machine's rsync operator paths regardless of ownership (local only, as in rsync)
     #[arg(long)]
     pub insecure_links: bool,
     /// Preserve permissions

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -158,9 +158,18 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
     })
 }
 
-fn source_operator_symlink_policy(args: &Args) -> OperatorSymlinkPolicy {
+/// Rsync's `--insecure-links` is local only: it is never sent to the remote
+/// side of a transfer, so a remote endpoint keeps the default trusted-owner
+/// policy and the confined source paths even when the operator passed the
+/// flag here. Rsync mode never places the coordinator remotely, so "this
+/// machine" is the one the operator invoked syq on.
+fn rsync_insecure_links(args: &Args, endpoint_is_local: bool) -> bool {
+    args.interface == Interface::Rsync && args.insecure_links && endpoint_is_local
+}
+
+fn source_operator_symlink_policy(args: &Args, source_is_local: bool) -> OperatorSymlinkPolicy {
     if args.interface == Interface::Rsync {
-        rsync_operator_symlink_policy(args.insecure_links)
+        rsync_operator_symlink_policy(rsync_insecure_links(args, source_is_local))
     } else if args.follows_native_source_paths() {
         OperatorSymlinkPolicy::FollowAll
     } else {
@@ -168,9 +177,12 @@ fn source_operator_symlink_policy(args: &Args) -> OperatorSymlinkPolicy {
     }
 }
 
-fn destination_operator_symlink_policy(args: &Args) -> OperatorSymlinkPolicy {
+fn destination_operator_symlink_policy(
+    args: &Args,
+    destination_is_local: bool,
+) -> OperatorSymlinkPolicy {
     if args.interface == Interface::Rsync {
-        rsync_operator_symlink_policy(args.insecure_links)
+        rsync_operator_symlink_policy(rsync_insecure_links(args, destination_is_local))
     } else if args.follows_native_destination_paths() {
         OperatorSymlinkPolicy::FollowAll
     } else {
@@ -1196,8 +1208,8 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         update: args.update,
         ignore_existing: args.ignore_existing,
         existing: args.existing,
-        insecure_links: args.interface == Interface::Rsync && args.insecure_links,
-        operator_symlink_policy: destination_operator_symlink_policy(&args),
+        insecure_links: rsync_insecure_links(&args, !src_ep.is_remote()),
+        operator_symlink_policy: destination_operator_symlink_policy(&args, !dst_ep.is_remote()),
         max_size,
         min_size,
     });
@@ -2985,6 +2997,7 @@ fn register_source_roots(
     shared_workers: usize,
     independent_claim_workers: usize,
 ) -> Result<Vec<RegisteredSourceRoot>> {
+    let source_is_local = !sources.iter().any(Location::is_remote);
     let base = if let Some(path) = &args.native_source_root {
         SourceRootBase {
             path: Some(path.clone()),
@@ -3011,8 +3024,8 @@ fn register_source_roots(
         conn.call(Request::RegisterSourceRoots {
             base,
             selections,
-            symlink_policy: source_operator_symlink_policy(args),
-            allow_unconfined_paths: args.interface == Interface::Rsync && args.insecure_links,
+            symlink_policy: source_operator_symlink_policy(args, source_is_local),
+            allow_unconfined_paths: rsync_insecure_links(args, source_is_local),
             shared_workers,
             independent_claim_workers,
         })?,

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7904,6 +7904,72 @@ fn files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs() {
     assert!(!t.path("outside/secret2").exists());
 }
 
+/// Rsync's `--insecure-links` is local only and is never sent to the remote
+/// side. A remote source therefore keeps the confined default even when the
+/// operator passed the flag, and the flag still opts out locally in the same
+/// invocation.
+#[test]
+fn insecure_links_never_reaches_a_remote_endpoint() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    write(&t.path("outside/secret"), b"secret");
+    fs::create_dir_all(t.path("src/a")).unwrap();
+    std::os::unix::fs::symlink("../outside", t.path("src/link")).unwrap();
+    write(&t.path("src/a/listed"), b"l");
+    write(&t.path("list"), b"link/secret\na/listed\n");
+
+    // Remote source: the symlinked ancestor stays refused.
+    let remote_src = format!("fake:{}", t.s("src"));
+    let out = remote_syq(
+        &t,
+        &rsh,
+        &[
+            "-a",
+            "-r",
+            "--syq-no-bootstrap",
+            "--insecure-links",
+            "--files-from",
+            &t.s("list"),
+            &remote_src,
+            &t.s("dst"),
+        ],
+    );
+    assert_eq!(out.status.code(), Some(23), "{}", stderr_of(&out));
+    assert!(
+        stderr_of(&out).contains("link is not a directory"),
+        "{}",
+        stderr_of(&out)
+    );
+    assert_eq!(listing(&t.path("dst")), ["a", "a/listed"]);
+    assert!(!t.path("dst/link").exists());
+
+    // Local source, remote destination: the local opt-out still applies and
+    // the remote receiver is unaffected by it.
+    let remote_dst = format!("fake:{}", t.s("dst-remote"));
+    let out = remote_syq(
+        &t,
+        &rsh,
+        &[
+            "-a",
+            "-r",
+            "--syq-no-bootstrap",
+            "--insecure-links",
+            "--files-from",
+            &t.s("list"),
+            &t.s("src"),
+            &remote_dst,
+        ],
+    );
+    assert!(out.status.success(), "{}", stderr_of(&out));
+    assert_eq!(
+        listing(&t.path("dst-remote")),
+        ["a", "a/listed", "link", "link/secret"]
+    );
+    assert_eq!(read(&t.path("dst-remote/link/secret")), b"secret");
+}
+
 #[test]
 fn existing_never_creates_the_destination_root() {
     let t = Tmp::new();
@@ -9476,6 +9542,34 @@ fn foreign_owned_destination_root_symlink_is_refused() {
     let opted_out = syq(&["-a", "--insecure-links", &t.s("src/"), &t.s("dst/")]);
     assert_output_ok(&opted_out);
     assert_eq!(read(&t.path("outside/f")), b"payload");
+
+    // The opt-out is local only: a remote destination keeps refusing the link.
+    fs::remove_file(t.path("outside/f")).unwrap();
+    let rsh = fake_rsh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    let remote = format!("fake:{}/", t.s("dst"));
+    let refused = remote_syq(
+        &t,
+        &rsh,
+        &[
+            "-a",
+            "--syq-no-bootstrap",
+            "--insecure-links",
+            &t.s("src/"),
+            &remote,
+        ],
+    );
+    assert!(
+        !refused.status.success(),
+        "remote foreign-owned link was followed"
+    );
+    assert!(
+        stderr_of(&refused).contains("refusing symlink component"),
+        "{}",
+        stderr_of(&refused)
+    );
+    assert!(!t.path("outside/f").exists());
 }
 
 #[cfg(debug_assertions)]


### PR DESCRIPTION
## Summary

- PR #160 widened `--insecure-links` to match rsync 3.5's scope (destination and control paths, not only source traversal) but missed the other half of rsync's contract: the option is local only and is never sent to the remote side. Syq sent the coordinator's policy to remote endpoints, so a remote source or destination followed foreign-owned links and used the legacy unconfined source paths whenever the local operator passed the flag.
- The flag now applies only to an endpoint on the invoking machine and to the control files read there. Remote endpoints keep the default trusted-owner policy and confined source paths.
- Add a non-root regression that a remote source keeps refusing a `--files-from` path through a symlinked parent under `--insecure-links`, while the same invocation still opts out locally. Extend the root-only destination test with a remote receiver.
- Document the local-only rule in `docs/reference.md` and `docs/security.md`, and state the same-build design (identity exchange before any protocol message, no version negotiation) directly on the security page.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq` (403 passed)
- `cargo test --test local -- insecure_links files_from foreign_owned symlink` (49 passed) and `-- remote helper rsync_path operator` (36 passed)
- the new `insecure_links_never_reaches_a_remote_endpoint` test fails on `master` and passes here
- `python3 tests/rsync-compat/harness_test.py`, `python3 scripts/check-doc-links.py`
- `scripts/rsync-compat.py --area security` non-root: all 5 scenarios pass
- Not run: the root-only Rust test (`foreign_owned_destination_root_symlink_is_refused` needs euid 0; no CI job runs `cargo test` as root), the root compat matrix, `scripts/test-real-ssh.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2vmuqmTDc5YT1QM64yKau
