### PR TITLE
Reply to remote completion before the connection closes

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -7,7 +7,7 @@
 //! endpoint selection, and local/remote directory discovery remains in Rust.
 
 use crate::cli::{parse_native_endpoint, NativeEndpoint};
-use crate::conn::{Conn, RemoteSpec, SshMultiplexer};
+use crate::conn::{Conn, RemoteConn, RemoteSpec, SshMultiplexer};
 use crate::proto::{CompletionEntry, Request, Response};
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
@@ -1109,16 +1109,31 @@ fn remote_path_candidates(
     let prefix_for_thread = prefix.clone();
     let (sender, receiver) = std::sync::mpsc::sync_channel(1);
     std::thread::spawn(move || {
-        let result = fetch_remote_entries(
+        let connection = connect_completion_endpoint(
             endpoint_for_thread,
             pscope.as_deref(),
             syq_path,
             no_bootstrap,
-            directory_for_thread,
-            root_for_thread,
-            prefix_for_thread,
         );
+        let (result, connection) = match connection {
+            Ok(mut connection) => {
+                let result = list_remote_entries(
+                    &mut connection,
+                    directory_for_thread,
+                    root_for_thread,
+                    prefix_for_thread,
+                );
+                (result, Some(connection))
+            }
+            Err(error) => (Err(error), None),
+        };
+        // Hand the entries back before closing the connection. Closing it
+        // sends Shutdown and then waits for the remote helper's exit status,
+        // a whole network round trip that must not delay the candidates. The
+        // process exits once they are printed; the ssh child finishes on its
+        // own.
         let _ = sender.send(result);
+        drop(connection);
     });
     let entries = receiver
         .recv_timeout(REMOTE_COMPLETION_DEADLINE)
@@ -1131,15 +1146,12 @@ fn remote_path_candidates(
     ))
 }
 
-fn fetch_remote_entries(
+fn connect_completion_endpoint(
     endpoint: NativeEndpoint,
     pscope: Option<&Path>,
     syq_path: Option<String>,
     no_bootstrap: bool,
-    directory: Vec<u8>,
-    confined_root: Option<Vec<u8>>,
-    prefix: Vec<u8>,
-) -> Result<Vec<CompletionEntry>> {
+) -> Result<RemoteConn> {
     let multiplexer = match crate::persistence::scope_for_implicit_ssh(pscope)? {
         Some(scope) => Arc::new(SshMultiplexer::persistent(
             &scope,
@@ -1176,7 +1188,15 @@ fn fetch_remote_entries(
         tcp: Default::default(),
         diagnostics: Default::default(),
     };
-    let mut connection = spec.connect_completion()?;
+    spec.connect_completion()
+}
+
+fn list_remote_entries(
+    connection: &mut RemoteConn,
+    directory: Vec<u8>,
+    confined_root: Option<Vec<u8>>,
+    prefix: Vec<u8>,
+) -> Result<Vec<CompletionEntry>> {
     match connection.call(Request::ListDir {
         directory,
         confined_root,

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -13754,6 +13754,114 @@ fn ephemeral_scope(t: &Tmp) -> PathBuf {
     PathBuf::from(std::ffi::OsString::from_vec(path.to_vec()))
 }
 
+/// Candidates reach the shell as soon as the listing arrives. Closing the
+/// remote connection waits for the helper's exit status, a whole network
+/// round trip on a distant host, so the completion process must print and
+/// exit while that connection is still open.
+#[test]
+fn remote_completion_replies_before_the_remote_connection_closes() {
+    let t = Tmp::new();
+    fs::create_dir(t.runtime()).unwrap();
+    fs::create_dir_all(t.path("remote-home/data/nested")).unwrap();
+    write(&t.path("remote-home/data/name"), b"remote");
+    let ssh = fake_ssh(&t);
+    // A remote helper that serves normally and then stays alive until it is
+    // released, like an ssh session whose exit status has not come back yet.
+    // The wait is bounded so a regression fails instead of hanging.
+    let helper = t.path("lingering-syq");
+    executable(
+        &helper,
+        format!(
+            r#"#!/bin/sh
+'{syq}' "$@"
+status=$?
+n=0
+until [ -e '{release}' ] || [ "$n" -ge 400 ]; do
+    sleep 0.05
+    n=$((n + 1))
+done
+printf 'helper-exit\n' >> "$FAKE_RSH_LOG"
+exit "$status"
+"#,
+            syq = env!("CARGO_BIN_EXE_syq"),
+            release = t.s("release-helper"),
+        )
+        .as_bytes(),
+    );
+    let path = format!("{}/n", t.s("remote-home/data"));
+    let output = completion_command(
+        &t,
+        &[
+            "__complete",
+            "bash",
+            "6",
+            "--",
+            "syq",
+            "cp",
+            "--syq-path",
+            &t.s("lingering-syq"),
+            "--from",
+            "fake.example",
+            &path,
+        ],
+    )
+    .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+    .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+    .env("FAKE_RSH_LOG", t.path("rsh.log"))
+    .env(
+        "PATH",
+        format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+    )
+    .stdin(Stdio::null())
+    .stdout(Stdio::piped())
+    // The lingering helper inherits stderr; a captured pipe would keep this
+    // wait open until the helper exits.
+    .stderr(Stdio::null())
+    .start()
+    .unwrap()
+    .wait_with_output()
+    .unwrap();
+    assert!(output.status.success(), "{:?}", output.status);
+    assert_eq!(
+        completion_values(&output.stdout),
+        vec![
+            (
+                b'f',
+                t.path("remote-home/data/name")
+                    .as_os_str()
+                    .as_encoded_bytes()
+                    .to_vec(),
+            ),
+            (
+                b'p',
+                t.path("remote-home/data/nested/")
+                    .as_os_str()
+                    .as_encoded_bytes()
+                    .to_vec(),
+            ),
+        ]
+    );
+    let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    assert!(
+        !log.contains("helper-exit"),
+        "completion waited for the remote helper to exit:\n{log}"
+    );
+
+    write(&t.path("release-helper"), b"");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+        if log.contains("helper-exit") {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "released remote helper never exited:\n{log}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}
+
 #[test]
 fn persistence_policy_and_ephemeral_scopes_have_separate_lifecycles() {
     let t = Tmp::new();


### PR DESCRIPTION
Remote shell completion handed its candidates back only after its control connection had closed, and closing a connection waits for the ssh child's exit status. On a distant host that is a whole extra round trip on every Tab.

Send the entries first and drop the connection afterwards. The process exits as soon as the candidates are printed; the ssh child finishes on its own once the remote helper has exited (it already received `Shutdown`, or sees EOF).

Measured on the 255 ms benchmark path with a warm OpenSSH master, five repetitions each, spread under 15 ms:

| Warm remote completion | Time |
|---|---:|
| master `42540ce` | 1.289 s |
| this branch `e6c0f2c` | 1.003 s |
| `ssh true` over the same master, for reference | 0.507 s |

This is step 0 of `current-plans/active/persistent-sessions.md`; the remaining turns (session setup and the hello) are what the session pool there is for.

Verification at `e6c0f2c`:

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --bin syq`: passed.
- `cargo test --test local remote_completion`: both tests pass. The new test runs the remote helper through a wrapper that lingers until released; without the fix it fails after the wrapper's 20 s bound (checked by reverting `src/completion.rs`), with the fix it finishes in 0.08 s.
- `scripts/test-real-ssh.sh` (default profile): passed, including the persistent-completion scenario.
- Not run: `cargo test --all-targets`, the `max-sessions-1` real-SSH profile, macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8QyeXSteeVg8XAGMkw2BD
