### PR TITLE
Push small files in one control-connection turn

### DIFF
--- a/docs/speed.md
+++ b/docs/speed.md
@@ -52,7 +52,11 @@ table](reference.md#compatibility-options)).
    file. Workers connect while the source is still being scanned, address
    probes run while the control connection prepares the destination, and a
    transfer of nothing but fresh small files over ssh reuses the authenticated
-   control connection instead of paying a handshake per worker.
+   control connection instead of paying a handshake per worker. A native push
+   of a few small local files into an existing remote directory goes further:
+   the destination check, the placement, and the writes travel as one request
+   on the control connection, so the copy costs one network round trip once
+   the connection is up.
 6. **Compression that costs nothing when it cannot help.** Remote transfers
    try zstd level 1 on each piece of data they send, sending the compressed
    form only when it is smaller, so archives, media, and encrypted data are not expanded on the

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -483,6 +483,7 @@ impl Conn for LocalConn {
                     | Request::RegisterSourceRoots { .. }
                     | Request::CreateOperatorDirectory { .. }
                     | Request::AnchorDestination { .. }
+                    | Request::CopySmallFiles(_)
                     | Request::Receipt
             )
         {

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -710,6 +710,14 @@ fn mkdir_operator_directory_at(parent: &File, component: &[u8], mode: u32) -> io
     }
 }
 
+/// One file of a small copy, staged but not yet published.
+struct StagedSmallFile {
+    root: Arc<Root>,
+    partial: RelativePath,
+    target: RelativePath,
+    file: File,
+}
+
 /// The single directory entry a small-copy file names beneath the request
 /// prefix. Nested paths are the ordinary engine's business.
 fn small_copy_leaf<'a>(request_prefix: &[u8], path: &'a [u8]) -> Result<&'a [u8]> {
@@ -1723,14 +1731,14 @@ impl FsOps {
             canonical.push(OsStr::from_bytes(leaf));
         }
         let identity = &request.identity;
-        let job_identity = crate::resume::job_identity(
+        let copy_identity = crate::resume::copy_identity(
             &identity.src_endpoint,
             &identity.src_roots,
             &identity.dst_endpoint,
             &crate::transfer::path_identity(&canonical),
             &identity.semantic_flags,
         );
-        let partial_id = crate::resume::partial_id(&job_identity);
+        let copy_id = crate::resume::copy_id(&copy_identity);
 
         let (selection, anchor) =
             select_operator_directory(&request.directory, false, request.symlink_policy)?;
@@ -1756,35 +1764,119 @@ impl FsOps {
                 }
             }
         }
+        // The engine's fresh-destination capacity preflight, on the retained
+        // selection. An exact target whose leaf is absent is fresh; a
+        // directory is fresh only while it is empty. A filesystem that cannot
+        // report its capacity is no reason to refuse, as for the engine.
+        let exact = request.identity.dst_leaf.is_some();
+        self.operator_selection = Some(selection);
+        let info = self.destination_filesystem_info(!exact, None).ok();
+        let fresh = exact || info.as_ref().is_some_and(|info| info.empty == Some(true));
+        if let Some(info) = info.filter(|_| fresh) {
+            let assessment = crate::transfer::FreshCapacityAssessment {
+                logical_bytes: total,
+                objects: request.files.len() as u64,
+                available_bytes: info.available_bytes,
+                available_inodes: info.available_inodes,
+            };
+            if !assessment.sufficient() {
+                self.operator_selection = None;
+                return Ok(Response::SmallFilesCopied(SmallCopyResponse {
+                    anchor,
+                    outcome: SmallCopyOutcome::CapacityShort,
+                }));
+            }
+        }
+        let selection = self
+            .operator_selection
+            .take()
+            .expect("selection retained for the capacity preflight");
         let ticket = self.descriptor_session.register(selection.directory)?;
         let directory = self.descriptor_session.acquire(&ticket)?;
         self.install_destination(directory, &request.request_prefix)?;
 
-        let results = request
-            .files
+        // Stage everything before publishing anything, so a failure leaves
+        // the destination exactly as it was found.
+        let mut staged = Vec::with_capacity(request.files.len());
+        for file in &request.files {
+            match self.stage_small_file(
+                &file.path,
+                &copy_id,
+                &file.data,
+                file.hash,
+                &file.meta,
+                request.flags,
+            ) {
+                Ok(item) => staged.push(item),
+                Err(error) => {
+                    for item in &staged {
+                        let _ = item.root.unlink(&item.partial);
+                    }
+                    return Ok(Response::SmallFilesCopied(SmallCopyResponse {
+                        anchor,
+                        outcome: SmallCopyOutcome::StagingFailed(wire_error(&error)),
+                    }));
+                }
+            }
+        }
+        let results = staged
             .iter()
-            .map(|file| {
-                let put = SmallPut {
-                    path: match self.destination_relative(&file.path) {
-                        Ok(path) => path,
-                        Err(error) => return Some(wire_error(&error)),
-                    },
-                    partial_id,
-                    data: file.data.clone(),
-                    hash: file.hash,
-                    meta: file.meta,
-                    flags: request.flags,
-                    inplace: false,
-                    condition: TargetCondition::Absent,
-                    guard: None,
-                };
-                self.put_small(&put).err().map(|error| wire_error(&error))
+            .map(|item| {
+                publish_partial_rooted(
+                    &item.root,
+                    &item.partial,
+                    &item.target,
+                    &item.file,
+                    TargetCondition::Absent,
+                )
+                .err()
+                .map(|error| wire_error(&error))
             })
             .collect();
         Ok(Response::SmallFilesCopied(SmallCopyResponse {
             anchor,
             outcome: SmallCopyOutcome::Published(results),
         }))
+    }
+
+    /// Stage one small file as a private sidecar beneath the destination
+    /// root, ready to publish: the staging half of `put_small`'s default path.
+    fn stage_small_file(
+        &mut self,
+        path: &[u8],
+        copy_id: &CopyId,
+        data: &[u8],
+        hash: ContentDigest,
+        meta: &Meta,
+        flags: u8,
+    ) -> Result<StagedSmallFile> {
+        if content_digest(data) != hash {
+            bail!("block hash mismatch on receive");
+        }
+        let path = self.destination_relative(path)?;
+        let rooted = self
+            .rooted_destination_target(&path, None)?
+            .context("small copy requires the destination root")?;
+        self.uncache_rooted(&rooted.root, &rooted.relative);
+        let (partial, label) = rooted_partial_target(&rooted, copy_id)?;
+        let (file, _) = self
+            .open_private_partial_rooted(&rooted.root, &partial, &label, true)?
+            .context("sidecar creation was requested")?;
+        file.set_len(0)?;
+        file.write_all_at(data, 0)
+            .with_context(|| format!("write {}", label.display()))?;
+        file.set_len(data.len() as u64)?;
+        set_meta_file(&file, meta, flags)
+            .with_context(|| format!("set metadata {}", label.display()))?;
+        require_safe_rooted_named_partial(&rooted.root, &partial, &label, &file)?;
+        #[cfg(debug_assertions)]
+        fail_put_small_before_rename_for_test(&rooted.label)?;
+        Ok(StagedSmallFile {
+            root: rooted.root,
+            partial,
+            target: rooted.relative,
+            file,
+        })
     }
 
     /// Install the exact control-session root delivered during worker

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -722,11 +722,11 @@ struct StagedSmallFile {
 /// prefix. Nested paths are the ordinary engine's business.
 fn small_copy_leaf<'a>(request_prefix: &[u8], path: &'a [u8]) -> Result<&'a [u8]> {
     let mut prefix_len = request_prefix.len();
-    while prefix_len > 0 && request_prefix[prefix_len - 1] == b'/' {
+    while prefix_len > 1 && request_prefix[prefix_len - 1] == b'/' {
         prefix_len -= 1;
     }
     let leaf = match path.strip_prefix(&request_prefix[..prefix_len]) {
-        Some(rest) if prefix_len == 0 => rest,
+        Some(rest) if prefix_len == 0 || &request_prefix[..prefix_len] == b"/" => rest,
         Some(rest) if rest.first() == Some(&b'/') => &rest[1..],
         _ => bail!("small copy path is not beneath the request prefix"),
     };
@@ -1795,8 +1795,8 @@ impl FsOps {
         let directory = self.descriptor_session.acquire(&ticket)?;
         self.install_destination(directory, &request.request_prefix)?;
 
-        // Stage everything before publishing anything, so a failure leaves
-        // the destination exactly as it was found.
+        // Stage everything before publishing any final files. A staging
+        // failure can leave sidecars for the fallback engine to resume.
         let mut staged = Vec::with_capacity(request.files.len());
         for file in &request.files {
             match self.stage_small_file(
@@ -1819,6 +1819,8 @@ impl FsOps {
                 }
             }
         }
+        // Each publication has its own outcome; earlier successes remain
+        // published if a later file fails.
         let results = staged
             .iter()
             .map(|item| {
@@ -7386,6 +7388,33 @@ mod tests {
         );
         assert!(target.is_dir());
         fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn small_copy_leaf_accepts_root_and_relative_prefixes_without_nested_paths() {
+        for (prefix, path) in [
+            (&b"/"[..], &b"/file"[..]),
+            (b"/directory/", b"/directory/file"),
+            (b".", b"./file"),
+            (b"directory", b"directory/file"),
+            (b"", b"file"),
+        ] {
+            assert_eq!(small_copy_leaf(prefix, path).unwrap(), b"file");
+        }
+        for (prefix, path) in [
+            (&b"/"[..], &b"/nested/file"[..]),
+            (b"/", b"//file"),
+            (b"/", b"/.."),
+            (b"/", b"/"),
+            (b".", b"../file"),
+            (b"directory", b"directory-other/file"),
+            (b"directory", b"directory/nested/file"),
+        ] {
+            assert!(
+                small_copy_leaf(prefix, path).is_err(),
+                "{prefix:?}: {path:?}"
+            );
+        }
     }
 
     /// The one-turn small copy publishes fresh files through the ordinary

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -710,6 +710,25 @@ fn mkdir_operator_directory_at(parent: &File, component: &[u8], mode: u32) -> io
     }
 }
 
+/// The single directory entry a small-copy file names beneath the request
+/// prefix. Nested paths are the ordinary engine's business.
+fn small_copy_leaf<'a>(request_prefix: &[u8], path: &'a [u8]) -> Result<&'a [u8]> {
+    let mut prefix_len = request_prefix.len();
+    while prefix_len > 0 && request_prefix[prefix_len - 1] == b'/' {
+        prefix_len -= 1;
+    }
+    let leaf = match path.strip_prefix(&request_prefix[..prefix_len]) {
+        Some(rest) if prefix_len == 0 => rest,
+        Some(rest) if rest.first() == Some(&b'/') => &rest[1..],
+        _ => bail!("small copy path is not beneath the request prefix"),
+    };
+    if leaf.is_empty() || leaf == b"." || leaf == b".." || leaf.contains(&b'/') || leaf.contains(&0)
+    {
+        bail!("small copy path must name one entry beneath the destination directory");
+    }
+    Ok(leaf)
+}
+
 fn operator_lstat_at(parent: &File, component: &[u8]) -> io::Result<libc::stat> {
     let component = CString::new(component).expect("path component was checked for NUL");
     loop {
@@ -1658,6 +1677,116 @@ impl FsOps {
         Ok(ticket)
     }
 
+    /// One-turn push of fresh small files. This composes the steps the
+    /// ordinary engine issues separately, in the same order, on one fresh
+    /// control session: select and retain the operator directory, refuse if
+    /// any target exists, register and install the directory as the
+    /// destination root exactly as `AnchorDestination` does, then publish
+    /// every file through `put_small` with an absent-target condition. A
+    /// refusal leaves the session as it found it, so the engine can continue
+    /// on this connection.
+    fn copy_small_files(&mut self, request: &SmallCopyRequest) -> Result<Response> {
+        if self.operator_selection.is_some()
+            || self.destination_root.is_some()
+            || self.destination_prefix.is_some()
+            || !self.source_roots.is_empty()
+        {
+            bail!("small copy is valid only on a fresh control session");
+        }
+        if request.files.is_empty() || request.files.len() > SMALL_COPY_MAX_FILES {
+            bail!(
+                "small copy carries {} files; the limit is {SMALL_COPY_MAX_FILES}",
+                request.files.len()
+            );
+        }
+        let mut total = 0u64;
+        let mut names: Vec<&[u8]> = Vec::with_capacity(request.files.len());
+        for file in &request.files {
+            let bytes = file.data.len() as u64;
+            if bytes > SMALL_COPY_MAX_FILE_BYTES {
+                bail!("small copy file exceeds {SMALL_COPY_MAX_FILE_BYTES} bytes");
+            }
+            total = total
+                .checked_add(bytes)
+                .filter(|total| *total <= SMALL_COPY_MAX_TOTAL_BYTES)
+                .context("small copy exceeds its total byte limit")?;
+            let name = small_copy_leaf(&request.request_prefix, &file.path)?;
+            if names.contains(&name) {
+                bail!("small copy names one destination twice");
+            }
+            names.push(name);
+        }
+        // The engine canonicalizes before it walks the directory; the job
+        // identity, and therefore every sidecar name, comes from that spelling.
+        let mut canonical = normalize(&resolve(&request.directory));
+        if let Some(leaf) = &request.identity.dst_leaf {
+            canonical.push(OsStr::from_bytes(leaf));
+        }
+        let identity = &request.identity;
+        let job_identity = crate::resume::job_identity(
+            &identity.src_endpoint,
+            &identity.src_roots,
+            &identity.dst_endpoint,
+            &crate::transfer::path_identity(&canonical),
+            &identity.semantic_flags,
+        );
+        let partial_id = crate::resume::partial_id(&job_identity);
+
+        let (selection, anchor) =
+            select_operator_directory(&request.directory, false, request.symlink_policy)?;
+        let anchor = anchor.context("destination directory is missing")?;
+        // Freshness is decided through the retained descriptor, before
+        // anything is registered, so a refusal has no session side effect.
+        for name in &names {
+            match operator_lstat_at(&selection.directory, name) {
+                Ok(_) => {
+                    return Ok(Response::SmallFilesCopied(SmallCopyResponse {
+                        anchor,
+                        outcome: SmallCopyOutcome::NotFresh,
+                    }))
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "inspect destination entry {}",
+                            String::from_utf8_lossy(name)
+                        )
+                    })
+                }
+            }
+        }
+        let ticket = self.descriptor_session.register(selection.directory)?;
+        let directory = self.descriptor_session.acquire(&ticket)?;
+        self.install_destination(directory, &request.request_prefix)?;
+
+        let results = request
+            .files
+            .iter()
+            .map(|file| {
+                let put = SmallPut {
+                    path: match self.destination_relative(&file.path) {
+                        Ok(path) => path,
+                        Err(error) => return Some(wire_error(&error)),
+                    },
+                    partial_id,
+                    data: file.data.clone(),
+                    hash: file.hash,
+                    meta: file.meta,
+                    flags: request.flags,
+                    inplace: false,
+                    condition: TargetCondition::Absent,
+                    guard: None,
+                };
+                self.put_small(&put).err().map(|error| wire_error(&error))
+            })
+            .collect();
+        Ok(Response::SmallFilesCopied(SmallCopyResponse {
+            anchor,
+            outcome: SmallCopyOutcome::Published(results),
+        }))
+    }
+
     /// Install the exact control-session root delivered during worker
     /// initialization. A same-process TCP worker clones it from the shared
     /// registry; an independent worker claims it with SCM_RIGHTS.
@@ -2396,7 +2525,8 @@ impl FsOps {
             | Request::DestinationFilesystemInfo { .. }
             | Request::TransportStats
             | Request::Receipt
-            | Request::Shutdown => {}
+            | Request::Shutdown
+            | Request::CopySmallFiles(_) => {}
         }
         Ok(req)
     }
@@ -5645,6 +5775,7 @@ impl FsOps {
             } => self
                 .anchor_destination(*expected_dev, *expected_ino, request_prefix)
                 .map(Response::DestinationRegistered),
+            Request::CopySmallFiles(request) => self.copy_small_files(request),
             Request::DestinationFilesystemInfo {
                 check_empty,
                 target,
@@ -7162,6 +7293,130 @@ mod tests {
             "{response:?}"
         );
         assert!(target.is_dir());
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// The one-turn small copy publishes fresh files through the ordinary
+    /// staged path and leaves the session anchored; an existing target makes
+    /// it write nothing and leave the session untouched; its bounds and the
+    /// one-entry shape are enforced here, not only by the coordinator.
+    #[test]
+    fn small_copy_publishes_fresh_files_and_declines_existing_ones() {
+        let dir = test_dir();
+        fs::create_dir(&dir).unwrap();
+        let prefix = dir.as_os_str().as_bytes().to_vec();
+        let file = |name: &str, data: &[u8]| SmallCopyFile {
+            path: join(&prefix, name.as_bytes()),
+            data: data.to_vec(),
+            hash: content_digest(data),
+            meta: Meta {
+                mode: 0o640,
+                uid: 0,
+                gid: 0,
+                mtime: 1_700_000_000,
+                mtime_nsec: 0,
+            },
+        };
+        let request = |directory: PathBytes, files: Vec<SmallCopyFile>| {
+            Request::CopySmallFiles(SmallCopyRequest {
+                directory,
+                symlink_policy: OperatorSymlinkPolicy::Refuse,
+                request_prefix: prefix.clone(),
+                identity: SmallCopyIdentity {
+                    src_endpoint: "local".into(),
+                    src_roots: vec![("source".into(), false)],
+                    dst_endpoint: "example".into(),
+                    dst_leaf: None,
+                    semantic_flags: "{}".into(),
+                },
+                flags: flags::MODE | flags::TIMES,
+                files,
+            })
+        };
+        let message = |response: &Response| match response {
+            Response::Err(message) => message.clone(),
+            Response::EndpointError(error) => error.message.clone(),
+            other => panic!("{other:?}"),
+        };
+
+        let mut operations = FsOps::new();
+        let response = operations.handle(&request(
+            prefix.clone(),
+            vec![file("one", b"first"), file("two", b"")],
+        ));
+        match response {
+            Response::SmallFilesCopied(SmallCopyResponse {
+                anchor,
+                outcome: SmallCopyOutcome::Published(results),
+            }) => {
+                assert_eq!(results, vec![None, None]);
+                assert_eq!(anchor.ino, fs::metadata(&dir).unwrap().ino());
+            }
+            other => panic!("{other:?}"),
+        }
+        assert_eq!(fs::read(dir.join("one")).unwrap(), b"first");
+        assert_eq!(fs::read(dir.join("two")).unwrap(), b"");
+        let metadata = fs::metadata(dir.join("one")).unwrap();
+        assert_eq!(metadata.mode() & 0o7777, 0o640);
+        assert_eq!(metadata.mtime(), 1_700_000_000);
+        let leftovers: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .filter(|name| name != "one" && name != "two")
+            .collect();
+        assert!(leftovers.is_empty(), "{leftovers:?}");
+        assert!(operations.destination_root.is_some());
+        let again = operations.handle(&request(prefix.clone(), vec![file("three", b"x")]));
+        assert!(
+            message(&again).contains("fresh control session"),
+            "{again:?}"
+        );
+        assert!(!dir.join("three").exists());
+
+        let mut declined = FsOps::new();
+        let response = declined.handle(&request(
+            prefix.clone(),
+            vec![file("three", b"x"), file("one", b"replaced")],
+        ));
+        assert!(
+            matches!(
+                &response,
+                Response::SmallFilesCopied(SmallCopyResponse {
+                    outcome: SmallCopyOutcome::NotFresh,
+                    ..
+                })
+            ),
+            "{response:?}"
+        );
+        assert!(!dir.join("three").exists());
+        assert_eq!(fs::read(dir.join("one")).unwrap(), b"first");
+        assert!(declined.destination_root.is_none() && declined.operator_selection.is_none());
+        let canonical = declined.handle(&Request::Canonicalize {
+            path: prefix.clone(),
+            guard: None,
+        });
+        assert!(matches!(canonical, Response::Path(_)), "{canonical:?}");
+
+        let nested = SmallCopyFile {
+            path: join(&prefix, b"sub/deep"),
+            ..file("x", b"x")
+        };
+        let response = FsOps::new().handle(&request(prefix.clone(), vec![nested]));
+        assert!(
+            message(&response).contains("one entry beneath"),
+            "{response:?}"
+        );
+        let response = FsOps::new().handle(&request(
+            prefix.clone(),
+            vec![file("dup", b"a"), file("dup", b"b")],
+        ));
+        assert!(message(&response).contains("twice"), "{response:?}");
+        let response = FsOps::new().handle(&request(prefix.clone(), Vec::new()));
+        assert!(message(&response).contains("limit"), "{response:?}");
+        let response =
+            FsOps::new().handle(&request(join(&prefix, b"absent"), vec![file("x", b"x")]));
+        assert!(!message(&response).is_empty());
+        assert!(!dir.join("absent").exists() && !dir.join("x").exists());
         fs::remove_dir_all(&dir).unwrap();
     }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -879,6 +879,14 @@ pub enum SmallCopyOutcome {
     /// session holds no selection or root, so the ordinary engine can
     /// continue on this connection.
     NotFresh,
+    /// The fresh-destination capacity preflight would refuse this copy.
+    /// Nothing was written and the session is untouched; the engine repeats
+    /// the preflight and reports the shortage itself.
+    CapacityShort,
+    /// Staging failed before anything was published. Every staged sidecar
+    /// was removed, but the session now holds the destination root, so the
+    /// engine needs a fresh control session to continue.
+    StagingFailed(WireError),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -883,9 +883,9 @@ pub enum SmallCopyOutcome {
     /// Nothing was written and the session is untouched; the engine repeats
     /// the preflight and reports the shortage itself.
     CapacityShort,
-    /// Staging failed before anything was published. Every staged sidecar
-    /// was removed, but the session now holds the destination root, so the
-    /// engine needs a fresh control session to continue.
+    /// Staging failed before any final file was published. Sidecars may
+    /// remain for resume, and the session now holds the destination root,
+    /// so the engine needs a fresh control session to continue.
     StagingFailed(WireError),
 }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -817,6 +817,74 @@ pub enum Request {
     /// ends the grant's mutation authority.
     Receipt,
     Shutdown,
+    /// One turn for a push of fresh small regular files on a fresh control
+    /// session: select and retain the destination directory, refuse if any
+    /// target already exists, register the directory as the session's
+    /// destination root, then stage and publish every file through the
+    /// ordinary small-file path. See `SmallCopyRequest`.
+    CopySmallFiles(SmallCopyRequest),
+}
+
+/// Bounds for one-turn small pushes. The receiver enforces them independently
+/// of the coordinator's eligibility check.
+pub const SMALL_COPY_MAX_FILES: usize = 64;
+pub const SMALL_COPY_MAX_FILE_BYTES: u64 = 1 << 20;
+pub const SMALL_COPY_MAX_TOTAL_BYTES: u64 = 4 << 20;
+
+/// The parts of a job identity only the coordinator knows. The receiver adds
+/// the canonical destination it resolves, so the sidecar names it stages
+/// through are the ones the ordinary engine would use for the same copy.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SmallCopyIdentity {
+    pub src_endpoint: String,
+    pub src_roots: Vec<(String, bool)>,
+    pub dst_endpoint: String,
+    /// Exact placement names a directory entry beneath the selected
+    /// directory; its identity is the canonical parent plus this leaf.
+    pub dst_leaf: Option<PathBytes>,
+    pub semantic_flags: String,
+}
+
+/// One file of a small push. `path` is spelled as the ordinary engine would
+/// send it: beneath the request prefix, one component below the selected
+/// directory.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SmallCopyFile {
+    pub path: PathBytes,
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+    pub hash: ContentDigest,
+    pub meta: Meta,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SmallCopyRequest {
+    /// The operator directory: the `--into` directory, or the parent of an
+    /// `--as` leaf. It must already exist.
+    pub directory: PathBytes,
+    pub symlink_policy: OperatorSymlinkPolicy,
+    /// What `AnchorDestination` would register as the request prefix.
+    pub request_prefix: PathBytes,
+    pub identity: SmallCopyIdentity,
+    /// Publication metadata flags, as for `SmallPut`.
+    pub flags: u8,
+    pub files: Vec<SmallCopyFile>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum SmallCopyOutcome {
+    /// Every file was attempted; one result per file in request order.
+    Published(Vec<Option<WireError>>),
+    /// At least one target already exists. Nothing was written and the
+    /// session holds no selection or root, so the ordinary engine can
+    /// continue on this connection.
+    NotFresh,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SmallCopyResponse {
+    pub anchor: DirectoryAnchor,
+    pub outcome: SmallCopyOutcome,
 }
 
 impl Request {
@@ -917,6 +985,7 @@ pub enum Response {
     /// deliberately distinct from `Err`: filenames and other diagnostics are
     /// untrusted text and must never select a recovery path.
     CopyLocalUnsupported,
+    SmallFilesCopied(SmallCopyResponse),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -2392,7 +2392,10 @@ impl RestrictedAuthority {
                     put.guard = Some(self.guard.clone());
                 }
             }
-            Request::CopyLocal { .. } | Request::ReadRange { .. } | Request::ReadSmallBatch(_) => {
+            Request::CopyLocal { .. }
+            | Request::ReadRange { .. }
+            | Request::ReadSmallBatch(_)
+            | Request::CopySmallFiles(_) => {
                 bail!("request is not valid on a command-restricted destination")
             }
             Request::ListDir { .. } => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -305,6 +305,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
                     | Request::RegisterSourceRoots { .. }
                     | Request::CreateOperatorDirectory { .. }
                     | Request::AnchorDestination { .. }
+                    | Request::CopySmallFiles(_)
                     | Request::Receipt
             )
         {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -301,7 +301,8 @@ fn remote_helper_mode(spec: &RemoteSpec, interface: Interface) -> &'static str {
     }
 }
 
-fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
+/// The control-connection and helper lines of a remote endpoint's -vv report.
+fn print_remote_control_diagnostics(spec: &RemoteSpec, args: &Args) {
     let diagnostics = spec.diagnostics();
     crate::output::diagnostic!("syq: {}:", spec.label());
     if let Some(peer) = &diagnostics.peer {
@@ -316,7 +317,25 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
         let helper_mode = remote_helper_mode(spec, args.interface);
         crate::output::diagnostic!("  helper: {} ({helper_mode})", peer.identity);
     }
+}
 
+/// What -vv explains for a copy whose files travelled on the control
+/// connection: the same helper lines, and a route that involved no data
+/// connection at all.
+fn print_small_copy_diagnostics(args: &Args, dst_ep: &Endpoint) {
+    if args.quiet || args.verbose < 2 {
+        return;
+    }
+    if let Endpoint::Remote(spec) = dst_ep {
+        print_remote_control_diagnostics(spec, args);
+        eprintln!("  transport: control connection (small files sent in one request)");
+    }
+    eprintln!("syq: concurrency: no data connections (small files sent on the control connection)");
+}
+
+fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
+    print_remote_control_diagnostics(spec, args);
+    let diagnostics = spec.diagnostics();
     if let Some(probe) = &diagnostics.tcp_probe {
         let fastest = probe
             .candidates
@@ -794,6 +813,10 @@ enum SmallCopy {
     /// written and the control session is untouched, so the ordinary engine
     /// continues on the same connections and reports any error itself.
     Declined,
+    /// Staging failed with nothing published, but the receiver now holds the
+    /// destination root; the engine continues on a fresh control session and
+    /// reports the failure itself.
+    Reconnect,
 }
 
 /// Whether a native push of local files to a remote directory may try the
@@ -853,12 +876,20 @@ fn attempt_small_copy(
     srcs: &[Location],
     dst: &Location,
     src_ep: &Endpoint,
+    dst_ep: &Endpoint,
     src_ctl: &mut dyn Conn,
     dst_ctl: &mut dyn Conn,
     roots: &[RegisteredSourceRoot],
     progress: &Progress,
     t0: std::time::Instant,
 ) -> Result<SmallCopy> {
+    // A source named like a syq sidecar gets the engine's warning.
+    if srcs
+        .iter()
+        .any(|source| is_partial_name(OsStr::from_bytes(&source.basename())))
+    {
+        return Ok(SmallCopy::Declined);
+    }
     let follow = args.follows_native_source_paths();
     let mut entries = Vec::with_capacity(srcs.len());
     let mut total = 0u64;
@@ -1005,6 +1036,29 @@ fn attempt_small_copy(
             }
             return Ok(SmallCopy::Declined);
         }
+        Response::SmallFilesCopied(SmallCopyResponse {
+            outcome: SmallCopyOutcome::CapacityShort,
+            ..
+        }) => {
+            if debug() {
+                eprintln!(
+                    "syq: small copy: capacity preflight would refuse; using the ordinary engine"
+                );
+            }
+            return Ok(SmallCopy::Declined);
+        }
+        Response::SmallFilesCopied(SmallCopyResponse {
+            outcome: SmallCopyOutcome::StagingFailed(error),
+            ..
+        }) => {
+            if debug() {
+                eprintln!(
+                    "syq: small copy: staging failed ({}); using the ordinary engine on a new control connection",
+                    error.message
+                );
+            }
+            return Ok(SmallCopy::Reconnect);
+        }
         Response::SmallFilesCopied(_) => bail!("small copy returned a mismatched result count"),
         // The receiver could not select the directory; the engine's own
         // preflight reproduces and reports that condition.
@@ -1029,6 +1083,7 @@ fn attempt_small_copy(
         );
     }
     announce_detached_ready()?;
+    print_small_copy_diagnostics(args, dst_ep);
 
     // Did any source change while we were at it? Same check as the worker's
     // small-file batch, through the same registered references.
@@ -1945,6 +2000,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             srcs,
             dst,
             &src_ep,
+            &dst_ep,
             &mut *src_ctl,
             &mut *dst_ctl,
             source_roots.get().expect("source roots registered"),
@@ -1953,6 +2009,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         )? {
             SmallCopy::Done(code) => return Ok(code),
             SmallCopy::Declined => {}
+            SmallCopy::Reconnect => dst_ctl = connect_ctl(&dst_ep, &args)?,
         }
     }
     let tcp_ports = use_tcp.then(|| parse_ports(&args.tcp_ports)).transpose()?;
@@ -3870,12 +3927,14 @@ struct FreshCapacityPlan {
     overflowed: bool,
 }
 
+/// The fresh-destination capacity rule, shared with the receiver's one-turn
+/// small copy so both refuse the same copies.
 #[derive(Clone, Copy)]
-struct FreshCapacityAssessment {
-    logical_bytes: u64,
-    objects: u64,
-    available_bytes: u64,
-    available_inodes: Option<u64>,
+pub(crate) struct FreshCapacityAssessment {
+    pub(crate) logical_bytes: u64,
+    pub(crate) objects: u64,
+    pub(crate) available_bytes: u64,
+    pub(crate) available_inodes: Option<u64>,
 }
 
 impl FreshCapacityAssessment {
@@ -3888,7 +3947,7 @@ impl FreshCapacityAssessment {
             .is_some_and(|available| self.objects.saturating_add(64) > available)
     }
 
-    fn sufficient(self) -> bool {
+    pub(crate) fn sufficient(self) -> bool {
         !self.byte_shortage() && !self.inode_shortage()
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -328,9 +328,13 @@ fn print_small_copy_diagnostics(args: &Args, dst_ep: &Endpoint) {
     }
     if let Endpoint::Remote(spec) = dst_ep {
         print_remote_control_diagnostics(spec, args);
-        eprintln!("  transport: control connection (small files sent in one request)");
+        crate::output::diagnostic!(
+            "  transport: control connection (small files sent in one request)"
+        );
     }
-    eprintln!("syq: concurrency: no data connections (small files sent on the control connection)");
+    crate::output::diagnostic!(
+        "syq: concurrency: no data connections (small files sent on the control connection)"
+    );
 }
 
 fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
@@ -1038,7 +1042,9 @@ fn attempt_small_copy(
             ..
         }) => {
             if debug() {
-                crate::output::diagnostic!("syq: small copy: a destination exists; using the ordinary engine");
+                crate::output::diagnostic!(
+                    "syq: small copy: a destination exists; using the ordinary engine"
+                );
             }
             return Ok(SmallCopy::Declined);
         }
@@ -1047,7 +1053,7 @@ fn attempt_small_copy(
             ..
         }) => {
             if debug() {
-                eprintln!(
+                crate::output::diagnostic!(
                     "syq: small copy: capacity preflight would refuse; using the ordinary engine"
                 );
             }
@@ -1058,7 +1064,7 @@ fn attempt_small_copy(
             ..
         }) => {
             if debug() {
-                eprintln!(
+                crate::output::diagnostic!(
                     "syq: small copy: staging failed ({}); using the ordinary engine on a new control connection",
                     error.message
                 );

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -658,7 +658,7 @@ fn endpoint_identity(l: &Location) -> String {
 
 /// Keep existing partial identities unchanged for UTF-8 paths, while giving
 /// native raw-byte paths a lossless and unambiguous spelling.
-fn path_identity(path: &std::path::Path) -> String {
+pub(crate) fn path_identity(path: &std::path::Path) -> String {
     if let Some(path) = path.to_str() {
         return path.to_string();
     }
@@ -730,27 +730,16 @@ fn resolve_copy_identity(
     // Relative native bases and selectors get their meaning from the source
     // endpoint's process cwd. Identify that already-held cwd separately;
     // never canonicalize the registered selection after it has been pinned.
-    let native_endpoint_cwd = (args.interface == Interface::NativeCp)
-        .then(|| {
-            canonical_path(src_ctl, b".", srcs[0].is_remote()).map(|path| path_identity(&path))
-        })
-        .transpose()?;
-    let mut src_roots: Vec<(String, bool)> = Vec::with_capacity(srcs.len());
-    for source in srcs {
-        let identity = if args.interface == Interface::NativeCp {
-            native_source_identity(
-                args,
-                source,
-                native_endpoint_cwd
-                    .as_deref()
-                    .expect("native endpoint cwd was identified"),
-            )
-        } else {
-            let path = canonical_path(src_ctl, &source.path, source.is_remote())?;
-            path_identity(&path)
-        };
-        src_roots.push((identity, source.copies_contents()));
-    }
+    let src_roots: Vec<(String, bool)> = if args.interface == Interface::NativeCp {
+        source_identity_parts(args, srcs, src_ctl)?
+    } else {
+        srcs.iter()
+            .map(|source| {
+                let path = canonical_path(src_ctl, &source.path, source.is_remote())?;
+                Ok((path_identity(&path), source.copies_contents()))
+            })
+            .collect::<Result<_>>()?
+    };
     let dst_root = match dst_canonical {
         Some(path) => path,
         None => canonical_path(dst_ctl, &dst.path, dst.is_remote())?,
@@ -763,6 +752,419 @@ fn resolve_copy_identity(
         &dst_root,
         &semantic_flags(opts, args, srcs),
     ))
+}
+
+/// The job-identity inputs that do not depend on the destination endpoint:
+/// what a small push sends so the receiver can finish the identity with the
+/// canonical destination it resolves.
+fn source_identity_parts(
+    args: &Args,
+    srcs: &[Location],
+    src_ctl: &mut dyn Conn,
+) -> Result<Vec<(String, bool)>> {
+    let native_endpoint_cwd =
+        canonical_path(src_ctl, b".", srcs[0].is_remote()).map(|path| path_identity(&path))?;
+    Ok(srcs
+        .iter()
+        .map(|source| {
+            (
+                native_source_identity(args, source, &native_endpoint_cwd),
+                source.copies_contents(),
+            )
+        })
+        .collect())
+}
+
+/// Mode a fresh destination file is created with: the source mode under -p,
+/// otherwise the source mode minus the umask (rsync semantics).
+fn fresh_file_mode(opts: &Opts, entry: &Entry) -> u32 {
+    if opts.perms {
+        entry.mode & 0o7777
+    } else {
+        entry.mode & 0o777 & !opts.umask
+    }
+}
+
+/// Outcome of the one-turn small push attempted before the ordinary engine
+/// starts its destination preflight.
+enum SmallCopy {
+    /// The copy completed on the control connection and the run is settled.
+    Done(i32),
+    /// Not applicable, not fresh, or refused by the receiver. Nothing was
+    /// written and the control session is untouched, so the ordinary engine
+    /// continues on the same connections and reports any error itself.
+    Declined,
+}
+
+/// Whether a native push of local files to a remote directory may try the
+/// one-turn small copy. Everything the ordinary engine decides from flags
+/// that the fused request does not carry stays with the engine.
+fn small_copy_eligible(
+    args: &Args,
+    srcs: &[Location],
+    dst: &Location,
+    src_ep: &Endpoint,
+    dst_ep: &Endpoint,
+) -> bool {
+    #[cfg(debug_assertions)]
+    if std::env::var_os("SYQ_TEST_DISABLE_SMALL_COPY").is_some() {
+        return false;
+    }
+    args.interface == Interface::NativeCp
+        && matches!(args.placement, Placement::Into | Placement::As)
+        && args.target_existence == Existence::Any
+        && dst.is_remote()
+        && dst_ep.is_remote()
+        && !src_ep.is_remote()
+        && !srcs.iter().any(Location::is_remote)
+        && args.restricted_grant.is_none()
+        && !args.dry_run
+        && !args.verify_only
+        && !args.inplace
+        && !args.delete
+        && !args.update
+        && !args.checksum
+        && !args.ignore_existing
+        && !args.existing
+        && !args.stats
+        && args.files_from.is_none()
+        && args.native_mapping.is_none()
+        && args.ignore_lines.is_empty()
+        && args.bwlimit_bytes == 0
+        && args.max_size.is_none()
+        && args.min_size.is_none()
+        && !args.follows_native_destination_paths()
+        && !srcs.is_empty()
+        && srcs.len() <= SMALL_COPY_MAX_FILES
+        && srcs.iter().all(|source| !source.copies_contents())
+        && (args.placement == Placement::Into || srcs.len() == 1)
+        && clean_root(&dst.path) != b"~"
+}
+
+/// Push fresh small regular files in one control-connection turn. Sources
+/// are read through the same registered references the engine's workers
+/// use; the receiver selects, anchors, checks, stages, and publishes in one
+/// request. Every result record and the summary come from the same counters
+/// the engine settles from.
+#[allow(clippy::too_many_arguments)]
+fn attempt_small_copy(
+    args: &Args,
+    opts: &Opts,
+    srcs: &[Location],
+    dst: &Location,
+    src_ep: &Endpoint,
+    src_ctl: &mut dyn Conn,
+    dst_ctl: &mut dyn Conn,
+    roots: &[RegisteredSourceRoot],
+    progress: &Progress,
+    t0: std::time::Instant,
+) -> Result<SmallCopy> {
+    let follow = args.follows_native_source_paths();
+    let mut entries = Vec::with_capacity(srcs.len());
+    let mut total = 0u64;
+    for (source, root) in srcs.iter().zip(roots) {
+        // A missing or unusable source is the engine's to report.
+        let Ok(Some(entry)) = stat_one_registered(
+            src_ctl,
+            &source.path,
+            &root.selection,
+            source.follows_root(follow),
+        ) else {
+            return Ok(SmallCopy::Declined);
+        };
+        if entry.kind != Kind::File
+            || validate_native_source_type(&source.path, source.selection, entry.kind).is_err()
+            || entry.size > SMALL_COPY_MAX_FILE_BYTES
+        {
+            return Ok(SmallCopy::Declined);
+        }
+        total += entry.size;
+        if total > SMALL_COPY_MAX_TOTAL_BYTES {
+            return Ok(SmallCopy::Declined);
+        }
+        entries.push(entry);
+    }
+
+    // Destination spellings exactly as the planner produces them.
+    let operator_dst_root = clean_root(&dst.path);
+    let (directory, dst_leaf) = match args.placement {
+        Placement::Into => (operator_dst_root.clone(), None),
+        Placement::As => {
+            let Some(leaf) = operator_dst_root
+                .rsplit(|byte| *byte == b'/')
+                .next()
+                .filter(|component| !component.is_empty())
+            else {
+                return Ok(SmallCopy::Declined);
+            };
+            (parent_path(&operator_dst_root), Some(leaf.to_vec()))
+        }
+        Placement::Rsync => return Ok(SmallCopy::Declined),
+    };
+    let request_prefix = directory.clone();
+    let mut targets: Vec<(PathBytes, PathBytes, String)> = Vec::with_capacity(srcs.len());
+    for source in srcs {
+        let (dst_path, rel_bytes) = if args.placement == Placement::Into {
+            let name = source.basename();
+            (join(&operator_dst_root, &name), name)
+        } else {
+            (operator_dst_root.clone(), Vec::new())
+        };
+        if targets.iter().any(|(existing, _, _)| *existing == dst_path) {
+            return Ok(SmallCopy::Declined);
+        }
+        let rel = display(&source.basename());
+        targets.push((dst_path, rel_bytes, rel));
+    }
+
+    // Read through the engine's source-worker path.
+    let Ok(mut reader) = src_ep.connect_with_sources(args.compress, roots.to_vec()) else {
+        return Ok(SmallCopy::Declined);
+    };
+    let reads: Vec<SmallRead> = srcs
+        .iter()
+        .zip(roots)
+        .zip(&entries)
+        .filter(|(_, entry)| entry.size > 0)
+        .map(|((source, root), entry)| SmallRead {
+            path: source.path.clone(),
+            source: Some(root.selection.clone()),
+            attempt: 0,
+            len: entry.size as u32,
+        })
+        .collect();
+    let mut blocks = if reads.is_empty() {
+        Vec::new()
+    } else {
+        let count = reads.len();
+        reader.send(Request::ReadSmallBatch(reads))?;
+        match ok(reader.recv()?, "read small batch")? {
+            Response::SmallBlocks(blocks) if blocks.len() == count => blocks,
+            other => bail!("unexpected response {other:?}"),
+        }
+    }
+    .into_iter();
+    let flags = publication_metadata_flags(opts.flags);
+    let mut files = Vec::with_capacity(srcs.len());
+    for (entry, (dst_path, _, _)) in entries.iter().zip(&targets) {
+        let (data, hash) = if entry.size == 0 {
+            (Vec::new(), content_digest(&[]))
+        } else {
+            match blocks.next() {
+                Some(Ok(block)) if block.data.len() as u64 == entry.size => {
+                    (block.data, block.hash)
+                }
+                // A read failure or a changed size is the engine's to
+                // report or retry.
+                _ => return Ok(SmallCopy::Declined),
+            }
+        };
+        let mut meta = entry.meta();
+        meta.mode = fresh_file_mode(opts, entry);
+        files.push(SmallCopyFile {
+            path: dst_path.clone(),
+            data,
+            hash,
+            meta,
+        });
+    }
+
+    let request = SmallCopyRequest {
+        directory,
+        symlink_policy: opts.operator_symlink_policy,
+        request_prefix,
+        identity: SmallCopyIdentity {
+            src_endpoint: endpoint_identity(&srcs[0]),
+            src_roots: source_identity_parts(args, srcs, src_ctl)?,
+            dst_endpoint: endpoint_identity(dst),
+            dst_leaf,
+            semantic_flags: semantic_flags(opts, args, srcs),
+        },
+        flags,
+        files,
+    };
+    if debug() {
+        crate::output::diagnostic!(
+            "syq: small copy: sending {} files ({} bytes) in one turn at {:.2}s",
+            srcs.len(),
+            total,
+            t0.elapsed().as_secs_f64()
+        );
+    }
+    let results = match dst_ctl.call(Request::CopySmallFiles(request))? {
+        Response::SmallFilesCopied(SmallCopyResponse {
+            outcome: SmallCopyOutcome::Published(results),
+            ..
+        }) if results.len() == srcs.len() => results,
+        Response::SmallFilesCopied(SmallCopyResponse {
+            outcome: SmallCopyOutcome::NotFresh,
+            ..
+        }) => {
+            if debug() {
+                crate::output::diagnostic!("syq: small copy: a destination exists; using the ordinary engine");
+            }
+            return Ok(SmallCopy::Declined);
+        }
+        Response::SmallFilesCopied(_) => bail!("small copy returned a mismatched result count"),
+        // The receiver could not select the directory; the engine's own
+        // preflight reproduces and reports that condition.
+        Response::Err(error) => {
+            if debug() {
+                crate::output::diagnostic!("syq: small copy declined: {error}");
+            }
+            return Ok(SmallCopy::Declined);
+        }
+        Response::EndpointError(error) => {
+            if debug() {
+                crate::output::diagnostic!("syq: small copy declined: {}", error.message);
+            }
+            return Ok(SmallCopy::Declined);
+        }
+        other => bail!("unexpected response {other:?}"),
+    };
+    if debug() {
+        crate::output::diagnostic!(
+            "syq: small copy: published at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
+    announce_detached_ready()?;
+
+    // Did any source change while we were at it? Same check as the worker's
+    // small-file batch, through the same registered references.
+    let now = stat_many_registered(
+        src_ctl,
+        srcs.iter().map(|source| source.path.clone()).collect(),
+        Some(roots.iter().map(|root| root.selection.clone()).collect()),
+        false,
+    )?;
+    for (((entry, (_, rel_bytes, rel)), result), now) in
+        entries.iter().zip(&targets).zip(results).zip(now)
+    {
+        progress.files_total.fetch_add(1, Relaxed);
+        progress.bytes_total.fetch_add(entry.size, Relaxed);
+        let failure = match result {
+            Some(error) => {
+                let error = endpoint_error(error).context("put");
+                Some(("unknown", os_kind_of(&error), format!("{error:#}")))
+            }
+            None => {
+                let changed = match &now {
+                    Some(e) => {
+                        e.kind != Kind::File
+                            || e.size != entry.size
+                            || e.mtime != entry.mtime
+                            || e.mtime_nsec != entry.mtime_nsec
+                    }
+                    None => true,
+                };
+                changed.then(|| {
+                    (
+                        "yes",
+                        None,
+                        "source changed during transfer (or vanished)".to_string(),
+                    )
+                })
+            }
+        };
+        if let Some((retryable, os_kind, message)) = failure {
+            progress.error_classified(&format!("syq: {rel}: {message}"), Some("io"), os_kind);
+            if let Some(results) = progress.results_writer() {
+                results.emit_operation(&crate::results::OperationRecord {
+                    action: "transfer_file",
+                    dst: rel_bytes,
+                    src: None,
+                    kind: "file",
+                    disposition: "failed",
+                    bytes: None,
+                    attempts: Some(1),
+                    retryable: Some(retryable),
+                    class: Some("io"),
+                    os_kind,
+                    message: Some(&message),
+                });
+            }
+            continue;
+        }
+        progress.add_bytes(entry.size);
+        progress.files_done.fetch_add(1, Relaxed);
+        if let Some(results) = progress.results_writer() {
+            results.emit_operation(&crate::results::OperationRecord {
+                action: "transfer_file",
+                dst: rel_bytes,
+                src: None,
+                kind: "file",
+                disposition: "succeeded",
+                bytes: Some(entry.size),
+                attempts: Some(1),
+                retryable: None,
+                class: None,
+                os_kind: None,
+                message: None,
+            });
+        }
+        if opts.verbose > 0 {
+            progress.println(rel);
+        }
+    }
+
+    progress.stop();
+    progress.clear();
+    let errors = progress.errors.load(Relaxed);
+    let (status, exit_code) = if errors > 0 {
+        ("partial", 23)
+    } else {
+        ("success", 0)
+    };
+    let terminal = crate::results::ResultRecord {
+        status,
+        exit_code,
+        dry_run: false,
+        files_transferred: progress.files_done.load(Relaxed),
+        files_unchanged: 0,
+        files_excluded: 0,
+        directories_created: 0,
+        symlinks_created: 0,
+        specials_created: 0,
+        errors,
+        bytes_transferred: progress.bytes_done.load(Relaxed),
+        bytes_unchanged: 0,
+        elapsed_ms: progress.start.elapsed().as_millis() as u64,
+        deletions_planned: None,
+        deletions_completed: None,
+        deletions_blocked: None,
+    };
+    if !args.quiet && !args.suppress_summary {
+        print_transfer_summary(&terminal, progress.start.elapsed().as_secs_f64(), "");
+    }
+    if let Some(results) = progress.results_writer() {
+        results.emit_result(&terminal);
+    }
+    Ok(SmallCopy::Done(exit_code))
+}
+
+/// The one summary line a completed copy prints, rendered from the same
+/// record the results stream settles with.
+fn print_transfer_summary(terminal: &crate::results::ResultRecord, elapsed: f64, deletions: &str) {
+    crate::output::human_stdout!(
+        "syq: transferred {} files ({}), {} unchanged ({} files), {} dirs created{}{}{}",
+        commas(terminal.files_transferred),
+        human(terminal.bytes_transferred),
+        human(terminal.bytes_unchanged),
+        commas(terminal.files_unchanged),
+        commas(terminal.directories_created),
+        deletions,
+        format_args!(
+            ", {} at {}/s",
+            crate::progress::hms(elapsed),
+            human((terminal.bytes_transferred as f64 / elapsed.max(0.001)) as u64)
+        ),
+        if terminal.errors > 0 {
+            format!(", {} errors", terminal.errors)
+        } else {
+            String::new()
+        }
+    );
 }
 
 /// Native source authority is the pinned endpoint-side base plus the raw
@@ -1494,31 +1896,6 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         }
         Endpoint::Local { .. } => crate::identity::supports_confined_socket_nodes(),
     };
-    let tcp_ports = use_tcp.then(|| parse_ports(&args.tcp_ports)).transpose()?;
-    let mut pending_tcp_setups = Vec::new();
-    if let Some(ports) = tcp_ports {
-        for (ep, ctl) in [(&src_ep, &mut src_ctl), (&dst_ep, &mut dst_ctl)] {
-            if let Endpoint::Remote(spec) = ep {
-                match spec.begin_tcp_setup(
-                    &mut **ctl,
-                    args.tcp_plain,
-                    ports,
-                    args.tcp_congestion.as_deref(),
-                ) {
-                    Ok(pending) => pending_tcp_setups.push((spec.clone(), pending)),
-                    Err(error) => {
-                        handle_tcp_setup_error(&args, spec, ports, error, &sched, &progress)?;
-                    }
-                }
-            }
-        }
-    }
-    if debug() {
-        crate::output::diagnostic!(
-            "syq: TCP route probes started at {:.2}s",
-            t0.elapsed().as_secs_f64()
-        );
-    }
     let maximum_workers = if autotune {
         tune::MAX
     } else {
@@ -1556,6 +1933,53 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     source_roots
         .set(registered_sources)
         .expect("source roots set once");
+    // A native push of a few small local files needs no data worker and no
+    // separate preflight: one control-connection turn selects, anchors,
+    // checks, and publishes. Source registration above was local, so nothing
+    // but the control handshake has crossed the network yet. Anything the
+    // fused request declines continues below on the same connections.
+    if small_copy_eligible(&args, srcs, dst, &src_ep, &dst_ep) {
+        match attempt_small_copy(
+            &args,
+            &opts,
+            srcs,
+            dst,
+            &src_ep,
+            &mut *src_ctl,
+            &mut *dst_ctl,
+            source_roots.get().expect("source roots registered"),
+            &progress,
+            t0,
+        )? {
+            SmallCopy::Done(code) => return Ok(code),
+            SmallCopy::Declined => {}
+        }
+    }
+    let tcp_ports = use_tcp.then(|| parse_ports(&args.tcp_ports)).transpose()?;
+    let mut pending_tcp_setups = Vec::new();
+    if let Some(ports) = tcp_ports {
+        for (ep, ctl) in [(&src_ep, &mut src_ctl), (&dst_ep, &mut dst_ctl)] {
+            if let Endpoint::Remote(spec) = ep {
+                match spec.begin_tcp_setup(
+                    &mut **ctl,
+                    args.tcp_plain,
+                    ports,
+                    args.tcp_congestion.as_deref(),
+                ) {
+                    Ok(pending) => pending_tcp_setups.push((spec.clone(), pending)),
+                    Err(error) => {
+                        handle_tcp_setup_error(&args, spec, ports, error, &sched, &progress)?;
+                    }
+                }
+            }
+        }
+    }
+    if debug() {
+        crate::output::diagnostic!(
+            "syq: TCP route probes started at {:.2}s",
+            t0.elapsed().as_secs_f64()
+        );
+    }
     // One spelling for the destination root: every derived key — claims,
     // delete roots, destination-walk paths, receiver-computed sidecar names —
     // flows from this, and the receiver rebuilds paths through `Path`, which
@@ -2690,24 +3114,10 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 crate::progress::hms(elapsed)
             );
         } else {
-            crate::output::human_stdout!(
-                "syq: transferred {} files ({}), {} unchanged ({} files), {} dirs created{}{}{}",
-                commas(terminal.files_transferred),
-                human(terminal.bytes_transferred),
-                human(terminal.bytes_unchanged),
-                commas(terminal.files_unchanged),
-                commas(terminal.directories_created),
-                deletion_summary(delete_plan, deleted, opts.max_delete),
-                format_args!(
-                    ", {} at {}/s",
-                    crate::progress::hms(elapsed),
-                    human((terminal.bytes_transferred as f64 / elapsed.max(0.001)) as u64)
-                ),
-                if terminal.errors > 0 {
-                    format!(", {} errors", terminal.errors)
-                } else {
-                    String::new()
-                }
+            print_transfer_summary(
+                &terminal,
+                elapsed,
+                &deletion_summary(delete_plan, deleted, opts.max_delete),
             );
         }
     }
@@ -7209,12 +7619,9 @@ impl Worker {
     /// with -p the source mode; without -p an existing file keeps its own mode
     /// and a new file gets the source mode minus the umask.
     fn create_mode(&self, job: &FileJob) -> u32 {
-        if self.opts.perms {
-            job.entry.mode & 0o7777
-        } else if let Some(d) = job.dst_entry.as_ref().filter(|d| d.kind == Kind::File) {
-            d.mode & 0o7777
-        } else {
-            job.entry.mode & 0o777 & !self.opts.umask
+        match job.dst_entry.as_ref().filter(|d| d.kind == Kind::File) {
+            Some(d) if !self.opts.perms => d.mode & 0o7777,
+            _ => fresh_file_mode(&self.opts, &job.entry),
         }
     }
 

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -939,7 +939,13 @@ fn attempt_small_copy(
             let name = source.basename();
             (join(&operator_dst_root, &name), name)
         } else {
-            (operator_dst_root.clone(), Vec::new())
+            (
+                join(
+                    &directory,
+                    dst_leaf.as_ref().expect("exact destination leaf"),
+                ),
+                Vec::new(),
+            )
         };
         if targets.iter().any(|(existing, _, _)| *existing == dst_path) {
             return Ok(SmallCopy::Declined);

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7264,6 +7264,211 @@ fn small_pushes_take_one_turn_and_match_the_engine() {
     assert_eq!(read(&t.path("dest-fast/new/one.txt")), b"one");
 }
 
+/// The one-turn push refuses, fails, warns, and explains itself exactly as
+/// the engine does: the fresh-destination capacity preflight, a staging
+/// failure that publishes nothing, a source named like a sidecar, and the
+/// -vv route report.
+#[test]
+fn small_push_refusals_and_failures_match_the_engine() {
+    let t = Tmp::new();
+    let ssh = fake_ssh(&t);
+    write(&t.path("src/one.txt"), b"one");
+    write(&t.path("src/two.txt"), b"two");
+    write(&t.path("src/three.txt"), b"three");
+    let sources = [t.s("src/one.txt"), t.s("src/two.txt"), t.s("src/three.txt")];
+    let push = |label: &str,
+                engine: bool,
+                env: &[(&str, &str)],
+                extra: &[&str],
+                sources: &[String],
+                placement: &[&str]| {
+        let results = t.s(&format!("{label}.ndjson"));
+        let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+        command
+            .args([
+                "cp",
+                "--syq-path",
+                env!("CARGO_BIN_EXE_syq"),
+                "--no-progress",
+                "--results",
+                &results,
+            ])
+            .args(extra)
+            .args(sources)
+            .args(["--to", "fake.example"])
+            .args(placement)
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path(&format!("{label}.rsh.log")))
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+            )
+            .env("SYQ_DEBUG", "1");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        if engine {
+            command.env("SYQ_TEST_DISABLE_SMALL_COPY", "1");
+        }
+        let output = command.run().unwrap();
+        let records: Vec<serde_json::Value> = String::from_utf8(read(Path::new(results.as_str())))
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        (output, records)
+    };
+    // Records compare with the destination directory's own name masked,
+    // since a failure message names the path it failed on.
+    let comparable = |records: &[serde_json::Value], dir: &str| {
+        let mut operations: Vec<String> = records
+            .iter()
+            .filter(|record| record["type"] == "operation_result")
+            .map(|record| {
+                let mut record = record.clone();
+                record.as_object_mut().unwrap().remove("seq");
+                record.to_string().replace(&t.s(dir), "<destination>")
+            })
+            .collect();
+        operations.sort();
+        let mut terminal = records.last().unwrap().clone();
+        for key in ["seq", "elapsed_ms"] {
+            terminal.as_object_mut().unwrap().remove(key);
+        }
+        assert_eq!(terminal["type"], "result");
+        (operations, terminal)
+    };
+
+    // An empty destination directory is fresh, so the capacity preflight
+    // applies; with no space reported, both refuse before writing anything.
+    for dir in ["cap-fast", "cap-engine"] {
+        fs::create_dir_all(t.path(dir)).unwrap();
+    }
+    let no_space = [("SYQ_TEST_AVAILABLE_BYTES", "0")];
+    let (fast, fast_records) = push(
+        "cap-fast",
+        false,
+        &no_space,
+        &[],
+        &sources,
+        &["--into", &t.s("cap-fast")],
+    );
+    let (engine, engine_records) = push(
+        "cap-engine",
+        true,
+        &no_space,
+        &[],
+        &sources,
+        &["--into", &t.s("cap-engine")],
+    );
+    assert_eq!(fast.status.code(), Some(1));
+    assert_eq!(engine.status.code(), Some(1));
+    for output in [&fast, &engine] {
+        assert!(
+            stderr_of(output).contains("fresh destination capacity preflight failed"),
+            "{}",
+            stderr_of(output)
+        );
+    }
+    assert!(
+        stderr_of(&fast).contains("capacity preflight would refuse"),
+        "{}",
+        stderr_of(&fast)
+    );
+    assert_eq!(
+        comparable(&fast_records, "cap-fast"),
+        comparable(&engine_records, "cap-engine")
+    );
+    for dir in ["cap-fast", "cap-engine"] {
+        assert!(fs::read_dir(t.path(dir)).unwrap().next().is_none(), "{dir}");
+    }
+
+    // A staging failure publishes nothing and leaves no sidecar; the engine
+    // then reports the same failure for the same file and publishes the rest.
+    for dir in ["stage-fast", "stage-engine"] {
+        fs::create_dir_all(t.path(dir)).unwrap();
+    }
+    let injected = [("SYQ_TEST_FAIL_PUT_SMALL_BEFORE_RENAME", "/two.txt")];
+    let (fast, fast_records) = push(
+        "stage-fast",
+        false,
+        &injected,
+        &[],
+        &sources,
+        &["--into", &t.s("stage-fast")],
+    );
+    let (engine, engine_records) = push(
+        "stage-engine",
+        true,
+        &injected,
+        &[],
+        &sources,
+        &["--into", &t.s("stage-engine")],
+    );
+    assert!(
+        stderr_of(&fast).contains("staging failed"),
+        "{}",
+        stderr_of(&fast)
+    );
+    assert_eq!(fast.status.code(), Some(23));
+    assert_eq!(engine.status.code(), Some(23));
+    assert_eq!(
+        comparable(&fast_records, "stage-fast"),
+        comparable(&engine_records, "stage-engine")
+    );
+    for dir in ["stage-fast", "stage-engine"] {
+        assert_eq!(read(&t.path(dir).join("one.txt")), b"one", "{dir}");
+        assert_eq!(read(&t.path(dir).join("three.txt")), b"three", "{dir}");
+        assert!(!t.path(dir).join("two.txt").exists(), "{dir}");
+        assert_eq!(partial_files(&t.path(dir)).len(), 1, "{dir}");
+    }
+
+    // A source named like a sidecar reaches the engine, which warns.
+    let sidecar = partial_files(&t.path("stage-engine")).pop().unwrap();
+    fs::create_dir_all(t.path("side")).unwrap();
+    let (side, _) = push(
+        "side",
+        false,
+        &[],
+        &[],
+        &[sidecar.to_string_lossy().into_owned()],
+        &["--into", &t.s("side")],
+    );
+    assert_output_ok(&side);
+    assert!(
+        !stderr_of(&side).contains("small copy: sending"),
+        "{}",
+        stderr_of(&side)
+    );
+    assert!(
+        stderr_of(&side).contains("recognizable SYQ partial path"),
+        "{}",
+        stderr_of(&side)
+    );
+
+    // -vv explains the helper and the route.
+    fs::create_dir_all(t.path("verbose")).unwrap();
+    let (verbose, _) = push(
+        "verbose",
+        false,
+        &[],
+        &["-vv"],
+        &sources,
+        &["--into", &t.s("verbose")],
+    );
+    assert_output_ok(&verbose);
+    let report = stderr_of(&verbose);
+    assert!(report.contains("small copy: published"), "{report}");
+    for line in [
+        "  helper: ",
+        "  transport: control connection",
+        "syq: concurrency: no data connections",
+    ] {
+        assert!(report.contains(line), "{line} missing from:\n{report}");
+    }
+}
+
 #[test]
 fn native_rm_rejects_conflicting_or_local_remote_helper_selection() {
     let t = Tmp::new();

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7071,6 +7071,7 @@ fn native_remote_rm_uses_explicit_or_path_selected_helpers() {
 fn small_pushes_take_one_turn_and_match_the_engine() {
     let t = Tmp::new();
     let ssh = fake_ssh(&t);
+    fs::create_dir_all(t.path("remote-home")).unwrap();
     write(&t.path("src/one.txt"), b"one");
     write(&t.path("src/two.txt"), b"");
     write(&t.path("src/three.bin"), &[7u8; 4096]);
@@ -7081,6 +7082,7 @@ fn small_pushes_take_one_turn_and_match_the_engine() {
         let results = t.s(&format!("{label}.ndjson"));
         let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
         command
+            .current_dir(t.path("remote-home"))
             .args([
                 "cp",
                 "--syq-path",
@@ -7218,6 +7220,37 @@ fn small_pushes_take_one_turn_and_match_the_engine() {
         comparable(&exact_records),
         comparable(&exact_engine_records)
     );
+
+    // Relative exact placement uses the same request-prefix spelling as the
+    // receiver. A plain leaf must not cost a declined request and fallback.
+    for (label, prefix) in [("relative", ""), ("dot-relative", "./")] {
+        let fast_name = format!("{prefix}{label}-fast.txt");
+        let engine_name = format!("{prefix}{label}-engine.txt");
+        let (fast, fast_records) = push(label, false, &sources[..1], &["--as", &fast_name]);
+        let (engine, engine_records) = push(
+            &format!("{label}-engine"),
+            true,
+            &sources[..1],
+            &["--as", &engine_name],
+        );
+        assert_output_ok(&fast);
+        assert_output_ok(&engine);
+        assert!(
+            stderr_of(&fast).contains("small copy: published"),
+            "{}",
+            stderr_of(&fast)
+        );
+        assert_eq!(read(&t.path("remote-home").join(&fast_name)), b"one");
+        assert_eq!(summary(&fast), summary(&engine));
+        assert_eq!(comparable(&fast_records), comparable(&engine_records));
+        assert_eq!(
+            fs::read_to_string(t.path(&format!("{label}.rsh.log")))
+                .unwrap()
+                .lines()
+                .count(),
+            1,
+        );
+    }
 
     // An existing target is the engine's case: the one-turn path writes
     // nothing and hands over on the same connection.
@@ -7384,8 +7417,8 @@ fn small_push_refusals_and_failures_match_the_engine() {
         assert!(fs::read_dir(t.path(dir)).unwrap().next().is_none(), "{dir}");
     }
 
-    // A staging failure publishes nothing and leaves no sidecar; the engine
-    // then reports the same failure for the same file and publishes the rest.
+    // A staging failure publishes no final files; the engine then reports
+    // the same failure, keeps its partial, and publishes the rest.
     for dir in ["stage-fast", "stage-engine"] {
         fs::create_dir_all(t.path(dir)).unwrap();
     }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7297,6 +7297,76 @@ fn small_pushes_take_one_turn_and_match_the_engine() {
     assert_eq!(read(&t.path("dest-fast/new/one.txt")), b"one");
 }
 
+/// Human output failures must leave the small-copy result and receipt intact.
+#[test]
+fn small_push_preserves_results_with_closed_human_streams() {
+    use std::os::fd::OwnedFd;
+    use std::os::unix::net::UnixStream;
+
+    let broken_output = || {
+        let (reader, writer) = UnixStream::pair().unwrap();
+        drop(reader);
+        Stdio::from(OwnedFd::from(writer))
+    };
+    for broken_stderr in [false, true] {
+        let t = Tmp::new();
+        let ssh = fake_ssh(&t);
+        fs::create_dir_all(t.path("remote-home/dest")).unwrap();
+        write(&t.path("source"), b"small copy survives broken output");
+        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "cp",
+                "--syq-path",
+                env!("CARGO_BIN_EXE_syq"),
+                "-vv",
+                "--no-progress",
+            ])
+            .arg(t.path("source"))
+            .args(["--to", "fake.example", "--into", &t.s("remote-home/dest")])
+            .args(["--results", &t.s("results.ndjson")])
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+            )
+            .env("SYQ_DEBUG", "1")
+            .stdin(Stdio::null())
+            .stdout(broken_output())
+            .stderr(if broken_stderr {
+                broken_output()
+            } else {
+                Stdio::piped()
+            })
+            .start()
+            .unwrap()
+            .wait_with_output()
+            .unwrap();
+        assert_output_ok(&output);
+        assert_eq!(
+            read(&t.path("remote-home/dest/source")),
+            read(&t.path("source"))
+        );
+        let records = fs::read_to_string(t.path("results.ndjson")).unwrap();
+        let terminal: serde_json::Value =
+            serde_json::from_str(records.lines().last().unwrap()).unwrap();
+        assert_eq!(terminal["type"], "result");
+        assert_eq!(terminal["exit_code"], 0);
+        assert_eq!(terminal["files_transferred"], 1);
+        assert_eq!(
+            fs::read_to_string(t.path("rsh.log"))
+                .unwrap()
+                .lines()
+                .count(),
+            1
+        );
+        if !broken_stderr {
+            assert!(stderr_of(&output).contains("small copy: published"));
+        }
+    }
+}
+
 /// The one-turn push refuses, fails, warns, and explains itself exactly as
 /// the engine does: the fresh-destination capacity preflight, a staging
 /// failure that publishes nothing, a source named like a sidecar, and the

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7063,6 +7063,207 @@ fn native_remote_rm_uses_explicit_or_path_selected_helpers() {
     assert!(log.contains("syq --server"), "{log}");
 }
 
+/// A native push of a few small local files into a remote directory travels
+/// as one control-connection request. Its destination state, summary, and
+/// results records must match the ordinary engine's for the same copy, and
+/// anything the one-turn path declines must reach the engine unchanged.
+#[test]
+fn small_pushes_take_one_turn_and_match_the_engine() {
+    let t = Tmp::new();
+    let ssh = fake_ssh(&t);
+    write(&t.path("src/one.txt"), b"one");
+    write(&t.path("src/two.txt"), b"");
+    write(&t.path("src/three.bin"), &[7u8; 4096]);
+    fs::set_permissions(t.path("src/one.txt"), fs::Permissions::from_mode(0o640)).unwrap();
+    set_mtime(&t.path("src/one.txt"), 1_700_000_000);
+    let sources = [t.s("src/one.txt"), t.s("src/two.txt"), t.s("src/three.bin")];
+    let push = |label: &str, engine: bool, sources: &[String], placement: &[&str]| {
+        let results = t.s(&format!("{label}.ndjson"));
+        let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+        command
+            .args([
+                "cp",
+                "--syq-path",
+                env!("CARGO_BIN_EXE_syq"),
+                "--no-progress",
+                "-v",
+                "--results",
+                &results,
+            ])
+            .args(sources)
+            .args(["--to", "fake.example"])
+            .args(placement)
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path(&format!("{label}.rsh.log")))
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+            )
+            .env("SYQ_DEBUG", "1");
+        if engine {
+            command.env("SYQ_TEST_DISABLE_SMALL_COPY", "1");
+        }
+        let output = command.run().unwrap();
+        let records: Vec<serde_json::Value> = String::from_utf8(read(Path::new(&results)))
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        (output, records)
+    };
+    // The comparable part of a results stream: operation records as a set,
+    // because worker order is not deterministic, and the terminal record
+    // without its timing. Periodic progress records are not part of it.
+    let comparable = |records: &[serde_json::Value]| {
+        let mut operations: Vec<String> = records
+            .iter()
+            .filter(|record| record["type"] == "operation_result")
+            .map(|record| {
+                let mut record = record.clone();
+                record.as_object_mut().unwrap().remove("seq");
+                record.to_string()
+            })
+            .collect();
+        operations.sort();
+        let mut terminal = records.last().unwrap().clone();
+        for key in ["seq", "elapsed_ms"] {
+            terminal.as_object_mut().unwrap().remove(key);
+        }
+        assert_eq!(terminal["type"], "result");
+        (operations, terminal)
+    };
+    // The summary line without its elapsed time and rate.
+    let summary = |output: &Output| {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let line = stdout
+            .lines()
+            .find(|line| line.starts_with("syq: transferred"))
+            .unwrap_or_else(|| panic!("no summary in {stdout}"));
+        let (head, _) = line.rsplit_once(" at ").unwrap();
+        head.rsplit_once(", ").unwrap().0.to_string()
+    };
+
+    fs::create_dir_all(t.path("dest-fast")).unwrap();
+    fs::create_dir_all(t.path("dest-engine")).unwrap();
+    let (fast, fast_records) = push("fast", false, &sources, &["--into", &t.s("dest-fast")]);
+    let (engine, engine_records) = push("engine", true, &sources, &["--into", &t.s("dest-engine")]);
+    assert_output_ok(&fast);
+    assert_output_ok(&engine);
+    assert!(
+        stderr_of(&fast).contains("small copy: published"),
+        "{}",
+        stderr_of(&fast)
+    );
+    assert!(
+        !stderr_of(&engine).contains("small copy"),
+        "{}",
+        stderr_of(&engine)
+    );
+    assert_eq!(
+        summary(&fast),
+        "syq: transferred 3 files (4.00 KiB), 0 B unchanged (0 files), 0 dirs created"
+    );
+    assert_eq!(summary(&fast), summary(&engine));
+    assert_eq!(comparable(&fast_records), comparable(&engine_records));
+    for name in ["one.txt", "two.txt", "three.bin"] {
+        let (a, b) = (
+            t.path("dest-fast").join(name),
+            t.path("dest-engine").join(name),
+        );
+        assert_eq!(read(&a), read(&t.path("src").join(name)));
+        assert_eq!(read(&a), read(&b));
+        let (ma, mb) = (fs::metadata(&a).unwrap(), fs::metadata(&b).unwrap());
+        assert_eq!(ma.mode() & 0o7777, mb.mode() & 0o7777, "{name}");
+        assert_eq!(ma.mtime(), mb.mtime(), "{name}");
+    }
+    assert_eq!(
+        fs::metadata(t.path("dest-fast/one.txt")).unwrap().mtime(),
+        1_700_000_000
+    );
+    let listed: Vec<String> = String::from_utf8_lossy(&fast.stdout)
+        .lines()
+        .filter(|line| !line.starts_with("syq:"))
+        .map(str::to_string)
+        .collect();
+    assert_eq!(listed, ["one.txt", "two.txt", "three.bin"]);
+    // One ssh session carried the whole copy: no route probe, no data worker.
+    assert_eq!(
+        fs::read_to_string(t.path("fast.rsh.log"))
+            .unwrap()
+            .lines()
+            .count(),
+        1
+    );
+
+    // Exact placement of one file, in both paths.
+    let (exact, exact_records) = push(
+        "exact",
+        false,
+        &sources[..1],
+        &["--as", &t.s("dest-fast/renamed.txt")],
+    );
+    let (exact_engine, exact_engine_records) = push(
+        "exact-engine",
+        true,
+        &sources[..1],
+        &["--as", &t.s("dest-engine/renamed.txt")],
+    );
+    assert_output_ok(&exact);
+    assert_output_ok(&exact_engine);
+    assert!(stderr_of(&exact).contains("small copy: published"));
+    assert_eq!(read(&t.path("dest-fast/renamed.txt")), b"one");
+    assert_eq!(summary(&exact), summary(&exact_engine));
+    assert_eq!(
+        comparable(&exact_records),
+        comparable(&exact_engine_records)
+    );
+
+    // An existing target is the engine's case: the one-turn path writes
+    // nothing and hands over on the same connection.
+    write(&t.path("dest-fast/one.txt"), b"stale");
+    write(&t.path("dest-engine/one.txt"), b"stale");
+    let (fast_existing, fast_existing_records) = push(
+        "fast-existing",
+        false,
+        &sources,
+        &["--into", &t.s("dest-fast")],
+    );
+    let (engine_existing, engine_existing_records) = push(
+        "engine-existing",
+        true,
+        &sources,
+        &["--into", &t.s("dest-engine")],
+    );
+    assert_output_ok(&fast_existing);
+    assert_output_ok(&engine_existing);
+    let declined = stderr_of(&fast_existing);
+    assert!(declined.contains("using the ordinary engine"), "{declined}");
+    assert!(!declined.contains("small copy: published"), "{declined}");
+    assert_eq!(summary(&fast_existing), summary(&engine_existing));
+    assert_eq!(
+        comparable(&fast_existing_records),
+        comparable(&engine_existing_records)
+    );
+    assert_eq!(read(&t.path("dest-fast/one.txt")), b"one");
+
+    // A missing directory is the engine's to create after the receiver
+    // declines the one-turn request.
+    let (missing, _) = push(
+        "missing",
+        false,
+        &sources[..1],
+        &["--into", &t.s("dest-fast/new")],
+    );
+    assert_output_ok(&missing);
+    assert!(
+        stderr_of(&missing).contains("small copy declined"),
+        "{}",
+        stderr_of(&missing)
+    );
+    assert_eq!(read(&t.path("dest-fast/new/one.txt")), b"one");
+}
+
 #[test]
 fn native_rm_rejects_conflicting_or_local_remote_helper_selection() {
     let t = Tmp::new();

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -140,6 +140,33 @@ fi
 syq completion cache clear >/dev/null
 syq persist off >/dev/null
 
+printf 'case: small native push to an ordinary SSH destination takes one turn\n'
+small_source=/tmp/syq-real-ssh-small.bin
+small_debug=/tmp/syq-real-ssh-small.debug
+small_results=/tmp/syq-real-ssh-small.ndjson
+head -c 1024 /dev/urandom >"$small_source"
+ssh source 'rm -rf /tmp/syq-real-ssh/small-destination && install -d /tmp/syq-real-ssh/small-destination'
+SYQ_DEBUG=1 syq cp --no-progress --results "$small_results" \
+    "$small_source" --to source --into /tmp/syq-real-ssh/small-destination \
+    2>"$small_debug"
+small_status=$(tail -n 1 "$small_results")
+case "$small_status" in
+    *'"status":"success"'*'"type":"result"'*) ;;
+    *)
+        echo 'small push did not settle successfully:' >&2
+        cat "$small_results" "$small_debug" >&2
+        exit 1
+        ;;
+esac
+if ! grep -q 'small copy: published' "$small_debug"; then
+    echo 'small push did not use the one-turn path:' >&2
+    cat "$small_debug" >&2
+    exit 1
+fi
+small_expected=$(sha256sum "$small_source" | cut -d ' ' -f 1)
+small_actual=$(ssh source 'sha256sum /tmp/syq-real-ssh/small-destination/syq-real-ssh-small.bin' | cut -d ' ' -f 1)
+test "$small_expected" = "$small_actual"
+
 printf 'case: restricted enrollment refuses an SSH control-plane destination\n'
 make_tree source /tmp/syq-real-ssh/protected-source protected
 if protected_output=$(syq cp --no-progress -j 2 --preserve=permissions \


### PR DESCRIPTION
Native pushes of a few small local files can check the destination, stage the contents, and publish the files in one control-connection request. The request is limited to 64 regular files, 1 MiB per file and 4 MiB total, and uses the existing registered source and destination handles, metadata rules, capacity assessment, and result reporting.

The fast path handles both `--into` and `--as`, including a plain relative target such as `--as output`. Destination paths consistently include their request prefix, and the receiver accepts a root-directory prefix while still rejecting nested or escaping names. Tests compare file contents, summary and result records with the transfer engine and require a single SSH session.

Freshness or capacity refusals continue through the transfer engine. A staging failure opens a fresh destination control session and can leave resumable sidecars. Publications retain per-file outcomes, and comments now describe those outcomes accurately. Known differences: `-v` follows source order, short copies may finish before periodic progress output, and a source change detected after publication is reported as an error without a retry.

#187 merged into master as `f243421`. This PR now targets master; `92ab059` incorporates that base and resolves the overlapping speed-documentation edit from #203.

The rebase preserves master #202's output handling: a closed human-output stream cannot interrupt small-copy publication or result recording. A focused regression checks closed stdout and stderr, copied bytes, the terminal result, and one SSH session.

Validation on 2026-09-05:

- At `cf39545`: formatting, Clippy with warnings denied, 415 unit tests, all three `small_push` integration tests, all three output-failure integration tests, documentation links, and `git diff --check` passed.
- Combined verification branch at `dc63ccc` contains #187 `d7b3572`, #191 `cf39545`, and #197 `574e06f`. Formatting, Clippy with warnings denied, `cargo test --all-targets` (419 unit, 379 local integration, 3 output, 7 update tests), documentation links, and `git diff --check` passed.
- Both real-SSH profiles passed at combined `7054af7`. The only subsequent source change, verified with `git diff 7054af7 dc63ccc`, initializes the new field in an upstream unit-test fixture; production code is identical.
- Not run against these changes: macOS execution, the separate rsync-compat suite, or latency benchmarks.

The task worktree is clean. PRs do not trigger automated test workflows; the checks above were run locally. Ready for re-review; no PR has been merged by this update.

Pre-merge synchronization: documentation links and whitespace checks passed at `92ab059`. Its Rust code, executable test files, real-SSH fixtures, and Cargo inputs are unchanged from the tested `cf39545`; only the documentation audit and its conflict resolution were added.
