### PR TITLE
Write the rsync race flipper's reports with os.write

### DIFF
--- a/tests/rsync-compat/adaptations/rename-destination-symlink-race.patch
+++ b/tests/rsync-compat/adaptations/rename-destination-symlink-race.patch
@@ -107,7 +107,9 @@ index 0000000..b6a44bc
 +# SIGUSR1, reports readiness on stdout only after that handler is installed so
 +# the push starts under a running flipper, terminates with this test process,
 +# and has a hard backstop so an interrupted suite cannot leave a
-+# namespace-mutating process behind.
++# namespace-mutating process behind.  Both writes go straight to the
++# descriptor: a signal that lands while buffered stdout is mid-write would
++# make a print() in the handler fail with a reentrancy error.
 +flip_code = (
 +    "import os, signal, sys, time\n"
 +    "sub, link = sys.argv[1], sys.argv[2]\n"
@@ -115,8 +117,10 @@ index 0000000..b6a44bc
 +    "parent = os.getppid()\n"
 +    "deadline = time.monotonic() + 120\n"
 +    "cycles = 0\n"
-+    "signal.signal(signal.SIGUSR1, lambda *_: print(cycles, flush=True))\n"
-+    "print('ready', flush=True)\n"
++    "def report(*_):\n"
++    "    os.write(1, f'{cycles}\\n'.encode())\n"
++    "signal.signal(signal.SIGUSR1, report)\n"
++    "os.write(1, b'ready\\n')\n"
 +    "while time.monotonic() < deadline and os.getppid() == parent:\n"
 +    "    try:\n"
 +    "        os.makedirs(sub, exist_ok=True)\n"

--- a/tests/rsync-compat/adaptations/rename-destination-symlink-race.patch
+++ b/tests/rsync-compat/adaptations/rename-destination-symlink-race.patch
@@ -1,9 +1,9 @@
 diff --git a/testsuite/receiver-rename-symlink-race_test.py b/testsuite/receiver-rename-symlink-race_test.py
 new file mode 100755
-index 0000000..b6a44bc
+index 0000000..720ddc9
 --- /dev/null
 +++ b/testsuite/receiver-rename-symlink-race_test.py
-@@ -0,0 +1,200 @@
+@@ -0,0 +1,204 @@
 +#!/usr/bin/env python3
 +"""Normal staged-publication rename stays beneath the destination root.
 +


### PR DESCRIPTION
## Summary

`receiver-rename-symlink-race` failed at random in the conformance job (run 33878610118 and its rerun) with `RuntimeError: reentrant call inside <_io.BufferedWriter name='<stdout>'>` from the flipper subprocess our adaptation starts. Its SIGUSR1 handler printed the cycle count through buffered stdout, and the parent sends the first SIGUSR1 as soon as it reads `ready`, which can land while the child is still inside that `print`. Both writes now go straight to descriptor 1 with `os.write`, which is safe to call from a signal handler.

The first revision edited the patch by hand and left the hunk header at 200 lines while the body had grown to 204, so `git apply` silently dropped the generated test's final success diagnostic. The patch is now regenerated from the file with `git diff --cached`, so the header, blob id, and length agree and the generated test is complete.

## Verification

At the branch tip, worktree clean. `git apply` of the patch in a scratch repository yields all 204 lines and the file compiles; `scripts/rsync-compat.py --area security` passes locally, including `receiver-rename-symlink-race` under the live flip, and the run log ends with that scenario's success diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPohRhyNQ1xoWq3J6aTTns