### PR TITLE
Explain enrollment state storage and shared homes

### DIFF
--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -62,9 +62,7 @@ only costs a fresh helper bootstrap on the next transfer, but removing
 discards the record of which signed requests were already redeemed; revoke and
 enroll again instead. If hostB's home directory is on a network filesystem
 shared by several machines, they share the receiver, the forced key, and that
-record, so a signed request can be redeemed on only one of them. Each redemption
-is recorded by creating a link that fails if the name already exists, which
-stays atomic on NFS even where advisory locking does not.
+record, so a signed request can be redeemed on only one of them.
 
 Enrollment first tries local→hostB directly. If SSH reports a transport
 failure, it retries through hostA with OpenSSH `ProxyJump`; a remote validation

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -56,6 +56,16 @@ receiver enforces it authoritatively. This protection applies only to the
 enrolled command-restricted receiver; ordinary local and remote copies retain
 their normal destination semantics.
 
+That state directory is not a cache. Removing `~/.cache/syq` on either host
+only costs a fresh helper bootstrap on the next transfer, but removing
+`~/.local/share/syq/restricted` on hostB breaks every enrollment there and
+discards the record of which signed requests were already redeemed; revoke and
+enroll again instead. If hostB's home directory is on a network filesystem
+shared by several machines, they share the receiver, the forced key, and that
+record, so a signed request can be redeemed on only one of them. Each redemption
+is recorded by creating a link that fails if the name already exists, which
+stays atomic on NFS even where advisory locking does not.
+
 Enrollment first tries local→hostB directly. If SSH reports a transport
 failure, it retries through hostA with OpenSSH `ProxyJump`; a remote validation
 or installation error is reported against hostB without repeating it through

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -60,9 +60,7 @@ That state directory is not a cache. Removing `~/.cache/syq` on either host
 only costs a fresh helper bootstrap on the next transfer, but removing
 `~/.local/share/syq/restricted` on hostB breaks every enrollment there and
 discards the record of which signed requests were already redeemed; revoke and
-enroll again instead. If hostB's home directory is on a network filesystem
-shared by several machines, they share the receiver, the forced key, and that
-record, so a signed request can be redeemed on only one of them.
+enroll again instead.
 
 Enrollment first tries local→hostB directly. If SSH reports a transport
 failure, it retries through hostA with OpenSSH `ProxyJump`; a remote validation


### PR DESCRIPTION
## Summary

- state that the helper cache can be removed at the cost of a bootstrap, but the restricted enrollment state on hostB cannot, since removal breaks enrollments and discards redemption records

Docs only. Raised while auditing the #146/#158 receiver model; the storage locations were already documented, but not what an administrator may safely delete.

## Verification

- scripts/check-doc-links.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtY6ciZWkBcw5QuzhKGwhh