### PR TITLE
Remove unreachable detached restricted warning

### DIFF
--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -177,11 +177,11 @@ Diagnostic text is bounded context rather than a stable interface; structured
 codes and dispositions are authoritative. An authenticated expected manifest
 is required for source completeness and byte authenticity.
 
-Restricted `--detach` deliberately has a weaker boundary until durable local
-job state exists. The launcher prints a security warning even under `-q` and
-reports only that the job started. HostB's signed v2 stream is plaintext in
-hostA's detached log, so hostA can read or suppress it, and `--follow` displays
-but does not locally authenticate completion.
+`--detach` is not available with the command-restricted receiver because its
+constrained agent exists only while syq remains attached. A detached launch
+instead requires coordinator-owned peer credentials (`--no-forward-agent`) or
+an explicit `--rsh` policy. Neither path prepares a restricted grant or signed
+receipt; the returned remote log is not a locally authenticated receipt.
 
 ## Signed policies and options that fail closed
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -332,9 +332,11 @@ become a valid clean receipt, though suppression remains a denial of service.
 
 The receipt is hostB's closure-time account of hostB: it says what landed, not
 what hostA omitted or invented, and it is neither a transaction nor a rollback.
-A detached restricted transfer is weaker: the receipt lands in hostA's log in
-plaintext, the launcher warns about that even under `-q`, and `--follow`
-displays completion without verifying it locally.
+`--detach` is not available with this command-restricted receiver because its
+constrained agent exists only while syq remains attached. A detached launch
+instead requires coordinator-owned peer credentials through
+`--no-forward-agent`, or an explicit `--rsh` policy. Neither path prepares a
+restricted grant or signed receipt.
 
 ### Putting the layers together
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -857,7 +857,7 @@ struct NativeRemoteArgs {
         conflicts_with = "no_tcp"
     )]
     tcp_congestion: Option<String>,
-    /// Run at the remote coordinator and return after launch; restricted receipts remain plaintext in its log and are not locally verified
+    /// Run at the remote coordinator and return after launch; requires --no-forward-agent or --rsh
     #[arg(long)]
     detach: bool,
     /// Give a remote coordinator no forwarded agent; it must own credentials for the peer

--- a/src/direct.rs
+++ b/src/direct.rs
@@ -1141,11 +1141,6 @@ fn run_remote(
         );
     }
     if args.detach {
-        if receipt_expectation.is_some() {
-            eprintln!(
-                "syq: warning: detached restricted transfer reports only that the job started; its final signed receipt will be plaintext in hostA's log, visible to hostA, and will not be verified on this machine"
-            );
-        }
         let run = || {
             let mut cmd = make_command();
             cmd.stdin(Stdio::null())


### PR DESCRIPTION
## Summary

- remove the unreachable detached restricted-transfer warning branch
- document that detached transfers require coordinator-owned credentials or an explicit remote-shell policy
- clarify that detached modes do not prepare an enrolled grant or signed receipt

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq` — 409 passed
- `python3 scripts/check-doc-links.py`
- `mdbook build` with the repository-pinned mdBook v0.5.4
- `cargo run --quiet -- cp --help`