### PR TITLE
Drop the per-identity unlink lock in native rm

### DIFF
--- a/src/native_rm.rs
+++ b/src/native_rm.rs
@@ -1018,20 +1018,13 @@ fn remove_pinned(name: &PinnedName, held_directory: Option<&File>) -> Result<Rem
     Ok(outcome)
 }
 
-/// Serialize the inspect-then-unlink step per target identity. Linux orders
-/// concurrent unlinks of one name so exactly one succeeds, but macOS can
-/// report success to both callers, which would count a duplicate selector's
-/// entry twice. Striping by (dev, ino) keeps unrelated removals concurrent.
-fn unlink_serialization(identity: Identity) -> &'static Mutex<()> {
-    static LOCKS: [Mutex<()>; 64] = [const { Mutex::new(()) }; 64];
-    let index = identity.dev.wrapping_mul(31).wrapping_add(identity.ino) % 64;
-    &LOCKS[index as usize]
-}
-
+/// Two selectors that resolve to one entry race here. Linux orders their
+/// unlinks so exactly one succeeds and the other is already absent; macOS can
+/// report success to both, so the removed and already-absent counts may split
+/// differently there. Either way the entry is removed once, and the same
+/// outcomes already arise from an unrelated process removing the entry, so
+/// the race is not serialized.
 fn unlink_pinned(name: &PinnedName, directory: bool) -> Result<RemovePinnedOutcome> {
-    let _serialized = unlink_serialization(name.identity)
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let current = match metadata_at_cstring(name.parent.as_raw_fd(), &name.name) {
         Ok(identity) => identity,
         Err(error) if error.kind() == io::ErrorKind::NotFound => {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3096,8 +3096,16 @@ fn native_rm_duplicate_selectors_are_idempotent_without_deduplication() {
         .collect();
     assert_eq!(selectors, [0, 1], "{records:?}");
     let terminal = records.last().unwrap();
-    assert_eq!(terminal["entries_removed"], 1, "{records:?}");
-    assert_eq!(terminal["entries_already_absent"], 1, "{records:?}");
+    // Linux orders the two unlinks so exactly one succeeds. macOS lets two
+    // concurrent unlinks of one name both report success (measured on a
+    // macOS 14 runner: 685 of 3000 races), so the split there is not fixed.
+    let removed = terminal["entries_removed"].as_u64().unwrap();
+    let absent = terminal["entries_already_absent"].as_u64().unwrap();
+    if cfg!(target_os = "linux") {
+        assert_eq!((removed, absent), (1, 1), "{records:?}");
+    } else {
+        assert!(removed >= 1 && removed + absent == 2, "{records:?}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

PR #167 serialized native rm's inspect-then-unlink step through 64 mutexes striped by `(dev, ino)`, so that two selectors resolving to one entry would count as one removal plus one already-absent on macOS as well as Linux (macOS can report success to both concurrent unlinks of one name).

That lock only changed accounting. The entry is removed exactly once either way, and the same split of outcomes already arises whenever an unrelated process removes an entry concurrently, which native rm already accepts. It also introduced a contention path between unrelated removals that collide in the same stripe; on a high-latency filesystem one slow unlink could stall other workers for no benefit.

This removes the lock and lets the duplicate-selector test accept macOS's double-success split again, as it did before `50bf3fe`. Behavior on Linux is unchanged: the kernel already orders concurrent unlinks of one name.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq` (403 passed)
- `cargo test --test local native_rm` (24 passed)

Not run: the macOS suite. The relaxed assertion's non-Linux branch restores the one that passed on the macOS runner before it was tightened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzQTqDmGFUVn6XzWxKFBwY
