### PR TITLE
Keep a ready helper session per persistent endpoint

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -81,7 +81,8 @@ syq completion fish | source
 Remote completion logs in with a normal noninteractive SSH session. The first
 Tab on a remote endpoint can take a few seconds if syq must install the remote
 helper there. `syq persist on` makes later completions much faster by keeping
-the authenticated SSH connection available between commands.
+the authenticated SSH connection, and a ready helper session on it,
+available between commands.
 
 ## Update checks and self-update
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -471,9 +471,10 @@ endpoint. The next command takes the ready session instead of opening its
 own, so a remote completion or a small copy costs one round trip. The pool
 opens its session through the existing control connection only: it checks
 that the master is alive, attaches to it with every authentication method
-disabled, and never reads from the session it holds. If the master has gone
-away the pool simply stays empty, and the next command logs in normally and
-shows whatever OpenSSH has to say. The pool exits after five minutes without
+disabled, no agent, display, or port forwarding, and no proxy of its own, and
+never reads from the session it holds. If the master has gone away the pool
+simply stays empty, and the next command logs in normally and shows whatever
+OpenSSH has to say. The pool exits after five minutes without
 handing over a session, and the control connection's own five-minute window
 begins after that, so the reuse window after your last command can reach ten
 minutes in total. It also exits when its scope is removed or when a newer

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -459,14 +459,33 @@ syq persist off
 While it is on, transfer and removal commands that use syq's implicit SSH
 transport keep one control connection per `user@host:port` alive for five
 minutes after its last session (OpenSSH `ControlMaster` with
-`ControlPersist`). Later commands reuse that authenticated connection, cutting
-per-command setup to milliseconds and avoiding another hardware-token
-interaction. `status` shows the global scope and its recorded endpoints;
-`off` disables the policy, asks every live syq-owned master to exit, and
-removes the global runtime scope. The durable preference lives in
+`ControlPersist`). Later commands reuse that authenticated connection and
+avoid another hardware-token interaction.
+
+Reusing the connection alone still costs each command a new SSH session, a
+helper launch, and a handshake before its first request: three network round
+trips, which on a distant host is most of a second. So while persistence is
+on, the first command to reach an endpoint also starts a small background
+process, the session pool, that keeps one helper session ready for that
+endpoint. The next command takes the ready session instead of opening its
+own, so a remote completion or a small copy costs one round trip. The pool
+opens its session through the existing control connection only: it checks
+that the master is alive, attaches to it with every authentication method
+disabled, and never reads from the session it holds. If the master has gone
+away the pool simply stays empty, and the next command logs in normally and
+shows whatever OpenSSH has to say. The pool exits after five minutes without
+handing over a session, and the control connection's own five-minute window
+begins after that, so the reuse window after your last command can reach ten
+minutes in total. It also exits when its scope is removed or when a newer
+syq binary starts using the endpoint.
+
+`status` shows the global scope and its recorded endpoints, marking an
+endpoint whose session pool is running; `off` disables the policy, stops
+every session pool, asks every live syq-owned master to exit, and removes the
+global runtime scope. The durable preference lives in
 `$XDG_CONFIG_HOME/syq/persistence.json` (normally under `~/.config`), while
-control sockets live in a per-user runtime directory that only that user can
-read.
+control sockets and pool sockets live in a per-user runtime directory that
+only that user can read.
 
 Scripts can avoid changing that shared preference by creating an ephemeral
 persistence scope:
@@ -497,9 +516,11 @@ not from the open file handles syq uses for filters, mappings, file lists, and
 results.
 
 During either persistence window, anything able to act as the same local user
-can open sessions through the socket without touching the key or agent. This
-is comparable to sudo's credential cache; do not enable it where that window
-is unacceptable. Data connections are unaffected: they remain separate TCP
+can open sessions through the socket without touching the key or agent, and
+can take the ready helper session the pool holds. This is comparable to
+sudo's credential cache; do not enable it where that window is unacceptable.
+On the remote side the pool keeps one idle SSH session and one idle helper
+process per endpoint for as long as the window lasts, and nothing else. Data connections are unaffected: they remain separate TCP
 streams (or independent SSH processes under `--no-tcp`), so bulk throughput
 does not change. Persistence is not applied to an explicit `--rsh`, a
 coordinator running on a remote host, or authentication to the restricted
@@ -534,6 +555,7 @@ because syq cannot safely infer how an arbitrary wrapper should be invoked.
 Connection and listing failures simply produce no candidates; set
 `SYQ_COMPLETION_DEBUG=1` to show their diagnostics.
 
+<<<<<<< HEAD
 The helper syq installs on a remote host serves one bounded, read-only
 directory listing. If the matching helper is absent, the first completion may
 install it through the same signed, verified bootstrap used by a transfer.
@@ -541,6 +563,16 @@ With persistence enabled, completion uses the same per-endpoint SSH control
 connection as later transfers, which removes the repeated login latency.
 Without persistence, the completion process opens its own connection, which
 ends with that request.
+=======
+The remote helper serves one bounded, read-only directory listing. If the
+matching helper is absent, the first completion may install it through the
+same signed, verified bootstrap used by a transfer. With persistence enabled,
+completion uses the same per-endpoint SSH control connection as later
+transfers, which removes the repeated login latency, and takes the session
+pool's ready helper session when one is waiting, which makes a Tab one
+network round trip. Without persistence, the completion process uses a
+private connection that ends with that request.
+>>>>>>> 8dcd2cd (Keep a ready helper session per persistent endpoint)
 
 After a successful SSH connection, syq remembers the endpoint as a future
 suggestion. It also suggests literal aliases from SSH configuration,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -557,24 +557,14 @@ because syq cannot safely infer how an arbitrary wrapper should be invoked.
 Connection and listing failures simply produce no candidates; set
 `SYQ_COMPLETION_DEBUG=1` to show their diagnostics.
 
-<<<<<<< HEAD
 The helper syq installs on a remote host serves one bounded, read-only
 directory listing. If the matching helper is absent, the first completion may
 install it through the same signed, verified bootstrap used by a transfer.
 With persistence enabled, completion uses the same per-endpoint SSH control
-connection as later transfers, which removes the repeated login latency.
-Without persistence, the completion process opens its own connection, which
-ends with that request.
-=======
-The remote helper serves one bounded, read-only directory listing. If the
-matching helper is absent, the first completion may install it through the
-same signed, verified bootstrap used by a transfer. With persistence enabled,
-completion uses the same per-endpoint SSH control connection as later
-transfers, which removes the repeated login latency, and takes the session
-pool's ready helper session when one is waiting, which makes a Tab one
-network round trip. Without persistence, the completion process uses a
-private connection that ends with that request.
->>>>>>> 8dcd2cd (Keep a ready helper session per persistent endpoint)
+connection as later transfers, which removes the repeated login latency. It
+also takes the session pool's ready helper when one is waiting, which makes a
+Tab one network round trip. Without persistence, the completion process opens
+its own connection, which ends with that request.
 
 After a successful SSH connection, syq remembers the endpoint as a future
 suggestion. It also suggests literal aliases from SSH configuration,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -521,7 +521,8 @@ can open sessions through the socket without touching the key or agent, and
 can take the ready helper session the pool holds. This is comparable to
 sudo's credential cache; do not enable it where that window is unacceptable.
 On the remote side the pool keeps one idle SSH session and one idle helper
-process per endpoint for as long as the window lasts, and nothing else. Data connections are unaffected: they remain separate TCP
+process per endpoint for as long as the window lasts, and nothing else. Data
+connections are unaffected: they remain separate TCP
 streams (or independent SSH processes under `--no-tcp`), so bulk throughput
 does not change. Persistence is not applied to an explicit `--rsh`, a
 coordinator running on a remote host, or authentication to the restricted

--- a/docs/security.md
+++ b/docs/security.md
@@ -396,6 +396,31 @@ rather than shell commands, which is what makes it auditable, and a grant names
 an operation, a destination directory, and limits. The policies it enforces
 are the copy, verify, and delete semantics of syq's own transfers.
 
+## Persistent connections
+
+`syq persist on` trades a little exposure for speed, and the trade should be
+understood before it is made. While it is on, an OpenSSH control connection
+to each endpoint you use stays authenticated for five minutes after the last
+command, and a small per-endpoint background process keeps one helper
+session opened on that connection ready for the next command. During that
+window, anything that can act as the same local user can run commands on
+those endpoints without touching your key or agent: through the control
+socket, or by taking the ready session. This is the same boundary as sudo's
+credential cache. The sockets live in a private runtime directory that only
+your user can open, the pool checks the caller's user id as well, and the
+window ends with `syq persist off`.
+
+The pool cannot widen that boundary. It never authenticates: a session is
+opened only after the master answers a liveness check, with every
+authentication method turned off, so a dead connection leaves the pool empty
+rather than logging in on its own, and a changed host key or a required
+prompt reaches you through the next command you run yourself. It never reads
+from the session it holds, so the command that takes it sees exactly what a
+fresh session would show. It matches the exact remote command and syq build
+of the command asking, and exits when a different build appears, when its
+scope is removed, or after five minutes idle. Restricted receivers, explicit
+remote shells, and remote coordinators do not use it.
+
 ## Release and bootstrap integrity
 
 Using a file tool over ssh means running its code on the other machine. With

--- a/docs/security.md
+++ b/docs/security.md
@@ -412,9 +412,12 @@ window ends with `syq persist off`.
 
 The pool cannot widen that boundary. It never authenticates: a session is
 opened only after the master answers a liveness check, with every
-authentication method turned off, so a dead connection leaves the pool empty
-rather than logging in on its own, and a changed host key or a required
-prompt reaches you through the next command you run yourself. It never reads
+authentication method turned off and the proxy pinned to a command that
+fails, so a connection that has gone away leaves the pool empty rather than
+logging in on its own, even through a configured `ProxyCommand` or
+`ProxyJump`, and a changed host key or a required prompt reaches you through
+the next command you run yourself. Its idle session carries none of your
+agent, display, or port forwardings to the remote host. It never reads
 from the session it holds, so the command that takes it sees exactly what a
 fresh session would show. It matches the exact remote command and syq build
 of the command asking, and exits when a different build appears, when its

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1162,6 +1162,7 @@ fn connect_completion_endpoint(
         quiet: true,
         tcp: Default::default(),
         diagnostics: Default::default(),
+        primed_control: Default::default(),
     };
     spec.connect_completion()
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -599,6 +599,9 @@ pub struct RemoteConn {
     peer: Option<PeerInfo>,
     tcp_socket: Option<TcpStream>,
     multiplexed_ssh: bool,
+    /// A session taken from the session pool: no child of ours to wait for,
+    /// and a reader that ends when the remote closes the pipe.
+    detached: bool,
 }
 
 const READ_AHEAD: usize = 4;
@@ -662,7 +665,45 @@ fn validate_remote_scan_batch(batch: &[Entry], saw_root: &mut bool) -> Result<()
     Ok(())
 }
 
+impl std::fmt::Debug for RemoteConn {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RemoteConn")
+            .field("label", &self.label)
+            .field("detached", &self.detached)
+            .finish()
+    }
+}
+
 impl RemoteConn {
+    /// A control session taken from the session pool: the ssh client's
+    /// pipes, with the preamble and hello already sent by the pool and their
+    /// replies unread. The pool reaps the ssh client once this process has
+    /// closed the pipes.
+    pub(crate) fn from_pooled(
+        session: crate::session_pool::PooledSession,
+        compress: bool,
+        label: String,
+    ) -> Self {
+        let (rx, reader) = spawn_reader(Box::new(session.stdout));
+        let mut stderr = session.stderr;
+        std::thread::spawn(move || {
+            let _ = std::io::copy(&mut stderr, &mut std::io::stderr());
+        });
+        RemoteConn {
+            child: None,
+            w: FrameWriter::with_preamble_written(Box::new(session.stdin), compress),
+            rx: Some(rx),
+            reader: Some(reader),
+            label,
+            dead: false,
+            peer: None,
+            tcp_socket: None,
+            multiplexed_ssh: false,
+            detached: true,
+        }
+    }
+
     fn transport_stats_with_timeout(
         &mut self,
         timeout: std::time::Duration,
@@ -837,6 +878,13 @@ impl Drop for RemoteConn {
     fn drop(&mut self) {
         if !self.dead {
             let _ = self.w.write_msg(&Request::Shutdown);
+        }
+        if self.detached {
+            // Closing the pipes is the whole teardown: the remote exits on
+            // Shutdown or EOF, and waiting for its exit status would cost
+            // the round trip the pool exists to save.
+            self.rx.take();
+            return;
         }
         // Sending Shutdown asks for an orderly peer exit; shutting down the
         // retained TCP descriptor also wakes our reader clone and the peer's
@@ -1167,6 +1215,9 @@ pub struct RemoteSpec {
     pub tcp: std::sync::Arc<std::sync::Mutex<Option<TcpInfo>>>,
     /// User-facing facts gathered by the same connection path the transfer uses.
     pub diagnostics: std::sync::Arc<std::sync::Mutex<RemoteDiagnostics>>,
+    /// A pooled control session taken ahead of time on the main thread, for
+    /// the control connection to consume. Shared across clones like `tcp`.
+    pub(crate) primed_control: std::sync::Arc<std::sync::Mutex<Option<RemoteConn>>>,
 }
 
 impl RemoteSpec {
@@ -1185,6 +1236,7 @@ impl RemoteSpec {
             quiet,
             tcp: Default::default(),
             diagnostics: Default::default(),
+            primed_control: Default::default(),
         }
     }
 
@@ -1315,6 +1367,71 @@ impl RemoteSpec {
         }
     }
 
+    fn pool_endpoint(&self) -> crate::session_pool::PoolEndpoint {
+        crate::session_pool::PoolEndpoint {
+            user: self.user.clone(),
+            host: self.host.clone(),
+            port: self.port,
+            program: self.program_command(&["--server".into()]),
+        }
+    }
+
+    /// A ready control session from the persistence scope's pool, if the
+    /// pool has one for exactly the remote command this connection would
+    /// run. The pool sent the hello with a default command's flags; this
+    /// process reads the reply. Anything short of a usable session is a
+    /// reason to connect directly, never an error.
+    fn take_pooled_control(&self, compress: bool) -> Option<RemoteConn> {
+        if let Some(conn) = self.primed_control.lock().unwrap().take() {
+            return Some(conn);
+        }
+        let multiplexer = self.ssh_multiplexer.as_ref()?;
+        if !multiplexer.persistent
+            || self.local_process
+            || self.restricted_grant.is_some()
+            || !self
+                .rsh
+                .first()
+                .is_some_and(|program| program.ends_with("ssh"))
+        {
+            return None;
+        }
+        let program = self.program_command(&["--server".into()]);
+        let session = crate::session_pool::take(&multiplexer.path, &program)?;
+        let conn = RemoteConn::from_pooled(session, compress, self.label());
+        match receive_hello(conn, false) {
+            Ok(conn) => {
+                if crate::transfer::debug() {
+                    eprintln!(
+                        "syq: {}: control connection from the session pool",
+                        self.label()
+                    );
+                }
+                self.record_peer(&conn);
+                Some(conn)
+            }
+            Err(error) => {
+                if crate::transfer::debug() {
+                    eprintln!(
+                        "syq: {}: pooled session unusable ({error:#}); connecting directly",
+                        self.label()
+                    );
+                }
+                None
+            }
+        }
+    }
+
+    /// Take a pooled control session now, on the calling thread, for the
+    /// control connection to use later. Pooled sessions arrive as
+    /// descriptors, and Darwin cannot receive those close-on-exec
+    /// atomically, so this runs before any child is spawned alongside.
+    pub(crate) fn prime_pooled_control(&self, compress: bool) {
+        if let Some(conn) = self.take_pooled_control(compress) {
+            *self.primed_control.lock().unwrap() = Some(conn);
+        }
+    }
+
     /// A shell command that runs syq with `args` on this host.  Automatic mode
     /// addresses the exact release/build-identified helper; explicit mode preserves the
     /// administrator-provided path; disabling bootstrap uses normal PATH lookup.
@@ -1346,6 +1463,9 @@ impl RemoteSpec {
     /// transfer engine's exponential retries while retaining the exact same
     /// managed-helper bootstrap and persistent control socket behavior.
     pub(crate) fn connect_completion(&self) -> Result<RemoteConn> {
+        if let Some(conn) = self.take_pooled_control(false) {
+            return Ok(conn);
+        }
         let role = ConnectionRole::Control;
         let first = self.connect_once(false, SshConnection::Control, role.clone());
         let Err(first_error) = first else {
@@ -1371,6 +1491,11 @@ impl RemoteSpec {
         limited: bool,
         role: ConnectionRole,
     ) -> Result<RemoteConn> {
+        if matches!(role, ConnectionRole::Control) && compress {
+            if let Some(conn) = self.take_pooled_control(compress) {
+                return Ok(conn);
+            }
+        }
         let first = self.connect_retried(compress, limited, role.clone());
         let Err(first_error) = first else {
             return first;
@@ -1505,6 +1630,7 @@ impl RemoteSpec {
             peer: None,
             tcp_socket: None,
             multiplexed_ssh: ssh_connection == SshConnection::Worker,
+            detached: false,
         };
         let conn = hello(conn, compress, Vec::new(), role)?;
         self.record_peer(&conn);
@@ -1521,6 +1647,14 @@ impl RemoteSpec {
                 &self.host,
                 self.port,
             );
+            // With persistence on, the next command should find a session
+            // ready. The pool is started here, after this connection is up,
+            // so it never sits on the critical path.
+            if let Some(multiplexer) = &self.ssh_multiplexer {
+                if multiplexer.persistent {
+                    crate::session_pool::ensure(&multiplexer.path, &self.pool_endpoint());
+                }
+            }
         }
         Ok(conn)
     }
@@ -1819,6 +1953,7 @@ impl RemoteSpec {
                 peer: None,
                 tcp_socket: Some(tcp_socket),
                 multiplexed_ssh: false,
+                detached: false,
             };
             let conn = hello(conn, compress, info.token.clone(), role.clone())?;
             self.record_peer(&conn);
@@ -1955,6 +2090,23 @@ impl std::fmt::Debug for TcpInfo {
     }
 }
 
+/// The first request on every connection. The session pool sends it on a
+/// command's behalf with a default command's flags.
+pub(crate) fn hello_request(
+    compress: bool,
+    debug: bool,
+    token: Vec<u8>,
+    role: ConnectionRole,
+) -> Request {
+    Request::Hello {
+        identity: crate::identity::build().to_string(),
+        compress,
+        debug,
+        token,
+        role,
+    }
+}
+
 fn hello(
     mut conn: RemoteConn,
     compress: bool,
@@ -1962,13 +2114,16 @@ fn hello(
     role: ConnectionRole,
 ) -> Result<RemoteConn> {
     let worker = !matches!(role, ConnectionRole::Control);
-    conn.send(Request::Hello {
-        identity: crate::identity::build().to_string(),
+    conn.send(hello_request(
         compress,
-        debug: crate::transfer::debug(),
+        crate::transfer::debug(),
         token,
         role,
-    })?;
+    ))?;
+    receive_hello(conn, worker)
+}
+
+fn receive_hello(mut conn: RemoteConn, worker: bool) -> Result<RemoteConn> {
     match conn.recv() {
         Ok(Response::HelloOk {
             identity,
@@ -2889,6 +3044,7 @@ mod tests {
             quiet: false,
             tcp: Default::default(),
             diagnostics: Default::default(),
+            primed_control: Default::default(),
         };
         let info = TcpInfo {
             addrs: vec!["127.0.0.1".into()],
@@ -2907,8 +3063,7 @@ mod tests {
                 false,
                 ConnectionRole::SourceWorker { roots: Vec::new() },
             )
-            .err()
-            .expect("unregistered congestion control should fail locally");
+            .expect_err("unregistered congestion control should fail locally");
         let message = format!("{error:#}");
         assert!(is_tcp_congestion_error(&error));
         assert!(message.contains(
@@ -2989,6 +3144,7 @@ mod tests {
             peer: None,
             tcp_socket: None,
             multiplexed_ssh: false,
+            detached: false,
         };
         let conn = hello(
             conn,
@@ -3034,10 +3190,10 @@ mod tests {
             peer: None,
             tcp_socket: None,
             multiplexed_ssh: false,
+            detached: false,
         };
         let error = hello(conn, false, Vec::new(), ConnectionRole::Control)
-            .err()
-            .expect("an operation response is not a valid handshake");
+            .expect_err("an operation response is not a valid handshake");
         let message = format!("{error:#}");
         assert!(
             message.contains("unexpected handshake response"),
@@ -3075,6 +3231,7 @@ mod tests {
             peer: None,
             tcp_socket: None,
             multiplexed_ssh: false,
+            detached: false,
         };
         let error = conn.io_err(
             std::io::Error::new(
@@ -3134,6 +3291,7 @@ mod tests {
                 peer: None,
                 tcp_socket: Some(tcp_socket),
                 multiplexed_ssh: false,
+                detached: false,
             };
             let timeout = std::time::Duration::from_millis(5);
             let start = std::time::Instant::now();
@@ -3263,6 +3421,7 @@ mod tests {
             quiet: false,
             tcp: Default::default(),
             diagnostics: Default::default(),
+            primed_control: Default::default(),
         };
         let command = spec.ssh_command(SshConnection::Independent);
         assert!(!command
@@ -3349,6 +3508,7 @@ mod tests {
             quiet: false,
             tcp: Default::default(),
             diagnostics: Default::default(),
+            primed_control: Default::default(),
         };
         let args = |connection| {
             spec.ssh_command(connection)
@@ -3415,6 +3575,7 @@ mod tests {
             quiet: false,
             tcp: Default::default(),
             diagnostics: Default::default(),
+            primed_control: Default::default(),
         };
         let args = |connection| {
             spec.ssh_command(connection)
@@ -3465,6 +3626,7 @@ mod tests {
             quiet: false,
             tcp: Default::default(),
             diagnostics: Default::default(),
+            primed_control: Default::default(),
         };
 
         let command = spec.ssh_command(SshConnection::Control);

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1427,6 +1427,11 @@ impl RemoteSpec {
     /// descriptors, and Darwin cannot receive those close-on-exec
     /// atomically, so this runs before any child is spawned alongside.
     pub(crate) fn prime_pooled_control(&self, compress: bool) {
+        // The same gate as the control connection's: a --no-compress command
+        // connects directly and must not hold a session it will not use.
+        if !compress {
+            return;
+        }
         if let Some(conn) = self.take_pooled_control(compress) {
             *self.primed_control.lock().unwrap() = Some(conn);
         }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1410,7 +1410,7 @@ impl RemoteSpec {
         match receive_hello(conn, false) {
             Ok(conn) => {
                 if crate::transfer::debug() {
-                    eprintln!(
+                    crate::output::diagnostic!(
                         "syq: {}: control connection from the session pool",
                         self.label()
                     );
@@ -1420,7 +1420,7 @@ impl RemoteSpec {
             }
             Err(error) => {
                 if crate::transfer::debug() {
-                    eprintln!(
+                    crate::output::diagnostic!(
                         "syq: {}: pooled session unusable ({error:#}); connecting directly",
                         self.label()
                     );
@@ -3493,6 +3493,7 @@ mod tests {
                 next: Default::default(),
             }))),
             diagnostics: Default::default(),
+            primed_control: Default::default(),
         };
         let endpoint = Endpoint::Remote(spec.clone());
         assert!(endpoint

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1216,8 +1216,16 @@ pub struct RemoteSpec {
     /// User-facing facts gathered by the same connection path the transfer uses.
     pub diagnostics: std::sync::Arc<std::sync::Mutex<RemoteDiagnostics>>,
     /// A pooled control session taken ahead of time on the main thread, for
-    /// the control connection to consume. Shared across clones like `tcp`.
-    pub(crate) primed_control: std::sync::Arc<std::sync::Mutex<Option<RemoteConn>>>,
+    /// the control connection to consume. An empty result also prevents
+    /// descriptor receipt during the later parallel connect.
+    pub(crate) primed_control: std::sync::Arc<std::sync::Mutex<PrimedControl>>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) enum PrimedControl {
+    #[default]
+    Unchecked,
+    Checked(Option<RemoteConn>),
 }
 
 impl RemoteSpec {
@@ -1382,8 +1390,8 @@ impl RemoteSpec {
     /// process reads the reply. Anything short of a usable session is a
     /// reason to connect directly, never an error.
     fn take_pooled_control(&self, compress: bool) -> Option<RemoteConn> {
-        if let Some(conn) = self.primed_control.lock().unwrap().take() {
-            return Some(conn);
+        if let PrimedControl::Checked(conn) = &mut *self.primed_control.lock().unwrap() {
+            return conn.take();
         }
         let multiplexer = self.ssh_multiplexer.as_ref()?;
         if !multiplexer.persistent
@@ -1432,9 +1440,8 @@ impl RemoteSpec {
         if !compress {
             return;
         }
-        if let Some(conn) = self.take_pooled_control(compress) {
-            *self.primed_control.lock().unwrap() = Some(conn);
-        }
+        let conn = self.take_pooled_control(compress);
+        *self.primed_control.lock().unwrap() = PrimedControl::Checked(conn);
     }
 
     /// A shell command that runs syq with `args` on this host.  Automatic mode
@@ -3543,6 +3550,31 @@ mod tests {
 
         let independent = args(SshConnection::Independent);
         assert!(independent.iter().any(|arg| arg == "ControlPath=none"));
+    }
+
+    #[test]
+    fn a_pool_appearing_after_priming_is_not_queried_during_connect() {
+        use std::os::unix::net::UnixListener;
+        let directory = crate::test_support::tempdir().unwrap();
+        let scope = directory.path().join("scope");
+        crate::persistence::initialize_scope(&scope).unwrap();
+        let multiplexer = SshMultiplexer::persistent(&scope, None, "example", None).unwrap();
+        let socket = crate::session_pool::socket_path(&multiplexer.path);
+        let mut spec = RemoteSpec::local_receiver(true);
+        spec.local_process = false;
+        spec.rsh = vec!["ssh".into()];
+        spec.ssh_multiplexer = Some(std::sync::Arc::new(multiplexer));
+
+        // The pool is absent during the main-thread prime, then starts
+        // before the parallel connect. The cloned spec must keep that miss.
+        spec.prime_pooled_control(true);
+        let listener = UnixListener::bind(socket).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        assert!(spec.clone().take_pooled_control(true).is_none());
+        assert_eq!(
+            listener.accept().unwrap_err().kind(),
+            std::io::ErrorKind::WouldBlock
+        );
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1225,7 +1225,7 @@ pub struct RemoteSpec {
 pub(crate) enum PrimedControl {
     #[default]
     Unchecked,
-    Checked(Option<RemoteConn>),
+    Checked(Option<Box<RemoteConn>>),
 }
 
 impl RemoteSpec {
@@ -1391,7 +1391,7 @@ impl RemoteSpec {
     /// reason to connect directly, never an error.
     fn take_pooled_control(&self, compress: bool) -> Option<RemoteConn> {
         if let PrimedControl::Checked(conn) = &mut *self.primed_control.lock().unwrap() {
-            return conn.take();
+            return conn.take().map(|conn| *conn);
         }
         let multiplexer = self.ssh_multiplexer.as_ref()?;
         if !multiplexer.persistent
@@ -1441,7 +1441,7 @@ impl RemoteSpec {
             return;
         }
         let conn = self.take_pooled_control(compress);
-        *self.primed_control.lock().unwrap() = PrimedControl::Checked(conn);
+        *self.primed_control.lock().unwrap() = PrimedControl::Checked(conn.map(Box::new));
     }
 
     /// A shell command that runs syq with `args` on this host.  Automatic mode

--- a/src/descriptor_broker.rs
+++ b/src/descriptor_broker.rs
@@ -605,6 +605,153 @@ fn send_descriptor(socket: RawFd, descriptor: RawFd) -> io::Result<()> {
     }
 }
 
+const MAX_MESSAGE_DESCRIPTORS: usize = 3;
+const MESSAGE_CONTROL_LEN: usize = unsafe {
+    libc::CMSG_SPACE((MAX_MESSAGE_DESCRIPTORS * size_of::<RawFd>()) as libc::c_uint) as usize
+};
+
+#[repr(C)]
+union MessageControl {
+    _align: libc::cmsghdr,
+    bytes: [u8; MESSAGE_CONTROL_LEN],
+}
+
+/// Send one payload together with up to three descriptors, as the session
+/// pool hands a session over. Payload and descriptors travel in one message,
+/// so a reader cannot consume one without the other.
+pub(crate) fn send_message(socket: RawFd, payload: &[u8], descriptors: &[RawFd]) -> io::Result<()> {
+    if payload.is_empty() || descriptors.len() > MAX_MESSAGE_DESCRIPTORS {
+        return Err(io::Error::other("unsupported descriptor message"));
+    }
+    let mut payload = payload.to_vec();
+    let mut iovec = libc::iovec {
+        iov_base: payload.as_mut_ptr().cast(),
+        iov_len: payload.len(),
+    };
+    let mut control = MessageControl {
+        bytes: [0; MESSAGE_CONTROL_LEN],
+    };
+    let mut message: libc::msghdr = unsafe { zeroed() };
+    message.msg_iov = &mut iovec;
+    message.msg_iovlen = 1;
+    if !descriptors.is_empty() {
+        let data_len = std::mem::size_of_val(descriptors);
+        message.msg_control = unsafe { control.bytes.as_mut_ptr().cast() };
+        message.msg_controllen = unsafe { libc::CMSG_SPACE(data_len as libc::c_uint) } as _;
+        unsafe {
+            let header = libc::CMSG_FIRSTHDR(&message);
+            if header.is_null() {
+                return Err(io::Error::other("SCM_RIGHTS control buffer is too small"));
+            }
+            (*header).cmsg_level = libc::SOL_SOCKET;
+            (*header).cmsg_type = libc::SCM_RIGHTS;
+            (*header).cmsg_len = libc::CMSG_LEN(data_len as libc::c_uint) as _;
+            for (index, descriptor) in descriptors.iter().enumerate() {
+                std::ptr::write_unaligned(
+                    libc::CMSG_DATA(header).cast::<RawFd>().add(index),
+                    *descriptor,
+                );
+            }
+        }
+    }
+    loop {
+        let sent = unsafe { libc::sendmsg(socket, &message, 0) };
+        if sent == payload.len() as isize {
+            return Ok(());
+        }
+        if sent >= 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "descriptor message was sent incompletely",
+            ));
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+/// Receive one payload of at most `max_payload` bytes and the descriptors
+/// sent with it, each wrapped exactly once and close-on-exec.
+pub(crate) fn receive_message(
+    socket: RawFd,
+    max_payload: usize,
+) -> io::Result<(Vec<u8>, Vec<File>)> {
+    let mut payload = vec![0u8; max_payload];
+    let mut iovec = libc::iovec {
+        iov_base: payload.as_mut_ptr().cast(),
+        iov_len: payload.len(),
+    };
+    let mut control = MessageControl {
+        bytes: [0; MESSAGE_CONTROL_LEN],
+    };
+    let mut message: libc::msghdr = unsafe { zeroed() };
+    message.msg_iov = &mut iovec;
+    message.msg_iovlen = 1;
+    message.msg_control = unsafe { control.bytes.as_mut_ptr().cast() };
+    message.msg_controllen = MESSAGE_CONTROL_LEN as _;
+    #[cfg(target_os = "linux")]
+    let flags = libc::MSG_CMSG_CLOEXEC;
+    #[cfg(not(target_os = "linux"))]
+    let flags = 0;
+    let received = loop {
+        let received = unsafe { libc::recvmsg(socket, &mut message, flags) };
+        if received > 0 {
+            break received as usize;
+        }
+        if received == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "peer closed without a message",
+            ));
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    };
+    payload.truncate(received);
+    let mut descriptors = Vec::new();
+    let mut malformed = message.msg_flags & libc::MSG_CTRUNC != 0;
+    // SAFETY: as in receive_descriptor; every received descriptor is wrapped
+    // exactly once so a rejection closes all of them.
+    unsafe {
+        let mut header = libc::CMSG_FIRSTHDR(&message);
+        while !header.is_null() {
+            let header_len = libc::CMSG_LEN(0) as usize;
+            let control_len = (*header).cmsg_len as usize;
+            if (*header).cmsg_level == libc::SOL_SOCKET
+                && (*header).cmsg_type == libc::SCM_RIGHTS
+                && control_len >= header_len
+            {
+                let data_len = control_len - header_len;
+                malformed |= data_len == 0 || !data_len.is_multiple_of(size_of::<RawFd>());
+                for index in 0..data_len / size_of::<RawFd>() {
+                    let raw = std::ptr::read_unaligned(
+                        libc::CMSG_DATA(header).cast::<RawFd>().add(index),
+                    );
+                    descriptors.push(File::from_raw_fd(raw));
+                }
+            } else {
+                malformed = true;
+            }
+            header = libc::CMSG_NXTHDR(&message, header);
+        }
+    }
+    if malformed || descriptors.len() > MAX_MESSAGE_DESCRIPTORS {
+        drop(descriptors);
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "descriptor message carried malformed ancillary data",
+        ));
+    }
+    for descriptor in &descriptors {
+        set_close_on_exec(descriptor)?;
+    }
+    Ok((payload, descriptors))
+}
+
 fn receive_descriptor(socket: RawFd) -> io::Result<(u8, Option<File>)> {
     let mut status = [0u8];
     let mut iovec = libc::iovec {

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ fn main() {
     }
     if argv.get(1).and_then(|arg| arg.to_str()) == Some("--session-pool") {
         if let Err(error) = session_pool::run(&argv[2..]) {
-            eprintln!("syq session pool: {error:#}");
+            crate::output::diagnostic!("syq session pool: {error:#}");
             std::process::exit(1);
         }
         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod rooted;
 mod scan;
 mod sched;
 mod server;
+mod session_pool;
 mod tcp_records;
 #[cfg(test)]
 mod test_support;
@@ -167,6 +168,13 @@ fn main() {
         }
         if let Err(error) = restricted::run_receiver(enrollment.unwrap()) {
             crate::output::diagnostic!("syq restricted receiver: {error:#}");
+            std::process::exit(1);
+        }
+        return;
+    }
+    if argv.get(1).and_then(|arg| arg.to_str()) == Some("--session-pool") {
+        if let Err(error) = session_pool::run(&argv[2..]) {
+            eprintln!("syq session pool: {error:#}");
             std::process::exit(1);
         }
         return;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -452,7 +452,7 @@ fn create_marker(scope: &Path) -> Result<()> {
     Ok(())
 }
 
-fn validate_scope(scope: &Path) -> Result<()> {
+pub(crate) fn validate_scope(scope: &Path) -> Result<()> {
     validate_openssh_control_path(scope)?;
     secure_directory(scope, false, false)?;
     let marker_path = scope.join(SCOPE_MARKER);
@@ -615,12 +615,18 @@ fn print_scope_status(scope: &Path, kind: Option<&str>) -> Result<()> {
     }
     println!("connections: {}", records.len());
     for (key, record) in records {
-        let state = if socket_is_live(&scope.join(key)) {
+        let control = scope.join(&key);
+        let state = if socket_is_live(&control) {
             "live"
         } else {
             "inactive"
         };
-        println!("  {}  {state}", record.label());
+        let pool = if crate::session_pool::is_running(&control) {
+            ", session pool"
+        } else {
+            ""
+        };
+        println!("  {}  {state}{pool}", record.label());
     }
     Ok(())
 }
@@ -640,6 +646,13 @@ fn close_scope(scope: &Path) -> Result<()> {
                 continue;
             }
         }
+        if let Some(owner) = crate::session_pool::owned_name(name.as_bytes())
+            .and_then(|owner| std::str::from_utf8(owner).ok())
+        {
+            if valid_endpoint_key(owner) && record_keys.contains(owner) {
+                continue;
+            }
+        }
         bail!(
             "refusing to remove persistence scope {} because it contains unrecognized entry {:?}",
             scope.display(),
@@ -649,6 +662,8 @@ fn close_scope(scope: &Path) -> Result<()> {
 
     for (key, record) in records {
         let socket = scope.join(&key);
+        // The pool holds live sessions on the master, so it goes first.
+        crate::session_pool::stop(&socket)?;
         if socket_is_live(&socket) {
             close_master(&socket, &record)?;
         }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1120,6 +1120,16 @@ impl<W: Write> FrameWriter<W> {
         }
     }
 
+    /// A writer for a stream whose preamble another process already sent:
+    /// a control session taken from the session pool.
+    pub fn with_preamble_written(w: W, compress: bool) -> Self {
+        FrameWriter {
+            w: BufWriter::with_capacity(1 << 20, w),
+            compress,
+            preamble_written: true,
+        }
+    }
+
     pub fn write_preamble(&mut self) -> io::Result<()> {
         if self.preamble_written {
             return Ok(());

--- a/src/remote_to_remote.rs
+++ b/src/remote_to_remote.rs
@@ -885,6 +885,7 @@ fn run_remote(
         quiet: args.quiet,
         tcp: Default::default(),
         diagnostics: Default::default(),
+        primed_control: Default::default(),
     };
 
     // Rebuild the native command for the remote coordinator. Placement stays

--- a/src/session_pool.rs
+++ b/src/session_pool.rs
@@ -96,7 +96,10 @@ fn suffixed(path: &Path, suffix: &[u8]) -> PathBuf {
 
 /// Whether a pool holds this endpoint's lock. Liveness is the lock, not the
 /// socket file: a stale socket cannot claim to be alive, and two pools
-/// cannot race each other's sockets.
+/// cannot race each other's sockets. A `flock` lock is held by every copy of
+/// its descriptor, so a process that forked while a pool held it keeps it
+/// until it execs; that window is microseconds, and every caller tolerates
+/// a briefly stale answer: `ensure` is best effort and `stop` waits.
 pub(crate) fn is_running(control: &Path) -> bool {
     matches!(try_lock(control, false), Ok(None))
 }
@@ -748,7 +751,16 @@ mod tests {
         assert!(is_running(&control));
         assert!(try_lock(&control, true).unwrap().is_none());
         drop(held);
-        assert!(!is_running(&control));
+        // Another test in this process may be between fork and exec with a
+        // copy of the descriptor, which keeps the lock for a moment.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while is_running(&control) {
+            assert!(
+                Instant::now() < deadline,
+                "released lock still reported held"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
         stop(&control).unwrap();
         assert!(!lock_path(&control).exists());
     }

--- a/src/session_pool.rs
+++ b/src/session_pool.rs
@@ -444,8 +444,12 @@ impl Pool {
         Verdict::Continue
     }
 
-    /// The ssh command every spare shares: attach to the live master only,
-    /// and never authenticate.
+    /// The ssh command every spare shares: attach to the live master and
+    /// nothing else. With a missing socket OpenSSH would otherwise fall back
+    /// to an ordinary connection, and a configured ProxyCommand or ProxyJump
+    /// could authenticate on its own even with target authentication off, so
+    /// the proxy is pinned to a command that fails; and an idle session must
+    /// not carry the user's agent, display, or forwardings to the remote.
     fn ssh(&self) -> Command {
         let mut command = Command::new("ssh");
         command
@@ -454,6 +458,22 @@ impl Pool {
             .arg("-S")
             .arg(crate::persistence::openssh_control_path(&self.control))
             .args([
+                "-o",
+                "ProxyJump=none",
+                "-o",
+                "ProxyCommand=false",
+                "-o",
+                "ForwardAgent=no",
+                "-o",
+                "ForwardX11=no",
+                "-o",
+                "ClearAllForwardings=yes",
+                "-o",
+                "PermitLocalCommand=no",
+                "-o",
+                "GSSAPIDelegateCredentials=no",
+                "-o",
+                "RequestTTY=no",
                 "-o",
                 "BatchMode=yes",
                 "-o",
@@ -505,40 +525,20 @@ impl Pool {
             .stderr(Stdio::piped())
             .spawn()
             .context("start a spare session")?;
-        // SAFETY: each descriptor comes from a piped child stdio handle this
-        // process owns and is wrapped exactly once.
-        let stdin = child
-            .stdin
-            .take()
-            .map(|pipe| unsafe { File::from_raw_fd(pipe.into_raw_fd()) })
-            .context("spare session stdin was not piped")?;
-        let stdout = child
-            .stdout
-            .take()
-            .map(|pipe| unsafe { File::from_raw_fd(pipe.into_raw_fd()) })
-            .context("spare session stdout was not piped")?;
-        let stderr = child
-            .stderr
-            .take()
-            .map(|pipe| unsafe { File::from_raw_fd(pipe.into_raw_fd()) })
-            .context("spare session stderr was not piped")?;
-        // The hello goes out now; the taker reads its reply. A default
-        // command's flags are used so the receiver's writer matches them.
-        {
-            let mut writer = FrameWriter::new(&stdin, true);
-            writer.write_msg(&crate::conn::hello_request(
-                true,
-                false,
-                Vec::new(),
-                ConnectionRole::Control,
-            ))?;
+        match greet_spare(&mut child) {
+            Ok((stdin, stdout, stderr)) => Ok(Spare {
+                child,
+                stdin,
+                stdout,
+                stderr,
+            }),
+            Err(error) => {
+                // A refused or lost session is not left as a zombie.
+                let _ = child.kill();
+                let _ = child.wait();
+                Err(error)
+            }
         }
-        Ok(Spare {
-            child,
-            stdin,
-            stdout,
-            stderr,
-        })
     }
 
     fn handle_client(&mut self, mut stream: UnixStream) -> Verdict {
@@ -625,6 +625,37 @@ impl Pool {
         }
         let _ = fs::remove_file(lock_path(&self.control));
     }
+}
+
+/// Take a spare's pipes and send the hello on it. The taker reads the reply;
+/// a default command's flags are used so the receiver's writer matches them.
+fn greet_spare(child: &mut Child) -> Result<(File, File, File)> {
+    // SAFETY: each descriptor comes from a piped child stdio handle this
+    // process owns and is wrapped exactly once.
+    let stdin = child
+        .stdin
+        .take()
+        .map(|pipe| unsafe { File::from_raw_fd(pipe.into_raw_fd()) })
+        .context("spare session stdin was not piped")?;
+    let stdout = child
+        .stdout
+        .take()
+        .map(|pipe| unsafe { File::from_raw_fd(pipe.into_raw_fd()) })
+        .context("spare session stdout was not piped")?;
+    let stderr = child
+        .stderr
+        .take()
+        .map(|pipe| unsafe { File::from_raw_fd(pipe.into_raw_fd()) })
+        .context("spare session stderr was not piped")?;
+    let mut writer = FrameWriter::new(&stdin, true);
+    writer.write_msg(&crate::conn::hello_request(
+        true,
+        false,
+        Vec::new(),
+        ConnectionRole::Control,
+    ))?;
+    drop(writer);
+    Ok((stdin, stdout, stderr))
 }
 
 /// One request line, read a byte at a time so nothing beyond it is consumed.

--- a/src/session_pool.rs
+++ b/src/session_pool.rs
@@ -403,6 +403,9 @@ impl Pool {
                     let mut spare = self.spares.remove(index - 1);
                     let _ = spare.child.kill();
                     let _ = spare.child.wait();
+                    // spawn can succeed before SSH refuses the session or
+                    // the helper exits. Back off these failures too.
+                    self.last_failure = Some(Instant::now());
                 }
             }
             if fds[0].revents & libc::POLLIN != 0 {

--- a/src/session_pool.rs
+++ b/src/session_pool.rs
@@ -1,0 +1,731 @@
+//! Ready control sessions for persistent SSH endpoints.
+//!
+//! With persistence on, every command still opened an exec channel through
+//! the OpenSSH master, launched the remote helper, and exchanged the hello
+//! before its first useful request: three network turns. A session pool is a
+//! small detached process, one per endpoint in a persistence scope, that
+//! keeps one such session opened ahead of time and hands its pipes to the
+//! next command over a Unix socket beside the control socket.
+//!
+//! Two invariants keep it simple and safe. The pool never reads from a
+//! session: it writes the hello and watches the pipe for hang-up only, so a
+//! taken session is byte-for-byte what a fresh one would be, and the command
+//! completes the hello itself. And the pool never authenticates: a spare is
+//! attached to a live master with every authentication method disabled, so a
+//! dead master leaves the pool empty until the next foreground command shows
+//! the ordinary OpenSSH prompt or warning.
+
+use crate::descriptor_broker::{receive_message, send_message};
+use crate::proto::{ConnectionRole, FrameWriter};
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::ffi::OsString;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const SOCKET_SUFFIX: &[u8] = b".pool";
+const LOCK_SUFFIX: &[u8] = b".pool.lock";
+/// Spares kept ready per endpoint. One covers a person typing; a burst
+/// takes the in-flight spare, whose hello it then finishes itself.
+const DEPTH: usize = 1;
+/// Exit after this long without a handoff. Spares are live channels, so
+/// the master's own ControlPersist window begins only after this.
+const IDLE: Duration = Duration::from_secs(300);
+/// A failed spare open (usually a dead master) is not retried sooner.
+const RETRY_AFTER_FAILURE: Duration = Duration::from_secs(5);
+const HOUSEKEEPING: Duration = Duration::from_secs(1);
+const CLIENT_IO_TIMEOUT: Duration = Duration::from_secs(2);
+const STOP_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_MESSAGE: usize = 8192;
+
+/// What the pool needs to open a session for one endpoint. The program is
+/// the exact remote command a command would run itself, so a command that
+/// would run something else (another `--syq-path`, say) gets no session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PoolEndpoint {
+    pub user: Option<String>,
+    pub host: String,
+    pub port: Option<u16>,
+    pub program: String,
+}
+
+/// A session handed over by the pool: the ssh client's three pipes. The
+/// hello request has been written; its reply has not been read.
+pub(crate) struct PooledSession {
+    pub stdin: File,
+    pub stdout: File,
+    pub stderr: File,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ClientRequest {
+    identity: String,
+    #[serde(default)]
+    program: Option<String>,
+    #[serde(default)]
+    exit: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PoolReply {
+    status: String,
+    identity: String,
+}
+
+pub(crate) fn socket_path(control: &Path) -> PathBuf {
+    suffixed(control, SOCKET_SUFFIX)
+}
+
+pub(crate) fn lock_path(control: &Path) -> PathBuf {
+    suffixed(control, LOCK_SUFFIX)
+}
+
+fn suffixed(path: &Path, suffix: &[u8]) -> PathBuf {
+    let mut bytes = path.as_os_str().as_bytes().to_vec();
+    bytes.extend_from_slice(suffix);
+    PathBuf::from(OsString::from_vec(bytes))
+}
+
+/// Whether a pool holds this endpoint's lock. Liveness is the lock, not the
+/// socket file: a stale socket cannot claim to be alive, and two pools
+/// cannot race each other's sockets.
+pub(crate) fn is_running(control: &Path) -> bool {
+    matches!(try_lock(control, false), Ok(None))
+}
+
+/// Take the lock, or report who holds it. `Ok(None)` means another pool has
+/// it; `Err` means the lock file could not be opened.
+fn try_lock(control: &Path, create: bool) -> Result<Option<File>> {
+    let path = lock_path(control);
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .write(create)
+        .create(create)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let file = match options.open(&path) {
+        Ok(file) => file,
+        Err(error) if !create && error.kind() == io::ErrorKind::NotFound => {
+            bail!("no session pool lock");
+        }
+        Err(error) => {
+            return Err(error).with_context(|| format!("open {}", path.display()));
+        }
+    };
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } {
+        bail!(
+            "session pool lock {} must be a regular file owned by the current user",
+            path.display()
+        );
+    }
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        return Ok(Some(file));
+    }
+    let error = io::Error::last_os_error();
+    if error.kind() == io::ErrorKind::WouldBlock {
+        return Ok(None);
+    }
+    Err(error).with_context(|| format!("lock {}", path.display()))
+}
+
+/// Start a pool for this endpoint unless one is running. Best effort and
+/// off the critical path: the caller has just opened its own connection.
+pub(crate) fn ensure(control: &Path, endpoint: &PoolEndpoint) {
+    if is_running(control) {
+        return;
+    }
+    let Ok(program) = std::env::current_exe() else {
+        return;
+    };
+    let mut command = Command::new(program);
+    command
+        .arg("--session-pool")
+        .arg(control)
+        .arg(endpoint.user.as_deref().unwrap_or(""))
+        .arg(&endpoint.host)
+        .arg(
+            endpoint
+                .port
+                .map(|port| port.to_string())
+                .unwrap_or_default(),
+        )
+        .arg(&endpoint.program)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // SAFETY: setsid takes no arguments, touches no memory, and is safe to
+    // call between fork and exec. It detaches the pool from the terminal so
+    // a Ctrl-C or hangup meant for the command never reaches it.
+    unsafe {
+        command.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+    if let Ok(mut child) = command.spawn() {
+        // The pool outlives this process; reap it only if it exits first.
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+    }
+}
+
+/// Take a ready session for `program`, or nothing. Every failure is a
+/// reason to connect directly, never an error for the command.
+pub(crate) fn take(control: &Path, program: &str) -> Option<PooledSession> {
+    let mut stream = UnixStream::connect(socket_path(control)).ok()?;
+    stream.set_read_timeout(Some(CLIENT_IO_TIMEOUT)).ok()?;
+    stream.set_write_timeout(Some(CLIENT_IO_TIMEOUT)).ok()?;
+    let request = ClientRequest {
+        identity: crate::identity::build().to_string(),
+        program: Some(program.to_string()),
+        exit: false,
+    };
+    let mut line = serde_json::to_vec(&request).ok()?;
+    line.push(b'\n');
+    stream.write_all(&line).ok()?;
+    let (payload, mut descriptors) = receive_message(stream.as_raw_fd(), MAX_MESSAGE).ok()?;
+    let reply: PoolReply = serde_json::from_slice(&payload).ok()?;
+    if reply.status != "session" || reply.identity != crate::identity::build() {
+        return None;
+    }
+    if descriptors.len() != 3
+        || descriptors
+            .iter()
+            .any(|descriptor| !descriptor.metadata().is_ok_and(|m| m.file_type().is_fifo()))
+    {
+        return None;
+    }
+    let stderr = descriptors.pop()?;
+    let stdout = descriptors.pop()?;
+    let stdin = descriptors.pop()?;
+    Some(PooledSession {
+        stdin,
+        stdout,
+        stderr,
+    })
+}
+
+/// Ask a running pool to exit, wait for it, and remove its files. A pool
+/// that is not running leaves only stale files, which are removed too.
+pub(crate) fn stop(control: &Path) -> Result<()> {
+    if is_running(control) {
+        if let Ok(mut stream) = UnixStream::connect(socket_path(control)) {
+            let _ = stream.set_write_timeout(Some(CLIENT_IO_TIMEOUT));
+            let request = ClientRequest {
+                identity: crate::identity::build().to_string(),
+                program: None,
+                exit: true,
+            };
+            let mut line = serde_json::to_vec(&request)?;
+            line.push(b'\n');
+            let _ = stream.write_all(&line);
+        }
+        let deadline = Instant::now() + STOP_TIMEOUT;
+        while is_running(control) {
+            if Instant::now() >= deadline {
+                bail!(
+                    "session pool for {} did not exit",
+                    control.file_name().unwrap_or_default().to_string_lossy()
+                );
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+    for path in [socket_path(control), lock_path(control)] {
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.is_dir() => {
+                bail!("refusing to remove unexpected directory {}", path.display())
+            }
+            Ok(_) => fs::remove_file(&path)
+                .with_context(|| format!("remove session pool file {}", path.display()))?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error).with_context(|| format!("inspect {}", path.display())),
+        }
+    }
+    Ok(())
+}
+
+/// The names beside a control socket that belong to its pool, for the scope
+/// inventory: `<key>.pool` and `<key>.pool.lock`.
+pub(crate) fn owned_name(name: &[u8]) -> Option<&[u8]> {
+    name.strip_suffix(LOCK_SUFFIX)
+        .or_else(|| name.strip_suffix(SOCKET_SUFFIX))
+}
+
+struct Spare {
+    child: Child,
+    stdin: File,
+    stdout: File,
+    stderr: File,
+}
+
+struct Pool {
+    endpoint: PoolEndpoint,
+    control: PathBuf,
+    socket: PathBuf,
+    bound_ino: u64,
+    listener: UnixListener,
+    _lock: File,
+    spares: Vec<Spare>,
+    handed: Vec<Child>,
+    last_handoff: Instant,
+    last_failure: Option<Instant>,
+    idle: Duration,
+}
+
+enum Verdict {
+    Continue,
+    Exit,
+}
+
+/// `syq --session-pool CONTROL USER HOST PORT PROGRAM`: the pool process.
+pub(crate) fn run(argv: &[OsString]) -> Result<()> {
+    let [control, user, host, port, program] = argv else {
+        bail!("session pool takes exactly control-socket, user, host, port, and program arguments");
+    };
+    let control = PathBuf::from(control);
+    let text = |value: &OsString| {
+        value
+            .to_str()
+            .map(str::to_owned)
+            .context("session pool arguments must be UTF-8")
+    };
+    let user = text(user)?;
+    let port = text(port)?;
+    let endpoint = PoolEndpoint {
+        user: (!user.is_empty()).then_some(user),
+        host: text(host)?,
+        port: if port.is_empty() {
+            None
+        } else {
+            Some(port.parse().context("session pool port")?)
+        },
+        program: text(program)?,
+    };
+    let scope = control
+        .parent()
+        .context("control socket path has no parent")?;
+    crate::persistence::validate_scope(scope)?;
+    let Some(lock) = try_lock(&control, true)? else {
+        // Another pool serves this endpoint.
+        return Ok(());
+    };
+    let socket = socket_path(&control);
+    match fs::symlink_metadata(&socket) {
+        Ok(metadata) if metadata.file_type().is_socket() => fs::remove_file(&socket)
+            .with_context(|| format!("remove stale session pool socket {}", socket.display()))?,
+        Ok(_) => bail!("unexpected entry at {}", socket.display()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error).with_context(|| format!("inspect {}", socket.display())),
+    }
+    let listener =
+        UnixListener::bind(&socket).with_context(|| format!("bind {}", socket.display()))?;
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))?;
+    listener.set_nonblocking(true)?;
+    let bound_ino = fs::symlink_metadata(&socket)?.ino();
+    let mut idle = IDLE;
+    #[cfg(debug_assertions)]
+    if let Some(seconds) = std::env::var_os("SYQ_TEST_POOL_IDLE_SECS")
+        .and_then(|value| value.to_str()?.parse::<u64>().ok())
+    {
+        idle = Duration::from_secs(seconds);
+    }
+    let mut pool = Pool {
+        endpoint,
+        control,
+        socket,
+        bound_ino,
+        listener,
+        _lock: lock,
+        spares: Vec::new(),
+        handed: Vec::new(),
+        last_handoff: Instant::now(),
+        last_failure: None,
+        idle,
+    };
+    let result = pool.serve();
+    pool.shutdown();
+    result
+}
+
+impl Pool {
+    fn serve(&mut self) -> Result<()> {
+        loop {
+            if let Verdict::Exit = self.housekeeping() {
+                return Ok(());
+            }
+            // Spares are watched for hang-up only: a readable pipe just
+            // holds the hello reply the taker will read.
+            let mut fds: Vec<libc::pollfd> = Vec::with_capacity(1 + self.spares.len());
+            fds.push(libc::pollfd {
+                fd: self.listener.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            });
+            for spare in &self.spares {
+                fds.push(libc::pollfd {
+                    fd: spare.stdout.as_raw_fd(),
+                    events: 0,
+                    revents: 0,
+                });
+            }
+            let ready = unsafe {
+                libc::poll(
+                    fds.as_mut_ptr(),
+                    fds.len() as libc::nfds_t,
+                    HOUSEKEEPING.as_millis() as libc::c_int,
+                )
+            };
+            if ready < 0 {
+                let error = io::Error::last_os_error();
+                if error.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(error).context("poll session pool descriptors");
+            }
+            let hung_up = libc::POLLHUP | libc::POLLERR | libc::POLLNVAL;
+            for (index, pollfd) in fds.iter().enumerate().skip(1).rev() {
+                if pollfd.revents & hung_up != 0 {
+                    let mut spare = self.spares.remove(index - 1);
+                    let _ = spare.child.kill();
+                    let _ = spare.child.wait();
+                }
+            }
+            if fds[0].revents & libc::POLLIN != 0 {
+                loop {
+                    match self.listener.accept() {
+                        Ok((stream, _)) => {
+                            if let Verdict::Exit = self.handle_client(stream) {
+                                return Ok(());
+                            }
+                        }
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => break,
+                        Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                        Err(error) => return Err(error).context("accept session pool client"),
+                    }
+                }
+            }
+        }
+    }
+
+    fn housekeeping(&mut self) -> Verdict {
+        self.handed
+            .retain_mut(|child| !matches!(child.try_wait(), Ok(Some(_))));
+        if self.last_handoff.elapsed() >= self.idle {
+            return Verdict::Exit;
+        }
+        // The scope was closed, or someone replaced the socket: nothing that
+        // connects there is ours to serve.
+        match fs::symlink_metadata(&self.socket) {
+            Ok(metadata) if metadata.ino() == self.bound_ino => {}
+            _ => return Verdict::Exit,
+        }
+        if self.spares.len() < DEPTH
+            && self
+                .last_failure
+                .is_none_or(|failure| failure.elapsed() >= RETRY_AFTER_FAILURE)
+        {
+            match self.open_spare() {
+                Ok(spare) => self.spares.push(spare),
+                Err(_) => self.last_failure = Some(Instant::now()),
+            }
+        }
+        Verdict::Continue
+    }
+
+    /// The ssh command every spare shares: attach to the live master only,
+    /// and never authenticate.
+    fn ssh(&self) -> Command {
+        let mut command = Command::new("ssh");
+        command
+            .arg("-o")
+            .arg("ControlMaster=no")
+            .arg("-S")
+            .arg(crate::persistence::openssh_control_path(&self.control))
+            .args([
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=3",
+                "-o",
+                "ConnectionAttempts=1",
+                "-o",
+                "PubkeyAuthentication=no",
+                "-o",
+                "PasswordAuthentication=no",
+                "-o",
+                "KbdInteractiveAuthentication=no",
+                "-o",
+                "GSSAPIAuthentication=no",
+                "-o",
+                "HostbasedAuthentication=no",
+                "-o",
+                crate::conn::CIPHERS,
+            ]);
+        if let Some(user) = &self.endpoint.user {
+            command.args(["-l", user]);
+        }
+        if let Some(port) = self.endpoint.port {
+            command.args(["-p", &port.to_string()]);
+        }
+        command
+    }
+
+    fn open_spare(&self) -> Result<Spare> {
+        let live = self
+            .ssh()
+            .args(["-O", "check", "--"])
+            .arg(&self.endpoint.host)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .context("check the SSH master")?;
+        if !live.success() {
+            bail!("no live SSH master");
+        }
+        let mut child = self
+            .ssh()
+            .arg("--")
+            .arg(&self.endpoint.host)
+            .arg(&self.endpoint.program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("start a spare session")?;
+        // SAFETY: each descriptor comes from a piped child stdio handle this
+        // process owns and is wrapped exactly once.
+        let stdin = child
+            .stdin
+            .take()
+            .map(|pipe| unsafe { File::from_raw_fd(pipe.into_raw_fd()) })
+            .context("spare session stdin was not piped")?;
+        let stdout = child
+            .stdout
+            .take()
+            .map(|pipe| unsafe { File::from_raw_fd(pipe.into_raw_fd()) })
+            .context("spare session stdout was not piped")?;
+        let stderr = child
+            .stderr
+            .take()
+            .map(|pipe| unsafe { File::from_raw_fd(pipe.into_raw_fd()) })
+            .context("spare session stderr was not piped")?;
+        // The hello goes out now; the taker reads its reply. A default
+        // command's flags are used so the receiver's writer matches them.
+        {
+            let mut writer = FrameWriter::new(&stdin, true);
+            writer.write_msg(&crate::conn::hello_request(
+                true,
+                false,
+                Vec::new(),
+                ConnectionRole::Control,
+            ))?;
+        }
+        Ok(Spare {
+            child,
+            stdin,
+            stdout,
+            stderr,
+        })
+    }
+
+    fn handle_client(&mut self, mut stream: UnixStream) -> Verdict {
+        let _ = stream.set_read_timeout(Some(CLIENT_IO_TIMEOUT));
+        let _ = stream.set_write_timeout(Some(CLIENT_IO_TIMEOUT));
+        if peer_uid(&stream).ok() != Some(unsafe { libc::geteuid() }) {
+            return Verdict::Continue;
+        }
+        let Some(request) = read_request(&mut stream) else {
+            return Verdict::Continue;
+        };
+        if request.exit {
+            self.reply(&stream, "exiting", &[]);
+            return Verdict::Exit;
+        }
+        if request.identity != crate::identity::build() {
+            // A newer syq is in use; its next command starts its own pool.
+            self.reply(&stream, "identity", &[]);
+            return Verdict::Exit;
+        }
+        let Some(program) = request.program else {
+            self.reply(&stream, "none", &[]);
+            return Verdict::Continue;
+        };
+        if program != self.endpoint.program {
+            // Serve what commands actually run; the spares opened for the
+            // old command line are useless to them.
+            self.endpoint.program = program;
+            for mut spare in self.spares.drain(..) {
+                let _ = spare.child.kill();
+                let _ = spare.child.wait();
+            }
+            self.reply(&stream, "none", &[]);
+            return Verdict::Continue;
+        }
+        let Some(spare) = self.spares.pop() else {
+            self.reply(&stream, "none", &[]);
+            return Verdict::Continue;
+        };
+        let Spare {
+            child,
+            stdin,
+            stdout,
+            stderr,
+        } = spare;
+        let sent = self.reply(
+            &stream,
+            "session",
+            &[stdin.as_raw_fd(), stdout.as_raw_fd(), stderr.as_raw_fd()],
+        );
+        // Our copies close here, so the taker's end is the only one left.
+        drop((stdin, stdout, stderr));
+        if sent {
+            self.last_handoff = Instant::now();
+            self.handed.push(child);
+        } else {
+            let mut child = child;
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        Verdict::Continue
+    }
+
+    fn reply(&self, stream: &UnixStream, status: &str, descriptors: &[i32]) -> bool {
+        let reply = PoolReply {
+            status: status.to_string(),
+            identity: crate::identity::build().to_string(),
+        };
+        let Ok(payload) = serde_json::to_vec(&reply) else {
+            return false;
+        };
+        send_message(stream.as_raw_fd(), &payload, descriptors).is_ok()
+    }
+
+    fn shutdown(&mut self) {
+        for mut spare in self.spares.drain(..) {
+            let _ = spare.child.kill();
+            let _ = spare.child.wait();
+        }
+        if let Ok(metadata) = fs::symlink_metadata(&self.socket) {
+            if metadata.ino() == self.bound_ino {
+                let _ = fs::remove_file(&self.socket);
+            }
+        }
+        let _ = fs::remove_file(lock_path(&self.control));
+    }
+}
+
+/// One request line, read a byte at a time so nothing beyond it is consumed.
+fn read_request(stream: &mut UnixStream) -> Option<ClientRequest> {
+    let mut line = Vec::new();
+    let mut byte = [0u8];
+    loop {
+        match stream.read(&mut byte) {
+            Ok(1) if byte[0] == b'\n' => break,
+            Ok(1) => {
+                line.push(byte[0]);
+                if line.len() > MAX_MESSAGE {
+                    return None;
+                }
+            }
+            Ok(_) => return None,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(_) => return None,
+        }
+    }
+    serde_json::from_slice(&line).ok()
+}
+
+#[cfg(target_os = "linux")]
+fn peer_uid(stream: &UnixStream) -> io::Result<u32> {
+    let mut credentials: libc::ucred = unsafe { std::mem::zeroed() };
+    let mut length = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: the buffer and its length describe one ucred that the kernel
+    // fills for a connected Unix stream socket.
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            (&mut credentials as *mut libc::ucred).cast(),
+            &mut length,
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(credentials.uid)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn peer_uid(stream: &UnixStream) -> io::Result<u32> {
+    let mut uid: libc::uid_t = 0;
+    let mut gid: libc::gid_t = 0;
+    // SAFETY: getpeereid writes the peer's ids through the two pointers.
+    let result = unsafe { libc::getpeereid(stream.as_raw_fd(), &mut uid, &mut gid) };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(uid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pool_files_sit_beside_the_control_socket_and_are_recognized() {
+        let control = Path::new("/run/user/1/scope/cm-00112233aabbccdd");
+        assert_eq!(
+            socket_path(control),
+            Path::new("/run/user/1/scope/cm-00112233aabbccdd.pool")
+        );
+        assert_eq!(
+            lock_path(control),
+            Path::new("/run/user/1/scope/cm-00112233aabbccdd.pool.lock")
+        );
+        assert_eq!(
+            owned_name(b"cm-00112233aabbccdd.pool"),
+            Some(&b"cm-00112233aabbccdd"[..])
+        );
+        assert_eq!(
+            owned_name(b"cm-00112233aabbccdd.pool.lock"),
+            Some(&b"cm-00112233aabbccdd"[..])
+        );
+        assert_eq!(owned_name(b"cm-00112233aabbccdd"), None);
+        assert_eq!(owned_name(b"cm-00112233aabbccdd.json"), None);
+    }
+
+    #[test]
+    fn a_missing_lock_means_no_pool_and_a_held_lock_means_one() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let control = temporary.path().join("cm-00112233aabbccdd");
+        assert!(!is_running(&control));
+        let held = try_lock(&control, true).unwrap().unwrap();
+        assert!(is_running(&control));
+        assert!(try_lock(&control, true).unwrap().is_none());
+        drop(held);
+        assert!(!is_running(&control));
+        stop(&control).unwrap();
+        assert!(!lock_path(&control).exists());
+    }
+
+    #[test]
+    fn the_client_gets_nothing_from_an_absent_pool() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let control = temporary.path().join("cm-00112233aabbccdd");
+        assert!(take(&control, "syq --server").is_none());
+    }
+}

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -153,6 +153,7 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
                 quiet: args.quiet,
                 tcp: Default::default(),
                 diagnostics: Default::default(),
+                primed_control: Default::default(),
             })
         }
     })
@@ -1463,6 +1464,13 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         }
     };
     let t0 = std::time::Instant::now();
+    // Pooled sessions are received as descriptors; take them on this thread
+    // before the parallel connect can spawn a child beside the receipt.
+    for endpoint in [&src_ep, &dst_ep] {
+        if let Endpoint::Remote(spec) = endpoint {
+            spec.prime_pooled_control(args.compress);
+        }
+    }
     let (mut src_ctl, mut dst_ctl) = {
         let (a, b) = (src_ep.clone(), args.clone());
         let t = std::thread::spawn(move || connect_ctl(&a, &b));

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1129,6 +1129,7 @@ mod tests {
                 next: Default::default(),
             }))),
             diagnostics: Default::default(),
+            primed_control: Default::default(),
         })
     }
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -14196,6 +14196,50 @@ fn session_pool_serves_later_commands_without_new_ssh_sessions() {
     );
 }
 
+/// An SSH child can start successfully and only then refuse its exec
+/// channel. Such failures need the same delay as a failed master check.
+#[test]
+fn session_pool_backs_off_when_a_live_master_refuses_sessions() {
+    let t = Tmp::new();
+    fs::create_dir(t.runtime()).unwrap();
+    let scope = ephemeral_scope(&t);
+    let ssh = t.path("bin/ssh");
+    executable(
+        &ssh,
+        br#"#!/bin/sh
+case " $* " in
+    *" -O check "*) exit 0 ;;
+esac
+# Wait for the pool's hello so this is an asynchronous session failure.
+dd bs=1 count=1 >/dev/null 2>&1
+sleep 0.05
+printf 'refused\n' >> "$FAKE_RSH_LOG"
+exit 255
+"#,
+    );
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("--session-pool")
+        .arg(scope.join("cm-00112233aabbccdd"))
+        .args(["", "fake.example", "", "unused --server"])
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+        )
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("SYQ_TEST_POOL_IDLE_SECS", "8")
+        .run()
+        .unwrap();
+    assert_output_ok(&output);
+    let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    assert_eq!(
+        log.lines().count(),
+        2,
+        "a refused spare should retry after five seconds: {log}"
+    );
+    assert!(!scope.join("cm-00112233aabbccdd.pool").exists());
+    assert!(!scope.join("cm-00112233aabbccdd.pool.lock").exists());
+}
+
 /// A pool never opens a session on its own authority: when the master is
 /// gone the check fails, no spare is opened, and commands connect directly.
 #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3734,6 +3734,9 @@ fi
 printf '%s\n' "$*" >> "$FAKE_RSH_LOG"
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        # A control-master query: answer for a live master unless the test
+        # says otherwise, as the session pool asks before every spare.
+        -O) if [ "$2" = check ]; then exit "${FAKE_SSH_CHECK_STATUS:-0}"; fi; shift 2 ;;
         -o|-l|-p|-S) shift 2 ;;
         -a|-A|-x|-k|-T) shift ;;
         --) shift; break ;;
@@ -14002,6 +14005,283 @@ fn persistence_policy_and_ephemeral_scopes_have_separate_lifecycles() {
     let status = persistence_command(&t, &["status"]).run().unwrap();
     assert_output_ok(&status);
     assert!(String::from_utf8_lossy(&status.stdout).contains("is off"));
+}
+
+/// Poll a condition with a hard deadline; the message names what never came.
+fn wait_for(what: &str, deadline: std::time::Duration, mut condition: impl FnMut() -> bool) {
+    let end = std::time::Instant::now() + deadline;
+    while !condition() {
+        assert!(
+            std::time::Instant::now() < end,
+            "timed out waiting for {what}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+/// The session pool's own ssh invocations, as the fake logs them: a master
+/// check, or a spare opened with every authentication method disabled.
+fn pool_lines(log: &str) -> (Vec<&str>, Vec<&str>) {
+    let checks = log
+        .lines()
+        .filter(|line| line.contains("-O check"))
+        .collect();
+    let spares = log
+        .lines()
+        .filter(|line| line.contains("PubkeyAuthentication=no") && line.contains("--server"))
+        .collect();
+    (checks, spares)
+}
+
+/// With persistence on, the first command starts a session pool for its
+/// endpoint. The pool opens a spare without authenticating, later commands
+/// take it instead of opening an ssh session of their own, and `persist off`
+/// stops the pool with the scope.
+#[test]
+fn session_pool_serves_later_commands_without_new_ssh_sessions() {
+    let t = Tmp::new();
+    fs::create_dir(t.runtime()).unwrap();
+    fs::create_dir_all(t.path("remote-home/data/nested")).unwrap();
+    write(&t.path("remote-home/data/name"), b"remote");
+    write(&t.path("local.txt"), b"hello");
+    fs::create_dir_all(t.path("remote-home/dest")).unwrap();
+    let ssh = fake_ssh(&t);
+    let scope = ephemeral_scope(&t);
+    let scope_text = scope.to_str().unwrap().to_string();
+    let executable = env!("CARGO_BIN_EXE_syq");
+    let path = format!("{}/n", t.s("remote-home/data"));
+    let complete = |t: &Tmp| {
+        completion_command(
+            t,
+            &[
+                "__complete",
+                "bash",
+                "8",
+                "--",
+                "syq",
+                "cp",
+                "--pscope",
+                &scope_text,
+                "--syq-path",
+                executable,
+                "--from",
+                "fake.example",
+                &path,
+            ],
+        )
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+        )
+        .env("SYQ_COMPLETION_DEBUG", "1")
+        .run()
+        .unwrap()
+    };
+    let log = |t: &Tmp| fs::read_to_string(t.path("rsh.log")).unwrap_or_default();
+
+    let first = complete(&t);
+    assert_output_ok(&first);
+    assert_eq!(completion_values(&first.stdout).len(), 2);
+    assert!(log(&t).contains("ControlMaster=auto"), "{}", log(&t));
+    wait_for(
+        "the pool's first spare",
+        std::time::Duration::from_secs(15),
+        || !pool_lines(&log(&t)).1.is_empty(),
+    );
+    let warmed = log(&t);
+    let (checks, spares) = pool_lines(&warmed);
+    assert!(!checks.is_empty(), "{warmed}");
+    for option in [
+        "ControlMaster=no",
+        "BatchMode=yes",
+        "PubkeyAuthentication=no",
+        "PasswordAuthentication=no",
+        "KbdInteractiveAuthentication=no",
+        "GSSAPIAuthentication=no",
+        "HostbasedAuthentication=no",
+    ] {
+        assert!(
+            spares[0].contains(option),
+            "{option} missing: {}",
+            spares[0]
+        );
+    }
+    assert!(!spares[0].contains("ControlPersist"), "{}", spares[0]);
+    let status = persistence_command(&t, &["status", "--pscope", &scope_text])
+        .run()
+        .unwrap();
+    assert_output_ok(&status);
+    assert!(
+        String::from_utf8_lossy(&status.stdout).contains("session pool"),
+        "{}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+
+    // The next completion takes the spare: no session of its own.
+    write(&t.path("rsh.log"), b"");
+    let second = complete(&t);
+    assert_output_ok(&second);
+    assert_eq!(
+        completion_values(&second.stdout),
+        completion_values(&first.stdout)
+    );
+    assert!(!log(&t).contains("ControlMaster=auto"), "{}", log(&t));
+    wait_for(
+        "the pool's replacement spare",
+        std::time::Duration::from_secs(15),
+        || !pool_lines(&log(&t)).1.is_empty(),
+    );
+
+    // So does a copy, which says so under SYQ_DEBUG.
+    write(&t.path("rsh.log"), b"");
+    let copy = Command::new(executable)
+        .args([
+            "cp",
+            "--pscope",
+            &scope_text,
+            "--syq-path",
+            executable,
+            "-q",
+        ])
+        .arg(t.path("local.txt"))
+        .args(["--to", "fake.example", "--into", &t.s("remote-home/dest")])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+        )
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.runtime())
+        .env("SYQ_DEBUG", "1")
+        .run()
+        .unwrap();
+    assert_output_ok(&copy);
+    assert!(
+        stderr_of(&copy).contains("control connection from the session pool"),
+        "{}",
+        stderr_of(&copy)
+    );
+    assert_eq!(read(&t.path("remote-home/dest/local.txt")), b"hello");
+    assert!(!log(&t).contains("ControlMaster=auto"), "{}", log(&t));
+
+    // Closing the scope stops the pool and removes its files with the rest.
+    let closed = persistence_command(&t, &["off", "--pscope", &scope_text])
+        .run()
+        .unwrap();
+    assert_output_ok(&closed);
+    assert!(!scope.exists());
+    wait_for(
+        "the pool process to exit",
+        std::time::Duration::from_secs(10),
+        || {
+            !Command::new("pgrep")
+                .args(["-f", &scope_text])
+                .run()
+                .map(|output| output.status.success())
+                .unwrap_or(false)
+        },
+    );
+}
+
+/// A pool never opens a session on its own authority: when the master is
+/// gone the check fails, no spare is opened, and commands connect directly.
+#[test]
+fn session_pool_stays_empty_without_a_live_master() {
+    let t = Tmp::new();
+    fs::create_dir(t.runtime()).unwrap();
+    fs::create_dir_all(t.path("remote-home/data")).unwrap();
+    write(&t.path("remote-home/data/name"), b"remote");
+    let ssh = fake_ssh(&t);
+    let scope = ephemeral_scope(&t);
+    let scope_text = scope.to_str().unwrap().to_string();
+    let executable = env!("CARGO_BIN_EXE_syq");
+    let path = format!("{}/n", t.s("remote-home/data"));
+    let complete = |t: &Tmp| {
+        completion_command(
+            t,
+            &[
+                "__complete",
+                "bash",
+                "8",
+                "--",
+                "syq",
+                "cp",
+                "--pscope",
+                &scope_text,
+                "--syq-path",
+                executable,
+                "--from",
+                "fake.example",
+                &path,
+            ],
+        )
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .env("FAKE_SSH_CHECK_STATUS", "255")
+        .env("SYQ_TEST_POOL_IDLE_SECS", "1")
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+        )
+        .env("SYQ_COMPLETION_DEBUG", "1")
+        .run()
+        .unwrap()
+    };
+    let log = |t: &Tmp| fs::read_to_string(t.path("rsh.log")).unwrap_or_default();
+
+    let first = complete(&t);
+    assert_output_ok(&first);
+    wait_for(
+        "the pool's master check",
+        std::time::Duration::from_secs(15),
+        || !pool_lines(&log(&t)).0.is_empty(),
+    );
+    let second = complete(&t);
+    assert_output_ok(&second);
+    assert_eq!(completion_values(&second.stdout).len(), 1);
+    let checked = log(&t);
+    let (_, spares) = pool_lines(&checked);
+    assert!(spares.is_empty(), "{checked}");
+    assert_eq!(
+        log(&t)
+            .lines()
+            .filter(|line| line.contains("ControlMaster=auto"))
+            .count(),
+        2,
+        "{}",
+        log(&t)
+    );
+
+    // Idle, the pool leaves on its own; the scope's own files remain.
+    wait_for(
+        "the idle pool to exit",
+        std::time::Duration::from_secs(15),
+        || {
+            !scope.read_dir().unwrap().any(|entry| {
+                entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .ends_with(".pool.lock")
+            })
+        },
+    );
+    let status = persistence_command(&t, &["status", "--pscope", &scope_text])
+        .run()
+        .unwrap();
+    assert_output_ok(&status);
+    assert!(!String::from_utf8_lossy(&status.stdout).contains("session pool"));
+    let closed = persistence_command(&t, &["off", "--pscope", &scope_text])
+        .run()
+        .unwrap();
+    assert_output_ok(&closed);
+    assert!(!scope.exists());
 }
 
 #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -14096,6 +14096,14 @@ fn session_pool_serves_later_commands_without_new_ssh_sessions() {
     assert!(!checks.is_empty(), "{warmed}");
     for option in [
         "ControlMaster=no",
+        "ProxyJump=none",
+        "ProxyCommand=false",
+        "ForwardAgent=no",
+        "ForwardX11=no",
+        "ClearAllForwardings=yes",
+        "PermitLocalCommand=no",
+        "GSSAPIDelegateCredentials=no",
+        "RequestTTY=no",
         "BatchMode=yes",
         "PubkeyAuthentication=no",
         "PasswordAuthentication=no",

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -109,34 +109,71 @@ fi
 
 printf 'case: remote filename completion reuses a persistent ordinary SSH login\n'
 ssh source 'rm -rf /tmp/syq-real-ssh/completion; mkdir -p /tmp/syq-real-ssh/completion/alpine; : > "/tmp/syq-real-ssh/completion/alpha file"'
-rm -f /tmp/syq-real-ssh-ssh.trace
+trace=/tmp/syq-real-ssh-ssh.trace
+rm -f "$trace"
 syq persist on >/dev/null
 completion_output=/tmp/syq-real-ssh-completion.out
 completion_expected=/tmp/syq-real-ssh-completion.expected
-for _ in 1 2; do
+{
+    printf '%s\000' '/tmp/syq-real-ssh/completion/alpha file'
+    printf '%s\000' '/tmp/syq-real-ssh/completion/alpine/'
+} >"$completion_expected"
+complete_remote() {
     syq completion __complete fish 6 -- \
         syq cp --syq-path /usr/local/bin/syq --from source \
         /tmp/syq-real-ssh/completion/al >"$completion_output"
-    {
-        printf '%s\000' '/tmp/syq-real-ssh/completion/alpha file'
-        printf '%s\000' '/tmp/syq-real-ssh/completion/alpine/'
-    } >"$completion_expected"
     cmp "$completion_expected" "$completion_output"
+}
+# Completed logins of the completion's own: the first becomes the master.
+direct_logins() {
+    awk -F '\t' '
+        $1 == "phase=end" &&
+        $3 == "host=source" &&
+        $4 == "control_master=auto" &&
+        $8 == "status=0" { count++ }
+        END { print count + 0 }
+    ' "$trace"
+}
+# Sessions the pool holds open through the master: attached with
+# ControlMaster=no to a present socket and not yet ended. A master check
+# starts and ends at once, so it never counts here.
+open_spares() {
+    awk -F '\t' '
+        $3 == "host=source" &&
+        $4 == "control_master=no" &&
+        $6 == "control_socket=present" {
+            if ($1 == "phase=start") open++
+            if ($1 == "phase=end") open--
+        }
+        END { print open + 0 }
+    ' "$trace"
+}
+complete_remote
+test "$(direct_logins)" -eq 1
+n=0
+while [ "$(open_spares)" -lt 1 ] && [ "$n" -lt 150 ]; do
+    sleep 0.1
+    n=$((n + 1))
 done
-test "$(syq completion cache list)" = source
-reused_completion=$(awk -F '\t' '
-    $1 == "phase=end" &&
-    $3 == "host=source" &&
-    $4 == "control_master=auto" &&
-    $6 == "control_socket=present" &&
-    $8 == "status=0" { count++ }
-    END { print count + 0 }
-' /tmp/syq-real-ssh-ssh.trace)
-if [ "$reused_completion" -lt 1 ]; then
-    echo 'second remote completion did not reuse the persistent SSH socket:' >&2
-    cat /tmp/syq-real-ssh-ssh.trace >&2
+if [ "$(open_spares)" -lt 1 ]; then
+    echo 'session pool did not open a spare through the persistent master:' >&2
+    cat "$trace" >&2
     exit 1
 fi
+syq persist status | grep -q 'session pool' || {
+    echo 'persist status does not show the session pool:' >&2
+    syq persist status >&2
+    exit 1
+}
+# Later completions take the ready session: no login of their own.
+complete_remote
+complete_remote
+if [ "$(direct_logins)" -ne 1 ]; then
+    echo 'a later completion opened its own SSH login instead of taking the pooled session:' >&2
+    cat "$trace" >&2
+    exit 1
+fi
+test "$(syq completion cache list)" = source
 syq completion cache clear >/dev/null
 syq persist off >/dev/null
 


### PR DESCRIPTION
With persistence enabled, later commands can take a ready helper session from a per-endpoint pool instead of opening a new SSH exec channel, launching the helper, and repeating setup. The pool hands over the session's three pipes, and the command reads the hello reply itself. The pool opens spares only through a live SSH master with authentication, proxies and forwarding disabled, and expires after five minutes without a handoff.

A spare whose SSH process starts but then refuses the session now waits five seconds before retrying. An initial pool miss is remembered across cloned connection specifications, so parallel connection setup cannot receive descriptors after main-thread priming. Regression tests cover a live master that refuses sessions and a pool appearing after the initial lookup. The documentation's conflicting completion paragraphs are resolved.

The pool matches the exact helper command and build identity; `persist status` reports it and `persist off` stops it. The documented persistence window can reach ten minutes. This branch is based directly on the latest fetched `origin/master`, `02016d3`, and is independent of #187 and #191. Combining it with #191 enables a warm small push in one network round trip.

The rebase preserves master #202's output handling in the new pool diagnostics and initializes the pool state in its newly added connection test fixture.

Validation on 2026-09-05:

- At `574e06f`: formatting, Clippy with warnings denied, 416 unit tests, all three session-pool integration tests, all three output-failure integration tests, documentation links, and `git diff --check` passed. The refused-session regression observes two attempts over eight seconds; the priming regression prevents a second pool connection after an initial miss.
- Combined verification branch at `dc63ccc` contains #187 `d7b3572`, #191 `cf39545`, and #197 `574e06f`. Formatting, Clippy with warnings denied, `cargo test --all-targets` (419 unit, 379 local integration, 3 output, 7 update tests), documentation links, and `git diff --check` passed.
- Both real-SSH profiles passed at combined `7054af7`. The only subsequent source change, verified with `git diff 7054af7 dc63ccc`, initializes the new field in an upstream unit-test fixture; production code is identical.
- Not run against these changes: macOS execution, command-interruption cases, the separate rsync-compat suite, or latency benchmarks. Documenting and testing the inherited spawning environment (`SendEnv`) remains a separate follow-up.

The task worktree is clean. PRs do not trigger automated test workflows; the checks above were run locally. Ready for re-review; no PR has been merged by this update.
