### PR TITLE
Add scripts/branch-status.sh for branch, PR, and master CI status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,12 @@ jobs:
           (needs.scope.outputs.native == 'true' &&
            needs.scope.outputs.full_suite == 'true')
         run: scripts/test-release-orchestration.sh
+      - name: Test branch status tooling
+        if: >-
+          needs.scope.outputs.tooling == 'true' ||
+          (needs.scope.outputs.native == 'true' &&
+           needs.scope.outputs.full_suite == 'true')
+        run: scripts/test-branch-status.sh
       - name: Validate workflow syntax
         if: >-
           needs.scope.outputs.tooling == 'true' ||
@@ -140,7 +146,7 @@ jobs:
           needs.scope.outputs.tooling == 'true' ||
           (needs.scope.outputs.native == 'true' &&
            needs.scope.outputs.full_suite == 'true')
-        run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-ci.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/ci-scope.sh scripts/approve-generated-pr-runs.sh scripts/release-preflight.sh scripts/release-status.sh scripts/check-workflows.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-release-orchestration.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh scripts/test-real-ssh.sh tests/real-ssh/entrypoint.sh tests/real-ssh/scenarios.sh tests/real-ssh/ssh-wrapper.sh
+        run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-ci.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/ci-scope.sh scripts/approve-generated-pr-runs.sh scripts/release-preflight.sh scripts/release-status.sh scripts/branch-status.sh scripts/test-branch-status.sh scripts/check-workflows.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-release-orchestration.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh scripts/test-real-ssh.sh tests/real-ssh/entrypoint.sh tests/real-ssh/scenarios.sh tests/real-ssh/ssh-wrapper.sh
 
   sdks:
     needs: scope

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,17 @@ outlive its premise and steer later work in the wrong direction.
 - At review handoff, state the branch and exact short commit SHA, whether the
   worktree is clean, and which checks passed, failed, or were not run. Treat
   review-ready and merge-ready as separate states.
+- Run `scripts/branch-status.sh` from the task worktree before opening a pull
+  request, before asking for review, and before merging, and include its output
+  in the report. It prints the branch SHA and cleanliness, the pull request's
+  GitHub head and check results, and the latest post-merge `ci`,
+  `rsync-compat`, and `macos` runs on `master`. Pull requests run a reduced
+  suite, so a failure in the full suites first appears in those `master` runs,
+  and nothing else surfaces it. A red `master` run makes the script exit 1;
+  report it to the user even when the current task did not cause it, and do not
+  treat the task's own green pull-request checks as evidence that `master` is
+  healthy. `--check` also runs the Rust baseline below, and `--json` prints the
+  same facts for scripting.
 - Before removing a worktree or branch, require a clean worktree, no retained
   task-related stash, and no commits that still need integration. An ancestry
   result such as `git branch --merged` says nothing about uncommitted files.

--- a/scripts/branch-status.sh
+++ b/scripts/branch-status.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Report the state of the current task branch: the worktree, the branch's
+# pull request, and the latest post-merge CI runs on master. Its output is
+# what a status report or review request should state.
+#
+# Only reads git and GitHub state. With --check it also runs the fixed Rust
+# baseline (fmt, clippy, unit tests) in this worktree.
+#
+# Exit status: 0 when nothing needs attention; 1 when master's latest
+# post-merge run failed, the pull request's checks failed, the GitHub head is
+# stale or unrelated, or a --check step failed; 2 on usage or tooling errors.
+set -euo pipefail
+
+repository=greaber/syq
+workflows=(ci.yml rsync-compat.yml macos.yml)
+json=false
+check=false
+for argument in "$@"; do
+  case "$argument" in
+    --json) json=true ;;
+    --check) check=true ;;
+    *) echo "usage: $0 [--json] [--check]" >&2; exit 2 ;;
+  esac
+done
+for command in git gh jq; do
+  command -v "$command" >/dev/null || { echo "branch status needs $command" >&2; exit 2; }
+done
+
+warnings=()
+warn() { warnings+=("$1"); }
+
+# Worktree and branch.
+toplevel=$(git rev-parse --show-toplevel)
+head_sha=$(git rev-parse HEAD)
+short_sha=$(git rev-parse --short HEAD)
+branch=$(git symbolic-ref --quiet --short HEAD || echo HEAD)
+status_lines=$(git status --porcelain --untracked-files=all)
+staged=$(grep -c '^[MADRCT]' <<<"$status_lines" || true)
+unstaged=$(grep -c '^.[MADRCT]' <<<"$status_lines" || true)
+untracked=$(grep -c '^??' <<<"$status_lines" || true)
+if [ -z "$status_lines" ]; then clean=true; else clean=false; fi
+[ "$clean" = true ] || warn "worktree is dirty: $staged staged, $unstaged unstaged, $untracked untracked"
+
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)
+upstream_ahead=null
+upstream_behind=null
+if [ -n "$upstream" ]; then
+  read -r upstream_ahead upstream_behind < <(git rev-list --left-right --count "HEAD...$upstream")
+fi
+
+master_ref=
+for candidate in refs/heads/master refs/remotes/origin/master; do
+  if git rev-parse --verify --quiet "$candidate^{commit}" >/dev/null; then master_ref=$candidate; break; fi
+done
+master_sha=null
+master_short=
+behind_master=null
+ahead_of_master=null
+if [ -n "$master_ref" ]; then
+  master_sha=$(git rev-parse "$master_ref")
+  master_short=$(git rev-parse --short "$master_ref")
+  read -r ahead_of_master behind_master < <(git rev-list --left-right --count "HEAD...$master_ref")
+fi
+
+# Latest post-merge run of each workflow on master.
+master_runs='[]'
+for workflow in "${workflows[@]}"; do
+  if ! runs=$(gh run list --repo "$repository" --workflow "$workflow" --branch master --event push --limit 1 \
+      --json headSha,status,conclusion,url,createdAt,databaseId); then
+    echo "could not list $workflow runs on master" >&2
+    exit 2
+  fi
+  run=$(jq -c 'first // null' <<<"$runs")
+  state=missing
+  if [ "$run" != null ]; then
+    status=$(jq -r .status <<<"$run")
+    conclusion=$(jq -r '.conclusion // ""' <<<"$run")
+    if [ "$status" = completed ]; then state=$conclusion; else state=$status; fi
+  fi
+  case "$state" in
+    success) ;;
+    missing) warn "$workflow has no post-merge run on master" ;;
+    queued|in_progress|pending|waiting|requested) ;;
+    *) warn "master is red: $workflow $state at $(jq -r '.headSha[0:7]' <<<"$run") $(jq -r .url <<<"$run")" ;;
+  esac
+  master_runs=$(jq -c --arg workflow "$workflow" --arg state "$state" --argjson run "$run" \
+    '. + [{workflow:$workflow, state:$state, run:$run}]' <<<"$master_runs")
+done
+
+# The pull request for this branch, if any.
+pr=null
+if [ "$branch" != HEAD ]; then
+  if pr_json=$(gh pr view "$branch" --repo "$repository" \
+      --json number,url,state,isDraft,baseRefName,headRefOid,reviewDecision,mergeStateStatus,statusCheckRollup 2>/dev/null); then
+    pr=$pr_json
+  fi
+fi
+pr_head_relation=none
+if [ "$pr" != null ]; then
+  pr_head=$(jq -r .headRefOid <<<"$pr")
+  pr_number=$(jq -r .number <<<"$pr")
+  if [ "$pr_head" = "$head_sha" ]; then
+    pr_head_relation=matches
+  elif git merge-base --is-ancestor "$pr_head" HEAD 2>/dev/null; then
+    pr_head_relation=github-behind
+    warn "PR #$pr_number head ${pr_head:0:7} is behind local $short_sha; push before reporting"
+  elif git merge-base --is-ancestor "$head_sha" "$pr_head" 2>/dev/null; then
+    pr_head_relation=local-behind
+    warn "local $short_sha is behind PR #$pr_number head ${pr_head:0:7}"
+  else
+    pr_head_relation=unrelated
+    warn "PR #$pr_number head ${pr_head:0:7} is not related to local $short_sha"
+  fi
+  failed_checks=$(jq -r '[.statusCheckRollup[]? |
+    select((.conclusion // "") as $c | ($c | ascii_upcase) as $u |
+      ($u != "SUCCESS" and $u != "SKIPPED" and $u != "NEUTRAL" and $u != "")) |
+    (.name // .context) + " " + (.conclusion | ascii_downcase)] | join(", ")' <<<"$pr")
+  [ -z "$failed_checks" ] || warn "PR #$pr_number checks: $failed_checks"
+  pending_checks=$(jq -r '[.statusCheckRollup[]? |
+    select((.conclusion // "") == "" and ((.status // "") | ascii_upcase) != "COMPLETED") |
+    (.name // .context)] | join(", ")' <<<"$pr")
+fi
+
+# Optional fixed Rust baseline.
+checks='[]'
+if [ "$check" = true ]; then
+  run_check() {
+    local name=$1; shift
+    local result=pass
+    if ! (cd "$toplevel" && "$@"); then result=fail; warn "$name failed"; fi
+    checks=$(jq -c --arg name "$name" --arg command "$*" --arg result "$result" \
+      '. + [{name:$name, command:$command, result:$result}]' <<<"$checks")
+  }
+  run_check fmt cargo fmt --all -- --check
+  run_check clippy cargo clippy --all-targets --all-features -- -D warnings
+  run_check unit-tests cargo test --bin syq
+fi
+
+exit_status=0
+[ "${#warnings[@]}" -eq 0 ] || exit_status=1
+# A dirty worktree is worth stating but is not by itself a problem.
+if [ "${#warnings[@]}" -eq 1 ] && [[ "${warnings[0]}" == 'worktree is dirty'* ]]; then exit_status=0; fi
+
+warnings_json='[]'
+for warning in "${warnings[@]+"${warnings[@]}"}"; do
+  warnings_json=$(jq -c --arg warning "$warning" '. + [$warning]' <<<"$warnings_json")
+done
+
+if [ "$json" = true ]; then
+  jq -n \
+    --arg toplevel "$toplevel" --arg branch "$branch" --arg head "$head_sha" --arg short "$short_sha" \
+    --argjson clean "$clean" --argjson staged "$staged" --argjson unstaged "$unstaged" --argjson untracked "$untracked" \
+    --arg upstream "$upstream" --argjson upstream_ahead "$upstream_ahead" --argjson upstream_behind "$upstream_behind" \
+    --arg master_ref "$master_ref" --arg master_sha "$master_sha" \
+    --argjson ahead_of_master "$ahead_of_master" --argjson behind_master "$behind_master" \
+    --argjson master_runs "$master_runs" --argjson pr "$pr" --arg pr_head_relation "$pr_head_relation" \
+    --argjson checks "$checks" --argjson warnings "$warnings_json" \
+    --argjson exit_status "$exit_status" \
+    '{worktree:{path:$toplevel, branch:$branch, head:$head, short:$short, clean:$clean,
+       staged:$staged, unstaged:$unstaged, untracked:$untracked,
+       upstream:(if $upstream == "" then null else $upstream end),
+       ahead_of_upstream:$upstream_ahead, behind_upstream:$upstream_behind,
+       master_ref:(if $master_ref == "" then null else $master_ref end),
+       master:(if $master_sha == "null" then null else $master_sha end),
+       ahead_of_master:$ahead_of_master, behind_master:$behind_master},
+      master_ci:$master_runs, pull_request:$pr, pull_request_head:$pr_head_relation,
+      checks:$checks, warnings:$warnings, exit_status:$exit_status}'
+  exit "$exit_status"
+fi
+
+echo "Worktree: $toplevel"
+if [ "$clean" = true ]; then
+  echo "Branch:   $branch at $short_sha (clean)"
+else
+  echo "Branch:   $branch at $short_sha (dirty: $staged staged, $unstaged unstaged, $untracked untracked)"
+fi
+if [ -n "$upstream" ]; then
+  echo "Upstream: $upstream (ahead $upstream_ahead, behind $upstream_behind)"
+else
+  echo "Upstream: none"
+fi
+if [ -n "$master_ref" ]; then
+  echo "Master:   $master_short from $master_ref (branch is ahead $ahead_of_master, behind $behind_master)"
+else
+  echo "Master:   no local master ref"
+fi
+echo
+echo "Master CI (latest post-merge run per workflow):"
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  workflow=$(jq -r .workflow <<<"$entry")
+  state=$(jq -r .state <<<"$entry")
+  if [ "$(jq -r .run <<<"$entry")" = null ]; then
+    printf '  %-16s %-12s (no run)\n' "$workflow" "$state"
+  else
+    printf '  %-16s %-12s %s  %s\n' "$workflow" "$state" \
+      "$(jq -r '.run.headSha[0:7]' <<<"$entry")" "$(jq -r .run.url <<<"$entry")"
+  fi
+done < <(jq -c '.[]' <<<"$master_runs")
+echo
+if [ "$pr" = null ]; then
+  echo "Pull request: none for $branch"
+else
+  echo "Pull request: #$(jq -r .number <<<"$pr") $(jq -r .url <<<"$pr")"
+  echo "  base $(jq -r .baseRefName <<<"$pr"), $(jq -r 'if .isDraft then "draft" else .state | ascii_downcase end' <<<"$pr"), review $(jq -r '.reviewDecision // "" | if . == "" then "none" else ascii_downcase end' <<<"$pr"), merge state $(jq -r '.mergeStateStatus // "unknown" | ascii_downcase' <<<"$pr")"
+  echo "  GitHub head $(jq -r '.headRefOid[0:7]' <<<"$pr"): $pr_head_relation local $short_sha"
+  if [ -n "$failed_checks" ]; then
+    echo "  failed checks: $failed_checks"
+  elif [ -n "$pending_checks" ]; then
+    echo "  pending checks: $pending_checks"
+  else
+    echo "  checks: all completed successfully"
+  fi
+fi
+if [ "$check" = true ]; then
+  echo
+  echo "Baseline checks:"
+  jq -r '.[] | "  \(.name): \(.result)  (\(.command))"' <<<"$checks"
+fi
+if [ "${#warnings[@]}" -gt 0 ]; then
+  echo
+  for warning in "${warnings[@]}"; do echo "WARNING: $warning"; done
+fi
+exit "$exit_status"

--- a/scripts/branch-status.sh
+++ b/scripts/branch-status.sh
@@ -88,19 +88,15 @@ for workflow in "${workflows[@]}"; do
 done
 
 # The pull request for this branch, if any.
+# An empty list means no open pull request; a failed command is an error.
 pr=null
 if [ "$branch" != HEAD ]; then
-  pr_error=$(mktemp)
-  if pr_json=$(gh pr view "$branch" --repo "$repository" \
-      --json number,url,state,isDraft,baseRefName,headRefOid,reviewDecision,mergeStateStatus,statusCheckRollup 2>"$pr_error"); then
-    pr=$pr_json
-  elif ! grep -q 'no pull requests found' "$pr_error"; then
-    echo "could not look up the pull request for $branch:" >&2
-    cat "$pr_error" >&2
-    rm -f "$pr_error"
+  if ! pr_list=$(gh pr list --repo "$repository" --head "$branch" --state open --limit 1 \
+      --json number,url,state,isDraft,baseRefName,headRefOid,reviewDecision,mergeStateStatus,statusCheckRollup); then
+    echo "could not look up the pull request for $branch" >&2
     exit 2
   fi
-  rm -f "$pr_error"
+  pr=$(jq -c 'first // null' <<<"$pr_list")
 fi
 pr_head_relation=none
 if [ "$pr" != null ]; then

--- a/scripts/branch-status.sh
+++ b/scripts/branch-status.sh
@@ -90,10 +90,17 @@ done
 # The pull request for this branch, if any.
 pr=null
 if [ "$branch" != HEAD ]; then
+  pr_error=$(mktemp)
   if pr_json=$(gh pr view "$branch" --repo "$repository" \
-      --json number,url,state,isDraft,baseRefName,headRefOid,reviewDecision,mergeStateStatus,statusCheckRollup 2>/dev/null); then
+      --json number,url,state,isDraft,baseRefName,headRefOid,reviewDecision,mergeStateStatus,statusCheckRollup 2>"$pr_error"); then
     pr=$pr_json
+  elif ! grep -q 'no pull requests found' "$pr_error"; then
+    echo "could not look up the pull request for $branch:" >&2
+    cat "$pr_error" >&2
+    rm -f "$pr_error"
+    exit 2
   fi
+  rm -f "$pr_error"
 fi
 pr_head_relation=none
 if [ "$pr" != null ]; then
@@ -111,14 +118,19 @@ if [ "$pr" != null ]; then
     pr_head_relation=unrelated
     warn "PR #$pr_number head ${pr_head:0:7} is not related to local $short_sha"
   fi
-  failed_checks=$(jq -r '[.statusCheckRollup[]? |
-    select((.conclusion // "") as $c | ($c | ascii_upcase) as $u |
-      ($u != "SUCCESS" and $u != "SKIPPED" and $u != "NEUTRAL" and $u != "")) |
-    (.name // .context) + " " + (.conclusion | ascii_downcase)] | join(", ")' <<<"$pr")
+  # The rollup mixes check runs (name, status, conclusion) and commit status
+  # contexts (context, state); normalize both to a name, an outcome, and
+  # whether the check is still pending.
+  checks_json=$(jq -c '[.statusCheckRollup[]? |
+    {name: (.name // .context // "unnamed"),
+     outcome: ((.conclusion // .state // "") | ascii_upcase)} |
+    .pending = (.outcome == "" or .outcome == "PENDING" or .outcome == "EXPECTED")]' <<<"$pr")
+  check_count=$(jq 'length' <<<"$checks_json")
+  failed_checks=$(jq -r '[.[] | select(.pending | not) |
+    select(.outcome != "SUCCESS" and .outcome != "SKIPPED" and .outcome != "NEUTRAL") |
+    .name + " " + (.outcome | ascii_downcase)] | join(", ")' <<<"$checks_json")
   [ -z "$failed_checks" ] || warn "PR #$pr_number checks: $failed_checks"
-  pending_checks=$(jq -r '[.statusCheckRollup[]? |
-    select((.conclusion // "") == "" and ((.status // "") | ascii_upcase) != "COMPLETED") |
-    (.name // .context)] | join(", ")' <<<"$pr")
+  pending_checks=$(jq -r '[.[] | select(.pending) | .name] | join(", ")' <<<"$checks_json")
 fi
 
 # Optional fixed Rust baseline.
@@ -127,7 +139,8 @@ if [ "$check" = true ]; then
   run_check() {
     local name=$1; shift
     local result=pass
-    if ! (cd "$toplevel" && "$@"); then result=fail; warn "$name failed"; fi
+    # Keep stdout for the report, so --json stays a single document.
+    if ! (cd "$toplevel" && "$@" >&2); then result=fail; warn "$name failed"; fi
     checks=$(jq -c --arg name "$name" --arg command "$*" --arg result "$result" \
       '. + [{name:$name, command:$command, result:$result}]' <<<"$checks")
   }
@@ -204,7 +217,9 @@ else
   echo "Pull request: #$(jq -r .number <<<"$pr") $(jq -r .url <<<"$pr")"
   echo "  base $(jq -r .baseRefName <<<"$pr"), $(jq -r 'if .isDraft then "draft" else .state | ascii_downcase end' <<<"$pr"), review $(jq -r '.reviewDecision // "" | if . == "" then "none" else ascii_downcase end' <<<"$pr"), merge state $(jq -r '.mergeStateStatus // "unknown" | ascii_downcase' <<<"$pr")"
   echo "  GitHub head $(jq -r '.headRefOid[0:7]' <<<"$pr"): $pr_head_relation local $short_sha"
-  if [ -n "$failed_checks" ]; then
+  if [ "$check_count" -eq 0 ]; then
+    echo "  checks: none registered yet"
+  elif [ -n "$failed_checks" ]; then
     echo "  failed checks: $failed_checks"
   elif [ -n "$pending_checks" ]; then
     echo "  pending checks: $pending_checks"

--- a/scripts/test-branch-status.sh
+++ b/scripts/test-branch-status.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Exercise scripts/branch-status.sh against a scratch repository and a fake gh
+# that serves controlled run and pull-request JSON.
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+status_script="$script_dir/branch-status.sh"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/syq-branch-status-test.XXXXXXXX")
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT HUP INT TERM
+
+fakebin="$work/fakebin"
+runs_dir="$work/runs"
+mkdir -p "$fakebin" "$runs_dir"
+cat > "$fakebin/gh" <<'FAKE'
+#!/bin/sh
+case "$1:$2" in
+  run:list)
+    shift 2
+    workflow=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --workflow) workflow=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    cat "$SYQ_TEST_RUNS_DIR/$workflow.json"
+    ;;
+  pr:view)
+    if [ -n "${SYQ_TEST_PR_JSON:-}" ]; then
+      printf '%s\n' "$SYQ_TEST_PR_JSON"
+    else
+      echo 'no pull requests found for branch' >&2
+      exit 1
+    fi
+    ;;
+  *) echo "unexpected fake gh invocation: $*" >&2; exit 2 ;;
+esac
+FAKE
+chmod 755 "$fakebin/gh"
+
+# A scratch repository with master and a task branch two commits ahead.
+repo="$work/repo"
+git init -q -b master "$repo"
+git -C "$repo" config user.email test@example.com
+git -C "$repo" config user.name test
+git -C "$repo" commit -q --allow-empty -m 'initial'
+git -C "$repo" checkout -q -b task
+git -C "$repo" commit -q --allow-empty -m 'first task commit'
+git -C "$repo" commit -q --allow-empty -m 'second task commit'
+head_sha=$(git -C "$repo" rev-parse HEAD)
+short_sha=$(git -C "$repo" rev-parse --short HEAD)
+previous_sha=$(git -C "$repo" rev-parse HEAD^)
+master_sha=$(git -C "$repo" rev-parse master)
+
+set_run() {
+  local workflow=$1 status=$2 conclusion=$3
+  jq -cn --arg sha "$master_sha" --arg status "$status" --arg conclusion "$conclusion" --arg workflow "$workflow" \
+    '[{headSha:$sha, status:$status, conclusion:(if $conclusion == "" then null else $conclusion end),
+       url:("https://example.invalid/" + $workflow), createdAt:"2026-01-01T00:00:00Z", databaseId:1}]' \
+    > "$runs_dir/$workflow.json"
+}
+for workflow in ci.yml rsync-compat.yml macos.yml; do set_run "$workflow" completed success; done
+
+pr_json_for_run=
+run_status() {
+  (cd "$repo" && SYQ_TEST_RUNS_DIR="$runs_dir" SYQ_TEST_PR_JSON="$pr_json_for_run" \
+    PATH="$fakebin:$PATH" "$status_script" "$@")
+}
+with_pr() {
+  pr_json_for_run=$1
+  shift
+  "$@"
+  pr_json_for_run=
+}
+
+expect_exit() {
+  local expected=$1
+  shift
+  local actual=0
+  "$@" > "$work/out" 2>&1 || actual=$?
+  if [ "$actual" != "$expected" ]; then
+    echo "expected exit $expected, got $actual from: $*" >&2
+    sed 's/^/  /' "$work/out" >&2
+    exit 1
+  fi
+}
+
+expect_output() {
+  grep -F -- "$1" "$work/out" >/dev/null || {
+    echo "output did not contain '$1':" >&2
+    sed 's/^/  /' "$work/out" >&2
+    exit 1
+  }
+}
+
+expect_no_output() {
+  if grep -F -- "$1" "$work/out" >/dev/null; then
+    echo "output unexpectedly contained '$1':" >&2
+    sed 's/^/  /' "$work/out" >&2
+    exit 1
+  fi
+}
+
+# Clean branch, green master, no pull request.
+expect_exit 0 run_status
+expect_output "Branch:   task at $short_sha (clean)"
+expect_output 'branch is ahead 2, behind 0'
+expect_output 'ci.yml           success'
+expect_output 'macos.yml        success'
+expect_output 'Pull request: none for task'
+expect_no_output WARNING
+
+# A pull request whose GitHub head matches the local tip and whose checks passed.
+pr_json=$(jq -cn --arg head "$head_sha" '{number:7, url:"https://example.invalid/pull/7", state:"OPEN",
+  isDraft:false, baseRefName:"master", headRefOid:$head, reviewDecision:"", mergeStateStatus:"CLEAN",
+  statusCheckRollup:[{name:"rust", status:"COMPLETED", conclusion:"SUCCESS"},
+                     {name:"macos", status:"COMPLETED", conclusion:"SKIPPED"}]}')
+with_pr "$pr_json" expect_exit 0 run_status
+expect_output 'Pull request: #7 https://example.invalid/pull/7'
+expect_output "GitHub head ${head_sha:0:7}: matches local $short_sha"
+expect_output 'checks: all completed successfully'
+expect_no_output WARNING
+
+# The GitHub head lags an unpushed local commit.
+stale_pr=$(jq -c --arg head "$previous_sha" '.headRefOid = $head' <<<"$pr_json")
+with_pr "$stale_pr" expect_exit 1 run_status
+expect_output "GitHub head ${previous_sha:0:7}: github-behind local $short_sha"
+expect_output "WARNING: PR #7 head ${previous_sha:0:7} is behind local $short_sha; push before reporting"
+
+# A failed pull-request check.
+failed_pr=$(jq -c '.statusCheckRollup[0].conclusion = "FAILURE"' <<<"$pr_json")
+with_pr "$failed_pr" expect_exit 1 run_status
+expect_output 'failed checks: rust failure'
+expect_output 'WARNING: PR #7 checks: rust failure'
+
+# A pending pull-request check is reported without a warning.
+pending_pr=$(jq -c '.statusCheckRollup[0] = {name:"rust", status:"IN_PROGRESS", conclusion:null}' <<<"$pr_json")
+with_pr "$pending_pr" expect_exit 0 run_status
+expect_output 'pending checks: rust'
+expect_no_output WARNING
+
+# A red post-merge run on master is the alert this script exists for.
+set_run macos.yml completed failure
+expect_exit 1 run_status
+expect_output 'macos.yml        failure'
+expect_output "WARNING: master is red: macos.yml failure at ${master_sha:0:7} https://example.invalid/macos.yml"
+
+# A run still in progress is neither green nor an alert.
+set_run macos.yml in_progress ''
+expect_exit 0 run_status
+expect_output 'macos.yml        in_progress'
+expect_no_output WARNING
+set_run macos.yml completed success
+
+# A dirty worktree is stated but does not fail the report.
+touch "$repo/scratch"
+expect_exit 0 run_status
+expect_output "Branch:   task at $short_sha (dirty: 0 staged, 0 unstaged, 1 untracked)"
+expect_output 'WARNING: worktree is dirty: 0 staged, 0 unstaged, 1 untracked'
+rm "$repo/scratch"
+
+# JSON output carries the same facts.
+with_pr "$pr_json" expect_exit 0 run_status --json
+jq -e --arg head "$head_sha" --arg master "$master_sha" '
+  .worktree.branch == "task" and .worktree.head == $head and .worktree.clean == true
+  and .worktree.master == $master and .worktree.ahead_of_master == 2 and .worktree.behind_master == 0
+  and (.master_ci | map(.state)) == ["success", "success", "success"]
+  and .pull_request.number == 7 and .pull_request_head == "matches"
+  and .warnings == [] and .exit_status == 0' "$work/out" >/dev/null
+set_run ci.yml completed failure
+expect_exit 1 run_status --json
+jq -e '.exit_status == 1 and (.warnings | length) == 1 and .master_ci[0].state == "failure"' "$work/out" >/dev/null
+set_run ci.yml completed success
+
+# Usage errors.
+expect_exit 2 run_status --bogus
+expect_output 'usage:'
+
+echo 'branch-status tests passed'

--- a/scripts/test-branch-status.sh
+++ b/scripts/test-branch-status.sh
@@ -28,7 +28,10 @@ case "$1:$2" in
     cat "$SYQ_TEST_RUNS_DIR/$workflow.json"
     ;;
   pr:view)
-    if [ -n "${SYQ_TEST_PR_JSON:-}" ]; then
+    if [ "${SYQ_TEST_PR_JSON:-}" = FAIL ]; then
+      echo 'GraphQL: simulated GraphQL failure' >&2
+      exit 1
+    elif [ -n "${SYQ_TEST_PR_JSON:-}" ]; then
       printf '%s\n' "$SYQ_TEST_PR_JSON"
     else
       echo 'no pull requests found for branch' >&2
@@ -135,6 +138,30 @@ with_pr "$failed_pr" expect_exit 1 run_status
 expect_output 'failed checks: rust failure'
 expect_output 'WARNING: PR #7 checks: rust failure'
 
+# A failed commit status context, which carries state rather than conclusion.
+context_pr=$(jq -c '.statusCheckRollup += [{context:"external", state:"FAILURE"}]' <<<"$pr_json")
+with_pr "$context_pr" expect_exit 1 run_status
+expect_output 'failed checks: external failure'
+expect_output 'WARNING: PR #7 checks: external failure'
+
+# A pending commit status context is neither green nor a failure.
+context_pr=$(jq -c '.statusCheckRollup += [{context:"external", state:"PENDING"}]' <<<"$pr_json")
+with_pr "$context_pr" expect_exit 0 run_status
+expect_output 'pending checks: external'
+expect_no_output WARNING
+
+# An empty rollup is not success.
+empty_pr=$(jq -c '.statusCheckRollup = []' <<<"$pr_json")
+with_pr "$empty_pr" expect_exit 0 run_status
+expect_output 'checks: none registered yet'
+expect_no_output 'all completed successfully'
+
+# A pull-request lookup failure other than "no pull request" is an error.
+with_pr FAIL expect_exit 2 run_status
+expect_output 'could not look up the pull request for task'
+expect_output 'simulated GraphQL failure'
+expect_no_output 'Pull request: none'
+
 # A pending pull-request check is reported without a warning.
 pending_pr=$(jq -c '.statusCheckRollup[0] = {name:"rust", status:"IN_PROGRESS", conclusion:null}' <<<"$pr_json")
 with_pr "$pending_pr" expect_exit 0 run_status
@@ -173,6 +200,23 @@ set_run ci.yml completed failure
 expect_exit 1 run_status --json
 jq -e '.exit_status == 1 and (.warnings | length) == 1 and .master_ci[0].state == "failure"' "$work/out" >/dev/null
 set_run ci.yml completed success
+
+# --json --check stays one JSON document even when the checks write to stdout.
+cat > "$fakebin/cargo" <<'FAKE'
+#!/bin/sh
+echo "fake cargo $*"
+[ "$1" != clippy ] || exit 1
+FAKE
+chmod 755 "$fakebin/cargo"
+json_check_status=0
+run_status --json --check > "$work/out" 2>"$work/err" || json_check_status=$?
+test "$json_check_status" = 1
+grep -F 'fake cargo clippy' "$work/err" >/dev/null
+jq -e '.checks == [{name:"fmt", command:"cargo fmt --all -- --check", result:"pass"},
+  {name:"clippy", command:"cargo clippy --all-targets --all-features -- -D warnings", result:"fail"},
+  {name:"unit-tests", command:"cargo test --bin syq", result:"pass"}]
+  and .warnings == ["clippy failed"] and .exit_status == 1' "$work/out" >/dev/null
+rm "$fakebin/cargo"
 
 # Usage errors.
 expect_exit 2 run_status --bogus

--- a/scripts/test-branch-status.sh
+++ b/scripts/test-branch-status.sh
@@ -27,15 +27,14 @@ case "$1:$2" in
     done
     cat "$SYQ_TEST_RUNS_DIR/$workflow.json"
     ;;
-  pr:view)
+  pr:list)
     if [ "${SYQ_TEST_PR_JSON:-}" = FAIL ]; then
       echo 'GraphQL: simulated GraphQL failure' >&2
       exit 1
     elif [ -n "${SYQ_TEST_PR_JSON:-}" ]; then
-      printf '%s\n' "$SYQ_TEST_PR_JSON"
+      printf '[%s]\n' "$SYQ_TEST_PR_JSON"
     else
-      echo 'no pull requests found for branch' >&2
-      exit 1
+      echo '[]'
     fi
     ;;
   *) echo "unexpected fake gh invocation: $*" >&2; exit 2 ;;
@@ -156,7 +155,7 @@ with_pr "$empty_pr" expect_exit 0 run_status
 expect_output 'checks: none registered yet'
 expect_no_output 'all completed successfully'
 
-# A pull-request lookup failure other than "no pull request" is an error.
+# A pull-request lookup failure is an error, not "no pull request".
 with_pr FAIL expect_exit 2 run_status
 expect_output 'could not look up the pull request for task'
 expect_output 'simulated GraphQL failure'


### PR DESCRIPTION
## Summary

- add `scripts/branch-status.sh`, which prints the branch and SHA, worktree cleanliness, the pull request's GitHub head compared with the local tip and its check results, and the latest post-merge `ci`, `rsync-compat`, and `macos` runs on `master`
- exit 1 when `master` is red, the GitHub head is stale or unrelated, or a PR check failed; `--check` runs the Rust baseline; `--json` emits the same facts
- add `scripts/test-branch-status.sh` (fake `gh`, scratch repository) and run it and shellcheck in the tooling CI step
- ask for the script in `AGENTS.md` before opening, reviewing, or merging a pull request

Since #137, pull requests run a reduced suite and the full suites run after merge. Nothing surfaced a red post-merge run, so the macOS compile breaks from #143 and #168 each sat on `master` across several merges. Every agent now sees `master`'s state as part of its normal report.

## Verification

- `shellcheck` over the full CI list including both new scripts
- `scripts/test-branch-status.sh`
- `scripts/check-workflows.sh`
- live runs against this branch and against #169, plus `--check` (fmt, clippy, `cargo test --bin syq` all pass) and `--json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeLYnmyND4J34cFJtDphqK
