### PR TITLE
Lint every tracked shell script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,13 +149,13 @@ jobs:
           (needs.scope.outputs.native == 'true' &&
            needs.scope.outputs.full_suite == 'true')
         run: scripts/test-secret-tools.sh
-      - name: Lint shell tooling
+      - name: Lint tracked shell scripts
         if: >-
           needs.scope.outputs.tooling == 'true' ||
           needs.scope.outputs.shellcheck == 'true' ||
           (needs.scope.outputs.native == 'true' &&
            needs.scope.outputs.full_suite == 'true')
-        run: shellcheck scripts/package-release.sh scripts/generate-installer.sh scripts/generate-homebrew-formula.sh scripts/sign-release-manifest.sh scripts/verify-release-tag.sh scripts/verify-release-ci.sh scripts/verify-release-assets.sh scripts/verify-crates-io-package.sh scripts/init-release-secrets.sh scripts/sync-github-secrets.sh scripts/ci-scope.sh scripts/approve-generated-pr-runs.sh scripts/release-preflight.sh scripts/release-status.sh scripts/branch-status.sh scripts/test-branch-status.sh scripts/check-workflows.sh scripts/test-cargo-package.sh scripts/test-installer.sh scripts/test-release-tools.sh scripts/test-release-orchestration.sh scripts/test-homebrew-formula.sh scripts/test-python-sdk-release-tools.sh scripts/test-secret-tools.sh scripts/test-real-ssh.sh tests/real-ssh/entrypoint.sh tests/real-ssh/scenarios.sh tests/real-ssh/ssh-wrapper.sh
+        run: git ls-files -z -- '*.sh' | xargs -0 shellcheck
 
   sdks:
     needs: scope

--- a/scripts/ci-scope.sh
+++ b/scripts/ci-scope.sh
@@ -80,6 +80,11 @@ saw_path=false
 while IFS= read -r path; do
   [ -n "$path" ] || continue
   saw_path=true
+  # Shell lint is cheap and independent of the path's product surface.
+  # Keep it selected even when the case below deliberately ignores the path.
+  if [[ "$path" == *.sh ]]; then
+    shellcheck=true
+  fi
   case "$path" in
     sdk/python/native-api.json)
       # This SDK-owned specification is compiled into the Rust CLI.
@@ -133,11 +138,6 @@ while IFS= read -r path; do
       ;;
     scripts/generate-homebrew-formula.sh|scripts/test-homebrew-formula.sh|scripts/generate-installer.sh|scripts/test-installer.sh)
       tooling=true
-      ;;
-    tests/real-ssh/*.sh)
-      # The real-SSH suite is run locally when affected; CI still lints its
-      # shell sources without promoting it to unrelated product suites.
-      shellcheck=true
       ;;
     tests/real-ssh/*)
       ;;

--- a/scripts/regen-automation-fixtures.sh
+++ b/scripts/regen-automation-fixtures.sh
@@ -142,4 +142,9 @@ mkdir -p "$dir"
     "$syq" rm -j1 --cwd missing --src victim --results raw.ndjson -q) || true
 normalize <"$dir/raw.ndjson" >"$out/rm-failed.ndjson"
 
-echo "regenerated $(ls "$out" | wc -l) fixtures in $out"
+fixture_count=0
+for fixture in "$out"/*; do
+    [ -e "$fixture" ] || continue
+    fixture_count=$((fixture_count + 1))
+done
+echo "regenerated $fixture_count fixtures in $out"

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -97,6 +97,11 @@ assert_scope "$scope" sdks false
 assert_scope "$scope" conformance false
 assert_scope "$scope" macos false
 assert_scope "$scope" linux_arm64 false
+printf 'docs/example.sh\n' >"$paths"
+scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
+assert_scope "$scope" shellcheck true
+assert_scope "$scope" tooling false
+assert_scope "$scope" native false
 printf 'tests/real-ssh/scenarios.sh\n' >"$paths"
 scope=$(SYQ_TEST_CHANGED_PATHS_FILE="$paths" "$script_dir/ci-scope.sh")
 assert_scope "$scope" shellcheck true


### PR DESCRIPTION
## Summary
- select shell lint whenever any changed path ends in `.sh`, including documentation and other otherwise inert paths
- discover every tracked `.sh` file in CI instead of maintaining a fixed inventory
- fix the one existing ShellCheck warning exposed by complete discovery

## Verification
- `git ls-files -z -- "*.sh" | xargs -0 shellcheck`
- `scripts/test-release-orchestration.sh`
- `scripts/check-workflows.sh`
- `git diff --check origin/master...HEAD`