### PR TITLE
Defer broad CI until after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,11 @@ jobs:
     outputs:
       native: ${{ steps.changes.outputs.native }}
       sdks: ${{ steps.changes.outputs.sdks }}
+      python_sdk: ${{ steps.changes.outputs.python_sdk }}
+      javascript_sdk: ${{ steps.changes.outputs.javascript_sdk }}
+      go_sdk: ${{ steps.changes.outputs.go_sdk }}
       tooling: ${{ steps.changes.outputs.tooling }}
+      shellcheck: ${{ steps.changes.outputs.shellcheck }}
       mapping_docs: ${{ steps.changes.outputs.mapping_docs }}
       macos: ${{ steps.changes.outputs.macos }}
       linux_arm64: ${{ steps.changes.outputs.linux_arm64 }}
@@ -48,12 +52,14 @@ jobs:
         if: >-
           needs.scope.outputs.native != 'true' &&
           needs.scope.outputs.tooling != 'true' &&
+          needs.scope.outputs.shellcheck != 'true' &&
           needs.scope.outputs.mapping_docs != 'true'
         run: echo 'Rust, executable documentation, and repository tooling are unaffected.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: >-
           needs.scope.outputs.native == 'true' ||
           needs.scope.outputs.tooling == 'true' ||
+          needs.scope.outputs.shellcheck == 'true' ||
           needs.scope.outputs.mapping_docs == 'true'
         with:
           persist-credentials: false
@@ -61,7 +67,9 @@ jobs:
         if: needs.scope.outputs.native == 'true'
         run: rustup component add rustfmt clippy
       - name: Check dependency policy
-        if: needs.scope.outputs.native == 'true'
+        if: >-
+          needs.scope.outputs.native == 'true' &&
+          needs.scope.outputs.full_suite == 'true'
         env:
           CARGO_DENY_VERSION: 0.20.2
           CARGO_DENY_SHA256: 9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5f
@@ -144,6 +152,7 @@ jobs:
       - name: Lint shell tooling
         if: >-
           needs.scope.outputs.tooling == 'true' ||
+          needs.scope.outputs.shellcheck == 'true' ||
           (needs.scope.outputs.native == 'true' &&
            needs.scope.outputs.full_suite == 'true')
         run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-ci.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/ci-scope.sh scripts/approve-generated-pr-runs.sh scripts/release-preflight.sh scripts/release-status.sh scripts/branch-status.sh scripts/test-branch-status.sh scripts/check-workflows.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-release-orchestration.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh scripts/test-real-ssh.sh tests/real-ssh/entrypoint.sh tests/real-ssh/scenarios.sh tests/real-ssh/ssh-wrapper.sh
@@ -164,14 +173,14 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        if: needs.scope.outputs.sdks == 'true'
+        if: needs.scope.outputs.python_sdk == 'true'
         with:
           python-version: "3.10"
       - name: Install pinned Python tooling
-        if: needs.scope.outputs.sdks == 'true'
+        if: needs.scope.outputs.python_sdk == 'true'
         run: python -m pip install --disable-pip-version-check --no-deps uv==0.11.6
       - name: Require the matching Python SDK for the latest syq release
-        if: needs.scope.outputs.sdks == 'true'
+        if: needs.scope.outputs.python_sdk == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -189,10 +198,10 @@ jobs:
             exit 1
           }
       - name: Build the candidate syq executable
-        if: needs.scope.outputs.sdks == 'true'
+        if: needs.scope.outputs.python_sdk == 'true'
         run: cargo build --locked --bin syq
       - name: Test and reproducibly package Python SDK
-        if: needs.scope.outputs.sdks == 'true'
+        if: needs.scope.outputs.python_sdk == 'true'
         env:
           PYTHONPATH: sdk/python/src
           SYQ_CANDIDATE_EXECUTABLE: ${{ github.workspace }}/target/debug/syq
@@ -221,24 +230,24 @@ jobs:
             --with "$1" \
             python -c 'import syq; assert syq.version() == syq.PINNED_SYQ_VERSION'
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: needs.scope.outputs.sdks == 'true'
+        if: needs.scope.outputs.javascript_sdk == 'true'
         with:
           node-version: "22.x"
           package-manager-cache: false
       - name: Test and package JavaScript SDK
-        if: needs.scope.outputs.sdks == 'true'
+        if: needs.scope.outputs.javascript_sdk == 'true'
         working-directory: sdk/js
         run: |
           npm ci --ignore-scripts
           npm test
           npm pack --dry-run
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        if: needs.scope.outputs.sdks == 'true'
+        if: needs.scope.outputs.go_sdk == 'true'
         with:
           go-version: "1.26.x"
           cache: false
       - name: Format, vet, and test Go SDK
-        if: needs.scope.outputs.sdks == 'true'
+        if: needs.scope.outputs.go_sdk == 'true'
         working-directory: sdk/go
         run: |
           test -z "$(gofmt -l .)"
@@ -308,7 +317,7 @@ jobs:
 
   # An actual Intel runner catches host-architecture cfg and libc differences
   # before the release workflow builds its x86-64 artifact. Keep this on full
-  # master/manual runs; pull requests get the ARM macOS behavior gate above.
+  # master/manual runs; pull requests defer macOS validation until after merge.
   macos_intel:
     needs: scope
     if: >-

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,8 +1,8 @@
 name: macOS suite
 
 # The complete native and SDK test suites, clippy, and release shell suites on
-# macOS. Pull-request CI runs a focused macOS job in ci.yml; this cumulative
-# run happens after every merge to master and on demand.
+# macOS. Pull-request CI defers this platform coverage; this cumulative run
+# happens after every merge to master and on demand.
 on:
   push:
     branches: [master]

--- a/.github/workflows/rsync-compat.yml
+++ b/.github/workflows/rsync-compat.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       conformance: ${{ steps.changes.outputs.conformance }}
+      full_suite: ${{ steps.changes.outputs.full_suite }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -35,11 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            label: linux
-          - os: macos-26
-            label: macos
+        include: ${{ fromJSON(needs.scope.outputs.full_suite == 'true' && '[{"os":"ubuntu-latest","label":"linux"},{"os":"macos-26","label":"macos"}]' || '[{"os":"ubuntu-latest","label":"linux"}]') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     env:
@@ -103,8 +100,9 @@ jobs:
           path: target/rsync-compat/reports/
           if-no-files-found: warn
 
-  # Keep the required check name stable while making it depend on both
-  # platform cells above.
+  # Keep the required check name stable while making it depend on the selected
+  # platform cells above. Pull requests run Linux; master and manual runs add
+  # macOS.
   conformance:
     needs: [scope, conformance_platforms]
     if: always()
@@ -116,13 +114,13 @@ jobs:
       - name: Complete the required check when conformance is unaffected
         if: needs.scope.outputs.conformance != 'true'
         run: echo 'Rsync conformance is deferred because this change does not affect it.'
-      - name: Require Linux and macOS conformance
+      - name: Require selected conformance
         if: >-
           needs.scope.outputs.conformance == 'true' &&
           needs.conformance_platforms.result != 'success'
         run: echo 'A platform conformance job failed or did not complete.' >&2; exit 1
-      - name: Record complete platform conformance
+      - name: Record selected conformance
         if: >-
           needs.scope.outputs.conformance == 'true' &&
           needs.conformance_platforms.result == 'success'
-        run: echo 'Linux and macOS rsync conformance succeeded.'
+        run: echo 'Selected rsync conformance succeeded.'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -265,14 +265,14 @@ as their sole release identity.
 The required `rust`, `sdks`, `linux-arm64`, `macos`, and `conformance` check
 names are stable, but the work behind them differs before and after merge.
 Pull requests run an affected-surface gate: Rust changes get formatting,
-clippy, native unit tests, focused Apple Silicon macOS tests, and the Linux and
-macOS rsync-conformance matrix. SDK-owned changes get their SDK suite;
-executable examples in `MAPPINGS.md` get focused integration tests; and
-repository-tooling changes get the packaging, release, workflow, and shell
-checks. Ordinary native pull requests still defer the complete filesystem and
-SDK suites, Linux ARM64 validation, and Intel macOS validation to `master`.
-The working agent chooses and reports any additional integration tests
-justified by the change.
+clippy, and native unit tests. SDK-owned changes get only the affected language
+suite; rsync-compatibility changes get Linux conformance; executable examples
+in `docs/mappings.md` get focused integration tests; and repository-tooling
+changes get the relevant workflow and shell checks. Pull requests defer the
+complete filesystem and cross-SDK suites, dependency-policy check, Linux ARM64
+validation, macOS validation, and macOS rsync conformance to `master`. The
+working agent chooses and reports any additional integration tests justified
+by the change.
 
 Every native push to `master` runs the complete native and SDK suites, Linux
 and macOS conformance, Linux ARM64 validation, focused Apple Silicon macOS
@@ -289,10 +289,11 @@ reject selective stubs as release evidence.
 The checked-in classifier uses a pull request's merge-base diff rather than
 including unrelated base-branch changes. Documentation-only changes finish
 with small successful required jobs, except for documentation consumed by a
-test or generator. Unknown paths fail safe by selecting every suite. Manual
-workflow runs also select everything. This keeps branch protection and
-release-tag verification attached to stable check names while avoiding the
-same expensive validation on both sides of a merge.
+test or generator. Unknown paths fail safe by selecting every affected-surface
+suite, while their platform jobs remain post-merge. Manual workflow runs select
+everything. This keeps branch protection and release-tag verification attached
+to stable check names while avoiding the same expensive validation on both
+sides of a merge.
 
 ## macOS signing
 

--- a/scripts/ci-scope.sh
+++ b/scripts/ci-scope.sh
@@ -10,7 +10,11 @@ run_everything() {
   printf '%s\n' \
     'native=true' \
     'sdks=true' \
+    'python_sdk=true' \
+    'javascript_sdk=true' \
+    'go_sdk=true' \
     'tooling=true' \
+    'shellcheck=true' \
     'mapping_docs=true' \
     'conformance=true' \
     'macos=true' \
@@ -63,7 +67,11 @@ fi
 
 native=false
 sdks=false
+python_sdk=false
+javascript_sdk=false
+go_sdk=false
 tooling=false
+shellcheck=false
 mapping_docs=false
 conformance=false
 macos=false
@@ -76,12 +84,24 @@ while IFS= read -r path; do
     sdk/python/native-api.json)
       # This SDK-owned specification is compiled into the Rust CLI.
       native=true
-      sdks=true
+      python_sdk=true
+      ;;
+    sdk/python/*)
+      python_sdk=true
+      ;;
+    sdk/js/*)
+      javascript_sdk=true
+      ;;
+    sdk/go/*)
+      go_sdk=true
       ;;
     sdk/*)
-      sdks=true
+      # Files shared by the language SDKs can affect all of them.
+      python_sdk=true
+      javascript_sdk=true
+      go_sdk=true
       ;;
-    MAPPINGS.md)
+    MAPPINGS.md|docs/mappings.md)
       # The documented jq programs are executable integration-test inputs.
       mapping_docs=true
       ;;
@@ -91,19 +111,13 @@ while IFS= read -r path; do
     tests/fixtures/*)
       # The same protocol fixtures are consumed by Rust and Python tests.
       native=true
-      sdks=true
+      python_sdk=true
       ;;
     Cargo.toml|Cargo.lock|rust-toolchain.toml|build.rs|src/*|tests/*.rs|schemas/*)
       native=true
       ;;
     .github/workflows/ci.yml)
-      native=true
       tooling=true
-      sdks=true
-      mapping_docs=true
-      conformance=true
-      macos=true
-      linux_arm64=true
       ;;
     .github/workflows/rsync-compat.yml)
       tooling=true
@@ -111,15 +125,21 @@ while IFS= read -r path; do
       ;;
     .github/workflows/prepare-python-sdk.yml|.github/workflows/publish-sdks.yml|.github/workflows/python-api-sync.yml)
       tooling=true
-      sdks=true
+      python_sdk=true
       ;;
     scripts/check-python-api-sync.py|scripts/normalize-python-sdist.py|scripts/prepare-python-sdk-release.py|scripts/select-trusted-pr.jq|scripts/test-python-sdk-release-tools.sh)
       tooling=true
-      sdks=true
+      python_sdk=true
       ;;
     scripts/generate-homebrew-formula.sh|scripts/test-homebrew-formula.sh|scripts/generate-installer.sh|scripts/test-installer.sh)
       tooling=true
-      macos=true
+      ;;
+    tests/real-ssh/*.sh)
+      # The real-SSH suite is run locally when affected; CI still lints its
+      # shell sources without promoting it to unrelated product suites.
+      shellcheck=true
+      ;;
+    tests/real-ssh/*)
       ;;
     scripts/*|.github/workflows/*|.env.release|deny.toml)
       tooling=true
@@ -129,39 +149,45 @@ while IFS= read -r path; do
     *)
       # Unknown inputs fail safe until their dependency boundary is explicit.
       native=true
-      sdks=true
+      python_sdk=true
+      javascript_sdk=true
+      go_sdk=true
       tooling=true
+      shellcheck=true
       mapping_docs=true
       conformance=true
-      macos=true
-      linux_arm64=true
       ;;
   esac
 done <<<"$changed_paths"
 
 if [ "$saw_path" = false ]; then
   native=true
-  sdks=true
+  python_sdk=true
+  javascript_sdk=true
+  go_sdk=true
   tooling=true
+  shellcheck=true
   mapping_docs=true
   conformance=true
-  macos=true
-  linux_arm64=true
 fi
 
-# Native pull requests exercise both host operating systems and rsync
-# conformance before merge. The cumulative master state still gets the broad
-# SDK, architecture, and complete native suites once after merge.
-if [ "$native" = true ]; then
+# Pull requests run only affected Linux checks. The cumulative master state
+# gets broad cross-subsystem and platform coverage once after merge.
+if [ "$full_suite" = true ] && [ "$native" = true ]; then
+  python_sdk=true
+  javascript_sdk=true
+  go_sdk=true
   conformance=true
   macos=true
-fi
-
-if [ "$full_suite" = true ] && [ "$native" = true ]; then
-  sdks=true
   linux_arm64=true
 fi
 
-printf 'native=%s\nsdks=%s\ntooling=%s\nmapping_docs=%s\nconformance=%s\nmacos=%s\nlinux_arm64=%s\nfull_suite=%s\n' \
-  "$native" "$sdks" "$tooling" "$mapping_docs" "$conformance" "$macos" "$linux_arm64" "$full_suite"
-echo "CI scope: native=$native sdks=$sdks tooling=$tooling mapping_docs=$mapping_docs conformance=$conformance macos=$macos linux_arm64=$linux_arm64 full_suite=$full_suite" >&2
+if [ "$python_sdk" = true ] || [ "$javascript_sdk" = true ] || [ "$go_sdk" = true ]; then
+  sdks=true
+fi
+
+printf 'native=%s\nsdks=%s\npython_sdk=%s\njavascript_sdk=%s\ngo_sdk=%s\ntooling=%s\nshellcheck=%s\nmapping_docs=%s\nconformance=%s\nmacos=%s\nlinux_arm64=%s\nfull_suite=%s\n' \
+  "$native" "$sdks" "$python_sdk" "$javascript_sdk" "$go_sdk" \
+  "$tooling" "$shellcheck" "$mapping_docs" "$conformance" "$macos" \
+  "$linux_arm64" "$full_suite"
+echo "CI scope: native=$native sdks=$sdks python_sdk=$python_sdk javascript_sdk=$javascript_sdk go_sdk=$go_sdk tooling=$tooling shellcheck=$shellcheck mapping_docs=$mapping_docs conformance=$conformance macos=$macos linux_arm64=$linux_arm64 full_suite=$full_suite" >&2

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -26,21 +26,25 @@ expect_failure() {
   }
 }
 
-# Scope pull requests to affected checks. Native changes exercise macOS and
-# rsync conformance before merge; broader cross-subsystem and architecture
-# checks remain cumulative.
+# Scope pull requests to affected Linux checks; broader cross-subsystem,
+# architecture, and platform checks remain cumulative after merge.
 assert_scope() {
   local output=$1 key=$2 expected=$3
   grep -Fx "$key=$expected" <<<"$output" >/dev/null
 }
 
+scope_keys=(
+  native sdks python_sdk javascript_sdk go_sdk tooling shellcheck mapping_docs
+  conformance macos linux_arm64 full_suite
+)
+
 paths="$work/paths"
 printf 'README.md\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
-for key in native sdks tooling mapping_docs conformance macos linux_arm64 full_suite; do
+for key in "${scope_keys[@]}"; do
   assert_scope "$scope" "$key" false
 done
-printf 'MAPPINGS.md\n' >"$paths"
+printf 'docs/mappings.md\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" mapping_docs true
 assert_scope "$scope" native false
@@ -48,10 +52,26 @@ printf 'sdk/python/src/syq/syq-release-manifest.json\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" native false
 assert_scope "$scope" sdks true
+assert_scope "$scope" python_sdk true
+assert_scope "$scope" javascript_sdk false
+assert_scope "$scope" go_sdk false
+printf 'sdk/js/src/index.js\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" sdks true
+assert_scope "$scope" python_sdk false
+assert_scope "$scope" javascript_sdk true
+assert_scope "$scope" go_sdk false
+printf 'sdk/go/client.go\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" sdks true
+assert_scope "$scope" python_sdk false
+assert_scope "$scope" javascript_sdk false
+assert_scope "$scope" go_sdk true
 printf 'sdk/python/native-api.json\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" native true
 assert_scope "$scope" sdks true
+assert_scope "$scope" python_sdk true
 for sdk_script in \
   scripts/check-python-api-sync.py \
   scripts/normalize-python-sdist.py \
@@ -63,6 +83,7 @@ do
   scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
   assert_scope "$scope" tooling true
   assert_scope "$scope" sdks true
+  assert_scope "$scope" python_sdk true
   assert_scope "$scope" native false
 done
 printf 'tests/rsync-compat/LEDGER.md\n' >"$paths"
@@ -73,9 +94,14 @@ printf 'src/main.rs\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" native true
 assert_scope "$scope" sdks false
-assert_scope "$scope" conformance true
-assert_scope "$scope" macos true
+assert_scope "$scope" conformance false
+assert_scope "$scope" macos false
 assert_scope "$scope" linux_arm64 false
+printf 'tests/real-ssh/scenarios.sh\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" shellcheck true
+assert_scope "$scope" tooling false
+assert_scope "$scope" native false
 printf 'scripts/test-installer.sh\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" tooling true
@@ -83,12 +109,9 @@ assert_scope "$scope" native false
 printf '.github/workflows/ci.yml\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" tooling true
-assert_scope "$scope" native true
-assert_scope "$scope" sdks true
-assert_scope "$scope" mapping_docs true
-assert_scope "$scope" conformance true
-assert_scope "$scope" macos true
-assert_scope "$scope" linux_arm64 true
+for key in native sdks python_sdk javascript_sdk go_sdk shellcheck mapping_docs conformance macos linux_arm64 full_suite; do
+  assert_scope "$scope" "$key" false
+done
 printf '.github/workflows/rsync-compat.yml\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" tooling true
@@ -98,7 +121,26 @@ printf '.github/workflows/python-api-sync.yml\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" tooling true
 assert_scope "$scope" sdks true
+assert_scope "$scope" python_sdk true
 assert_scope "$scope" native false
+
+# The surface touched by PR #190 should run the Rust baseline, Python SDK, and
+# shell lint without promoting the pull request to unrelated suites.
+printf '%s\n' \
+  docs/reference.md \
+  sdk/python/native-api.json \
+  sdk/python/src/syq/client.py \
+  src/cli.rs \
+  tests/local.rs \
+  tests/real-ssh/scenarios.sh >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" native true
+assert_scope "$scope" sdks true
+assert_scope "$scope" python_sdk true
+assert_scope "$scope" shellcheck true
+for key in javascript_sdk go_sdk tooling mapping_docs conformance macos linux_arm64 full_suite; do
+  assert_scope "$scope" "$key" false
+done
 
 scope_repo="$work/scope-repo"
 mkdir "$scope_repo"
@@ -121,6 +163,7 @@ jq -n --arg base "$scope_base" --arg head "$scope_head" \
 scope=$(cd "$scope_repo" && "$script_dir/ci-scope.sh" "$scope_event")
 assert_scope "$scope" native false
 assert_scope "$scope" sdks true
+assert_scope "$scope" python_sdk true
 assert_scope "$scope" full_suite false
 
 # A pull request branch may lag master. Scope its own three-dot diff rather
@@ -138,7 +181,7 @@ advanced_base=$(git -C "$scope_repo" rev-parse HEAD)
 jq -n --arg base "$advanced_base" --arg head "$docs_head" \
   '{pull_request:{base:{sha:$base},head:{sha:$head}}}' >"$scope_event"
 scope=$(cd "$scope_repo" && "$script_dir/ci-scope.sh" "$scope_event")
-for key in native sdks tooling mapping_docs conformance macos linux_arm64 full_suite; do
+for key in "${scope_keys[@]}"; do
   assert_scope "$scope" "$key" false
 done
 
@@ -161,6 +204,9 @@ jq -n --arg before "$scope_head" --arg after "$advanced_base" \
 scope=$(cd "$scope_repo" && "$script_dir/ci-scope.sh" "$push_event")
 assert_scope "$scope" native true
 assert_scope "$scope" sdks true
+assert_scope "$scope" python_sdk true
+assert_scope "$scope" javascript_sdk true
+assert_scope "$scope" go_sdk true
 assert_scope "$scope" conformance true
 assert_scope "$scope" macos true
 assert_scope "$scope" linux_arm64 true
@@ -169,7 +215,7 @@ assert_scope "$scope" full_suite true
 printf '{}\n' >"$work/workflow-dispatch-event.json"
 scope=$(cd "$scope_repo" && \
   "$script_dir/ci-scope.sh" "$work/workflow-dispatch-event.json")
-for key in native sdks tooling mapping_docs conformance macos linux_arm64 full_suite; do
+for key in "${scope_keys[@]}"; do
   assert_scope "$scope" "$key" true
 done
 


### PR DESCRIPTION
## Summary
- keep pull-request Rust validation to formatting, clippy, and native unit tests
- defer macOS, ARM64, dependency-policy, cross-SDK, and macOS rsync coverage to post-merge or manual runs
- run only the affected SDK language and classify real-SSH shell changes as shell lint instead of every suite
- fix executable mapping-document classification after its move to docs/mappings.md

For the file surface from #190, the classifier now selects only the Rust baseline, Python SDK, and shell lint.

## Verification
- scripts/test-release-orchestration.sh
- scripts/check-workflows.sh
- shellcheck on changed shell scripts and the real-SSH shell sources
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --bin syq (409 passed)