### PR TITLE
Honor the whole --as path in syq map

### DIFF
--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -70,7 +70,8 @@ yourself may use the base64 form for such names.
 `syq map` deliberately has a destination-independent surface: `-C`, `--root`,
 `--follow-src`/`--follow`, the source-selector family, and `--as`. It takes
 either `--src-src DIR` as the only selector or any number of relative named
-selectors. `--as` renames the single selected root. Destination, filtering,
+selectors. `--as PATH` places the single selected root at `PATH`, which may
+be nested; `cp --mapping` creates any missing parents. Destination, filtering,
 transfer, execution, result, receiver-ceiling, and receipt options belong to
 the later `syq cp --mapping` invocation or to a manifest transform, not to
 `syq map`.
@@ -229,7 +230,7 @@ those farms fall short — see [use-cases/link-farms.md](https://github.com/grea
   only; `syq rsync` is unchanged.
 - `syq map` accepts the local selector grammar, including the typed selectors
   `--src-file`/`--src-dir`, plus `--as PATH` (which emits the single selected
-  root under the destination's basename). Those selectors are validated exactly as
+  root at `PATH`). Those selectors are validated exactly as
   native `cp` validates them; see "Emitting a mapping" for the complete
   surface.
 - Fidelity is the native default (`-rlt`). There is no per-entry

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -534,8 +534,8 @@ syq map --src-src photos \
 ```
 
 `syq map` is local and destination-independent. Its options are `-C`,
-`--follow-src`/`--follow`, the source-selector family, and `--as` for renaming
-one selected root. Copy destinations, filtering, transfer policy, execution
+`--follow-src`/`--follow`, the source-selector family, and `--as PATH` for
+placing the single selected root at `PATH`. Copy destinations, filtering, transfer policy, execution
 controls, results, receiver ceilings, and receipts belong to the downstream `cp`
 invocation or the manifest transform.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1032,7 +1032,7 @@ fn validate_native_copy_argument_order(matches: &clap::ArgMatches) -> Result<()>
 struct NativeMapCommand {
     #[command(flatten)]
     source: NativeSourceArgs,
-    /// Rename the single selected root in the emitted mapping
+    /// Emit the single selected root at PATH, relative to the future destination container; PATH may be nested
     #[arg(long, value_name = "PATH")]
     r#as: Option<OsString>,
 }
@@ -1412,12 +1412,7 @@ fn parse_native_map(argv: &[OsString]) -> Result<Args> {
             if target.is_empty() {
                 bail!("--as target may not be empty");
             }
-            if native_basename(&target).is_none() {
-                bail!(
-                    "--as target {:?} has no basename",
-                    String::from_utf8_lossy(&target)
-                );
-            }
+            crate::transfer::validate_manifest_path(&target, "--as")?;
             (Placement::As, Some(target))
         }
         None => {

--- a/src/native_map.rs
+++ b/src/native_map.rs
@@ -4,7 +4,8 @@
 //! Emission is local and read-only, and destination-independent by design:
 //! `dst` values are relative to the target container, so the same manifest
 //! can be executed against any target with `syq cp --mapping`. Only `--as`
-//! changes emitted values, by renaming the single selected root. Names must
+//! changes emitted values, by placing the single selected root at a chosen
+//! container-relative path. Names must
 //! be valid UTF-8; a non-UTF-8 name aborts emission with an error so that
 //! text transforms downstream cannot silently corrupt a base64 value.
 
@@ -79,9 +80,7 @@ pub fn run(args: &Args) -> Result<i32> {
                 return Ok(Vec::new());
             }
             let destination = match (args.placement, &args.native_map_target) {
-                (Placement::As, Some(target)) => native_basename(target)
-                    .ok_or_else(|| anyhow!("--as destination has no basename"))?
-                    .to_vec(),
+                (Placement::As, Some(target)) => target.clone(),
                 _ => native_basename(&location.path)
                     .expect("parse validated that named selectors have a basename")
                     .to_vec(),

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -8031,7 +8031,7 @@ fn parse_manifest_entry(text: &str) -> Result<ManifestEntry> {
     Ok(ManifestEntry { src, dst, kind })
 }
 
-fn validate_manifest_path(path: &[u8], which: &str) -> Result<()> {
+pub(crate) fn validate_manifest_path(path: &[u8], which: &str) -> Result<()> {
     if path.is_empty() {
         bail!("{which} path is empty");
     }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -11684,6 +11684,39 @@ fn native_map_named_cwd_and_as_rename() {
     assert_eq!(dsts, ["album", "album/x", "album/x/a.jpg"]);
     let srcs: Vec<String> = lines.iter().map(|v| map_path(v, "src")).collect();
     assert_eq!(srcs, ["photos", "photos/x", "photos/x/a.jpg"]);
+    // --as PATH may be nested; every component is honored, none is dropped.
+    let lines = map_lines(&syq_map_in(
+        &t.path(""),
+        &["photos", "--as", "2024/07/album"],
+    ));
+    let dsts: Vec<String> = lines.iter().map(|v| map_path(v, "dst")).collect();
+    assert_eq!(
+        dsts,
+        ["2024/07/album", "2024/07/album/x", "2024/07/album/x/a.jpg"]
+    );
+}
+
+#[test]
+fn native_map_as_nested_path_round_trips_through_cp_mapping() {
+    let t = Tmp::new();
+    write(&t.path("src/photos/x/a.jpg"), b"img");
+    let mapped = syq_map_in(&t.path("src"), &["photos", "--as", "2024/07/album"]);
+    assert!(
+        mapped.status.success(),
+        "map failed: {}",
+        String::from_utf8_lossy(&mapped.stderr)
+    );
+    let copied = syq_cp_in(
+        &t.path(""),
+        &["--mapping", "-", "-C", "src", "--into", "dst", "-q"],
+        Some(&mapped.stdout),
+    );
+    assert!(
+        copied.status.success(),
+        "cp failed: {}",
+        String::from_utf8_lossy(&copied.stderr)
+    );
+    assert_eq!(read(&t.path("dst/2024/07/album/x/a.jpg")), b"img");
 }
 
 #[test]
@@ -11701,6 +11734,9 @@ fn native_map_refusals() {
     refuse(&["--src-src", "d1", "--src-src", "d2"], "only selector");
     refuse(&["--src-src", "d1", "d2"], "only selector");
     refuse(&["d1/n", "d2/n"], "same destination name");
+    refuse(&["d1", "--as", "/abs"], "is absolute");
+    refuse(&["d1", "--as", "../up"], "`..` component");
+    refuse(&["d1", "--as", "a//b"], "empty, `.`, or `..` component");
     refuse(
         &["d1", "--into-new", "z"],
         "unexpected argument '--into-new'",


### PR DESCRIPTION
`syq map --as a/b/c` kept only the final component and silently emitted entries under `c`. Mapping manifests already accept nested `dst` values and `cp --mapping` synthesizes missing ancestors parent-first, so the emitted prefix is now the full path.

The `--as` value is validated with the same rules the manifest reader applies to `dst` (relative; no empty, `.`, or `..` components; no NUL), so map output is always consumable by `cp --mapping`. Absolute and `..` values are now refused where they were previously truncated.

Verification: `cargo fmt`, `cargo clippy -D warnings`, `cargo test --bin syq` (410 passed), `scripts/check-doc-links.py`, and `cargo test --test local -- native_map native_cp_mapping` (26 passed, including a new test that pipes nested map output into `cp --mapping`). Not run: the full integration suite and the real-SSH suite; the change is local-only.

Part of the naming audit follow-ups in `current-plans/active/naming-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCarAsHM4k2ygsVQNnfpyk
