### PR TITLE
Release syq 0.2.0

### DIFF
--- a/.github/release-notes/v0.2.0.md
+++ b/.github/release-notes/v0.2.0.md
@@ -1,0 +1,26 @@
+syq 0.2.0 is the first release built around the new native command surface. It
+keeps syq's parallel transfer engine, makes direct remote-to-remote copies a
+first-class workflow, and adds the pieces needed to compose transfers from
+scripts and programs.
+
+## Highlights
+
+- Faster common transfers through lower metadata overhead, improved resource
+  use, and better tuning for short copies, while retaining parallel data paths
+  for fast LANs and lossy WANs.
+- Direct remote-to-remote copies with explicit coordinator placement, managed
+  SSH reuse, restricted receivers, and receiver-attested outcomes.
+- Mappings as data: `syq map` emits JSON Lines source-to-destination claims and
+  `syq cp --mapping` validates and executes them.
+- Preview automation results: native `cp` and `rm` can write versioned NDJSON
+  outcome streams with `--results` or `--results-fd`. This interface remains
+  experimental while it gets real-world use.
+- Stronger filesystem confinement, expanded rsync compatibility coverage,
+  shell completion, and improved macOS support.
+
+## Breaking native CLI changes since 0.1.8
+
+- `syq cp-prune` is now `syq cp --prune`.
+- `--checkpoint` and cross-run checkpoint files have been removed. Rerun an
+  interrupted copy; syq compares the destination and transfers what is still
+  needed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,8 +191,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          release_notes=".github/release-notes/$GITHUB_REF_NAME.md"
+          test -s "$release_notes" || {
+            echo "Release notes are missing: $release_notes" >&2
+            exit 1
+          }
           gh release create "$GITHUB_REF_NAME" --draft --verify-tag \
-            --title "syq ${GITHUB_REF_NAME#v}" --generate-notes
+            --title "syq ${GITHUB_REF_NAME#v}" --generate-notes \
+            --notes "$(cat "$release_notes")"
           gh release upload "$GITHUB_REF_NAME" dist/*
           scripts/verify-release-assets.sh "$GITHUB_REF_NAME" dist
           gh release edit "$GITHUB_REF_NAME" --draft=false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -136,8 +136,11 @@ connection, so enable it only for a trusted release host rather than globally.
 ## Cutting a release
 
 1. Update the package version in `Cargo.toml`, run `cargo check` to refresh
-   `Cargo.lock`, then run the normal locked checks to validate it. Update
-   release notes and merge through the protected branch. Peer compatibility is
+   `Cargo.lock`, then run the normal locked checks to validate it. Write the
+   curated introduction and breaking-change notes in
+   `.github/release-notes/v<version>.md`; the release workflow prepends that
+   file to GitHub's generated contributor and change list. Merge the version
+   and release notes through the protected branch. Peer compatibility is
    the immutable release identity, so there is no separate protocol number to
    maintain. Native command changes must also be classified in
    `sdk/python/native-api.json`. A feature may use the `follow_up` disposition

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 grep -F 'rust,sdks,macos,linux-arm64,conformance' \
   "$script_dir/../.github/workflows/release.yml" >/dev/null
+grep -F '.github/release-notes/$GITHUB_REF_NAME.md' \
+  "$script_dir/../.github/workflows/release.yml" >/dev/null
 work=$(mktemp -d "${TMPDIR:-/tmp}/syq-release-orchestration-test.XXXXXXXX")
 cleanup() { rm -rf "$work"; }
 trap cleanup EXIT HUP INT TERM

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 grep -F 'rust,sdks,macos,linux-arm64,conformance' \
   "$script_dir/../.github/workflows/release.yml" >/dev/null
-grep -F '.github/release-notes/$GITHUB_REF_NAME.md' \
+grep -F ".github/release-notes/\$GITHUB_REF_NAME.md" \
   "$script_dir/../.github/workflows/release.yml" >/dev/null
 work=$(mktemp -d "${TMPDIR:-/tmp}/syq-release-orchestration-test.XXXXXXXX")
 cleanup() { rm -rf "$work"; }

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -197,28 +197,40 @@ fn assert_failure_contains(output: &Output, expected: &str) {
     );
 }
 
+fn next_release_version() -> String {
+    let mut version = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    version.patch = version.patch.checked_add(1).unwrap();
+    version.to_string()
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn signed_self_update_replaces_only_the_receipted_copy() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
+    let release_version = next_release_version();
+    let fixture = UpdateFixture::new(&release_version, &format!("v{release_version}"));
     fixture.register();
 
     let update = fixture.command("--self-update");
     assert_success(&update);
-    assert!(String::from_utf8_lossy(&update.stdout).contains("updated syq to 0.2.0"));
+    assert!(String::from_utf8_lossy(&update.stdout)
+        .contains(&format!("updated syq to {release_version}")));
 
     let version = Command::new(&fixture.installed)
         .arg("--version")
         .output()
         .unwrap();
-    assert_eq!(String::from_utf8_lossy(&version.stdout).trim(), "syq 0.2.0");
-    assert_eq!(fixture.receipt()["version"], "0.2.0");
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).trim(),
+        format!("syq {release_version}")
+    );
+    assert_eq!(fixture.receipt()["version"], release_version);
 }
 
 #[cfg(target_os = "linux")]
 #[test]
 fn self_update_rejects_a_tampered_signed_manifest_without_changing_install() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
+    let release_version = next_release_version();
+    let fixture = UpdateFixture::new(&release_version, &format!("v{release_version}"));
     fixture.register();
     let path = fixture.temp.path("fixtures/syq-release-manifest.json");
     let mut manifest: serde_json::Value =
@@ -234,7 +246,8 @@ fn self_update_rejects_a_tampered_signed_manifest_without_changing_install() {
 #[cfg(target_os = "linux")]
 #[test]
 fn self_update_rejects_a_tampered_archive_without_changing_install() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
+    let release_version = next_release_version();
+    let fixture = UpdateFixture::new(&release_version, &format!("v{release_version}"));
     fixture.register();
     let target = if cfg!(target_arch = "x86_64") {
         "linux-x86_64"
@@ -257,7 +270,8 @@ fn self_update_rejects_a_tampered_archive_without_changing_install() {
 #[cfg(target_os = "linux")]
 #[test]
 fn self_update_rejects_an_executable_with_the_wrong_build_identity() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0+dev.wrong");
+    let release_version = next_release_version();
+    let fixture = UpdateFixture::new(&release_version, &format!("v{release_version}+dev.wrong"));
     fixture.register();
 
     let update = fixture.command("--self-update");
@@ -290,7 +304,8 @@ fn self_update_refuses_a_signed_downgrade() {
 #[cfg(target_os = "linux")]
 #[test]
 fn receipt_is_bound_to_the_exact_installed_executable() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
+    let release_version = next_release_version();
+    let fixture = UpdateFixture::new(&release_version, &format!("v{release_version}"));
     fixture.register();
     let other = fixture.temp.path("other/syq");
     fs::create_dir_all(other.parent().unwrap()).unwrap();
@@ -306,7 +321,8 @@ fn receipt_is_bound_to_the_exact_installed_executable() {
 #[cfg(target_os = "linux")]
 #[test]
 fn source_install_cannot_create_or_use_a_standalone_receipt_implicitly() {
-    let fixture = UpdateFixture::new("0.2.0", "v0.2.0");
+    let release_version = next_release_version();
+    let fixture = UpdateFixture::new(&release_version, &format!("v{release_version}"));
 
     let update = fixture.command("--self-update");
     assert_failure_contains(&update, "self-update is only available");


### PR DESCRIPTION
## Summary

- bump the syq crate and binary to 0.2.0
- prepend curated launch highlights and breaking changes to generated GitHub release notes
- make updater integration fixtures derive a newer version from the package under test

## Verification

- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets (410 unit, 367 local integration, 7 updater tests)
- scripts/test-real-ssh.sh
- scripts/check-workflows.sh
- scripts/test-release-orchestration.sh
- scripts/test-release-tools.sh
- scripts/test-cargo-package.sh
- scripts/test-installer.sh
- python3 scripts/check-python-api-sync.py
- scripts/branch-status.sh --check
