### PR TITLE
Keep one version of everything

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -424,7 +424,7 @@ per-command setup to milliseconds and avoiding another hardware-token
 interaction. `status` shows the global scope and its recorded endpoints;
 `off` disables the policy, asks every live syq-owned master to exit, and
 removes the global runtime scope. The durable preference lives in
-`$XDG_CONFIG_HOME/syq/persistence-v1.json` (normally under `~/.config`), while
+`$XDG_CONFIG_HOME/syq/persistence.json` (normally under `~/.config`), while
 control sockets live in a private per-user runtime directory.
 
 Scripts can avoid changing that shared preference by creating an isolated
@@ -505,8 +505,8 @@ scope. Port-specific entries are offered in native endpoint syntax only;
 `host:2222` is a remote path, not a port, in rsync syntax.
 
 The learned suggestions are a disposable local cache at
-`$XDG_CACHE_HOME/syq/completion-endpoints-v1.json`, normally
-`~/.cache/syq/completion-endpoints-v1.json`. It contains at most 100 recently
+`$XDG_CACHE_HOME/syq/completion-endpoints.json`, normally
+`~/.cache/syq/completion-endpoints.json`. It contains at most 100 recently
 successful endpoint names, users, ports, and timestamps. It contains no paths,
 credentials, keys, or transfer history. Manage it with:
 

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -138,7 +138,7 @@ key.
 ## Signed receipts
 
 HostA also cannot forge a clean account of what hostB's restricted receiver
-did. Every attached command-restricted transfer ends with a v2 receipt. Its
+did. Every attached command-restricted transfer ends with a receipt. Its
 canonical stream records one outcome for every receiver-visible logical
 pathname mutation: one file lifecycle, each directory/symlink/special or
 metadata operation, and each individual `--prune` unlink or rmdir. Failed and

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -197,8 +197,8 @@ Remembered results are keyed only by the directional endpoint path and
 transport (TCP and ssh learn separately), not by RTT, workload, filesystem or
 other volatile telemetry. A stale hint only costs the tuner a probe or two. The
 cache is
-`$XDG_CACHE_HOME/syq/tuning-v1.json` (normally
-`~/.cache/syq/tuning-v1.json`; set `SYQ_TUNING_CACHE` to override it or to an
+`$XDG_CACHE_HOME/syq/tuning.json` (normally
+`~/.cache/syq/tuning.json`; set `SYQ_TUNING_CACHE` to override it or to an
 empty value to disable it). An explicit connection count, dry runs, verification, short runs
 that compare no counts, failed/aborted copies, and runs whose TCP path falls
 back to ssh after workers start do not update it; the last case may contain

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -23,8 +23,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-const CACHE_VERSION: u8 = 1;
-const CACHE_FILE: &str = "completion-endpoints-v1.json";
+const CACHE_FILE: &str = "completion-endpoints.json";
 const CACHE_LOCK: &str = ".completion-endpoints.lock";
 const MAX_CACHED_ENDPOINTS: usize = 100;
 const MAX_CACHE_BYTES: u64 = 1024 * 1024;
@@ -129,20 +128,10 @@ impl CachedEndpoint {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct CompletionCache {
-    version: u8,
     endpoints: Vec<CachedEndpoint>,
-}
-
-impl Default for CompletionCache {
-    fn default() -> Self {
-        Self {
-            version: CACHE_VERSION,
-            endpoints: Vec::new(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -444,13 +433,6 @@ fn read_cache() -> Result<CompletionCache> {
     file.read_to_end(&mut bytes)?;
     let mut cache: CompletionCache = serde_json::from_slice(&bytes)
         .with_context(|| format!("parse completion cache {}", path.display()))?;
-    if cache.version != CACHE_VERSION {
-        bail!(
-            "unsupported completion cache version {} in {}",
-            cache.version,
-            path.display()
-        );
-    }
     cache.endpoints.truncate(MAX_CACHED_ENDPOINTS);
     Ok(cache)
 }

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -2221,9 +2221,9 @@ mod tests {
             &receipted,
             &context(SIGNER, TARGET, NOW, 0),
             &fixture.policy(),
-            &fixture.replay("in-process-receipt-v2-signature-replay"),
+            &fixture.replay("in-process-receipt-signature-replay"),
         )
-        .expect("OpenSSH must accept the signed receipt v2 policy");
+        .expect("OpenSSH must accept the signed receipt policy");
         let (_, extensions, digest, _) = verified.into_parts();
         assert_eq!(extensions.receipt_policy, expected_receipt_policy);
         assert_eq!(digest, expected_digest);

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -53,8 +53,7 @@ use std::time::{Duration, Instant};
 
 pub(crate) const SSHSIG_NAMESPACE: &str = "syq-grant@greaber.github";
 const WIRE_MAGIC: &[u8; 8] = b"SYQGRNT\0";
-const WIRE_VERSION: u16 = 3;
-const WIRE_HEADER_LEN: usize = WIRE_MAGIC.len() + 2 + 4 + 4;
+const WIRE_HEADER_LEN: usize = WIRE_MAGIC.len() + 4 + 4;
 const MAX_GRANT_BYTES: usize = 32 * 1024;
 const MAX_SIGNATURE_BYTES: usize = 16 * 1024;
 const MAX_ENVELOPE_BYTES: usize = WIRE_HEADER_LEN + MAX_GRANT_BYTES + MAX_SIGNATURE_BYTES;
@@ -78,8 +77,7 @@ const MAX_FILTER_RULES: usize = 4096;
 const MAX_FILTER_RULE_BYTES: usize = 4096;
 const MAX_FILTER_ROOTS: usize = 1024;
 const REDEMPTION_MAGIC: &[u8; 8] = b"SYQCLM\0\0";
-const CLAIM_VERSION: u16 = 1;
-const REDEMPTION_RECORD_LEN: usize = REDEMPTION_MAGIC.len() + 2 + 8 + 32 + 32;
+const REDEMPTION_RECORD_LEN: usize = REDEMPTION_MAGIC.len() + 8 + 32 + 32;
 
 use crate::enrollment::EnrollmentId;
 
@@ -405,17 +403,17 @@ struct GrantBody {
     max_file_data_bytes_per_second: u64,
     filters: FilterPolicy,
     root_existence: RootExistence,
-    receipt_v2: crate::receipt_v2::ReceiptPolicyV2,
+    receipt_policy: crate::receipt::ReceiptPolicy,
 }
 
 #[cfg(test)]
-fn test_receipt_policy() -> crate::receipt_v2::ReceiptPolicyV2 {
-    crate::receipt_v2::ReceiptPolicyV2 {
+fn test_receipt_policy() -> crate::receipt::ReceiptPolicy {
+    crate::receipt::ReceiptPolicy {
         required: true,
         hashed: false,
-        max_records: crate::receipt_v2::DEFAULT_MAX_RECORDS,
-        max_plaintext_bytes: crate::receipt_v2::DEFAULT_MAX_PLAINTEXT_BYTES,
-        delivery: crate::receipt_v2::ReceiptDeliveryV2::DetachedSignedPlaintext,
+        max_records: crate::receipt::DEFAULT_MAX_RECORDS,
+        max_plaintext_bytes: crate::receipt::DEFAULT_MAX_PLAINTEXT_BYTES,
+        delivery: crate::receipt::ReceiptDelivery::DetachedSignedPlaintext,
     }
 }
 
@@ -425,7 +423,7 @@ pub(crate) struct SignedGrantEnvelope {
     pub max_file_data_bytes_per_second: u64,
     pub filters: FilterPolicy,
     pub root_existence: RootExistence,
-    pub receipt_v2: crate::receipt_v2::ReceiptPolicyV2,
+    pub receipt_policy: crate::receipt::ReceiptPolicy,
     /// Canonical OpenSSH armored SSHSIG bytes.
     pub signature: Vec<u8>,
 }
@@ -438,7 +436,7 @@ impl SignedGrantEnvelope {
             max_file_data_bytes_per_second,
             filters: FilterPolicy::default(),
             root_existence: RootExistence::Any,
-            receipt_v2: test_receipt_policy(),
+            receipt_policy: test_receipt_policy(),
             signature,
         }
     }
@@ -451,7 +449,7 @@ impl SignedGrantEnvelope {
             self.max_file_data_bytes_per_second,
             &self.filters,
             self.root_existence,
-            &self.receipt_v2,
+            &self.receipt_policy,
         )?;
         if body.len() > MAX_GRANT_BYTES {
             bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
@@ -461,7 +459,6 @@ impl SignedGrantEnvelope {
         }
         let mut out = Vec::with_capacity(WIRE_HEADER_LEN + body.len() + self.signature.len());
         out.extend_from_slice(WIRE_MAGIC);
-        out.extend_from_slice(&WIRE_VERSION.to_be_bytes());
         out.extend_from_slice(&(body.len() as u32).to_be_bytes());
         out.extend_from_slice(&(self.signature.len() as u32).to_be_bytes());
         out.extend_from_slice(&body);
@@ -476,14 +473,9 @@ impl SignedGrantEnvelope {
         if bytes.len() < WIRE_HEADER_LEN || &bytes[..WIRE_MAGIC.len()] != WIRE_MAGIC {
             bail!("not a SYQ signed grant envelope");
         }
-        let version = u16::from_be_bytes(bytes[8..10].try_into().expect("fixed header"));
-        if version != WIRE_VERSION {
-            bail!("unsupported signed grant envelope version {version}");
-        }
-        let grant_len =
-            u32::from_be_bytes(bytes[10..14].try_into().expect("fixed header")) as usize;
+        let grant_len = u32::from_be_bytes(bytes[8..12].try_into().expect("fixed header")) as usize;
         let signature_len =
-            u32::from_be_bytes(bytes[14..18].try_into().expect("fixed header")) as usize;
+            u32::from_be_bytes(bytes[12..16].try_into().expect("fixed header")) as usize;
         if grant_len == 0 || grant_len > MAX_GRANT_BYTES {
             bail!("signed grant length is outside the supported range");
         }
@@ -504,21 +496,21 @@ impl SignedGrantEnvelope {
             max_file_data_bytes_per_second,
             filters,
             root_existence,
-            receipt_v2,
+            receipt_policy,
         } = body;
         if canonical_body_bytes(
             &grant,
             max_file_data_bytes_per_second,
             &filters,
             root_existence,
-            &receipt_v2,
+            &receipt_policy,
         )? != body_bytes
         {
             bail!("signed grant uses a noncanonical encoding");
         }
         grant.validate_static()?;
         filters.validate(&grant)?;
-        receipt_v2.validate()?;
+        receipt_policy.validate()?;
         let signature = bytes[WIRE_HEADER_LEN + grant_len..].to_vec();
         validate_canonical_sshsig(&signature)?;
         Ok(Self {
@@ -526,7 +518,7 @@ impl SignedGrantEnvelope {
             max_file_data_bytes_per_second,
             filters,
             root_existence,
-            receipt_v2,
+            receipt_policy,
             signature,
         })
     }
@@ -537,7 +529,7 @@ impl SignedGrantEnvelope {
             self.max_file_data_bytes_per_second,
             &self.filters,
             self.root_existence,
-            &self.receipt_v2,
+            &self.receipt_policy,
         )
     }
 }
@@ -551,7 +543,7 @@ pub(crate) fn sign_grant(
         max_file_data_bytes_per_second,
         mut filters,
         root_existence,
-        receipt_v2,
+        receipt_policy,
     } = constraints;
     if private_key.is_encrypted() {
         bail!("cannot sign a grant with an encrypted enrollment key");
@@ -570,7 +562,7 @@ pub(crate) fn sign_grant(
         max_file_data_bytes_per_second,
         &filters,
         root_existence,
-        &receipt_v2,
+        &receipt_policy,
     )?;
     let signature = private_key
         .sign(SSHSIG_NAMESPACE, HashAlg::Sha256, &payload)
@@ -583,7 +575,7 @@ pub(crate) fn sign_grant(
         max_file_data_bytes_per_second,
         filters,
         root_existence,
-        receipt_v2,
+        receipt_policy,
         signature,
     }
     .encode()
@@ -605,7 +597,7 @@ fn signing_payload(
     max_file_data_bytes_per_second: u64,
     filters: &FilterPolicy,
     root_existence: RootExistence,
-    receipt_v2: &crate::receipt_v2::ReceiptPolicyV2,
+    receipt_policy: &crate::receipt::ReceiptPolicy,
 ) -> Result<Vec<u8>> {
     grant.validate_static()?;
     filters.validate(grant)?;
@@ -614,14 +606,13 @@ fn signing_payload(
         max_file_data_bytes_per_second,
         filters,
         root_existence,
-        receipt_v2,
+        receipt_policy,
     )?;
     if body.len() > MAX_GRANT_BYTES {
         bail!("canonical grant exceeds {MAX_GRANT_BYTES} bytes");
     }
-    let mut out = Vec::with_capacity(WIRE_MAGIC.len() + 2 + 4 + body.len());
+    let mut out = Vec::with_capacity(WIRE_MAGIC.len() + 4 + body.len());
     out.extend_from_slice(WIRE_MAGIC);
-    out.extend_from_slice(&WIRE_VERSION.to_be_bytes());
     out.extend_from_slice(&(body.len() as u32).to_be_bytes());
     out.extend_from_slice(&body);
     Ok(out)
@@ -632,15 +623,15 @@ fn canonical_body_bytes(
     max_file_data_bytes_per_second: u64,
     filters: &FilterPolicy,
     root_existence: RootExistence,
-    receipt_v2: &crate::receipt_v2::ReceiptPolicyV2,
+    receipt_policy: &crate::receipt::ReceiptPolicy,
 ) -> Result<Vec<u8>> {
-    receipt_v2.validate()?;
+    receipt_policy.validate()?;
     postcard::to_stdvec(&GrantBody {
         grant: grant.clone(),
         max_file_data_bytes_per_second,
         filters: filters.clone(),
         root_existence,
-        receipt_v2: receipt_v2.clone(),
+        receipt_policy: receipt_policy.clone(),
     })
     .context("encode canonical signed grant")
 }
@@ -1083,7 +1074,7 @@ pub(crate) struct VerifiedGrant {
     max_file_data_bytes_per_second: u64,
     filters: FilterPolicy,
     root_existence: RootExistence,
-    receipt_v2: crate::receipt_v2::ReceiptPolicyV2,
+    receipt_policy: crate::receipt::ReceiptPolicy,
     grant_digest: [u8; 32],
     execution_deadline: Instant,
 }
@@ -1094,7 +1085,7 @@ pub(crate) struct GrantConstraints {
     pub max_file_data_bytes_per_second: u64,
     pub filters: FilterPolicy,
     pub root_existence: RootExistence,
-    pub receipt_v2: crate::receipt_v2::ReceiptPolicyV2,
+    pub receipt_policy: crate::receipt::ReceiptPolicy,
 }
 
 #[cfg(test)]
@@ -1104,7 +1095,7 @@ impl Default for GrantConstraints {
             max_file_data_bytes_per_second: 0,
             filters: FilterPolicy::default(),
             root_existence: RootExistence::Any,
-            receipt_v2: test_receipt_policy(),
+            receipt_policy: test_receipt_policy(),
         }
     }
 }
@@ -1122,7 +1113,7 @@ impl VerifiedGrant {
                 max_file_data_bytes_per_second: self.max_file_data_bytes_per_second,
                 filters: self.filters,
                 root_existence: self.root_existence,
-                receipt_v2: self.receipt_v2,
+                receipt_policy: self.receipt_policy,
             },
             self.grant_digest,
             self.execution_deadline,
@@ -1164,7 +1155,7 @@ pub(crate) fn verify_and_redeem(
         max_file_data_bytes_per_second: envelope.max_file_data_bytes_per_second,
         filters: envelope.filters,
         root_existence: envelope.root_existence,
-        receipt_v2: envelope.receipt_v2,
+        receipt_policy: envelope.receipt_policy,
         grant_digest,
         execution_deadline,
     })
@@ -1177,7 +1168,7 @@ pub(crate) fn signed_grant_digest(encoded: &[u8]) -> Result<[u8; 32]> {
 
 fn grant_transcript_digest(payload: &[u8]) -> [u8; 32] {
     let mut hasher = blake3::Hasher::new();
-    hasher.update(b"syq-grant-transcript-v1@greaber.github\0");
+    hasher.update(b"syq-grant-transcript@greaber.github\0");
     hasher.update(&(payload.len() as u64).to_be_bytes());
     hasher.update(payload);
     *hasher.finalize().as_bytes()
@@ -1535,7 +1526,6 @@ fn redeem_record(request: RequestId, digest: [u8; 32], redeemed_at: i64) -> Resu
     }
     let mut record = Vec::with_capacity(REDEMPTION_RECORD_LEN);
     record.extend_from_slice(REDEMPTION_MAGIC);
-    record.extend_from_slice(&CLAIM_VERSION.to_be_bytes());
     record.extend_from_slice(&redeemed_at.to_be_bytes());
     record.extend_from_slice(&request.0);
     record.extend_from_slice(&digest);
@@ -1543,20 +1533,17 @@ fn redeem_record(request: RequestId, digest: [u8; 32], redeemed_at: i64) -> Resu
 }
 
 fn validate_redeem_record(record: &[u8], request: RequestId, digest: [u8; 32]) -> Result<()> {
-    if record.len() != REDEMPTION_RECORD_LEN
-        || &record[..8] != REDEMPTION_MAGIC
-        || u16::from_be_bytes(record[8..10].try_into().expect("redeem header")) != CLAIM_VERSION
-    {
+    if record.len() != REDEMPTION_RECORD_LEN || &record[..8] != REDEMPTION_MAGIC {
         bail!("replay state is malformed; refusing signed request");
     }
-    let redeemed_at = i64::from_be_bytes(record[10..18].try_into().expect("redeem timestamp"));
+    let redeemed_at = i64::from_be_bytes(record[8..16].try_into().expect("redeem timestamp"));
     if !(0..=MAX_UNIX_TIMESTAMP).contains(&redeemed_at) {
         bail!("replay state has an invalid timestamp; refusing signed request");
     }
-    if record[18..50] != request.0 {
+    if record[16..48] != request.0 {
         bail!("replay state request ID does not match its filename");
     }
-    if record[50..82] != digest {
+    if record[48..80] != digest {
         bail!("request ID was already redeemed by a different signed grant");
     }
     Ok(())
@@ -2056,7 +2043,6 @@ mod tests {
         .expect("encode test grant");
         let mut out = Vec::new();
         out.extend_from_slice(WIRE_MAGIC);
-        out.extend_from_slice(&WIRE_VERSION.to_be_bytes());
         out.extend_from_slice(&(grant.len() as u32).to_be_bytes());
         out.extend_from_slice(&(signature.len() as u32).to_be_bytes());
         out.extend_from_slice(&grant);
@@ -2071,14 +2057,9 @@ mod tests {
         let decoded = SignedGrantEnvelope::decode(&encoded).expect("decode canonical grant");
         assert_eq!(decoded.grant, fixture_grant(1));
         assert_eq!(decoded.max_file_data_bytes_per_second, 0);
-        let mut unsupported = encoded.clone();
-        unsupported[8..10].copy_from_slice(&(WIRE_VERSION + 1).to_be_bytes());
-        assert!(SignedGrantEnvelope::decode(&unsupported).is_err());
-        let mut legacy = encoded.clone();
-        legacy[8..10].copy_from_slice(&1u16.to_be_bytes());
-        assert!(SignedGrantEnvelope::decode(&legacy).is_err());
-        legacy[8..10].copy_from_slice(&2u16.to_be_bytes());
-        assert!(SignedGrantEnvelope::decode(&legacy).is_err());
+        let mut bad_magic = encoded.clone();
+        bad_magic[3] ^= 1;
+        assert!(SignedGrantEnvelope::decode(&bad_magic).is_err());
 
         let mut trailing = encoded.clone();
         trailing.push(0);
@@ -2214,41 +2195,37 @@ mod tests {
 
         // The grant binds the complete receipt delivery policy, including the
         // per-transfer HPKE recipient key, into the signed grant transcript.
-        let policy_v2 = crate::receipt_v2::ReceiptPolicyV2 {
+        let expected_receipt_policy = crate::receipt::ReceiptPolicy {
             required: true,
             hashed: true,
             max_records: 32,
             max_plaintext_bytes: 64 * 1024,
-            delivery: crate::receipt_v2::ReceiptDeliveryV2::AttachedEncrypted {
-                suite: crate::receipt_v2::HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+            delivery: crate::receipt::ReceiptDelivery::AttachedEncrypted {
+                suite: crate::receipt::HpkeSuite::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
                 recipient_public_key: [4; 32],
             },
         };
-        let receipted_v2 = sign_grant(
+        let receipted = sign_grant(
             fixture_grant(53),
             GrantConstraints {
-                receipt_v2: policy_v2.clone(),
+                receipt_policy: expected_receipt_policy.clone(),
                 ..GrantConstraints::default()
             },
             &private,
         )
         .unwrap();
-        let decoded = SignedGrantEnvelope::decode(&receipted_v2).unwrap();
-        assert_eq!(
-            u16::from_be_bytes(receipted_v2[8..10].try_into().unwrap()),
-            WIRE_VERSION
-        );
-        assert_eq!(decoded.receipt_v2, policy_v2.clone());
-        let expected_digest = signed_grant_digest(&receipted_v2).unwrap();
+        let decoded = SignedGrantEnvelope::decode(&receipted).unwrap();
+        assert_eq!(decoded.receipt_policy, expected_receipt_policy.clone());
+        let expected_digest = signed_grant_digest(&receipted).unwrap();
         let verified = verify_and_redeem(
-            &receipted_v2,
+            &receipted,
             &context(SIGNER, TARGET, NOW, 0),
             &fixture.policy(),
             &fixture.replay("in-process-receipt-v2-signature-replay"),
         )
         .expect("OpenSSH must accept the signed receipt v2 policy");
         let (_, extensions, digest, _) = verified.into_parts();
-        assert_eq!(extensions.receipt_v2, policy_v2);
+        assert_eq!(extensions.receipt_policy, expected_receipt_policy);
         assert_eq!(digest, expected_digest);
     }
 
@@ -2507,7 +2484,7 @@ mod tests {
                 .join(format!("redeemed-{}", RequestId([22; 32]).file_component())),
         )
         .expect("read adjusted replay redeem");
-        let redeemed_at = i64::from_be_bytes(redeem[10..18].try_into().expect("redeem timestamp"));
+        let redeemed_at = i64::from_be_bytes(redeem[8..16].try_into().expect("redeem timestamp"));
         assert!(redeemed_at >= NOW + 3);
 
         let mut expired = fixture_grant(23);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ mod persistence;
 mod private_broker;
 mod progress;
 mod proto;
-mod receipt_v2;
+mod receipt;
 mod remote_helper;
 mod remote_to_remote;
 mod restricted;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -19,7 +19,7 @@ use std::process::Command;
 
 const CONFIG_FILE: &str = "persistence.json";
 const SCOPE_MARKER: &str = ".syq-persistence";
-const SCOPE_MARKER_CONTENT: &[u8] = b"syq persistence scope v1\n";
+const SCOPE_MARKER_CONTENT: &[u8] = b"syq persistence scope\n";
 
 #[derive(Parser, Debug)]
 #[command(

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -17,9 +17,8 @@ use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const CONFIG_VERSION: u8 = 1;
-const CONFIG_FILE: &str = "persistence-v1.json";
-const SCOPE_MARKER: &str = ".syq-persistence-v1";
+const CONFIG_FILE: &str = "persistence.json";
+const SCOPE_MARKER: &str = ".syq-persistence";
 const SCOPE_MARKER_CONTENT: &[u8] = b"syq persistence scope v1\n";
 
 #[derive(Parser, Debug)]
@@ -58,14 +57,12 @@ enum PersistAction {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PersistenceConfig {
-    version: u8,
     enabled: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct EndpointRecord {
-    version: u8,
     pub(crate) user: Option<String>,
     pub(crate) host: String,
     pub(crate) port: Option<u16>,
@@ -74,7 +71,6 @@ pub(crate) struct EndpointRecord {
 impl EndpointRecord {
     fn new(user: Option<&str>, host: &str, port: Option<u16>) -> Self {
         Self {
-            version: CONFIG_VERSION,
             user: user.map(str::to_owned),
             host: host.to_owned(),
             port,
@@ -348,13 +344,6 @@ fn read_global_config() -> Result<Option<PersistenceConfig>> {
     file.read_to_end(&mut bytes)?;
     let config: PersistenceConfig = serde_json::from_slice(&bytes)
         .with_context(|| format!("parse persistence configuration {}", path.display()))?;
-    if config.version != CONFIG_VERSION {
-        bail!(
-            "unsupported persistence configuration version {} in {}",
-            config.version,
-            path.display()
-        );
-    }
     Ok(Some(config))
 }
 
@@ -370,13 +359,7 @@ fn write_global_config(enabled: bool) -> Result<()> {
         .with_context(|| format!("create configuration directory {}", parent.display()))?;
     let mut temporary = tempfile::NamedTempFile::new_in(parent)
         .with_context(|| format!("create temporary configuration in {}", parent.display()))?;
-    serde_json::to_writer_pretty(
-        &mut temporary,
-        &PersistenceConfig {
-            version: CONFIG_VERSION,
-            enabled,
-        },
-    )?;
+    serde_json::to_writer_pretty(&mut temporary, &PersistenceConfig { enabled })?;
     temporary.write_all(b"\n")?;
     temporary.as_file().sync_all()?;
     temporary
@@ -580,13 +563,6 @@ fn read_endpoint_record(path: &Path) -> Result<EndpointRecord> {
     }
     let record: EndpointRecord = serde_json::from_reader(file)
         .with_context(|| format!("parse endpoint record {}", path.display()))?;
-    if record.version != CONFIG_VERSION {
-        bail!(
-            "unsupported endpoint record version {} in {}",
-            record.version,
-            path.display()
-        );
-    }
     Ok(record)
 }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -907,7 +907,7 @@ pub enum Response {
     TransportStats(Option<TcpSocketStats>),
     /// One bounded frame of a signed receipt stream. The final frame is marked
     /// inside the canonical frame encoding.
-    ReceiptV2(#[serde(with = "serde_bytes")] Vec<u8>),
+    Receipt(#[serde(with = "serde_bytes")] Vec<u8>),
     Ok,
     /// An endpoint operation failed with a preserved OS error number. Server
     /// and authorization protocol failures continue to use Err(String).
@@ -1099,7 +1099,7 @@ impl SizeHint for Response {
                     + 32
             }
             Response::Hashes(v) | Response::HeldHashes { hashes: v, .. } => v.len() * 32 + 24,
-            Response::ReceiptV2(v) => v.len() + 16,
+            Response::Receipt(v) => v.len() + 16,
             _ => 256,
         }
     }

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -25,14 +25,12 @@ type Kem = X25519HkdfSha256;
 type Kdf = HkdfSha256;
 type Aead = ChaCha20Poly1305;
 
-pub(crate) const RECEIPT_NAMESPACE: &str = "syq-receipt-v2@greaber.github";
-pub(crate) const RECEIPT_LINE_PREFIX: &str = "syq-receipt-v2:";
-const TERMINAL_MAGIC: &[u8; 8] = b"SYQRCV2\0";
-const TERMINAL_VERSION: u16 = 2;
-const FRAME_MAGIC: &[u8; 8] = b"SYQRFV2\0";
-const FRAME_VERSION: u16 = 2;
-const HEADER_LEN: usize = 8 + 2 + 4;
-const TERMINAL_HEADER_LEN: usize = 8 + 2 + 4 + 4;
+pub(crate) const RECEIPT_NAMESPACE: &str = "syq-receipt@greaber.github";
+pub(crate) const RECEIPT_LINE_PREFIX: &str = "syq-receipt:";
+const TERMINAL_MAGIC: &[u8; 8] = b"SYQRCPT\0";
+const FRAME_MAGIC: &[u8; 8] = b"SYQRFRM\0";
+const HEADER_LEN: usize = 8 + 4;
+const TERMINAL_HEADER_LEN: usize = 8 + 4 + 4;
 const MAX_TERMINAL_BYTES: usize = 64 * 1024;
 const MAX_SIGNATURE_BYTES: usize = 16 * 1024;
 const MAX_FRAME_BODY_BYTES: usize = 96 * 1024;
@@ -44,29 +42,29 @@ const STREAM_RECORD_HEADER_BYTES: usize = 4;
 const HPKE_TAG_BYTES: usize = 16;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum HpkeSuiteV1 {
+pub(crate) enum HpkeSuite {
     X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ReceiptDeliveryV2 {
+pub(crate) enum ReceiptDelivery {
     AttachedEncrypted {
-        suite: HpkeSuiteV1,
+        suite: HpkeSuite,
         recipient_public_key: [u8; 32],
     },
     DetachedSignedPlaintext,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct ReceiptPolicyV2 {
+pub(crate) struct ReceiptPolicy {
     pub required: bool,
     pub hashed: bool,
     pub max_records: u64,
     pub max_plaintext_bytes: u64,
-    pub delivery: ReceiptDeliveryV2,
+    pub delivery: ReceiptDelivery,
 }
 
-impl ReceiptPolicyV2 {
+impl ReceiptPolicy {
     pub(crate) fn validate(&self) -> Result<()> {
         if !self.required {
             bail!("receipt v2 policy must require a receipt");
@@ -78,14 +76,14 @@ impl ReceiptPolicyV2 {
             bail!("receipt byte limit is outside the supported range");
         }
         match &self.delivery {
-            ReceiptDeliveryV2::AttachedEncrypted {
+            ReceiptDelivery::AttachedEncrypted {
                 recipient_public_key,
                 ..
             } if recipient_public_key.iter().all(|byte| *byte == 0) => {
                 bail!("receipt recipient public key must be nonzero")
             }
-            ReceiptDeliveryV2::AttachedEncrypted { .. }
-            | ReceiptDeliveryV2::DetachedSignedPlaintext => Ok(()),
+            ReceiptDelivery::AttachedEncrypted { .. }
+            | ReceiptDelivery::DetachedSignedPlaintext => Ok(()),
         }
     }
 }
@@ -120,7 +118,7 @@ pub(crate) fn generate_recipient() -> Result<(RecipientSecret, [u8; 32])> {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum OperationActionV2 {
+pub(crate) enum OperationAction {
     PublishFile { size: u64, inplace: bool },
     EnsureDirectory,
     CreateSymlink,
@@ -132,7 +130,7 @@ pub(crate) enum OperationActionV2 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum OperationDispositionV2 {
+pub(crate) enum OperationDisposition {
     Applied,
     Failed,
     Incomplete,
@@ -140,7 +138,7 @@ pub(crate) enum OperationDispositionV2 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum OutcomeCodeV2 {
+pub(crate) enum OutcomeCode {
     None,
     ExecutionFailed,
     AuthorizationRefused,
@@ -149,25 +147,25 @@ pub(crate) enum OutcomeCodeV2 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct OperationRecordV2 {
+pub(crate) struct ReceiptOperationRecord {
     pub sequence: u64,
     pub scope: u32,
     pub path: Vec<u8>,
-    pub action: OperationActionV2,
-    pub disposition: OperationDispositionV2,
-    pub code: OutcomeCodeV2,
+    pub action: OperationAction,
+    pub disposition: OperationDisposition,
+    pub code: OutcomeCode,
     pub diagnostic: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct RefusalRecordV2 {
+pub(crate) struct RefusalReceiptRecord {
     pub sequence: u64,
-    pub code: OutcomeCodeV2,
+    pub code: OutcomeCode,
     pub diagnostic: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct ObjectMetadataV2 {
+pub(crate) struct ObjectMetadata {
     pub mode: u32,
     pub uid: u32,
     pub gid: u32,
@@ -177,39 +175,39 @@ pub(crate) struct ObjectMetadataV2 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum FinalObjectV2 {
+pub(crate) enum FinalObject {
     Absent,
     Present {
         kind: Kind,
         size: u64,
         digest: Option<[u8; 32]>,
         symlink_target: Option<Vec<u8>>,
-        metadata: ObjectMetadataV2,
+        metadata: ObjectMetadata,
         observation_error: Option<String>,
     },
     ObservationFailed {
-        code: OutcomeCodeV2,
+        code: OutcomeCode,
         diagnostic: Option<String>,
     },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct FinalStateRecordV2 {
+pub(crate) struct FinalStateReceiptRecord {
     pub sequence: u64,
     pub scope: u32,
     pub path: Vec<u8>,
-    pub object: FinalObjectV2,
+    pub object: FinalObject,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum RecordV2 {
-    Operation(OperationRecordV2),
-    Refusal(RefusalRecordV2),
-    FinalState(FinalStateRecordV2),
+pub(crate) enum ReceiptRecord {
+    Operation(ReceiptOperationRecord),
+    Refusal(RefusalReceiptRecord),
+    FinalState(FinalStateReceiptRecord),
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct ReceiptSummaryV2 {
+pub(crate) struct ReceiptSummary {
     pub operations: u64,
     pub applied: u64,
     pub failed: u64,
@@ -226,84 +224,84 @@ pub(crate) struct ReceiptSummaryV2 {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ReceiptStatusV2 {
+pub(crate) enum ReceiptStatus {
     Clean,
     Failed,
     Incomplete,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum RecordingFailureV2 {
+pub(crate) enum RecordingFailure {
     LimitExceeded,
     StorageFailed,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ManifestStatusV2 {
+pub(crate) enum ManifestStatus {
     NotProvided,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ReceiptSchemaV2 {
-    LogicalMutationsAndFinalStateV2,
+pub(crate) enum ReceiptSchema {
+    LogicalMutationsAndFinalState,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum DigestAlgorithmV2 {
+pub(crate) enum DigestAlgorithm {
     Blake3,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct TerminalReceiptV2 {
-    pub schema: ReceiptSchemaV2,
+pub(crate) struct TerminalReceipt {
+    pub schema: ReceiptSchema,
     pub enrollment_id: EnrollmentId,
     pub request_id: RequestId,
     pub grant_digest: [u8; 32],
     pub issued_at: i64,
-    pub status: ReceiptStatusV2,
+    pub status: ReceiptStatus,
     pub authority_closed: bool,
     pub in_flight: u64,
     pub stream_digest: [u8; 32],
-    pub stream_digest_algorithm: DigestAlgorithmV2,
-    pub content_digest_algorithm: Option<DigestAlgorithmV2>,
+    pub stream_digest_algorithm: DigestAlgorithm,
+    pub content_digest_algorithm: Option<DigestAlgorithm>,
     pub record_count: u64,
     pub plaintext_bytes: u64,
-    pub summary: ReceiptSummaryV2,
-    pub policy: ReceiptPolicyV2,
-    pub recording_failure: Option<RecordingFailureV2>,
+    pub summary: ReceiptSummary,
+    pub policy: ReceiptPolicy,
+    pub recording_failure: Option<RecordingFailure>,
     pub expected_manifest_digest: Option<[u8; 32]>,
-    pub manifest_status: ManifestStatusV2,
+    pub manifest_status: ManifestStatus,
 }
 
 /// Append-only canonical receipt stream. The anonymous temporary file keeps
 /// receipt size off the heap; its signed policy bounds both records and bytes.
-pub(crate) struct StreamWriterV2 {
+pub(crate) struct ReceiptStreamWriter {
     file: File,
     hasher: blake3::Hasher,
     record_buffer: Vec<u8>,
     record_count: u64,
     plaintext_bytes: u64,
-    summary: ReceiptSummaryV2,
+    summary: ReceiptSummary,
     max_records: u64,
     max_plaintext_bytes: u64,
-    recording_failure: Option<RecordingFailureV2>,
+    recording_failure: Option<RecordingFailure>,
 }
 
-pub(crate) struct ReceiptClosureV2<'a> {
+pub(crate) struct ReceiptClosure<'a> {
     pub enrollment_id: EnrollmentId,
     pub request_id: RequestId,
     pub grant_digest: [u8; 32],
     pub issued_at: i64,
-    pub policy: ReceiptPolicyV2,
+    pub policy: ReceiptPolicy,
     pub entries_touched: u64,
     pub transferred_bytes: u64,
     pub signing_key: &'a PrivateKey,
 }
 
-impl std::fmt::Debug for StreamWriterV2 {
+impl std::fmt::Debug for ReceiptStreamWriter {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
-            .debug_struct("StreamWriterV2")
+            .debug_struct("ReceiptStreamWriter")
             .field("record_count", &self.record_count)
             .field("plaintext_bytes", &self.plaintext_bytes)
             .field("summary", &self.summary)
@@ -312,8 +310,8 @@ impl std::fmt::Debug for StreamWriterV2 {
     }
 }
 
-impl StreamWriterV2 {
-    pub(crate) fn new(policy: &ReceiptPolicyV2) -> Result<Self> {
+impl ReceiptStreamWriter {
+    pub(crate) fn new(policy: &ReceiptPolicy) -> Result<Self> {
         policy.validate()?;
         Ok(Self {
             file: tempfile::tempfile().context("create receiver receipt spool")?,
@@ -321,7 +319,7 @@ impl StreamWriterV2 {
             record_buffer: Vec::new(),
             record_count: 0,
             plaintext_bytes: 0,
-            summary: ReceiptSummaryV2::default(),
+            summary: ReceiptSummary::default(),
             max_records: policy.max_records,
             max_plaintext_bytes: policy.max_plaintext_bytes,
             recording_failure: None,
@@ -338,15 +336,15 @@ impl StreamWriterV2 {
 
     pub(crate) fn mark_recording_failure(&mut self) {
         self.recording_failure
-            .get_or_insert(RecordingFailureV2::StorageFailed);
+            .get_or_insert(RecordingFailure::StorageFailed);
     }
 
-    pub(crate) fn append(&mut self, record: &RecordV2) {
+    pub(crate) fn append(&mut self, record: &ReceiptRecord) {
         if self.recording_failure.is_some() {
             return;
         }
         if record_sequence(record) != self.record_count {
-            self.recording_failure = Some(RecordingFailureV2::StorageFailed);
+            self.recording_failure = Some(RecordingFailure::StorageFailed);
             return;
         }
         let mut body = std::mem::take(&mut self.record_buffer);
@@ -354,7 +352,7 @@ impl StreamWriterV2 {
         let body = match postcard::to_extend(record, body) {
             Ok(body) => body,
             Err(_) => {
-                self.recording_failure = Some(RecordingFailureV2::StorageFailed);
+                self.recording_failure = Some(RecordingFailure::StorageFailed);
                 return;
             }
         };
@@ -362,7 +360,7 @@ impl StreamWriterV2 {
             Some(length) => length,
             None => {
                 self.record_buffer = body;
-                self.recording_failure = Some(RecordingFailureV2::LimitExceeded);
+                self.recording_failure = Some(RecordingFailure::LimitExceeded);
                 return;
             }
         };
@@ -370,20 +368,20 @@ impl StreamWriterV2 {
             Some(bytes) => bytes,
             None => {
                 self.record_buffer = body;
-                self.recording_failure = Some(RecordingFailureV2::LimitExceeded);
+                self.recording_failure = Some(RecordingFailure::LimitExceeded);
                 return;
             }
         };
         if self.record_count >= self.max_records || new_bytes > self.max_plaintext_bytes {
             self.record_buffer = body;
-            self.recording_failure = Some(RecordingFailureV2::LimitExceeded);
+            self.recording_failure = Some(RecordingFailure::LimitExceeded);
             return;
         }
         let length = match u32::try_from(body.len()) {
             Ok(length) => length.to_be_bytes(),
             Err(_) => {
                 self.record_buffer = body;
-                self.recording_failure = Some(RecordingFailureV2::LimitExceeded);
+                self.recording_failure = Some(RecordingFailure::LimitExceeded);
                 return;
             }
         };
@@ -394,7 +392,7 @@ impl StreamWriterV2 {
             .is_err()
         {
             self.record_buffer = body;
-            self.recording_failure = Some(RecordingFailureV2::StorageFailed);
+            self.recording_failure = Some(RecordingFailure::StorageFailed);
             return;
         }
         self.hasher.update(&length);
@@ -405,8 +403,8 @@ impl StreamWriterV2 {
         self.record_buffer = body;
     }
 
-    pub(crate) fn finish(mut self, closure: ReceiptClosureV2<'_>) -> Result<IssuedReceiptV2> {
-        let ReceiptClosureV2 {
+    pub(crate) fn finish(mut self, closure: ReceiptClosure<'_>) -> Result<IssuedReceipt> {
+        let ReceiptClosure {
             enrollment_id,
             request_id,
             grant_digest,
@@ -423,17 +421,17 @@ impl StreamWriterV2 {
         self.summary.entries_touched = entries_touched;
         self.summary.transferred_bytes = transferred_bytes;
         let status = if self.recording_failure.is_some() || self.summary.observation_failures > 0 {
-            ReceiptStatusV2::Incomplete
+            ReceiptStatus::Incomplete
         } else if self.summary.failed > 0
             || self.summary.incomplete > 0
             || self.summary.refusals > 0
         {
-            ReceiptStatusV2::Failed
+            ReceiptStatus::Failed
         } else {
-            ReceiptStatusV2::Clean
+            ReceiptStatus::Clean
         };
-        let terminal = TerminalReceiptV2 {
-            schema: ReceiptSchemaV2::LogicalMutationsAndFinalStateV2,
+        let terminal = TerminalReceipt {
+            schema: ReceiptSchema::LogicalMutationsAndFinalState,
             enrollment_id,
             request_id,
             grant_digest,
@@ -442,17 +440,17 @@ impl StreamWriterV2 {
             authority_closed: true,
             in_flight: 0,
             stream_digest: *self.hasher.finalize().as_bytes(),
-            stream_digest_algorithm: DigestAlgorithmV2::Blake3,
-            content_digest_algorithm: policy.hashed.then_some(DigestAlgorithmV2::Blake3),
+            stream_digest_algorithm: DigestAlgorithm::Blake3,
+            content_digest_algorithm: policy.hashed.then_some(DigestAlgorithm::Blake3),
             record_count: self.record_count,
             plaintext_bytes: self.plaintext_bytes,
             summary: self.summary,
             policy: policy.clone(),
             recording_failure: self.recording_failure,
             expected_manifest_digest: None,
-            manifest_status: ManifestStatusV2::NotProvided,
+            manifest_status: ManifestStatus::NotProvided,
         };
-        Ok(IssuedReceiptV2 {
+        Ok(IssuedReceipt {
             stream: self.file,
             stream_len: self.plaintext_bytes,
             signed_terminal: sign_terminal(&terminal, signing_key)?,
@@ -464,52 +462,52 @@ impl StreamWriterV2 {
     }
 }
 
-fn record_sequence(record: &RecordV2) -> u64 {
+fn record_sequence(record: &ReceiptRecord) -> u64 {
     match record {
-        RecordV2::Operation(record) => record.sequence,
-        RecordV2::Refusal(record) => record.sequence,
-        RecordV2::FinalState(record) => record.sequence,
+        ReceiptRecord::Operation(record) => record.sequence,
+        ReceiptRecord::Refusal(record) => record.sequence,
+        ReceiptRecord::FinalState(record) => record.sequence,
     }
 }
 
-fn summarize(record: &RecordV2, summary: &mut ReceiptSummaryV2) {
+fn summarize(record: &ReceiptRecord, summary: &mut ReceiptSummary) {
     match record {
-        RecordV2::Operation(record) => {
+        ReceiptRecord::Operation(record) => {
             summary.operations += 1;
             match record.disposition {
-                OperationDispositionV2::Applied | OperationDispositionV2::Observed => {
+                OperationDisposition::Applied | OperationDisposition::Observed => {
                     summary.applied += 1
                 }
-                OperationDispositionV2::Failed => summary.failed += 1,
-                OperationDispositionV2::Incomplete => summary.incomplete += 1,
+                OperationDisposition::Failed => summary.failed += 1,
+                OperationDisposition::Incomplete => summary.incomplete += 1,
             }
             match record.action {
-                OperationActionV2::PublishFile { size, .. }
-                    if record.disposition == OperationDispositionV2::Applied =>
+                OperationAction::PublishFile { size, .. }
+                    if record.disposition == OperationDisposition::Applied =>
                 {
                     summary.published_files += 1;
                     summary.published_bytes = summary.published_bytes.saturating_add(size);
                 }
-                OperationActionV2::DeleteFile | OperationActionV2::DeleteDirectory
-                    if record.disposition == OperationDispositionV2::Applied =>
+                OperationAction::DeleteFile | OperationAction::DeleteDirectory
+                    if record.disposition == OperationDisposition::Applied =>
                 {
                     summary.deletions += 1;
                 }
-                OperationActionV2::ObserveFileHash
-                    if record.disposition == OperationDispositionV2::Observed =>
+                OperationAction::ObserveFileHash
+                    if record.disposition == OperationDisposition::Observed =>
                 {
                     summary.observed_hashes += 1;
                 }
                 _ => {}
             }
         }
-        RecordV2::Refusal(_) => summary.refusals += 1,
-        RecordV2::FinalState(record) => {
+        ReceiptRecord::Refusal(_) => summary.refusals += 1,
+        ReceiptRecord::FinalState(record) => {
             summary.final_states += 1;
             if matches!(
                 record.object,
-                FinalObjectV2::ObservationFailed { .. }
-                    | FinalObjectV2::Present {
+                FinalObject::ObservationFailed { .. }
+                    | FinalObject::Present {
                         observation_error: Some(_),
                         ..
                     }
@@ -520,26 +518,26 @@ fn summarize(record: &RecordV2, summary: &mut ReceiptSummaryV2) {
     }
 }
 
-pub(crate) struct IssuedReceiptV2 {
+pub(crate) struct IssuedReceipt {
     stream: File,
     stream_len: u64,
     signed_terminal: Vec<u8>,
     enrollment_id: EnrollmentId,
     request_id: RequestId,
     grant_digest: [u8; 32],
-    delivery: ReceiptDeliveryV2,
+    delivery: ReceiptDelivery,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ReceiptDeliveryKindV2 {
+pub(crate) enum ReceiptDeliveryKind {
     AttachedEncrypted,
     DetachedSignedPlaintext,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) enum ReceiptFrameV2 {
+pub(crate) enum ReceiptFrame {
     Start {
-        mode: ReceiptDeliveryKindV2,
+        mode: ReceiptDeliveryKind,
         encapsulated_key: Vec<u8>,
     },
     Chunk {
@@ -553,9 +551,9 @@ pub(crate) enum ReceiptFrameV2 {
 }
 
 #[derive(Serialize)]
-enum BorrowedReceiptFrameV2<'a> {
+enum BorrowedReceiptFrame<'a> {
     Start {
-        mode: ReceiptDeliveryKindV2,
+        mode: ReceiptDeliveryKind,
         encapsulated_key: &'a [u8],
     },
     Chunk {
@@ -569,21 +567,21 @@ enum BorrowedReceiptFrameV2<'a> {
 }
 
 #[cfg(test)]
-impl ReceiptFrameV2 {
-    fn as_borrowed(&self) -> BorrowedReceiptFrameV2<'_> {
+impl ReceiptFrame {
+    fn as_borrowed(&self) -> BorrowedReceiptFrame<'_> {
         match self {
             Self::Start {
                 mode,
                 encapsulated_key,
-            } => BorrowedReceiptFrameV2::Start {
+            } => BorrowedReceiptFrame::Start {
                 mode: *mode,
                 encapsulated_key,
             },
-            Self::Chunk { sequence, payload } => BorrowedReceiptFrameV2::Chunk {
+            Self::Chunk { sequence, payload } => BorrowedReceiptFrame::Chunk {
                 sequence: *sequence,
                 payload,
             },
-            Self::End { sequence, payload } => BorrowedReceiptFrameV2::End {
+            Self::End { sequence, payload } => BorrowedReceiptFrame::End {
                 sequence: *sequence,
                 payload,
             },
@@ -592,13 +590,13 @@ impl ReceiptFrameV2 {
 }
 
 pub(crate) fn emit_receipt_frames(
-    mut issued: IssuedReceiptV2,
+    mut issued: IssuedReceipt,
     mut emit: impl FnMut(Vec<u8>) -> Result<()>,
 ) -> Result<()> {
     let info = hpke_info(issued.enrollment_id, issued.request_id, issued.grant_digest)?;
     match issued.delivery {
-        ReceiptDeliveryV2::AttachedEncrypted {
-            suite: HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+        ReceiptDelivery::AttachedEncrypted {
+            suite: HpkeSuite::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
             recipient_public_key,
         } => {
             let public = <Kem as hpke::Kem>::PublicKey::from_bytes(&recipient_public_key)
@@ -608,8 +606,8 @@ pub(crate) fn emit_receipt_frames(
                     .map_err(|_| anyhow!("set up HPKE receipt sender"))?;
             let encapsulated = encapsulated.to_bytes();
             emit(encode_borrowed_receipt_frame(
-                &BorrowedReceiptFrameV2::Start {
-                    mode: ReceiptDeliveryKindV2::AttachedEncrypted,
+                &BorrowedReceiptFrame::Start {
+                    mode: ReceiptDeliveryKind::AttachedEncrypted,
                     encapsulated_key: encapsulated.as_slice(),
                 },
             )?)?;
@@ -626,8 +624,8 @@ pub(crate) fn emit_receipt_frames(
                 let payload = sender
                     .seal(&buffer[..wanted], &frame_aad(sequence, false))
                     .map_err(|_| anyhow!("encrypt receipt stream frame"))?;
-                emit(encode_borrowed_receipt_frame(
-                    &BorrowedReceiptFrameV2::Chunk {
+            emit(encode_borrowed_receipt_frame(
+                &BorrowedReceiptFrame::Chunk {
                         sequence,
                         payload: &payload,
                     },
@@ -639,16 +637,16 @@ pub(crate) fn emit_receipt_frames(
                 .seal(&issued.signed_terminal, &frame_aad(sequence, true))
                 .map_err(|_| anyhow!("encrypt receipt terminal frame"))?;
             emit(encode_borrowed_receipt_frame(
-                &BorrowedReceiptFrameV2::End {
+                &BorrowedReceiptFrame::End {
                     sequence,
                     payload: &payload,
                 },
             )?)?;
         }
-        ReceiptDeliveryV2::DetachedSignedPlaintext => {
+        ReceiptDelivery::DetachedSignedPlaintext => {
             emit(encode_borrowed_receipt_frame(
-                &BorrowedReceiptFrameV2::Start {
-                    mode: ReceiptDeliveryKindV2::DetachedSignedPlaintext,
+                &BorrowedReceiptFrame::Start {
+                    mode: ReceiptDeliveryKind::DetachedSignedPlaintext,
                     encapsulated_key: &[],
                 },
             )?)?;
@@ -662,8 +660,8 @@ pub(crate) fn emit_receipt_frames(
                     .stream
                     .read_exact(&mut buffer[..wanted])
                     .context("read receiver receipt spool")?;
-                emit(encode_borrowed_receipt_frame(
-                    &BorrowedReceiptFrameV2::Chunk {
+            emit(encode_borrowed_receipt_frame(
+                &BorrowedReceiptFrame::Chunk {
                         sequence,
                         payload: &buffer[..wanted],
                     },
@@ -672,7 +670,7 @@ pub(crate) fn emit_receipt_frames(
                 remaining -= wanted as u64;
             }
             emit(encode_borrowed_receipt_frame(
-                &BorrowedReceiptFrameV2::End {
+                &BorrowedReceiptFrame::End {
                     sequence,
                     payload: &issued.signed_terminal,
                 },
@@ -683,17 +681,18 @@ pub(crate) fn emit_receipt_frames(
 }
 
 #[cfg(test)]
-pub(crate) fn encode_receipt_frame(frame: &ReceiptFrameV2) -> Result<Vec<u8>> {
+pub(crate) fn encode_receipt_frame(frame: &ReceiptFrame) -> Result<Vec<u8>> {
     encode_borrowed_receipt_frame(&frame.as_borrowed())
 }
 
-fn encode_borrowed_receipt_frame(frame: &BorrowedReceiptFrameV2<'_>) -> Result<Vec<u8>> {
+fn encode_borrowed_receipt_frame(frame: &BorrowedReceiptFrame<'_>) -> Result<Vec<u8>> {
     let payload_len = match frame {
-        BorrowedReceiptFrameV2::Start {
+        BorrowedReceiptFrame::Start {
             encapsulated_key, ..
         } => encapsulated_key.len(),
-        BorrowedReceiptFrameV2::Chunk { payload, .. }
-        | BorrowedReceiptFrameV2::End { payload, .. } => payload.len(),
+        BorrowedReceiptFrame::Chunk { payload, .. } | BorrowedReceiptFrame::End { payload, .. } => {
+            payload.len()
+        }
     };
     // Postcard adds only enum tags and variable-length integer fields around
     // the byte payload. Leave modest headroom so normal frames need one
@@ -710,45 +709,40 @@ fn encode_borrowed_receipt_frame(frame: &BorrowedReceiptFrameV2<'_>) -> Result<V
         bail!("receipt frame exceeds size limit");
     }
     encoded[..8].copy_from_slice(FRAME_MAGIC);
-    encoded[8..10].copy_from_slice(&FRAME_VERSION.to_be_bytes());
-    encoded[10..HEADER_LEN].copy_from_slice(&(body_len as u32).to_be_bytes());
+    encoded[8..HEADER_LEN].copy_from_slice(&(body_len as u32).to_be_bytes());
     Ok(encoded)
 }
 
-pub(crate) fn decode_receipt_frame(encoded: &[u8]) -> Result<ReceiptFrameV2> {
+pub(crate) fn decode_receipt_frame(encoded: &[u8]) -> Result<ReceiptFrame> {
     if encoded.len() < HEADER_LEN || &encoded[..8] != FRAME_MAGIC {
-        bail!("not a receipt v2 frame");
+        bail!("not a receipt frame");
     }
-    let version = u16::from_be_bytes(encoded[8..10].try_into().expect("fixed header"));
-    if version != FRAME_VERSION {
-        bail!("unsupported receipt transport version {version}");
-    }
-    let body_len = u32::from_be_bytes(encoded[10..14].try_into().expect("fixed header")) as usize;
+    let body_len = u32::from_be_bytes(encoded[8..12].try_into().expect("fixed header")) as usize;
     if body_len == 0 || body_len > MAX_FRAME_BODY_BYTES || encoded.len() != HEADER_LEN + body_len {
         bail!("receipt frame length is noncanonical");
     }
     let body = &encoded[HEADER_LEN..];
-    let frame: ReceiptFrameV2 = postcard::from_bytes(body).context("decode receipt frame")?;
+    let frame: ReceiptFrame = postcard::from_bytes(body).context("decode receipt frame")?;
     if postcard::to_stdvec(&frame)? != body {
         bail!("receipt frame uses a noncanonical encoding");
     }
     match &frame {
-        ReceiptFrameV2::Start {
-            mode: ReceiptDeliveryKindV2::AttachedEncrypted,
+        ReceiptFrame::Start {
+            mode: ReceiptDeliveryKind::AttachedEncrypted,
             encapsulated_key,
         } if encapsulated_key.len() != 32 => bail!("invalid HPKE encapsulated-key length"),
-        ReceiptFrameV2::Start {
-            mode: ReceiptDeliveryKindV2::DetachedSignedPlaintext,
+        ReceiptFrame::Start {
+            mode: ReceiptDeliveryKind::DetachedSignedPlaintext,
             encapsulated_key,
         } if !encapsulated_key.is_empty() => {
             bail!("plaintext receipt start frame carries an encapsulated key")
         }
-        ReceiptFrameV2::Chunk { payload, .. }
+        ReceiptFrame::Chunk { payload, .. }
             if payload.len() > PLAINTEXT_CHUNK_BYTES + HPKE_TAG_BYTES =>
         {
             bail!("receipt chunk payload exceeds size limit")
         }
-        ReceiptFrameV2::End { payload, .. }
+        ReceiptFrame::End { payload, .. }
             if payload.len()
                 > MAX_TERMINAL_BYTES
                     + MAX_SIGNATURE_BYTES
@@ -765,19 +759,19 @@ pub(crate) fn decode_receipt_frame(encoded: &[u8]) -> Result<ReceiptFrameV2> {
 pub(crate) fn receipt_frame_is_end(encoded: &[u8]) -> Result<bool> {
     Ok(matches!(
         decode_receipt_frame(encoded)?,
-        ReceiptFrameV2::End { .. }
+        ReceiptFrame::End { .. }
     ))
 }
 
-pub(crate) struct VerifiedReceiptV2 {
-    pub terminal: TerminalReceiptV2,
+pub(crate) struct VerifiedReceipt {
+    pub terminal: TerminalReceipt,
     stream: File,
 }
 
-impl VerifiedReceiptV2 {
+impl VerifiedReceipt {
     pub(crate) fn for_each_record(
         &mut self,
-        mut visit: impl FnMut(RecordV2) -> Result<()>,
+        mut visit: impl FnMut(ReceiptRecord) -> Result<()>,
     ) -> Result<()> {
         self.stream.seek(SeekFrom::Start(0))?;
         for _ in 0..self.terminal.record_count {
@@ -803,7 +797,7 @@ pub(crate) struct EmittedAutomationRecords {
 /// `provenance: "receiver_attested"`. Scope-relative paths are not expanded
 /// into ambient hostB paths.
 pub(crate) fn emit_automation_records(
-    receipt: &mut VerifiedReceiptV2,
+    receipt: &mut VerifiedReceipt,
     writer: &crate::results::ResultsWriter,
     results_status: &'static str,
     exit_code: i32,
@@ -815,33 +809,33 @@ pub(crate) fn emit_automation_records(
     let mut errors_emitted = 0u64;
     receipt.for_each_record(|record| {
         let value = match record {
-            RecordV2::Operation(record) => {
+            ReceiptRecord::Operation(record) => {
                 let (action, kind, bytes) = match record.action {
-                    OperationActionV2::PublishFile { size, .. } => {
+                    OperationAction::PublishFile { size, .. } => {
                         ("transfer_file", Some("file"), Some(size))
                     }
-                    OperationActionV2::EnsureDirectory => {
-                        if record.disposition == OperationDispositionV2::Applied {
+                    OperationAction::EnsureDirectory => {
+                        if record.disposition == OperationDisposition::Applied {
                             directories_created += 1;
                         }
                         ("create_directory", Some("dir"), None)
                     }
-                    OperationActionV2::CreateSymlink => {
-                        if record.disposition == OperationDispositionV2::Applied {
+                    OperationAction::CreateSymlink => {
+                        if record.disposition == OperationDisposition::Applied {
                             symlinks_created += 1;
                         }
                         ("create_symlink", Some("symlink"), None)
                     }
-                    OperationActionV2::CreateSpecial { .. } => {
-                        if record.disposition == OperationDispositionV2::Applied {
+                    OperationAction::CreateSpecial { .. } => {
+                        if record.disposition == OperationDisposition::Applied {
                             specials_created += 1;
                         }
                         ("create_special", Some("special"), None)
                     }
-                    OperationActionV2::SetMetadata { .. } => ("set_metadata", None, None),
-                    OperationActionV2::DeleteFile => ("delete", Some("file"), None),
-                    OperationActionV2::DeleteDirectory => ("delete", Some("dir"), None),
-                    OperationActionV2::ObserveFileHash => ("observe_hash", Some("file"), None),
+                    OperationAction::SetMetadata { .. } => ("set_metadata", None, None),
+                    OperationAction::DeleteFile => ("delete", Some("file"), None),
+                    OperationAction::DeleteDirectory => ("delete", Some("dir"), None),
+                    OperationAction::ObserveFileHash => ("observe_hash", Some("file"), None),
                 };
                 let mut value = serde_json::json!({
                     "type": "operation_result",
@@ -857,7 +851,7 @@ pub(crate) fn emit_automation_records(
                 if let Some(kind) = kind {
                     object.insert("kind".into(), kind.into());
                 }
-                if record.code != OutcomeCodeV2::None {
+                if record.code != OutcomeCode::None {
                     object.insert("code".into(), outcome_name(record.code).into());
                 }
                 if let Some(bytes) = bytes {
@@ -868,7 +862,7 @@ pub(crate) fn emit_automation_records(
                 }
                 if matches!(
                     record.disposition,
-                    OperationDispositionV2::Failed | OperationDispositionV2::Incomplete
+                    OperationDisposition::Failed | OperationDisposition::Incomplete
                 ) {
                     writer.emit_value(value);
                     errors_emitted += 1;
@@ -888,7 +882,7 @@ pub(crate) fn emit_automation_records(
                     value
                 }
             }
-            RecordV2::Refusal(record) => {
+            ReceiptRecord::Refusal(record) => {
                 errors_emitted += 1;
                 serde_json::json!({
                     "type": "error",
@@ -901,10 +895,10 @@ pub(crate) fn emit_automation_records(
                         .unwrap_or_else(|| "receiver refused the request".to_string()),
                 })
             }
-            RecordV2::FinalState(record) => {
+            ReceiptRecord::FinalState(record) => {
                 let object = match record.object {
-                    FinalObjectV2::Absent => serde_json::json!({"state": "absent"}),
-                    FinalObjectV2::ObservationFailed { code, diagnostic } => {
+                    FinalObject::Absent => serde_json::json!({"state": "absent"}),
+                    FinalObject::ObservationFailed { code, diagnostic } => {
                         writer.emit_value(serde_json::json!({
                             "type": "error",
                             "provenance": "receiver_attested",
@@ -930,7 +924,7 @@ pub(crate) fn emit_automation_records(
                         }
                         object
                     }
-                    FinalObjectV2::Present {
+                    FinalObject::Present {
                         kind,
                         size,
                         digest,
@@ -1054,44 +1048,42 @@ fn encode_hex(bytes: &[u8]) -> String {
     encoded
 }
 
-fn disposition_name(disposition: OperationDispositionV2) -> &'static str {
+fn disposition_name(disposition: OperationDisposition) -> &'static str {
     match disposition {
-        OperationDispositionV2::Applied => "succeeded",
-        OperationDispositionV2::Failed => "failed",
-        OperationDispositionV2::Incomplete => "incomplete",
-        OperationDispositionV2::Observed => "observed",
+        OperationDisposition::Applied => "succeeded",
+        OperationDisposition::Failed => "failed",
+        OperationDisposition::Incomplete => "incomplete",
+        OperationDisposition::Observed => "observed",
     }
 }
 
-fn outcome_name(code: OutcomeCodeV2) -> &'static str {
+fn outcome_name(code: OutcomeCode) -> &'static str {
     match code {
-        OutcomeCodeV2::None => "none",
-        OutcomeCodeV2::ExecutionFailed => "execution_failed",
-        OutcomeCodeV2::AuthorizationRefused => "authorization_refused",
-        OutcomeCodeV2::FileLifecycleIncomplete => "file_lifecycle_incomplete",
-        OutcomeCodeV2::ObservationFailed => "observation_failed",
+        OutcomeCode::None => "none",
+        OutcomeCode::ExecutionFailed => "execution_failed",
+        OutcomeCode::AuthorizationRefused => "authorization_refused",
+        OutcomeCode::FileLifecycleIncomplete => "file_lifecycle_incomplete",
+        OutcomeCode::ObservationFailed => "observation_failed",
     }
 }
 
-pub(crate) fn receipt_status_label(status: ReceiptStatusV2) -> &'static str {
+pub(crate) fn receipt_status_label(status: ReceiptStatus) -> &'static str {
     receipt_status_name(status)
 }
 
-fn error_class_for(code: OutcomeCodeV2) -> &'static str {
+fn error_class_for(code: OutcomeCode) -> &'static str {
     match code {
-        OutcomeCodeV2::AuthorizationRefused => "safety_limit",
-        OutcomeCodeV2::FileLifecycleIncomplete => "integrity",
-        OutcomeCodeV2::ExecutionFailed | OutcomeCodeV2::ObservationFailed | OutcomeCodeV2::None => {
-            "io"
-        }
+        OutcomeCode::AuthorizationRefused => "safety_limit",
+        OutcomeCode::FileLifecycleIncomplete => "integrity",
+        OutcomeCode::ExecutionFailed | OutcomeCode::ObservationFailed | OutcomeCode::None => "io",
     }
 }
 
-fn receipt_status_name(status: ReceiptStatusV2) -> &'static str {
+fn receipt_status_name(status: ReceiptStatus) -> &'static str {
     match status {
-        ReceiptStatusV2::Clean => "clean",
-        ReceiptStatusV2::Failed => "failed",
-        ReceiptStatusV2::Incomplete => "incomplete",
+        ReceiptStatus::Clean => "clean",
+        ReceiptStatus::Failed => "failed",
+        ReceiptStatus::Incomplete => "incomplete",
     }
 }
 
@@ -1118,8 +1110,8 @@ pub(crate) fn open_attached_frames<I>(
     expected_enrollment_id: EnrollmentId,
     expected_request_id: RequestId,
     expected_grant_digest: [u8; 32],
-    expected_policy: &ReceiptPolicyV2,
-) -> Result<VerifiedReceiptV2>
+    expected_policy: &ReceiptPolicy,
+) -> Result<VerifiedReceipt>
 where
     I: IntoIterator<Item = Result<Vec<u8>>>,
 {
@@ -1128,12 +1120,12 @@ where
         .next()
         .context("receipt stream has no start frame")??;
     let encapsulated_key = match decode_receipt_frame(&first)? {
-        ReceiptFrameV2::Start {
-            mode: ReceiptDeliveryKindV2::AttachedEncrypted,
+        ReceiptFrame::Start {
+            mode: ReceiptDeliveryKind::AttachedEncrypted,
             encapsulated_key,
         } => encapsulated_key,
-        ReceiptFrameV2::Start {
-            mode: ReceiptDeliveryKindV2::DetachedSignedPlaintext,
+        ReceiptFrame::Start {
+            mode: ReceiptDeliveryKind::DetachedSignedPlaintext,
             ..
         } => bail!("attached transfer received a detached plaintext receipt"),
         _ => bail!("receipt stream does not begin with a start frame"),
@@ -1157,7 +1149,7 @@ where
             .next()
             .context("receipt stream has no terminal frame")??;
         match decode_receipt_frame(&encoded)? {
-            ReceiptFrameV2::Chunk {
+            ReceiptFrame::Chunk {
                 sequence: observed,
                 payload,
             } => {
@@ -1172,7 +1164,7 @@ where
                     .context("write local decrypted receipt spool")?;
                 sequence += 1;
             }
-            ReceiptFrameV2::End {
+            ReceiptFrame::End {
                 sequence: observed,
                 payload,
             } => {
@@ -1184,7 +1176,7 @@ where
                     .map_err(|_| anyhow!("receipt terminal frame failed authentication"))?;
                 break terminal;
             }
-            ReceiptFrameV2::Start { .. } => bail!("receipt stream contains a second start frame"),
+            ReceiptFrame::Start { .. } => bail!("receipt stream contains a second start frame"),
         }
     };
     if frames.next().is_some() {
@@ -1204,14 +1196,14 @@ where
         bail!("receipt policy does not match the signed grant");
     }
     verify_stream(&mut stream, &terminal)?;
-    Ok(VerifiedReceiptV2 { terminal, stream })
+    Ok(VerifiedReceipt { terminal, stream })
 }
 
-fn verify_stream(stream: &mut File, terminal: &TerminalReceiptV2) -> Result<()> {
-    if terminal.schema != ReceiptSchemaV2::LogicalMutationsAndFinalStateV2
-        || terminal.stream_digest_algorithm != DigestAlgorithmV2::Blake3
+fn verify_stream(stream: &mut File, terminal: &TerminalReceipt) -> Result<()> {
+    if terminal.schema != ReceiptSchema::LogicalMutationsAndFinalState
+        || terminal.stream_digest_algorithm != DigestAlgorithm::Blake3
         || terminal.content_digest_algorithm
-            != terminal.policy.hashed.then_some(DigestAlgorithmV2::Blake3)
+            != terminal.policy.hashed.then_some(DigestAlgorithm::Blake3)
     {
         bail!("receipt schema or digest algorithms are inconsistent with its policy");
     }
@@ -1221,7 +1213,7 @@ fn verify_stream(stream: &mut File, terminal: &TerminalReceiptV2) -> Result<()> 
         bail!("receipt stream exceeds its signed policy limit");
     }
     if terminal.expected_manifest_digest.is_some()
-        || terminal.manifest_status != ManifestStatusV2::NotProvided
+        || terminal.manifest_status != ManifestStatus::NotProvided
     {
         bail!("receipt uses an expected-manifest result not supported by this version");
     }
@@ -1234,7 +1226,7 @@ fn verify_stream(stream: &mut File, terminal: &TerminalReceiptV2) -> Result<()> 
     }
     stream.seek(SeekFrom::Start(0))?;
     let mut hasher = blake3::Hasher::new();
-    let mut summary = ReceiptSummaryV2::default();
+    let mut summary = ReceiptSummary::default();
     let mut final_locations = BTreeSet::new();
     for expected_sequence in 0..terminal.record_count {
         let mut length = [0u8; STREAM_RECORD_HEADER_BYTES];
@@ -1249,7 +1241,7 @@ fn verify_stream(stream: &mut File, terminal: &TerminalReceiptV2) -> Result<()> 
         stream
             .read_exact(&mut body)
             .context("receipt record is truncated")?;
-        let record: RecordV2 = postcard::from_bytes(&body).context("decode receipt record")?;
+        let record: ReceiptRecord = postcard::from_bytes(&body).context("decode receipt record")?;
         if postcard::to_stdvec(&record)? != body {
             bail!("receipt record uses a noncanonical encoding");
         }
@@ -1257,7 +1249,7 @@ fn verify_stream(stream: &mut File, terminal: &TerminalReceiptV2) -> Result<()> 
             bail!("receipt record sequence is not contiguous");
         }
         validate_record(&record, &terminal.policy)?;
-        if let RecordV2::FinalState(record) = &record {
+        if let ReceiptRecord::FinalState(record) = &record {
             if !final_locations.insert((record.scope, record.path.clone())) {
                 bail!("receipt repeats a final-state location");
             }
@@ -1288,11 +1280,11 @@ fn verify_stream(stream: &mut File, terminal: &TerminalReceiptV2) -> Result<()> 
     }
     let expected_status =
         if terminal.recording_failure.is_some() || summary.observation_failures > 0 {
-            ReceiptStatusV2::Incomplete
+            ReceiptStatus::Incomplete
         } else if summary.failed > 0 || summary.incomplete > 0 || summary.refusals > 0 {
-            ReceiptStatusV2::Failed
+            ReceiptStatus::Failed
         } else {
-            ReceiptStatusV2::Clean
+            ReceiptStatus::Clean
         };
     if terminal.status != expected_status {
         bail!("receipt status is inconsistent with its records");
@@ -1301,7 +1293,7 @@ fn verify_stream(stream: &mut File, terminal: &TerminalReceiptV2) -> Result<()> 
     Ok(())
 }
 
-fn validate_record(record: &RecordV2, policy: &ReceiptPolicyV2) -> Result<()> {
+fn validate_record(record: &ReceiptRecord, policy: &ReceiptPolicy) -> Result<()> {
     let valid_relative_path = |path: &[u8]| {
         !path.starts_with(b"/")
             && !path.contains(&0)
@@ -1316,49 +1308,47 @@ fn validate_record(record: &RecordV2, policy: &ReceiptPolicyV2) -> Result<()> {
             .is_none_or(|message| message.len() <= MAX_DIAGNOSTIC_BYTES + '…'.len_utf8())
     };
     match record {
-        RecordV2::Operation(record) => {
+        ReceiptRecord::Operation(record) => {
             if !valid_relative_path(&record.path) || !valid_diagnostic(&record.diagnostic) {
                 bail!("receipt operation has an invalid path or diagnostic");
             }
             let expected_code = match record.disposition {
-                OperationDispositionV2::Applied | OperationDispositionV2::Observed => {
-                    OutcomeCodeV2::None
-                }
-                OperationDispositionV2::Failed => OutcomeCodeV2::ExecutionFailed,
-                OperationDispositionV2::Incomplete => OutcomeCodeV2::FileLifecycleIncomplete,
+                OperationDisposition::Applied | OperationDisposition::Observed => OutcomeCode::None,
+                OperationDisposition::Failed => OutcomeCode::ExecutionFailed,
+                OperationDisposition::Incomplete => OutcomeCode::FileLifecycleIncomplete,
             };
             if record.code != expected_code
-                || (record.disposition == OperationDispositionV2::Observed
-                    && record.action != OperationActionV2::ObserveFileHash)
-                || (record.action == OperationActionV2::ObserveFileHash
-                    && matches!(record.disposition, OperationDispositionV2::Applied))
+                || (record.disposition == OperationDisposition::Observed
+                    && record.action != OperationAction::ObserveFileHash)
+                || (record.action == OperationAction::ObserveFileHash
+                    && matches!(record.disposition, OperationDisposition::Applied))
                 || (matches!(
                     record.disposition,
-                    OperationDispositionV2::Applied | OperationDispositionV2::Observed
+                    OperationDisposition::Applied | OperationDisposition::Observed
                 ) && record.diagnostic.is_some())
             {
                 bail!("receipt operation code, disposition, and diagnostic are inconsistent");
             }
         }
-        RecordV2::Refusal(record) => {
-            if record.code != OutcomeCodeV2::AuthorizationRefused
+        ReceiptRecord::Refusal(record) => {
+            if record.code != OutcomeCode::AuthorizationRefused
                 || !valid_diagnostic(&record.diagnostic)
             {
                 bail!("receipt refusal is inconsistent");
             }
         }
-        RecordV2::FinalState(record) => {
+        ReceiptRecord::FinalState(record) => {
             if !valid_relative_path(&record.path) {
                 bail!("receipt final state has an invalid relative path");
             }
             match &record.object {
-                FinalObjectV2::Absent => {}
-                FinalObjectV2::ObservationFailed { code, diagnostic } => {
-                    if *code != OutcomeCodeV2::ObservationFailed || !valid_diagnostic(diagnostic) {
+                FinalObject::Absent => {}
+                FinalObject::ObservationFailed { code, diagnostic } => {
+                    if *code != OutcomeCode::ObservationFailed || !valid_diagnostic(diagnostic) {
                         bail!("receipt final-state failure is inconsistent");
                     }
                 }
-                FinalObjectV2::Present {
+                FinalObject::Present {
                     kind,
                     digest,
                     symlink_target,
@@ -1386,7 +1376,7 @@ fn validate_record(record: &RecordV2, policy: &ReceiptPolicyV2) -> Result<()> {
     Ok(())
 }
 
-fn read_record(stream: &mut File) -> Result<RecordV2> {
+fn read_record(stream: &mut File) -> Result<ReceiptRecord> {
     let mut length = [0u8; STREAM_RECORD_HEADER_BYTES];
     stream.read_exact(&mut length)?;
     let body_len = u32::from_be_bytes(length) as usize;
@@ -1395,14 +1385,14 @@ fn read_record(stream: &mut File) -> Result<RecordV2> {
     }
     let mut body = vec![0u8; body_len];
     stream.read_exact(&mut body)?;
-    let record: RecordV2 = postcard::from_bytes(&body)?;
+    let record: ReceiptRecord = postcard::from_bytes(&body)?;
     if postcard::to_stdvec(&record)? != body {
         bail!("receipt record uses a noncanonical encoding");
     }
     Ok(record)
 }
 
-fn sign_terminal(receipt: &TerminalReceiptV2, private_key: &PrivateKey) -> Result<Vec<u8>> {
+fn sign_terminal(receipt: &TerminalReceipt, private_key: &PrivateKey) -> Result<Vec<u8>> {
     if private_key.is_encrypted() {
         bail!("cannot sign a receipt with an encrypted key");
     }
@@ -1415,7 +1405,6 @@ fn sign_terminal(receipt: &TerminalReceiptV2, private_key: &PrivateKey) -> Resul
     let mut encoded =
         Vec::with_capacity(TERMINAL_HEADER_LEN + measured_body_len + MAX_SIGNATURE_BYTES);
     encoded.extend_from_slice(TERMINAL_MAGIC);
-    encoded.extend_from_slice(&TERMINAL_VERSION.to_be_bytes());
     encoded.extend_from_slice(&[0; std::mem::size_of::<u32>()]);
     encoded = postcard::to_extend(receipt, encoded).context("encode receipt terminal")?;
     let body_len = encoded.len() - signed_header_len;
@@ -1423,7 +1412,7 @@ fn sign_terminal(receipt: &TerminalReceiptV2, private_key: &PrivateKey) -> Resul
     if body_len > MAX_TERMINAL_BYTES {
         bail!("receipt terminal exceeds size limit");
     }
-    encoded[10..signed_header_len].copy_from_slice(&(body_len as u32).to_be_bytes());
+    encoded[8..signed_header_len].copy_from_slice(&(body_len as u32).to_be_bytes());
     let payload_len = encoded.len();
     let signature = private_key
         .sign(RECEIPT_NAMESPACE, HashAlg::Sha256, &encoded)
@@ -1442,17 +1431,13 @@ fn sign_terminal(receipt: &TerminalReceiptV2, private_key: &PrivateKey) -> Resul
     Ok(encoded)
 }
 
-fn verify_terminal(encoded: &[u8], public_key: &str) -> Result<TerminalReceiptV2> {
+fn verify_terminal(encoded: &[u8], public_key: &str) -> Result<TerminalReceipt> {
     if encoded.len() < TERMINAL_HEADER_LEN || &encoded[..8] != TERMINAL_MAGIC {
-        bail!("not a receipt v2 terminal envelope");
+        bail!("not a receipt terminal envelope");
     }
-    let version = u16::from_be_bytes(encoded[8..10].try_into().expect("fixed header"));
-    if version != TERMINAL_VERSION {
-        bail!("unsupported receipt terminal version {version}");
-    }
-    let body_len = u32::from_be_bytes(encoded[10..14].try_into().expect("fixed header")) as usize;
+    let body_len = u32::from_be_bytes(encoded[8..12].try_into().expect("fixed header")) as usize;
     let signature_len =
-        u32::from_be_bytes(encoded[14..18].try_into().expect("fixed header")) as usize;
+        u32::from_be_bytes(encoded[12..16].try_into().expect("fixed header")) as usize;
     if body_len == 0 || body_len > MAX_TERMINAL_BYTES {
         bail!("receipt terminal length is outside the supported range");
     }
@@ -1479,8 +1464,7 @@ fn verify_terminal(encoded: &[u8], public_key: &str) -> Result<TerminalReceiptV2
             &signature,
         )
         .context("receipt terminal signature does not verify")?;
-    let receipt: TerminalReceiptV2 =
-        postcard::from_bytes(body).context("decode receipt terminal")?;
+    let receipt: TerminalReceipt = postcard::from_bytes(body).context("decode receipt terminal")?;
     if postcard::to_stdvec(&receipt)? != body {
         bail!("receipt terminal uses a noncanonical encoding");
     }
@@ -1491,7 +1475,6 @@ fn verify_terminal(encoded: &[u8], public_key: &str) -> Result<TerminalReceiptV2
 fn terminal_signing_payload(body: &[u8]) -> Vec<u8> {
     let mut payload = Vec::with_capacity(8 + 2 + 4 + body.len());
     payload.extend_from_slice(TERMINAL_MAGIC);
-    payload.extend_from_slice(&TERMINAL_VERSION.to_be_bytes());
     payload.extend_from_slice(&(body.len() as u32).to_be_bytes());
     payload.extend_from_slice(body);
     payload
@@ -1503,7 +1486,7 @@ fn hpke_info(
     grant_digest: [u8; 32],
 ) -> Result<Vec<u8>> {
     postcard::to_stdvec(&(
-        "syq-receipt-v2-hpke@greaber.github",
+        "syq-receipt-hpke@greaber.github",
         enrollment_id,
         request_id,
         grant_digest,
@@ -1513,7 +1496,7 @@ fn hpke_info(
 
 fn frame_aad(sequence: u64, terminal: bool) -> Vec<u8> {
     let mut aad = Vec::with_capacity(32);
-    aad.extend_from_slice(b"syq-receipt-v2-frame\0");
+    aad.extend_from_slice(b"syq-receipt-frame\0");
     aad.extend_from_slice(&sequence.to_be_bytes());
     aad.push(u8::from(terminal));
     aad
@@ -1566,17 +1549,17 @@ mod tests {
 
     fn key(seed: u8) -> PrivateKey {
         let keypair = ssh_key::private::Ed25519Keypair::from_seed(&[seed; 32]);
-        PrivateKey::new(keypair.into(), "syq-receipt-v2-test").unwrap()
+        PrivateKey::new(keypair.into(), "syq-receipt-test").unwrap()
     }
 
-    fn policy(public: [u8; 32]) -> ReceiptPolicyV2 {
-        ReceiptPolicyV2 {
+    fn policy(public: [u8; 32]) -> ReceiptPolicy {
+        ReceiptPolicy {
             required: true,
             hashed: true,
             max_records: 32,
             max_plaintext_bytes: 64 * 1024,
-            delivery: ReceiptDeliveryV2::AttachedEncrypted {
-                suite: HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+            delivery: ReceiptDelivery::AttachedEncrypted {
+                suite: HpkeSuite::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
                 recipient_public_key: public,
             },
         }
@@ -1590,45 +1573,45 @@ mod tests {
         let request_id = RequestId::fresh(1_900_000_000).unwrap();
         let grant_digest = [7; 32];
         let signing_key = key(3);
-        let mut stream = StreamWriterV2::new(&policy).unwrap();
-        stream.append(&RecordV2::Operation(OperationRecordV2 {
+        let mut stream = ReceiptStreamWriter::new(&policy).unwrap();
+        stream.append(&ReceiptRecord::Operation(ReceiptOperationRecord {
             sequence: stream.next_sequence(),
             scope: 0,
             path: b"artifact".to_vec(),
-            action: OperationActionV2::PublishFile {
+            action: OperationAction::PublishFile {
                 size: 3,
                 inplace: false,
             },
-            disposition: OperationDispositionV2::Failed,
-            code: OutcomeCodeV2::ExecutionFailed,
+            disposition: OperationDisposition::Failed,
+            code: OutcomeCode::ExecutionFailed,
             diagnostic: Some("short write".to_string()),
         }));
-        stream.append(&RecordV2::Refusal(RefusalRecordV2 {
+        stream.append(&ReceiptRecord::Refusal(RefusalReceiptRecord {
             sequence: stream.next_sequence(),
-            code: OutcomeCodeV2::AuthorizationRefused,
+            code: OutcomeCode::AuthorizationRefused,
             diagnostic: None,
         }));
-        stream.append(&RecordV2::FinalState(FinalStateRecordV2 {
+        stream.append(&ReceiptRecord::FinalState(FinalStateReceiptRecord {
             sequence: stream.next_sequence(),
             scope: 0,
             path: b"artifact".to_vec(),
-            object: FinalObjectV2::ObservationFailed {
-                code: OutcomeCodeV2::ObservationFailed,
+            object: FinalObject::ObservationFailed {
+                code: OutcomeCode::ObservationFailed,
                 diagnostic: None,
             },
         }));
         // A present object whose closure hash could not be taken: the object
         // is attested, but the partial observation still counts as an error.
-        stream.append(&RecordV2::FinalState(FinalStateRecordV2 {
+        stream.append(&ReceiptRecord::FinalState(FinalStateReceiptRecord {
             sequence: stream.next_sequence(),
             scope: 0,
             path: b"partial".to_vec(),
-            object: FinalObjectV2::Present {
+            object: FinalObject::Present {
                 kind: Kind::File,
                 size: 4,
                 digest: None,
                 symlink_target: None,
-                metadata: ObjectMetadataV2 {
+                metadata: ObjectMetadata {
                     mode: 0o100644,
                     uid: 1000,
                     gid: 1000,
@@ -1640,7 +1623,7 @@ mod tests {
             },
         }));
         let issued = stream
-            .finish(ReceiptClosureV2 {
+            .finish(ReceiptClosure {
                 enrollment_id,
                 request_id,
                 grant_digest,
@@ -1667,7 +1650,7 @@ mod tests {
             &policy,
         )
         .unwrap();
-        assert_eq!(verified.terminal.status, ReceiptStatusV2::Incomplete);
+        assert_eq!(verified.terminal.status, ReceiptStatus::Incomplete);
 
         #[derive(Clone, Default)]
         struct Sink(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
@@ -1748,15 +1731,15 @@ mod tests {
     #[test]
     fn borrowed_receipt_frames_preserve_wire_encoding() {
         let frames = [
-            ReceiptFrameV2::Start {
-                mode: ReceiptDeliveryKindV2::AttachedEncrypted,
+            ReceiptFrame::Start {
+                mode: ReceiptDeliveryKind::AttachedEncrypted,
                 encapsulated_key: vec![3; 32],
             },
-            ReceiptFrameV2::Chunk {
+            ReceiptFrame::Chunk {
                 sequence: u64::MAX,
                 payload: vec![5; PLAINTEXT_CHUNK_BYTES],
             },
-            ReceiptFrameV2::End {
+            ReceiptFrame::End {
                 sequence: 17,
                 payload: vec![7; 257],
             },
@@ -1780,29 +1763,29 @@ mod tests {
         let request_id = RequestId::fresh(1_900_000_000).unwrap();
         let grant_digest = [7; 32];
         let signing_key = key(3);
-        let mut stream = StreamWriterV2::new(&policy).unwrap();
-        stream.append(&RecordV2::Operation(OperationRecordV2 {
+        let mut stream = ReceiptStreamWriter::new(&policy).unwrap();
+        stream.append(&ReceiptRecord::Operation(ReceiptOperationRecord {
             sequence: stream.next_sequence(),
             scope: 0,
             path: b"artifact".to_vec(),
-            action: OperationActionV2::PublishFile {
+            action: OperationAction::PublishFile {
                 size: 3,
                 inplace: false,
             },
-            disposition: OperationDispositionV2::Applied,
-            code: OutcomeCodeV2::None,
+            disposition: OperationDisposition::Applied,
+            code: OutcomeCode::None,
             diagnostic: None,
         }));
-        stream.append(&RecordV2::FinalState(FinalStateRecordV2 {
+        stream.append(&ReceiptRecord::FinalState(FinalStateReceiptRecord {
             sequence: stream.next_sequence(),
             scope: 0,
             path: b"artifact".to_vec(),
-            object: FinalObjectV2::Present {
+            object: FinalObject::Present {
                 kind: Kind::File,
                 size: 3,
                 digest: Some([9; 32]),
                 symlink_target: None,
-                metadata: ObjectMetadataV2 {
+                metadata: ObjectMetadata {
                     mode: 0o100644,
                     uid: 1000,
                     gid: 1000,
@@ -1814,7 +1797,7 @@ mod tests {
             },
         }));
         let issued = stream
-            .finish(ReceiptClosureV2 {
+            .finish(ReceiptClosure {
                 enrollment_id,
                 request_id,
                 grant_digest,
@@ -1841,7 +1824,7 @@ mod tests {
             &policy,
         )
         .unwrap();
-        assert_eq!(verified.terminal.status, ReceiptStatusV2::Clean);
+        assert_eq!(verified.terminal.status, ReceiptStatus::Clean);
         let mut records = Vec::new();
         verified
             .for_each_record(|record| {
@@ -1918,18 +1901,18 @@ mod tests {
         .is_err());
 
         let issued = {
-            let mut stream = StreamWriterV2::new(&policy).unwrap();
-            stream.append(&RecordV2::Operation(OperationRecordV2 {
+            let mut stream = ReceiptStreamWriter::new(&policy).unwrap();
+            stream.append(&ReceiptRecord::Operation(ReceiptOperationRecord {
                 sequence: 0,
                 scope: 0,
                 path: b"artifact".to_vec(),
-                action: OperationActionV2::EnsureDirectory,
-                disposition: OperationDispositionV2::Applied,
-                code: OutcomeCodeV2::None,
+                action: OperationAction::EnsureDirectory,
+                disposition: OperationDisposition::Applied,
+                code: OutcomeCode::None,
                 diagnostic: None,
             }));
             stream
-                .finish(ReceiptClosureV2 {
+                .finish(ReceiptClosure {
                     enrollment_id,
                     request_id,
                     grant_digest,
@@ -1948,7 +1931,7 @@ mod tests {
         })
         .unwrap();
         let mut chunk = decode_receipt_frame(&tampered[1]).unwrap();
-        let ReceiptFrameV2::Chunk { payload, .. } = &mut chunk else {
+        let ReceiptFrame::Chunk { payload, .. } = &mut chunk else {
             panic!("expected encrypted stream chunk");
         };
         payload[0] ^= 1;
@@ -1967,34 +1950,34 @@ mod tests {
 
     #[test]
     fn detached_delivery_is_a_signed_plaintext_stream() {
-        let policy = ReceiptPolicyV2 {
+        let policy = ReceiptPolicy {
             required: true,
             hashed: false,
             max_records: 8,
             max_plaintext_bytes: 4096,
-            delivery: ReceiptDeliveryV2::DetachedSignedPlaintext,
+            delivery: ReceiptDelivery::DetachedSignedPlaintext,
         };
         let enrollment_id = EnrollmentId::random();
         let request_id = RequestId::fresh(1_900_000_000).unwrap();
         let signing_key = key(8);
-        let mut stream = StreamWriterV2::new(&policy).unwrap();
-        stream.append(&RecordV2::Operation(OperationRecordV2 {
+        let mut stream = ReceiptStreamWriter::new(&policy).unwrap();
+        stream.append(&ReceiptRecord::Operation(ReceiptOperationRecord {
             sequence: 0,
             scope: 1,
             path: b"plain".to_vec(),
-            action: OperationActionV2::EnsureDirectory,
-            disposition: OperationDispositionV2::Applied,
-            code: OutcomeCodeV2::None,
+            action: OperationAction::EnsureDirectory,
+            disposition: OperationDisposition::Applied,
+            code: OutcomeCode::None,
             diagnostic: None,
         }));
-        stream.append(&RecordV2::FinalState(FinalStateRecordV2 {
+        stream.append(&ReceiptRecord::FinalState(FinalStateReceiptRecord {
             sequence: 1,
             scope: 1,
             path: b"plain".to_vec(),
-            object: FinalObjectV2::Absent,
+            object: FinalObject::Absent,
         }));
         let issued = stream
-            .finish(ReceiptClosureV2 {
+            .finish(ReceiptClosure {
                 enrollment_id,
                 request_id,
                 grant_digest: [8; 32],
@@ -2013,17 +1996,17 @@ mod tests {
         .unwrap();
         assert!(matches!(
             frames[0],
-            ReceiptFrameV2::Start {
-                mode: ReceiptDeliveryKindV2::DetachedSignedPlaintext,
+            ReceiptFrame::Start {
+                mode: ReceiptDeliveryKind::DetachedSignedPlaintext,
                 ref encapsulated_key,
             } if encapsulated_key.is_empty()
         ));
-        let ReceiptFrameV2::Chunk { payload, .. } = &frames[1] else {
+        let ReceiptFrame::Chunk { payload, .. } = &frames[1] else {
             panic!("expected plaintext receipt chunk");
         };
         let mut spool = tempfile::tempfile().unwrap();
         spool.write_all(payload).unwrap();
-        let ReceiptFrameV2::End { payload, .. } = &frames[2] else {
+        let ReceiptFrame::End { payload, .. } = &frames[2] else {
             panic!("expected signed terminal frame");
         };
         let terminal =
@@ -2036,22 +2019,22 @@ mod tests {
         let (_, public) = generate_recipient().unwrap();
         let mut policy = policy(public);
         policy.max_records = 1;
-        let mut stream = StreamWriterV2::new(&policy).unwrap();
+        let mut stream = ReceiptStreamWriter::new(&policy).unwrap();
         for path in [b"a".as_slice(), b"b".as_slice()] {
-            stream.append(&RecordV2::Operation(OperationRecordV2 {
+            stream.append(&ReceiptRecord::Operation(ReceiptOperationRecord {
                 sequence: stream.next_sequence(),
                 scope: 0,
                 path: path.to_vec(),
-                action: OperationActionV2::EnsureDirectory,
-                disposition: OperationDispositionV2::Applied,
-                code: OutcomeCodeV2::None,
+                action: OperationAction::EnsureDirectory,
+                disposition: OperationDisposition::Applied,
+                code: OutcomeCode::None,
                 diagnostic: None,
             }));
         }
         assert!(stream.is_failed());
         let signing_key = key(4);
         let terminal = stream
-            .finish(ReceiptClosureV2 {
+            .finish(ReceiptClosure {
                 enrollment_id: EnrollmentId::random(),
                 request_id: RequestId::fresh(1_900_000_000).unwrap(),
                 grant_digest: [1; 32],

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -1,4 +1,4 @@
-//! Receipt v2: a complete receiver-authored record stream, a small signed
+//! Receipts: a complete receiver-authored record stream, a small signed
 //! terminal commitment, and optional HPKE delivery to the invoking machine.
 //!
 //! The stream records logical pathname operations and closure-time state. It
@@ -67,7 +67,7 @@ pub(crate) struct ReceiptPolicy {
 impl ReceiptPolicy {
     pub(crate) fn validate(&self) -> Result<()> {
         if !self.required {
-            bail!("receipt v2 policy must require a receipt");
+            bail!("receipt policy must require a receipt");
         }
         if self.max_records == 0 || self.max_records > DEFAULT_MAX_RECORDS {
             bail!("receipt record limit is outside the supported range");
@@ -624,8 +624,8 @@ pub(crate) fn emit_receipt_frames(
                 let payload = sender
                     .seal(&buffer[..wanted], &frame_aad(sequence, false))
                     .map_err(|_| anyhow!("encrypt receipt stream frame"))?;
-            emit(encode_borrowed_receipt_frame(
-                &BorrowedReceiptFrame::Chunk {
+                emit(encode_borrowed_receipt_frame(
+                    &BorrowedReceiptFrame::Chunk {
                         sequence,
                         payload: &payload,
                     },
@@ -636,12 +636,10 @@ pub(crate) fn emit_receipt_frames(
             let payload = sender
                 .seal(&issued.signed_terminal, &frame_aad(sequence, true))
                 .map_err(|_| anyhow!("encrypt receipt terminal frame"))?;
-            emit(encode_borrowed_receipt_frame(
-                &BorrowedReceiptFrame::End {
-                    sequence,
-                    payload: &payload,
-                },
-            )?)?;
+            emit(encode_borrowed_receipt_frame(&BorrowedReceiptFrame::End {
+                sequence,
+                payload: &payload,
+            })?)?;
         }
         ReceiptDelivery::DetachedSignedPlaintext => {
             emit(encode_borrowed_receipt_frame(
@@ -660,8 +658,8 @@ pub(crate) fn emit_receipt_frames(
                     .stream
                     .read_exact(&mut buffer[..wanted])
                     .context("read receiver receipt spool")?;
-            emit(encode_borrowed_receipt_frame(
-                &BorrowedReceiptFrame::Chunk {
+                emit(encode_borrowed_receipt_frame(
+                    &BorrowedReceiptFrame::Chunk {
                         sequence,
                         payload: &buffer[..wanted],
                     },
@@ -669,12 +667,10 @@ pub(crate) fn emit_receipt_frames(
                 sequence += 1;
                 remaining -= wanted as u64;
             }
-            emit(encode_borrowed_receipt_frame(
-                &BorrowedReceiptFrame::End {
-                    sequence,
-                    payload: &issued.signed_terminal,
-                },
-            )?)?;
+            emit(encode_borrowed_receipt_frame(&BorrowedReceiptFrame::End {
+                sequence,
+                payload: &issued.signed_terminal,
+            })?)?;
         }
     }
     Ok(())

--- a/src/remote_helper.rs
+++ b/src/remote_helper.rs
@@ -15,7 +15,7 @@ pub const REMOTE_DOWNLOAD_FALLBACK_EXIT: i32 = 75;
 pub const REMOTE_DOWNLOAD_INTEGRITY_EXIT: i32 = 76;
 /// The remote cache itself could not be written or finalized; upload cannot fix it.
 pub const INSTALL_FAILED_EXIT: i32 = 77;
-const DOWNLOAD_CACHE_GENERATION: &str = "release-v1";
+const DOWNLOAD_CACHE_GENERATION: &str = "release";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Target {

--- a/src/remote_to_remote.rs
+++ b/src/remote_to_remote.rs
@@ -70,8 +70,8 @@ fn receipt_settlement_outcome(
     }
 }
 
-const MAX_RECEIPT_V2_LINE_BYTES: usize = 192 * 1024;
-const MAX_RECEIPT_V2_CAPTURE_BYTES: u64 = 640 * 1024 * 1024;
+const MAX_RECEIPT_LINE_BYTES: usize = 192 * 1024;
+const MAX_RECEIPT_CAPTURE_BYTES: u64 = 640 * 1024 * 1024;
 
 struct CapturedReceipt {
     file: std::fs::File,
@@ -101,7 +101,7 @@ impl CapturedReceipt {
             .bytes
             .checked_add(added)
             .context("receipt capture byte count overflow")?;
-        if self.bytes > MAX_RECEIPT_V2_CAPTURE_BYTES {
+        if self.bytes > MAX_RECEIPT_CAPTURE_BYTES {
             bail!("the relayed receipt exceeds its local capture limit");
         }
         self.file.write_all(&length.to_be_bytes())?;
@@ -201,8 +201,8 @@ fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<CapturedReceipt>> {
                     .context("relay remote coordinator output")?;
             }
             if let Some(payload) = capturing.as_mut() {
-                if payload.len() > MAX_RECEIPT_V2_LINE_BYTES {
-                    bail!("the relayed receipt line exceeds {MAX_RECEIPT_V2_LINE_BYTES} bytes");
+                if payload.len() > MAX_RECEIPT_LINE_BYTES {
+                    bail!("the relayed receipt line exceeds {MAX_RECEIPT_LINE_BYTES} bytes");
                 }
             }
             if ends_line {
@@ -235,7 +235,7 @@ fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<CapturedReceipt>> {
 fn store_receipt_line(captured: &mut Option<CapturedReceipt>, payload: Vec<u8>) -> Result<()> {
     let encoded = base64::engine::general_purpose::STANDARD_NO_PAD
         .decode(payload.trim_ascii())
-        .context("decode a receipt v2 frame relayed from the source host")?;
+        .context("decode a receipt frame relayed from the source host")?;
     let receipt = match captured {
         Some(receipt) => receipt,
         None => captured.insert(CapturedReceipt::new()?),
@@ -1450,7 +1450,7 @@ mod tests {
     }
 
     #[test]
-    fn relay_passes_output_through_and_spools_v2_frames() {
+    fn relay_passes_output_through_and_spools_receipt_frames() {
         // Ordinary output streams through byte for byte, including bytes
         // that are not UTF-8; a stream with no receipt lines captures
         // nothing.
@@ -1488,13 +1488,13 @@ mod tests {
         }
         let mut captured = relay_stdout(&output[..])
             .unwrap()
-            .expect("captured receipt v2 frames");
+            .expect("captured receipt frames");
         let captured: Vec<Vec<u8>> = captured.frames().unwrap().map(Result::unwrap).collect();
         assert_eq!(captured, frames);
 
         // An oversized marker line is refused instead of buffered.
         let mut oversized = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes().to_vec();
-        oversized.extend(std::iter::repeat_n(b'A', MAX_RECEIPT_V2_LINE_BYTES + 1));
+        oversized.extend(std::iter::repeat_n(b'A', MAX_RECEIPT_LINE_BYTES + 1));
         oversized.push(b'\n');
         assert!(relay_stdout(oversized.as_slice()).is_err());
     }

--- a/src/remote_to_remote.rs
+++ b/src/remote_to_remote.rs
@@ -16,8 +16,8 @@ struct ReceiptExpectation {
     public_key: String,
     enrollment_id: EnrollmentId,
     request_id: RequestId,
-    recipient_secret: Option<crate::receipt_v2::RecipientSecret>,
-    policy: crate::receipt_v2::ReceiptPolicyV2,
+    recipient_secret: Option<crate::receipt::RecipientSecret>,
+    policy: crate::receipt::ReceiptPolicy,
     grant_digest: Option<[u8; 32]>,
 }
 
@@ -29,7 +29,7 @@ struct ReceiptSettlementOutcome {
 }
 
 fn receipt_settlement_outcome(
-    receipt_status: crate::receipt_v2::ReceiptStatusV2,
+    receipt_status: crate::receipt::ReceiptStatus,
     refusals: u64,
     coordinator_exit_code: i32,
 ) -> ReceiptSettlementOutcome {
@@ -37,11 +37,10 @@ fn receipt_settlement_outcome(
     // receipt against a coordinator that claimed success is a contradiction
     // the exit code must surface.
     let rejects_receipt = refusals > 0
-        || (receipt_status != crate::receipt_v2::ReceiptStatusV2::Clean
-            && coordinator_exit_code == 0);
+        || (receipt_status != crate::receipt::ReceiptStatus::Clean && coordinator_exit_code == 0);
     // Status first, then the exit code the automation contract pairs with
     // it — the two can never disagree.
-    let results_status = if receipt_status == crate::receipt_v2::ReceiptStatusV2::Incomplete {
+    let results_status = if receipt_status == crate::receipt::ReceiptStatus::Incomplete {
         // An incomplete receipt stream can omit operations. Never describe it
         // as safe input for a per-entry retry, even when the coordinator also
         // reported a conventional partial-transfer exit.
@@ -52,8 +51,7 @@ fn receipt_settlement_outcome(
         "failed"
     } else if refusals > 0 || coordinator_exit_code == 25 {
         "refused"
-    } else if receipt_status != crate::receipt_v2::ReceiptStatusV2::Clean
-        || coordinator_exit_code == 23
+    } else if receipt_status != crate::receipt::ReceiptStatus::Clean || coordinator_exit_code == 23
     {
         "partial"
     } else {
@@ -96,7 +94,7 @@ impl CapturedReceipt {
         if self.ended {
             bail!("the relayed receipt contains a frame after its terminal frame");
         }
-        let terminal = crate::receipt_v2::receipt_frame_is_end(encoded)?;
+        let terminal = crate::receipt::receipt_frame_is_end(encoded)?;
         let length = u32::try_from(encoded.len()).context("receipt frame length exceeds u32")?;
         let added = 4u64 + u64::from(length);
         self.bytes = self
@@ -151,7 +149,7 @@ impl Iterator for CapturedFrames<'_> {
 /// other transfers inherit stdout untouched. Frames are decoded one line
 /// at a time and spooled rather than accumulated in memory.
 fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<CapturedReceipt>> {
-    let prefix = crate::receipt_v2::RECEIPT_LINE_PREFIX.as_bytes();
+    let prefix = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes();
     let mut reader = std::io::BufReader::with_capacity(64 * 1024, stdout);
     let mut out = std::io::stdout().lock();
     let mut receipt = None;
@@ -273,10 +271,10 @@ fn settle_receipt(
             settlement.src_host
         );
     };
-    settle_receipt_v2(expectation, captured, settlement)
+    settle_captured_receipt(expectation, captured, settlement)
 }
 
-fn settle_receipt_v2(
+fn settle_captured_receipt(
     expectation: &ReceiptExpectation,
     captured: &mut CapturedReceipt,
     settlement: ReceiptSettlement<'_>,
@@ -300,7 +298,7 @@ fn settle_receipt_v2(
     let policy = &expectation.policy;
     if !matches!(
         policy.delivery,
-        crate::receipt_v2::ReceiptDeliveryV2::AttachedEncrypted { .. }
+        crate::receipt::ReceiptDelivery::AttachedEncrypted { .. }
     ) {
         bail!("an attached transfer has a detached receipt policy");
     }
@@ -308,7 +306,7 @@ fn settle_receipt_v2(
         .grant_digest
         .context("the signed grant digest is unavailable")?;
     let frames = captured.frames()?;
-    let mut receipt = crate::receipt_v2::open_attached_frames(
+    let mut receipt = crate::receipt::open_attached_frames(
         frames,
         secret,
         &expectation.public_key,
@@ -323,11 +321,11 @@ fn settle_receipt_v2(
     receipt.for_each_record(|record| {
         if first_problem.is_none() {
             first_problem = match record {
-                crate::receipt_v2::RecordV2::Operation(record)
+                crate::receipt::ReceiptRecord::Operation(record)
                     if !matches!(
                         record.disposition,
-                        crate::receipt_v2::OperationDispositionV2::Applied
-                            | crate::receipt_v2::OperationDispositionV2::Observed
+                        crate::receipt::OperationDisposition::Applied
+                            | crate::receipt::OperationDisposition::Observed
                     ) =>
                 {
                     Some(format!(
@@ -343,7 +341,7 @@ fn settle_receipt_v2(
                             .unwrap_or_default()
                     ))
                 }
-                crate::receipt_v2::RecordV2::Refusal(record) => Some(format!(
+                crate::receipt::ReceiptRecord::Refusal(record) => Some(format!(
                     "receiver refusal{}",
                     record
                         .diagnostic
@@ -351,11 +349,11 @@ fn settle_receipt_v2(
                         .map(|message| format!(": {message}"))
                         .unwrap_or_default()
                 )),
-                crate::receipt_v2::RecordV2::FinalState(record)
+                crate::receipt::ReceiptRecord::FinalState(record)
                     if matches!(
                         record.object,
-                        crate::receipt_v2::FinalObjectV2::ObservationFailed { .. }
-                            | crate::receipt_v2::FinalObjectV2::Present {
+                        crate::receipt::FinalObject::ObservationFailed { .. }
+                            | crate::receipt::FinalObject::Present {
                                 observation_error: Some(_),
                                 ..
                             }
@@ -385,8 +383,7 @@ fn settle_receipt_v2(
             terminal.summary.refusals,
             first_problem.as_deref().unwrap_or("(no detail recorded)")
         ))
-    } else if terminal.status != crate::receipt_v2::ReceiptStatusV2::Clean
-        && coordinator_exit_code == 0
+    } else if terminal.status != crate::receipt::ReceiptStatus::Clean && coordinator_exit_code == 0
     {
         Some(format!(
             "the receiver on {dst_host} issued a {:?} receipt{}, yet {src_host} reported success",
@@ -401,7 +398,7 @@ fn settle_receipt_v2(
     };
     debug_assert_eq!(outcome.rejects_receipt, settlement_error.is_some());
     if let Some(writer) = results {
-        let emitted = crate::receipt_v2::emit_automation_records(
+        let emitted = crate::receipt::emit_automation_records(
             &mut receipt,
             writer,
             outcome.results_status,
@@ -419,7 +416,7 @@ fn settle_receipt_v2(
                 crate::progress::human(terminal.summary.transferred_bytes),
                 terminal.summary.deletions,
                 emitted.errors,
-                crate::receipt_v2::receipt_status_label(terminal.status),
+                crate::receipt::receipt_status_label(terminal.status),
                 outcome.results_status,
             );
         }
@@ -434,7 +431,7 @@ fn settle_receipt_v2(
     if let Some(message) = settlement_error {
         bail!(message);
     }
-    if terminal.status != crate::receipt_v2::ReceiptStatusV2::Clean {
+    if terminal.status != crate::receipt::ReceiptStatus::Clean {
         let message = format!(
             "the receiver on {dst_host} issued a {:?} receipt{}",
             terminal.status,
@@ -1425,7 +1422,7 @@ mod tests {
 
     #[test]
     fn receipt_settlement_preserves_terminal_outcomes() {
-        use crate::receipt_v2::ReceiptStatusV2::{Clean, Failed, Incomplete};
+        use crate::receipt::ReceiptStatus::{Clean, Failed, Incomplete};
 
         // Every (status, exit_code) pair matches the automation contract's
         // table: success/0, partial/23, refused/25, failed/1, aborted/1.
@@ -1465,23 +1462,23 @@ mod tests {
         // Marker lines are decoded and spooled as separate bounded frames,
         // not accumulated into one receipt allocation.
         let frames = [
-            crate::receipt_v2::ReceiptFrameV2::Start {
-                mode: crate::receipt_v2::ReceiptDeliveryKindV2::DetachedSignedPlaintext,
+            crate::receipt::ReceiptFrame::Start {
+                mode: crate::receipt::ReceiptDeliveryKind::DetachedSignedPlaintext,
                 encapsulated_key: Vec::new(),
             },
-            crate::receipt_v2::ReceiptFrameV2::Chunk {
+            crate::receipt::ReceiptFrame::Chunk {
                 sequence: 0,
                 payload: b"stream".to_vec(),
             },
-            crate::receipt_v2::ReceiptFrameV2::End {
+            crate::receipt::ReceiptFrame::End {
                 sequence: 1,
                 payload: b"terminal".to_vec(),
             },
         ]
-        .map(|frame| crate::receipt_v2::encode_receipt_frame(&frame).unwrap());
+        .map(|frame| crate::receipt::encode_receipt_frame(&frame).unwrap());
         let mut output = b"ordinary line\n".to_vec();
         for frame in &frames {
-            output.extend_from_slice(crate::receipt_v2::RECEIPT_LINE_PREFIX.as_bytes());
+            output.extend_from_slice(crate::receipt::RECEIPT_LINE_PREFIX.as_bytes());
             output.extend_from_slice(
                 base64::engine::general_purpose::STANDARD_NO_PAD
                     .encode(frame)
@@ -1496,7 +1493,7 @@ mod tests {
         assert_eq!(captured, frames);
 
         // An oversized marker line is refused instead of buffered.
-        let mut oversized = crate::receipt_v2::RECEIPT_LINE_PREFIX.as_bytes().to_vec();
+        let mut oversized = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes().to_vec();
         oversized.extend(std::iter::repeat_n(b'A', MAX_RECEIPT_V2_LINE_BYTES + 1));
         oversized.push(b'\n');
         assert!(relay_stdout(oversized.as_slice()).is_err());

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -128,8 +128,8 @@ pub(crate) struct PreparedTransfer {
     /// Verifier for the receipt hostB will issue.
     pub(crate) receipt_public_key: String,
     /// Attached transfers keep this ephemeral HPKE key only until settlement.
-    pub(crate) receipt_recipient_secret: Option<crate::receipt_v2::RecipientSecret>,
-    pub(crate) receipt_policy: crate::receipt_v2::ReceiptPolicyV2,
+    pub(crate) receipt_recipient_secret: Option<crate::receipt::RecipientSecret>,
+    pub(crate) receipt_policy: crate::receipt::ReceiptPolicy,
     pub(crate) grant_digest: [u8; 32],
 }
 
@@ -160,10 +160,10 @@ struct AuthorityState {
     tcp_listener_started: bool,
     /// What hostB will attest to in its receipt.
     /// Receipt records live in an anonymous spool; only mutation-relevant paths
-    /// enter `touched_v2`, never paths merely returned by a destination scan.
-    ledger_v2: Option<crate::receipt_v2::StreamWriterV2>,
-    touched_v2: BTreeSet<Vec<u8>>,
-    file_lifecycles_v2: HashMap<(Vec<u8>, proto::PartialId), FileLifecycleV2>,
+    /// enter `touched`, never paths merely returned by a destination scan.
+    receipt_stream: Option<crate::receipt::ReceiptStreamWriter>,
+    touched: BTreeSet<Vec<u8>>,
+    file_lifecycles: HashMap<(Vec<u8>, proto::PartialId), FileLifecycle>,
     /// Requests authorized for execution whose outcome has not been settled
     /// yet, across every connection. The receipt waits for zero.
     in_flight: u64,
@@ -356,7 +356,7 @@ pub(crate) struct RestrictedAuthority {
     root_existence: RootExistence,
     enrollment_id: EnrollmentId,
     request_id: RequestId,
-    receipt_policy_v2: crate::receipt_v2::ReceiptPolicyV2,
+    receipt_policy: crate::receipt::ReceiptPolicy,
     grant_digest: [u8; 32],
     receipt_key: PrivateKey,
     file_data_limit: Option<crate::bwlimit::BandwidthLimit>,
@@ -382,7 +382,7 @@ impl RestrictedAuthority {
             max_file_data_bytes_per_second,
             filters,
             root_existence,
-            receipt_v2: receipt_policy_v2,
+            receipt_policy,
         } = extensions;
         let enrollment_id = grant.enrollment_id;
         let request_id = grant.request_id;
@@ -428,7 +428,7 @@ impl RestrictedAuthority {
         let receiver_umask = read_process_umask();
         let file_data_limit = (max_file_data_bytes_per_second > 0)
             .then(|| crate::bwlimit::BandwidthLimit::new(max_file_data_bytes_per_second));
-        let ledger_v2 = Some(crate::receipt_v2::StreamWriterV2::new(&receipt_policy_v2)?);
+        let receipt_stream = Some(crate::receipt::ReceiptStreamWriter::new(&receipt_policy)?);
         let authority = Self {
             guard: ContainerGuard {
                 root: config.root.as_bytes().to_vec(),
@@ -443,7 +443,7 @@ impl RestrictedAuthority {
             root_existence,
             enrollment_id,
             request_id,
-            receipt_policy_v2,
+            receipt_policy,
             grant_digest,
             receipt_key,
             file_data_limit,
@@ -463,9 +463,9 @@ impl RestrictedAuthority {
                 deletions: 0,
                 live_connections: 0,
                 tcp_listener_started: false,
-                ledger_v2,
-                touched_v2: BTreeSet::new(),
-                file_lifecycles_v2: HashMap::new(),
+                receipt_stream,
+                touched: BTreeSet::new(),
+                file_lifecycles: HashMap::new(),
                 in_flight: 0,
                 receipt_closing: false,
                 receipt_issued: false,
@@ -476,9 +476,9 @@ impl RestrictedAuthority {
     }
 
     /// Sign hostB's account of this grant and close it to further mutation.
-    pub(crate) fn issue_receipt(&self) -> Result<crate::receipt_v2::IssuedReceiptV2> {
+    pub(crate) fn issue_receipt(&self) -> Result<crate::receipt::IssuedReceipt> {
         let key = &self.receipt_key;
-        let policy = self.receipt_policy_v2.clone();
+        let policy = self.receipt_policy.clone();
         // Close the grant first, then wait for every request already
         // authorized on any connection to execute and settle, so the receipt
         // describes a final state rather than a snapshot with work in flight.
@@ -502,11 +502,11 @@ impl RestrictedAuthority {
         }
         state.receipt_issued = true;
         let mut stream = state
-            .ledger_v2
+            .receipt_stream
             .take()
             .context("receiver receipt spool is unavailable")?;
-        let lifecycles = std::mem::take(&mut state.file_lifecycles_v2);
-        let touched = std::mem::take(&mut state.touched_v2);
+        let lifecycles = std::mem::take(&mut state.file_lifecycles);
+        let touched = std::mem::take(&mut state.touched);
         let entries_touched = touched.len() as u64;
         let transferred_bytes = state.transferred_bytes;
         drop(state);
@@ -515,17 +515,17 @@ impl RestrictedAuthority {
             if lifecycle.recorded {
                 continue;
             }
-            self.append_operation_to_stream_v2(
+            self.append_operation_to_stream(
                 &mut stream,
                 &path,
-                crate::receipt_v2::OperationActionV2::PublishFile {
+                crate::receipt::OperationAction::PublishFile {
                     size: lifecycle.size,
                     inplace: lifecycle.inplace,
                 },
                 if lifecycle.last_error.is_some() {
-                    crate::receipt_v2::OperationDispositionV2::Failed
+                    crate::receipt::OperationDisposition::Failed
                 } else {
-                    crate::receipt_v2::OperationDispositionV2::Incomplete
+                    crate::receipt::OperationDisposition::Incomplete
                 },
                 lifecycle.last_error.as_deref().or(Some(
                     "file lifecycle ended without a successful finalization",
@@ -535,7 +535,7 @@ impl RestrictedAuthority {
 
         for path in touched {
             let object = match self.observe_final(&path) {
-                Ok(None) => crate::receipt_v2::FinalObjectV2::Absent,
+                Ok(None) => crate::receipt::FinalObject::Absent,
                 Ok(Some(metadata)) => {
                     let kind = kind_from_mode(metadata.mode);
                     let mut observation_error = None;
@@ -543,9 +543,9 @@ impl RestrictedAuthority {
                         match self.digest_published(&path) {
                             Ok(digest) => Some(digest),
                             Err(error) => {
-                                observation_error = crate::receipt_v2::bounded_format(
-                                    format_args!("hash final file: {error:#}"),
-                                );
+                                observation_error = crate::receipt::bounded_format(format_args!(
+                                    "hash final file: {error:#}"
+                                ));
                                 None
                             }
                         }
@@ -556,21 +556,21 @@ impl RestrictedAuthority {
                         match self.read_published_link(&path) {
                             Ok(target) => Some(target),
                             Err(error) => {
-                                observation_error = crate::receipt_v2::bounded_format(
-                                    format_args!("read final symlink: {error:#}"),
-                                );
+                                observation_error = crate::receipt::bounded_format(format_args!(
+                                    "read final symlink: {error:#}"
+                                ));
                                 None
                             }
                         }
                     } else {
                         None
                     };
-                    crate::receipt_v2::FinalObjectV2::Present {
+                    crate::receipt::FinalObject::Present {
                         kind,
                         size: metadata.len,
                         digest,
                         symlink_target,
-                        metadata: crate::receipt_v2::ObjectMetadataV2 {
+                        metadata: crate::receipt::ObjectMetadata {
                             mode: metadata.mode,
                             uid: metadata.uid,
                             gid: metadata.gid,
@@ -581,9 +581,9 @@ impl RestrictedAuthority {
                         observation_error,
                     }
                 }
-                Err(error) => crate::receipt_v2::FinalObjectV2::ObservationFailed {
-                    code: crate::receipt_v2::OutcomeCodeV2::ObservationFailed,
-                    diagnostic: crate::receipt_v2::bounded_format(format_args!("{error:#}")),
+                Err(error) => crate::receipt::FinalObject::ObservationFailed {
+                    code: crate::receipt::OutcomeCode::ObservationFailed,
+                    diagnostic: crate::receipt::bounded_format(format_args!("{error:#}")),
                 },
             };
             let Some((scope, relative)) = self.receipt_location(&path) else {
@@ -591,8 +591,8 @@ impl RestrictedAuthority {
                 continue;
             };
             let sequence = stream.next_sequence();
-            stream.append(&crate::receipt_v2::RecordV2::FinalState(
-                crate::receipt_v2::FinalStateRecordV2 {
+            stream.append(&crate::receipt::ReceiptRecord::FinalState(
+                crate::receipt::FinalStateReceiptRecord {
                     sequence,
                     scope,
                     path: relative,
@@ -600,7 +600,7 @@ impl RestrictedAuthority {
                 },
             ));
         }
-        stream.finish(crate::receipt_v2::ReceiptClosureV2 {
+        stream.finish(crate::receipt::ReceiptClosure {
             enrollment_id: self.enrollment_id,
             request_id: self.request_id,
             grant_digest: self.grant_digest,
@@ -969,9 +969,9 @@ impl RestrictedAuthority {
             bail!("the signed grant is closed: its receipt has been issued");
         }
         if state
-            .ledger_v2
+            .receipt_stream
             .as_ref()
-            .is_some_and(crate::receipt_v2::StreamWriterV2::is_failed)
+            .is_some_and(crate::receipt::ReceiptStreamWriter::is_failed)
         {
             bail!("the signed grant is closed because receipt recording failed");
         }
@@ -1017,26 +1017,26 @@ impl RestrictedAuthority {
             })
     }
 
-    fn append_operation_v2(
+    fn append_operation(
         &self,
         state: &mut AuthorityState,
         path: &[u8],
-        action: crate::receipt_v2::OperationActionV2,
-        disposition: crate::receipt_v2::OperationDispositionV2,
+        action: crate::receipt::OperationAction,
+        disposition: crate::receipt::OperationDisposition,
         error: Option<&str>,
     ) {
-        let Some(stream) = state.ledger_v2.as_mut() else {
+        let Some(stream) = state.receipt_stream.as_mut() else {
             return;
         };
-        self.append_operation_to_stream_v2(stream, path, action, disposition, error);
+        self.append_operation_to_stream(stream, path, action, disposition, error);
     }
 
-    fn append_operation_to_stream_v2(
+    fn append_operation_to_stream(
         &self,
-        stream: &mut crate::receipt_v2::StreamWriterV2,
+        stream: &mut crate::receipt::ReceiptStreamWriter,
         path: &[u8],
-        action: crate::receipt_v2::OperationActionV2,
-        disposition: crate::receipt_v2::OperationDispositionV2,
+        action: crate::receipt::OperationAction,
+        disposition: crate::receipt::OperationDisposition,
         error: Option<&str>,
     ) {
         let Some((scope, relative)) = self.receipt_location(path) else {
@@ -1045,26 +1045,24 @@ impl RestrictedAuthority {
         };
         let sequence = stream.next_sequence();
         let code = match disposition {
-            crate::receipt_v2::OperationDispositionV2::Failed => {
-                crate::receipt_v2::OutcomeCodeV2::ExecutionFailed
+            crate::receipt::OperationDisposition::Failed => {
+                crate::receipt::OutcomeCode::ExecutionFailed
             }
-            crate::receipt_v2::OperationDispositionV2::Incomplete => {
-                crate::receipt_v2::OutcomeCodeV2::FileLifecycleIncomplete
+            crate::receipt::OperationDisposition::Incomplete => {
+                crate::receipt::OutcomeCode::FileLifecycleIncomplete
             }
-            crate::receipt_v2::OperationDispositionV2::Applied
-            | crate::receipt_v2::OperationDispositionV2::Observed => {
-                crate::receipt_v2::OutcomeCodeV2::None
-            }
+            crate::receipt::OperationDisposition::Applied
+            | crate::receipt::OperationDisposition::Observed => crate::receipt::OutcomeCode::None,
         };
-        stream.append(&crate::receipt_v2::RecordV2::Operation(
-            crate::receipt_v2::OperationRecordV2 {
+        stream.append(&crate::receipt::ReceiptRecord::Operation(
+            crate::receipt::ReceiptOperationRecord {
                 sequence,
                 scope,
                 path: relative,
                 action,
                 disposition,
                 code,
-                diagnostic: error.and_then(crate::receipt_v2::bounded_diagnostic),
+                diagnostic: error.and_then(crate::receipt::bounded_diagnostic),
             },
         ));
     }
@@ -1077,10 +1075,10 @@ impl RestrictedAuthority {
         let Settlement {
             creations,
             outcomes,
-            touched_v2,
+            touched,
             tracked,
         } = settlement;
-        if creations.is_empty() && outcomes.is_empty() && touched_v2.is_empty() && !tracked {
+        if creations.is_empty() && outcomes.is_empty() && touched.is_empty() && !tracked {
             return;
         }
         let outcome_error = |index: usize| -> Option<&str> {
@@ -1105,47 +1103,47 @@ impl RestrictedAuthority {
                 state.created.insert(creation.path);
             }
         }
-        state.touched_v2.extend(touched_v2);
+        state.touched.extend(touched);
         for outcome in outcomes {
             match outcome {
                 PendingOutcome::Observe { path } => {
                     if let proto::Response::FileHash { .. } = response {
-                        self.append_operation_v2(
+                        self.append_operation(
                             &mut state,
                             &path,
-                            crate::receipt_v2::OperationActionV2::ObserveFileHash,
-                            crate::receipt_v2::OperationDispositionV2::Observed,
+                            crate::receipt::OperationAction::ObserveFileHash,
+                            crate::receipt::OperationDisposition::Observed,
                             None,
                         );
                     } else {
-                        self.append_operation_v2(
+                        self.append_operation(
                             &mut state,
                             &path,
-                            crate::receipt_v2::OperationActionV2::ObserveFileHash,
-                            crate::receipt_v2::OperationDispositionV2::Failed,
+                            crate::receipt::OperationAction::ObserveFileHash,
+                            crate::receipt::OperationDisposition::Failed,
                             outcome_error(0).or(Some("receiver returned no file hash")),
                         );
                     }
                 }
-                PendingOutcome::LogicalV2 {
+                PendingOutcome::Logical {
                     index,
                     path,
                     action,
                 } => {
                     let error = outcome_error(index);
-                    self.append_operation_v2(
+                    self.append_operation(
                         &mut state,
                         &path,
                         action,
                         if error.is_some() {
-                            crate::receipt_v2::OperationDispositionV2::Failed
+                            crate::receipt::OperationDisposition::Failed
                         } else {
-                            crate::receipt_v2::OperationDispositionV2::Applied
+                            crate::receipt::OperationDisposition::Applied
                         },
                         error,
                     );
                 }
-                PendingOutcome::FileStageV2 {
+                PendingOutcome::FileStage {
                     index,
                     path,
                     partial_id,
@@ -1171,16 +1169,16 @@ impl RestrictedAuthority {
                     if absent {
                         continue;
                     }
-                    if state.ledger_v2.is_none() {
+                    if state.receipt_stream.is_none() {
                         continue;
                     }
                     let error = outcome_error(index);
                     let mut inconsistent = false;
                     let emit_complete = {
                         let lifecycle = state
-                            .file_lifecycles_v2
+                            .file_lifecycles
                             .entry((path.clone(), partial_id))
-                            .or_insert(FileLifecycleV2 {
+                            .or_insert(FileLifecycle {
                                 size,
                                 inplace,
                                 recorded: false,
@@ -1189,19 +1187,19 @@ impl RestrictedAuthority {
                         if lifecycle.size != size || lifecycle.inplace != inplace {
                             inconsistent = true;
                         }
-                        if matches!(stage, FileStageV2::Prepare | FileStageV2::Write)
+                        if matches!(stage, FileStage::Prepare | FileStage::Write)
                             && lifecycle.recorded
                         {
                             lifecycle.recorded = false;
                             lifecycle.last_error = None;
                         }
                         if let Some(error) = error {
-                            lifecycle.last_error = crate::receipt_v2::bounded_diagnostic(error);
-                            if stage == FileStageV2::Finalize {
+                            lifecycle.last_error = crate::receipt::bounded_diagnostic(error);
+                            if stage == FileStage::Finalize {
                                 lifecycle.recorded = false;
                             }
                             false
-                        } else if stage == FileStageV2::Finalize && !lifecycle.recorded {
+                        } else if stage == FileStage::Finalize && !lifecycle.recorded {
                             lifecycle.recorded = true;
                             lifecycle.last_error = None;
                             true
@@ -1210,16 +1208,16 @@ impl RestrictedAuthority {
                         }
                     };
                     if inconsistent {
-                        if let Some(stream) = state.ledger_v2.as_mut() {
+                        if let Some(stream) = state.receipt_stream.as_mut() {
                             stream.mark_recording_failure();
                         }
                     }
                     if emit_complete {
-                        self.append_operation_v2(
+                        self.append_operation(
                             &mut state,
                             &path,
-                            crate::receipt_v2::OperationActionV2::PublishFile { size, inplace },
-                            crate::receipt_v2::OperationDispositionV2::Applied,
+                            crate::receipt::OperationAction::PublishFile { size, inplace },
+                            crate::receipt::OperationDisposition::Applied,
                             None,
                         );
                     }
@@ -1814,7 +1812,7 @@ impl RestrictedAuthority {
         index: usize,
         pending: &mut Vec<PendingCreation>,
         outcomes: &mut Vec<PendingOutcome>,
-        touched_v2: &mut Vec<Vec<u8>>,
+        touched: &mut Vec<Vec<u8>>,
     ) -> Result<()> {
         let path = match &*operation {
             Op::Mkdir { path, .. }
@@ -1838,23 +1836,23 @@ impl RestrictedAuthority {
             Op::Rmdir { path } => {
                 self.charge_deletion(path, true)?;
                 self.state.lock().unwrap().receiver_modes.remove(path);
-                outcomes.push(PendingOutcome::LogicalV2 {
+                outcomes.push(PendingOutcome::Logical {
                     index,
                     path: path.clone(),
-                    action: crate::receipt_v2::OperationActionV2::DeleteDirectory,
+                    action: crate::receipt::OperationAction::DeleteDirectory,
                 });
-                touched_v2.push(path.clone());
+                touched.push(path.clone());
                 return Ok(());
             }
             Op::Unlink { path } => {
                 self.charge_deletion(path, false)?;
                 self.state.lock().unwrap().receiver_modes.remove(path);
-                outcomes.push(PendingOutcome::LogicalV2 {
+                outcomes.push(PendingOutcome::Logical {
                     index,
                     path: path.clone(),
-                    action: crate::receipt_v2::OperationActionV2::DeleteFile,
+                    action: crate::receipt::OperationAction::DeleteFile,
                 });
-                touched_v2.push(path.clone());
+                touched.push(path.clone());
                 return Ok(());
             }
         };
@@ -1877,24 +1875,24 @@ impl RestrictedAuthority {
                     self.remember_receiver_creation(path, true)?;
                     *mode = 0o700;
                 }
-                outcomes.push(PendingOutcome::LogicalV2 {
+                outcomes.push(PendingOutcome::Logical {
                     index,
                     path: path.clone(),
-                    action: crate::receipt_v2::OperationActionV2::EnsureDirectory,
+                    action: crate::receipt::OperationAction::EnsureDirectory,
                 });
-                touched_v2.push(path.clone());
+                touched.push(path.clone());
                 Ok(())
             }
             Op::Symlink {
                 path, condition, ..
             } => {
                 self.constrain_creation(path, condition, false, index, pending)?;
-                outcomes.push(PendingOutcome::LogicalV2 {
+                outcomes.push(PendingOutcome::Logical {
                     index,
                     path: path.clone(),
-                    action: crate::receipt_v2::OperationActionV2::CreateSymlink,
+                    action: crate::receipt::OperationAction::CreateSymlink,
                 });
-                touched_v2.push(path.clone());
+                touched.push(path.clone());
                 Ok(())
             }
             Op::Mknod {
@@ -1913,12 +1911,12 @@ impl RestrictedAuthority {
                     let file_type = *mode & libc::S_IFMT as u32;
                     *mode = file_type | 0o600;
                 }
-                outcomes.push(PendingOutcome::LogicalV2 {
+                outcomes.push(PendingOutcome::Logical {
                     index,
                     path: path.clone(),
-                    action: crate::receipt_v2::OperationActionV2::CreateSpecial { kind },
+                    action: crate::receipt::OperationAction::CreateSpecial { kind },
                 });
-                touched_v2.push(path.clone());
+                touched.push(path.clone());
                 Ok(())
             }
             Op::SetMeta {
@@ -1935,12 +1933,12 @@ impl RestrictedAuthority {
                     condition,
                     ReceiverModeTarget::AnyExisting,
                 )?;
-                outcomes.push(PendingOutcome::LogicalV2 {
+                outcomes.push(PendingOutcome::Logical {
                     index,
                     path: path.clone(),
-                    action: crate::receipt_v2::OperationActionV2::SetMetadata { flags: *flags },
+                    action: crate::receipt::OperationAction::SetMetadata { flags: *flags },
                 });
-                touched_v2.push(path.clone());
+                touched.push(path.clone());
                 Ok(())
             }
             Op::SetFileMetaIfSame {
@@ -1957,12 +1955,12 @@ impl RestrictedAuthority {
                     condition,
                     ReceiverModeTarget::RegularFile,
                 )?;
-                outcomes.push(PendingOutcome::LogicalV2 {
+                outcomes.push(PendingOutcome::Logical {
                     index,
                     path: path.clone(),
-                    action: crate::receipt_v2::OperationActionV2::SetMetadata { flags: *flags },
+                    action: crate::receipt::OperationAction::SetMetadata { flags: *flags },
                 });
-                touched_v2.push(path.clone());
+                touched.push(path.clone());
                 Ok(())
             }
             Op::Remove { .. } | Op::Rmdir { .. } | Op::Unlink { .. } => Ok(()),
@@ -1975,7 +1973,7 @@ impl RestrictedAuthority {
     pub(crate) fn authorize(&self, request: &mut Request, over_ssh: bool) -> Result<Settlement> {
         let mut pending = Vec::new();
         let mut outcomes = Vec::new();
-        let mut touched_v2 = Vec::new();
+        let mut touched = Vec::new();
         // Requests the server executes and then settles; the receipt waits
         // for all of them. The others are answered inline without settling.
         let tracked = !matches!(
@@ -1998,25 +1996,19 @@ impl RestrictedAuthority {
                 bail!("the signed grant is closed: its receipt has been issued");
             }
             if state
-                .ledger_v2
+                .receipt_stream
                 .as_ref()
-                .is_some_and(crate::receipt_v2::StreamWriterV2::is_failed)
+                .is_some_and(crate::receipt::ReceiptStreamWriter::is_failed)
             {
                 bail!("the signed grant is closed because receipt recording failed");
             }
             state.in_flight += 1;
         }
-        match self.authorize_inner(
-            request,
-            over_ssh,
-            &mut pending,
-            &mut outcomes,
-            &mut touched_v2,
-        ) {
+        match self.authorize_inner(request, over_ssh, &mut pending, &mut outcomes, &mut touched) {
             Ok(()) => Ok(Settlement {
                 creations: pending,
                 outcomes,
-                touched_v2,
+                touched,
                 tracked,
             }),
             Err(error) => {
@@ -2028,15 +2020,13 @@ impl RestrictedAuthority {
                     state.in_flight = state.in_flight.saturating_sub(1);
                     self.settled.notify_all();
                 }
-                if let Some(stream) = state.ledger_v2.as_mut() {
+                if let Some(stream) = state.receipt_stream.as_mut() {
                     let sequence = stream.next_sequence();
-                    stream.append(&crate::receipt_v2::RecordV2::Refusal(
-                        crate::receipt_v2::RefusalRecordV2 {
+                    stream.append(&crate::receipt::ReceiptRecord::Refusal(
+                        crate::receipt::RefusalReceiptRecord {
                             sequence,
-                            code: crate::receipt_v2::OutcomeCodeV2::AuthorizationRefused,
-                            diagnostic: crate::receipt_v2::bounded_format(format_args!(
-                                "{error:#}"
-                            )),
+                            code: crate::receipt::OutcomeCode::AuthorizationRefused,
+                            diagnostic: crate::receipt::bounded_format(format_args!("{error:#}")),
                         },
                     ));
                 }
@@ -2051,7 +2041,7 @@ impl RestrictedAuthority {
         over_ssh: bool,
         pending: &mut Vec<PendingCreation>,
         outcomes: &mut Vec<PendingOutcome>,
-        touched_v2: &mut Vec<Vec<u8>>,
+        touched: &mut Vec<Vec<u8>>,
     ) -> Result<()> {
         self.check_deadline()?;
         match request {
@@ -2158,7 +2148,7 @@ impl RestrictedAuthority {
             }
             Request::Apply { ops, guard } => {
                 for (index, operation) in ops.iter_mut().enumerate() {
-                    self.authorize_op(operation, index, pending, outcomes, touched_v2)?;
+                    self.authorize_op(operation, index, pending, outcomes, touched)?;
                 }
                 *guard = Some(self.guard.clone());
             }
@@ -2220,13 +2210,13 @@ impl RestrictedAuthority {
                 self.check_mutation_path(path, false)?;
                 self.constrain_update(path, false, None, pending)?;
                 self.reserve_bytes(path, *partial_id, *len, false)?;
-                outcomes.push(PendingOutcome::FileStageV2 {
+                outcomes.push(PendingOutcome::FileStage {
                     index: 0,
                     path: path.clone(),
                     partial_id: *partial_id,
                     size: *len,
                     inplace: false,
-                    stage: FileStageV2::Prepare,
+                    stage: FileStage::Prepare,
                     skip_if_absent: false,
                     observation_hold: None,
                 });
@@ -2249,12 +2239,12 @@ impl RestrictedAuthority {
                     condition,
                     ReceiverModeTarget::RegularFile,
                 )?;
-                outcomes.push(PendingOutcome::LogicalV2 {
+                outcomes.push(PendingOutcome::Logical {
                     index: 0,
                     path: path.clone(),
-                    action: crate::receipt_v2::OperationActionV2::SetMetadata { flags: *flags },
+                    action: crate::receipt::OperationAction::SetMetadata { flags: *flags },
                 });
-                touched_v2.push(path.clone());
+                touched.push(path.clone());
                 *guard = Some(self.guard.clone());
             }
             Request::Prepare {
@@ -2276,20 +2266,20 @@ impl RestrictedAuthority {
                 self.constrain_prepare(path)?;
                 let observation_hold =
                     self.reserve_bytes(path, *partial_id, *size, !*create_if_missing)?;
-                outcomes.push(PendingOutcome::FileStageV2 {
+                outcomes.push(PendingOutcome::FileStage {
                     index: 0,
                     path: path.clone(),
                     partial_id: *partial_id,
                     size: *size,
                     inplace: *inplace,
-                    stage: FileStageV2::Prepare,
+                    stage: FileStage::Prepare,
                     skip_if_absent: !*create_if_missing,
                     observation_hold,
                 });
                 if *inplace {
                     // In-place preparation resizes the final file itself:
                     // the receipt must know even if no final step follows.
-                    touched_v2.push(path.clone());
+                    touched.push(path.clone());
                 }
                 *guard = Some(self.guard.clone());
             }
@@ -2313,15 +2303,15 @@ impl RestrictedAuthority {
                     bail!("file write extends past the size declared for it");
                 }
                 if *inplace {
-                    touched_v2.push(path.clone());
+                    touched.push(path.clone());
                 }
-                outcomes.push(PendingOutcome::FileStageV2 {
+                outcomes.push(PendingOutcome::FileStage {
                     index: 0,
                     path: path.clone(),
                     partial_id: *partial_id,
                     size: declared,
                     inplace: *inplace,
-                    stage: FileStageV2::Write,
+                    stage: FileStage::Write,
                     skip_if_absent: false,
                     observation_hold: None,
                 });
@@ -2344,17 +2334,17 @@ impl RestrictedAuthority {
                 self.check_mutation_path(path, false)?;
                 self.check_published_length(path, *partial_id, *inplace)?;
                 self.constrain_creation(path, condition, false, 0, pending)?;
-                outcomes.push(PendingOutcome::FileStageV2 {
+                outcomes.push(PendingOutcome::FileStage {
                     index: 0,
                     path: path.clone(),
                     partial_id: *partial_id,
                     size: self.declared_size(path, *partial_id)?,
                     inplace: *inplace,
-                    stage: FileStageV2::Finalize,
+                    stage: FileStage::Finalize,
                     skip_if_absent: false,
                     observation_hold: None,
                 });
-                touched_v2.push(path.clone());
+                touched.push(path.clone());
                 self.constrain_receiver_mode(
                     path,
                     meta,
@@ -2383,15 +2373,15 @@ impl RestrictedAuthority {
                 for (index, put) in puts.iter_mut().enumerate() {
                     self.charge_bytes(&put.path, 0, put.data.len())?;
                     self.constrain_creation(&put.path, &mut put.condition, false, index, pending)?;
-                    outcomes.push(PendingOutcome::LogicalV2 {
+                    outcomes.push(PendingOutcome::Logical {
                         index,
                         path: put.path.clone(),
-                        action: crate::receipt_v2::OperationActionV2::PublishFile {
+                        action: crate::receipt::OperationAction::PublishFile {
                             size: put.data.len() as u64,
                             inplace: false,
                         },
                     });
-                    touched_v2.push(put.path.clone());
+                    touched.push(put.path.clone());
                     self.constrain_receiver_mode(
                         &put.path,
                         &mut put.meta,
@@ -2438,13 +2428,13 @@ pub(crate) struct Settlement {
     creations: Vec<PendingCreation>,
     outcomes: Vec<PendingOutcome>,
     /// Final destination paths this admitted request could have changed.
-    touched_v2: Vec<Vec<u8>>,
+    touched: Vec<Vec<u8>>,
     /// The request counts as in flight until settled.
     tracked: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum FileStageV2 {
+enum FileStage {
     Prepare,
     Write,
     Finalize,
@@ -2472,7 +2462,7 @@ fn kind_from_mode(mode: u32) -> proto::Kind {
 }
 
 #[derive(Debug)]
-struct FileLifecycleV2 {
+struct FileLifecycle {
     size: u64,
     inplace: bool,
     recorded: bool,
@@ -2485,18 +2475,18 @@ enum PendingOutcome {
     Observe {
         path: Vec<u8>,
     },
-    LogicalV2 {
+    Logical {
         index: usize,
         path: Vec<u8>,
-        action: crate::receipt_v2::OperationActionV2,
+        action: crate::receipt::OperationAction,
     },
-    FileStageV2 {
+    FileStage {
         index: usize,
         path: Vec<u8>,
         partial_id: proto::PartialId,
         size: u64,
         inplace: bool,
-        stage: FileStageV2,
+        stage: FileStage,
         /// Ignore a successful observation-only Prepare when it found no
         /// resumable sidecar and therefore performed no lifecycle mutation.
         skip_if_absent: bool,
@@ -4089,23 +4079,23 @@ pub(crate) fn prepare_transfer(
     let (receipt_recipient_secret, receipt_delivery) = if args.detach {
         (
             None,
-            crate::receipt_v2::ReceiptDeliveryV2::DetachedSignedPlaintext,
+            crate::receipt::ReceiptDelivery::DetachedSignedPlaintext,
         )
     } else {
-        let (secret, public) = crate::receipt_v2::generate_recipient()?;
+        let (secret, public) = crate::receipt::generate_recipient()?;
         (
             Some(secret),
-            crate::receipt_v2::ReceiptDeliveryV2::AttachedEncrypted {
-                suite: crate::receipt_v2::HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+            crate::receipt::ReceiptDelivery::AttachedEncrypted {
+                suite: crate::receipt::HpkeSuite::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
                 recipient_public_key: public,
             },
         )
     };
-    let receipt_policy = crate::receipt_v2::ReceiptPolicyV2 {
+    let receipt_policy = crate::receipt::ReceiptPolicy {
         required: true,
         hashed: args.receiver_receipt == Some(crate::cli::ReceiptDetail::Digests),
-        max_records: crate::receipt_v2::DEFAULT_MAX_RECORDS,
-        max_plaintext_bytes: crate::receipt_v2::DEFAULT_MAX_PLAINTEXT_BYTES,
+        max_records: crate::receipt::DEFAULT_MAX_RECORDS,
+        max_plaintext_bytes: crate::receipt::DEFAULT_MAX_PLAINTEXT_BYTES,
         delivery: receipt_delivery,
     };
     let grant = delegation::sign_grant(
@@ -4118,7 +4108,7 @@ pub(crate) fn prepare_transfer(
                 delete_excluded: args.delete_excluded,
             },
             root_existence: root_existence_for(args.target_existence),
-            receipt_v2: receipt_policy.clone(),
+            receipt_policy: receipt_policy.clone(),
         },
         &private_key,
     )?;
@@ -4428,7 +4418,7 @@ pub(crate) mod tests {
         let temporary = crate::test_support::tempdir().unwrap();
         fs::set_permissions(temporary.path(), fs::Permissions::from_mode(0o700)).unwrap();
         let directory = open_directory(temporary.path()).unwrap();
-        atomic_replace_executable_locked(&directory, "syq-receiver", b"receiver-v1").unwrap();
+        atomic_replace_executable_locked(&directory, "syq-receiver", b"receiver-binary").unwrap();
         atomic_replace_executable_locked(&directory, "syq-receiver", b"receiver-v2").unwrap();
 
         let path = temporary.path().join("syq-receiver");
@@ -4650,13 +4640,13 @@ pub(crate) mod tests {
         .unwrap()
     }
 
-    fn test_receipt_policy() -> crate::receipt_v2::ReceiptPolicyV2 {
-        crate::receipt_v2::ReceiptPolicyV2 {
+    fn test_receipt_policy() -> crate::receipt::ReceiptPolicy {
+        crate::receipt::ReceiptPolicy {
             required: true,
             hashed: false,
-            max_records: crate::receipt_v2::DEFAULT_MAX_RECORDS,
-            max_plaintext_bytes: crate::receipt_v2::DEFAULT_MAX_PLAINTEXT_BYTES,
-            delivery: crate::receipt_v2::ReceiptDeliveryV2::DetachedSignedPlaintext,
+            max_records: crate::receipt::DEFAULT_MAX_RECORDS,
+            max_plaintext_bytes: crate::receipt::DEFAULT_MAX_PLAINTEXT_BYTES,
+            delivery: crate::receipt::ReceiptDelivery::DetachedSignedPlaintext,
         }
     }
 
@@ -4697,7 +4687,7 @@ pub(crate) mod tests {
         existing: ExistingDestinationPolicy,
         placement: DestinationPlacement,
         root_existence: RootExistence,
-        receipt_v2: Option<(PrivateKey, crate::receipt_v2::ReceiptPolicyV2)>,
+        receipt_policy: Option<(PrivateKey, crate::receipt::ReceiptPolicy)>,
     ) -> Result<RestrictedAuthority> {
         let opened = Root::open(root).unwrap();
         let identity = opened.identity();
@@ -4764,7 +4754,7 @@ pub(crate) mod tests {
                 },
             }),
         };
-        let (receipt_key, receipt_policy_v2) = match receipt_v2 {
+        let (receipt_key, receipt_policy) = match receipt_policy {
             Some((key, policy)) => (key, policy),
             None => (generate_receipt_key(id)?, test_receipt_policy()),
         };
@@ -4775,7 +4765,7 @@ pub(crate) mod tests {
                 max_file_data_bytes_per_second,
                 filters,
                 root_existence,
-                receipt_v2: receipt_policy_v2,
+                receipt_policy,
             },
             [0; 32],
             receipt_key,
@@ -5897,7 +5887,7 @@ pub(crate) mod tests {
 
     fn existence_authority_with_receipt(
         root: &Path,
-        policy: &crate::receipt_v2::ReceiptPolicyV2,
+        policy: &crate::receipt::ReceiptPolicy,
         deadline_ms: u64,
     ) -> RestrictedAuthority {
         let key = generate_receipt_key(EnrollmentId::random()).unwrap();
@@ -5994,18 +5984,18 @@ pub(crate) mod tests {
             .unwrap();
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::Operation(operation)
+            crate::receipt::ReceiptRecord::Operation(operation)
                 if operation.path == b"kept"
                     && operation.disposition
-                        == crate::receipt_v2::OperationDispositionV2::Observed
+                        == crate::receipt::OperationDisposition::Observed
         )));
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::FinalState(state)
+            crate::receipt::ReceiptRecord::FinalState(state)
                 if state.path == b"fresh"
                     && matches!(
                         state.object,
-                        crate::receipt_v2::FinalObjectV2::Present {
+                        crate::receipt::FinalObject::Present {
                             digest: Some(digest),
                             ..
                         } if digest == *blake3::hash(b"data").as_bytes()
@@ -6013,9 +6003,9 @@ pub(crate) mod tests {
         )));
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::FinalState(state)
+            crate::receipt::ReceiptRecord::FinalState(state)
                 if state.path == b"gone"
-                    && state.object == crate::receipt_v2::FinalObjectV2::Absent
+                    && state.object == crate::receipt::FinalObject::Absent
         )));
 
         // Issuing the receipt closes the grant: no mutation, no second copy,
@@ -6066,11 +6056,11 @@ pub(crate) mod tests {
         fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o600)).unwrap();
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::FinalState(state)
+            crate::receipt::ReceiptRecord::FinalState(state)
                 if state.path == b"unreadable"
                     && matches!(
                         &state.object,
-                        crate::receipt_v2::FinalObjectV2::Present {
+                        crate::receipt::FinalObject::Present {
                             digest: None,
                             observation_error: Some(_),
                             ..
@@ -6108,17 +6098,17 @@ pub(crate) mod tests {
             .unwrap();
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::FinalState(state)
+            crate::receipt::ReceiptRecord::FinalState(state)
                 if state.path == b"vanished"
-                    && state.object == crate::receipt_v2::FinalObjectV2::Absent
+                    && state.object == crate::receipt::FinalObject::Absent
         )));
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::FinalState(state)
+            crate::receipt::ReceiptRecord::FinalState(state)
                 if state.path == b"returned"
                     && matches!(
                         state.object,
-                        crate::receipt_v2::FinalObjectV2::Present { size: 4, .. }
+                        crate::receipt::FinalObject::Present { size: 4, .. }
                     )
         )));
     }
@@ -6166,7 +6156,7 @@ pub(crate) mod tests {
         authority.settle(second, &proto::Response::PartialSize(None));
         {
             let state = authority.state.lock().unwrap();
-            assert!(state.file_lifecycles_v2.is_empty());
+            assert!(state.file_lifecycles.is_empty());
             assert!(state.reserved.is_empty());
             assert_eq!(state.reserved_bytes, 0);
         }
@@ -6177,7 +6167,7 @@ pub(crate) mod tests {
         authority.settle(settlement, &proto::Response::PartialSize(Some(0)));
         let state = authority.state.lock().unwrap();
         assert!(state
-            .file_lifecycles_v2
+            .file_lifecycles
             .contains_key(&(path_bytes(&present_path), [1; 16])));
         assert_eq!(state.reserved_bytes, 4);
     }
@@ -6235,7 +6225,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn receipt_v2_records_each_outcome_and_closure_state_then_encrypts_it() {
+    fn receipt_policy_records_each_outcome_and_closure_state_then_encrypts_it() {
         let temporary = crate::test_support::tempdir().unwrap();
         let root = temporary.path().join("root");
         let target = root.join("target");
@@ -6254,14 +6244,14 @@ pub(crate) mod tests {
         let receipt_key = generate_receipt_key(EnrollmentId::random()).unwrap();
         let receipt_public = receipt_key.public_key().to_openssh().unwrap();
         let (recipient_secret, recipient_public_key) =
-            crate::receipt_v2::generate_recipient().unwrap();
-        let policy = crate::receipt_v2::ReceiptPolicyV2 {
+            crate::receipt::generate_recipient().unwrap();
+        let policy = crate::receipt::ReceiptPolicy {
             required: true,
             hashed: true,
             max_records: 64,
             max_plaintext_bytes: 1 << 20,
-            delivery: crate::receipt_v2::ReceiptDeliveryV2::AttachedEncrypted {
-                suite: crate::receipt_v2::HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+            delivery: crate::receipt::ReceiptDelivery::AttachedEncrypted {
+                suite: crate::receipt::HpkeSuite::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
                 recipient_public_key,
             },
         };
@@ -6311,12 +6301,12 @@ pub(crate) mod tests {
         assert!(authority.authorize(&mut late, false).is_err());
         assert!(authority.issue_receipt().is_err());
         let mut frames = Vec::new();
-        crate::receipt_v2::emit_receipt_frames(issued, |frame| {
+        crate::receipt::emit_receipt_frames(issued, |frame| {
             frames.push(Ok(frame));
             Ok(())
         })
         .unwrap();
-        let mut verified = crate::receipt_v2::open_attached_frames(
+        let mut verified = crate::receipt::open_attached_frames(
             frames,
             &recipient_secret,
             &receipt_public,
@@ -6328,7 +6318,7 @@ pub(crate) mod tests {
         .unwrap();
         assert_eq!(
             verified.terminal.status,
-            crate::receipt_v2::ReceiptStatusV2::Failed
+            crate::receipt::ReceiptStatus::Failed
         );
         assert_eq!(verified.terminal.summary.operations, 3);
         assert_eq!(verified.terminal.summary.refusals, 1);
@@ -6345,23 +6335,23 @@ pub(crate) mod tests {
             .unwrap();
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::Operation(operation)
+            crate::receipt::ReceiptRecord::Operation(operation)
                 if operation.path == copied_name
-                    && operation.disposition == crate::receipt_v2::OperationDispositionV2::Applied
+                    && operation.disposition == crate::receipt::OperationDisposition::Applied
         )));
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::Operation(operation)
+            crate::receipt::ReceiptRecord::Operation(operation)
                 if operation.path == b"failed"
-                    && operation.disposition == crate::receipt_v2::OperationDispositionV2::Failed
+                    && operation.disposition == crate::receipt::OperationDisposition::Failed
         )));
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::FinalState(state)
+            crate::receipt::ReceiptRecord::FinalState(state)
                 if state.path == copied_name
                     && matches!(
                         state.object,
-                        crate::receipt_v2::FinalObjectV2::Present {
+                        crate::receipt::FinalObject::Present {
                             digest: Some(digest),
                             ..
                         } if digest == *blake3::hash(b"new").as_bytes()
@@ -6369,9 +6359,9 @@ pub(crate) mod tests {
         )));
         assert!(records.iter().any(|record| matches!(
             record,
-            crate::receipt_v2::RecordV2::FinalState(state)
+            crate::receipt::ReceiptRecord::FinalState(state)
                 if state.path == b"removed"
-                    && state.object == crate::receipt_v2::FinalObjectV2::Absent
+                    && state.object == crate::receipt::FinalObject::Absent
         )));
     }
 
@@ -6428,7 +6418,7 @@ pub(crate) mod tests {
         let verified = open_issued(&authority, &secret, &policy);
         assert_eq!(
             verified.terminal.status,
-            crate::receipt_v2::ReceiptStatusV2::Failed
+            crate::receipt::ReceiptStatus::Failed
         );
         assert!(verified.terminal.summary.incomplete > 0);
 
@@ -6474,7 +6464,7 @@ pub(crate) mod tests {
         let verified = open_issued(&finished, &secret, &policy);
         assert_eq!(
             verified.terminal.status,
-            crate::receipt_v2::ReceiptStatusV2::Clean
+            crate::receipt::ReceiptStatus::Clean
         );
         assert_eq!(verified.terminal.summary.incomplete, 0);
     }
@@ -6486,20 +6476,19 @@ pub(crate) mod tests {
     fn encrypted_v2_policy(
         hashed: bool,
     ) -> (
-        crate::receipt_v2::RecipientSecret,
-        crate::receipt_v2::ReceiptPolicyV2,
+        crate::receipt::RecipientSecret,
+        crate::receipt::ReceiptPolicy,
     ) {
-        let (secret, recipient_public_key) = crate::receipt_v2::generate_recipient().unwrap();
+        let (secret, recipient_public_key) = crate::receipt::generate_recipient().unwrap();
         (
             secret,
-            crate::receipt_v2::ReceiptPolicyV2 {
+            crate::receipt::ReceiptPolicy {
                 required: true,
                 hashed,
                 max_records: 64,
                 max_plaintext_bytes: 1 << 20,
-                delivery: crate::receipt_v2::ReceiptDeliveryV2::AttachedEncrypted {
-                    suite:
-                        crate::receipt_v2::HpkeSuiteV1::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+                delivery: crate::receipt::ReceiptDelivery::AttachedEncrypted {
+                    suite: crate::receipt::HpkeSuite::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
                     recipient_public_key,
                 },
             },
@@ -6508,17 +6497,17 @@ pub(crate) mod tests {
 
     fn open_issued(
         authority: &RestrictedAuthority,
-        secret: &crate::receipt_v2::RecipientSecret,
-        policy: &crate::receipt_v2::ReceiptPolicyV2,
-    ) -> crate::receipt_v2::VerifiedReceiptV2 {
+        secret: &crate::receipt::RecipientSecret,
+        policy: &crate::receipt::ReceiptPolicy,
+    ) -> crate::receipt::VerifiedReceipt {
         let issued = authority.issue_receipt().unwrap();
         let mut frames = Vec::new();
-        crate::receipt_v2::emit_receipt_frames(issued, |frame| {
+        crate::receipt::emit_receipt_frames(issued, |frame| {
             frames.push(Ok(frame));
             Ok(())
         })
         .unwrap();
-        crate::receipt_v2::open_attached_frames(
+        crate::receipt::open_attached_frames(
             frames,
             secret,
             &racing_public(authority),

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -4419,10 +4419,11 @@ pub(crate) mod tests {
         fs::set_permissions(temporary.path(), fs::Permissions::from_mode(0o700)).unwrap();
         let directory = open_directory(temporary.path()).unwrap();
         atomic_replace_executable_locked(&directory, "syq-receiver", b"receiver-binary").unwrap();
-        atomic_replace_executable_locked(&directory, "syq-receiver", b"receiver-v2").unwrap();
+        atomic_replace_executable_locked(&directory, "syq-receiver", b"replacement-receiver")
+            .unwrap();
 
         let path = temporary.path().join("syq-receiver");
-        assert_eq!(fs::read(&path).unwrap(), b"receiver-v2");
+        assert_eq!(fs::read(&path).unwrap(), b"replacement-receiver");
         assert_eq!(fs::metadata(&path).unwrap().mode() & 0o777, 0o700);
         assert_eq!(fs::read_dir(temporary.path()).unwrap().count(), 1);
     }
@@ -5922,7 +5923,7 @@ pub(crate) mod tests {
         fs::write(&kept, b"old").unwrap();
         fs::write(&gone, b"bye").unwrap();
         let key = generate_receipt_key(EnrollmentId::random()).unwrap();
-        let (secret, policy) = encrypted_v2_policy(true);
+        let (secret, policy) = encrypted_policy(true);
         let authority = test_authority_with_receipt(
             &root,
             DeletionPolicy::DeleteDestinationOnly,
@@ -6033,7 +6034,7 @@ pub(crate) mod tests {
         // A published file that cannot be read back at closure is attested
         // present with the hash failure recorded rather than silently
         // unhashed.
-        let (hashing_secret, hashing_policy) = encrypted_v2_policy(true);
+        let (hashing_secret, hashing_policy) = encrypted_policy(true);
         let hashing = existence_authority_with_receipt(&root, &hashing_policy, 5_000);
         let unreadable = target.join("unreadable");
         let settlement = hashing
@@ -6071,7 +6072,7 @@ pub(crate) mod tests {
         // The receipt states the final tree, not settlement order: a file
         // republished then deleted is absent, and one deleted then
         // republished is present.
-        let (racing_secret, racing_policy) = encrypted_v2_policy(false);
+        let (racing_secret, racing_policy) = encrypted_policy(false);
         let racing = existence_authority_with_receipt(&root, &racing_policy, 5_000);
         let vanished = target.join("vanished");
         let returned = target.join("returned");
@@ -6373,7 +6374,7 @@ pub(crate) mod tests {
         let image = target.join("image");
         fs::create_dir_all(&target).unwrap();
         let key = generate_receipt_key(EnrollmentId::random()).unwrap();
-        let (secret, policy) = encrypted_v2_policy(false);
+        let (secret, policy) = encrypted_policy(false);
         let authority = test_authority_with_receipt(
             &root,
             DeletionPolicy::Forbid,
@@ -6424,7 +6425,7 @@ pub(crate) mod tests {
 
         // With it, the same file is complete and the receipt is clean.
         let key = generate_receipt_key(EnrollmentId::random()).unwrap();
-        let (secret, policy) = encrypted_v2_policy(false);
+        let (secret, policy) = encrypted_policy(false);
         let finished = test_authority_with_receipt(
             &root,
             DeletionPolicy::Forbid,
@@ -6473,7 +6474,7 @@ pub(crate) mod tests {
         authority.receipt_key.public_key().to_openssh().unwrap()
     }
 
-    fn encrypted_v2_policy(
+    fn encrypted_policy(
         hashed: bool,
     ) -> (
         crate::receipt::RecipientSecret,

--- a/src/results.rs
+++ b/src/results.rs
@@ -16,7 +16,7 @@
 //! not reported per operation (dry runs do trace them as `metadata_differs`).
 //!
 //! Attached direct copies through a command-restricted receiver are the one
-//! exception: receipt_v2 emits their stream locally after verification, marks
+//! exception: receipt_policy emits their stream locally after verification, marks
 //! its provenance, omits source-side claims hostB cannot authenticate, and
 //! includes closure-time final-state records.
 

--- a/src/results.rs
+++ b/src/results.rs
@@ -16,7 +16,7 @@
 //! not reported per operation (dry runs do trace them as `metadata_differs`).
 //!
 //! Attached direct copies through a command-restricted receiver are the one
-//! exception: receipt_policy emits their stream locally after verification, marks
+//! exception: receipt emits their stream locally after verification, marks
 //! its provenance, omits source-side claims hostB cannot authenticate, and
 //! includes closure-time final-state records.
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -549,8 +549,8 @@ fn serve<R: Read + Send + 'static, W: Write>(
             Request::Receipt => match &authority {
                 Some(authority) => match authority.issue_receipt() {
                     Ok(receipt) => {
-                        crate::receipt_v2::emit_receipt_frames(receipt, |frame| {
-                            w.write_msg(&Response::ReceiptV2(frame))?;
+                        crate::receipt::emit_receipt_frames(receipt, |frame| {
+                            w.write_msg(&Response::Receipt(frame))?;
                             Ok(())
                         })?;
                     }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -2524,8 +2524,8 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         } else {
             loop {
                 match dst_ctl.recv() {
-                    Ok(Response::ReceiptV2(frame)) => {
-                        let terminal = match crate::receipt_v2::receipt_frame_is_end(&frame) {
+                    Ok(Response::Receipt(frame)) => {
+                        let terminal = match crate::receipt::receipt_frame_is_end(&frame) {
                             Ok(terminal) => terminal,
                             Err(error) => {
                                 progress.error(&format!("syq: receipt: {error:#}"));
@@ -2534,7 +2534,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         };
                         println!(
                             "{}{}",
-                            crate::receipt_v2::RECEIPT_LINE_PREFIX,
+                            crate::receipt::RECEIPT_LINE_PREFIX,
                             base64::engine::general_purpose::STANDARD_NO_PAD.encode(frame)
                         );
                         if terminal {

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -167,7 +167,7 @@ pub fn path_key(src: &Endpoint, dst: &Endpoint) -> Option<String> {
         .collect::<Vec<_>>()
         .join("+");
     Some(format!(
-        "v1|{}>{}|{transport}",
+        "{}>{}|{transport}",
         endpoint_key(src),
         endpoint_key(dst)
     ))

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -185,7 +185,7 @@ fn cache_path() -> Option<PathBuf> {
                 .filter(|path| !path.is_empty())
                 .map(|home| PathBuf::from(home).join(".cache"))
         })
-        .map(|root| root.join("syq/tuning-v1.json"))
+        .map(|root| root.join("syq/tuning.json"))
 }
 
 fn lock_file(path: &Path, exclusive: bool) -> std::io::Result<std::fs::File> {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3882,7 +3882,7 @@ fn cached_remote_helper(t: &Tmp) -> PathBuf {
     let identity = binary_identity("--build-identity");
     let target = helper_target();
     t.path(&format!(
-        "remote-home/.cache/syq/helpers/{identity}-release-v1/{target}/syq"
+        "remote-home/.cache/syq/helpers/{identity}-release/{target}/syq"
     ))
 }
 
@@ -8658,7 +8658,7 @@ fn local_copy_does_not_read_the_global_persistence_configuration() {
     write(&t.path("src/f"), b"data");
     // An eligible implicit SSH endpoint would report this malformed policy,
     // but a local copy has no persistence decision to make.
-    write(&t.path("config/syq/persistence-v1.json"), b"not valid JSON");
+    write(&t.path("config/syq/persistence.json"), b"not valid JSON");
     let out = compat_command()
         .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
         .env("XDG_CONFIG_HOME", t.path("config"))
@@ -13689,7 +13689,7 @@ fn remote_completion_uses_normal_ssh_and_learns_a_disposable_endpoint() {
     let listed = completion_command(&t, &["cache", "list"]).run().unwrap();
     assert_output_ok(&listed);
     assert_eq!(listed.stdout, b"fake.example\n");
-    let metadata = fs::metadata(t.path("cache/syq/completion-endpoints-v1.json")).unwrap();
+    let metadata = fs::metadata(t.path("cache/syq/completion-endpoints.json")).unwrap();
     assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
 
     let suggested = completion_command(
@@ -13742,7 +13742,7 @@ fn remote_completion_uses_normal_ssh_and_learns_a_disposable_endpoint() {
 
     let cleared = completion_command(&t, &["cache", "clear"]).run().unwrap();
     assert_output_ok(&cleared);
-    assert!(!t.path("cache/syq/completion-endpoints-v1.json").exists());
+    assert!(!t.path("cache/syq/completion-endpoints.json").exists());
 }
 
 fn ephemeral_scope(t: &Tmp) -> PathBuf {
@@ -13944,7 +13944,7 @@ fn absent_user_config_environment_keeps_ordinary_commands_nonpersistent() {
 fn remote_coordinator_does_not_resolve_local_persistence() {
     let t = Tmp::new();
     fs::create_dir(t.runtime()).unwrap();
-    write(&t.path("config/syq/persistence-v1.json"), b"not valid JSON");
+    write(&t.path("config/syq/persistence.json"), b"not valid JSON");
     let ssh = t.path("bin/ssh");
     executable(
         &ssh,

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -343,7 +343,7 @@ fn source_fd_preflight_accounts_for_independent_ssh_broker_claims() {
     write(
         &cache,
         serde_json::to_string_pretty(&serde_json::json!({
-            "paths": { "v1|fake>local|ssh": 64 }
+            "paths": { "fake>local|ssh": 64 }
         }))
         .unwrap()
         .as_bytes(),
@@ -4974,7 +4974,7 @@ fn remembered_path_count_seeds_auto_tuning_but_fixed_count_does_not_rewrite_it()
     write(
         &cache,
         serde_json::to_string_pretty(&serde_json::json!({
-            "paths": { "v1|local>fake|ssh": 1 }
+            "paths": { "local>fake|ssh": 1 }
         }))
         .unwrap()
         .as_bytes(),
@@ -5021,7 +5021,7 @@ fn remembered_path_count_seeds_auto_tuning_but_fixed_count_does_not_rewrite_it()
     let fixed = run("fixed", Some(3));
     assert_output_ok(&fixed);
     let cached: serde_json::Value = serde_json::from_slice(&read(&cache)).unwrap();
-    assert_eq!(cached["paths"]["v1|local>fake|ssh"], 1);
+    assert_eq!(cached["paths"]["local>fake|ssh"], 1);
 }
 
 #[cfg(debug_assertions)]
@@ -5086,7 +5086,7 @@ fn live_warming_retirement_and_post_sample_recovery_stay_consistent() {
     write(
         &cache,
         serde_json::to_string_pretty(&serde_json::json!({
-            "paths": { "v1|local>fake|ssh": 2 }
+            "paths": { "local>fake|ssh": 2 }
         }))
         .unwrap()
         .as_bytes(),

--- a/tests/real-ssh/entrypoint.sh
+++ b/tests/real-ssh/entrypoint.sh
@@ -11,7 +11,7 @@ seed_helper() {
             exit 1
             ;;
     esac
-    helper="/home/syq/.cache/syq/helpers/${identity}-release-v1/${target}/syq"
+    helper="/home/syq/.cache/syq/helpers/${identity}-release/${target}/syq"
     install -D -m 0755 -o syq -g syq /usr/local/bin/syq "$helper"
 }
 


### PR DESCRIPTION
Stacked on #192 (`harmonize-words`), which sits on #190 and #189; merge those first.

With version pinning, both ends of every connection run the exact same syq, so the codebase never has to read or write two versions of anything. The one exception stays: enrollment state on hostB outlives syq upgrades and keeps its `CONFIG_VERSION`.

- Every `V2`, `V1`, and `_v2` identifier loses its suffix (about 700 tokens), and `receipt_v2.rs` is `receipt.rs`. `OperationRecordV2` and `RecordV2` become `ReceiptOperationRecord` and `ReceiptRecord` so they do not collide with the results-stream names; `StreamWriterV2`/`ledger_v2` become `ReceiptStreamWriter`/`receipt_stream`; the grant's `receipt_v2` field is `receipt_policy`; `HpkeSuiteV1` is `HpkeSuite`.
- Wire formats drop their version fields: the grant envelope and canonical body (`WIRE_VERSION`), the receipt terminal (`TERMINAL_VERSION`), receipt frames (`FRAME_VERSION`), and hostB's redemption record (`CLAIM_VERSION`). Header lengths and offsets shrink accordingly; the test that flipped version bytes now flips a magic byte. The magics lose their digits (`SYQRCPT`, `SYQRFRM`), the signing namespaces and HPKE labels lose `-v1`/`-v2`, and the receipt marker line is `syq-receipt:`.
- Local state files drop the version stem and their `version` field: `persistence.json`, `.syq-persistence`, `completion-endpoints.json`, `tuning.json`, and the remote helper cache generation `release`. Existing copies of those files are simply ignored or re-created.

Left alone on purpose: the release manifest's `signature_scheme: "ed25519-jcs-v1"`, because already-installed binaries verify future manifests against it, and the automation stream's `schema_version` field, which is the one place a version belongs.

Verification: `cargo fmt`, `cargo clippy -D warnings`, `cargo test --bin syq` (409 passed), `scripts/check-doc-links.py`, the Python SDK suite (85 tests, 5 skipped), and the focused filter `receipt restricted receiver persist completion helper` (17 passed). The full `cargo test --test local` suite and the real-SSH suite are running and will be reported in a comment.

Part of the naming audit follow-ups in `current-plans/active/naming-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCarAsHM4k2ygsVQNnfpyk
