### PR TITLE
Preserve transfer outcomes when human output fails

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -76,7 +76,13 @@ below.
 Records land in `seq` order. Error and terminal records are flushed
 immediately. If writing the stream itself fails, syq warns once on
 stderr and stops writing; the consumer detects this as a missing
-terminal record. Argument and usage errors exit `2` with no stream at
+terminal record. Failure to write human output does not change the copy or
+removal result. For an attached receiver-attested copy, syq continues reading
+and verifying the receipt even if forwarding human output to stdout fails;
+a missing or invalid receipt still fails verification. Warnings are best effort
+when stderr is also unavailable.
+
+Argument and usage errors exit `2` with no stream at
 all: a consumer constructs its own argv, so a usage error is a
 consumer bug and gets no JSON. Every run that gets past argument
 parsing emits a terminal record, fatal setup failures included.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -375,6 +375,14 @@ outside the copy or removal trees; one inside them can make the run's own
 accounting unpredictable. A remote `rm` over a normal SSH login returns
 structured outcomes from the endpoint, but the restricted receiver rejects
 native removal because its signed grants authorize copy changes only.
+
+Copy and removal continue if writing human summaries, file listings, or
+diagnostics fails; the exit status still describes the filesystem operation.
+If stdout fails, syq attempts one warning on stderr. A failed stderr cannot
+carry that warning. A slow output consumer can still block the worker writing
+to it. Progress can continue on a separate, writable stderr or results stream
+while stdout is blocked.
+
 `--mapping` cannot be combined with `--prune` because mapping manifests define
 no region to prune; `--results` covers `--prune` runs, including their
 removals. `--max-delete` requires
@@ -426,6 +434,10 @@ the transfer route and finished checking the destination, before anything is
 written. If that readiness deadline expires, the launcher
 terminates and verifies the complete detached process group before reporting
 failure.
+
+If the job starts but the launcher cannot write its coordinator and log to
+stdout, the launcher exits with an error and attempts to report that location
+on stderr. The background job continues running.
 
 The restricted receiver, which serves one copy and then exits, requires
 encrypted TCP data connections. Consequently `--no-tcp`, falling back from TCP

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -181,7 +181,7 @@ pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
                 Ok(candidates) => candidates,
                 Err(error) => {
                     if std::env::var_os("SYQ_COMPLETION_DEBUG").is_some() {
-                        eprintln!("syq completion: {error:#}");
+                        crate::output::diagnostic!("syq completion: {error:#}");
                     }
                     Vec::new()
                 }
@@ -201,7 +201,7 @@ pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
                 }
                 Err(error) => {
                     if std::env::var_os("SYQ_COMPLETION_DEBUG").is_some() {
-                        eprintln!("syq completion: {error:#}");
+                        crate::output::diagnostic!("syq completion: {error:#}");
                     }
                     Vec::new()
                 }
@@ -274,7 +274,7 @@ fn run_cache(action: CacheAction) -> Result<()> {
 pub(crate) fn remember_endpoint_best_effort(user: Option<&str>, host: &str, port: Option<u16>) {
     if let Err(error) = remember_endpoint(user, host, port) {
         if std::env::var_os("SYQ_COMPLETION_DEBUG").is_some() {
-            eprintln!("syq completion cache: {error:#}");
+            crate::output::diagnostic!("syq completion cache: {error:#}");
         }
     }
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1413,7 +1413,7 @@ impl RemoteSpec {
                     // reuse for every later worker and retry immediately.
                     self.set_ssh_multiplexing(false);
                     if crate::transfer::debug() {
-                        eprintln!(
+                        crate::output::diagnostic!(
                             "syq: {}: multiplexed SSH worker rejected; using independent SSH connections",
                             self.label()
                         );
@@ -1431,7 +1431,7 @@ impl RemoteSpec {
                         None
                     };
                     if crate::transfer::debug() {
-                        eprintln!(
+                        crate::output::diagnostic!(
                             "syq: connect to {} failed (attempt {}): {e:#}{}",
                             self.label(),
                             attempt + 1,
@@ -1689,7 +1689,7 @@ impl RemoteSpec {
             bail!("no advertised data address is reachable");
         }
         if crate::transfer::debug() {
-            eprintln!(
+            crate::output::diagnostic!(
                 "syq: {}: data paths {:?} (advertised {:?})",
                 self.label(),
                 addrs,
@@ -1790,7 +1790,10 @@ impl RemoteSpec {
                 .map(|a| a.to_string())
                 .unwrap_or_default();
             if crate::transfer::debug() {
-                eprintln!("syq: {}: data connection via tcp {addr_s}", self.label());
+                crate::output::diagnostic!(
+                    "syq: {}: data connection via tcp {addr_s}",
+                    self.label()
+                );
             }
             stream.set_nodelay(true)?;
             let conn_id = TCP_CONN_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -2021,7 +2024,7 @@ impl RemoteSpec {
         let bootstrap = self.remote_bootstrap()?;
         let target = bootstrap.target;
         if !self.quiet {
-            eprintln!(
+            crate::output::diagnostic!(
                 "syq: {}: installing {} helper for {}",
                 self.label(),
                 remote_helper::helper_identity(),
@@ -2095,7 +2098,7 @@ impl RemoteSpec {
                 RemoteDownloadOutcome::Fallback { detail, helper } => {
                     trusted = helper;
                     if !self.quiet {
-                        eprintln!(
+                        crate::output::diagnostic!(
                             "syq: {}: remote download unavailable{}; uploading the verified helper over SSH",
                             self.label(),
                             parenthesized_detail(&detail)
@@ -2104,7 +2107,7 @@ impl RemoteSpec {
                 }
                 RemoteDownloadOutcome::Integrity { warning, helper } => {
                     trusted = helper;
-                    eprintln!(
+                    crate::output::diagnostic!(
                         "syq: warning: {}: {}; the remote download was discarded; uploading the verified helper over SSH",
                         self.label(),
                         warning
@@ -2112,7 +2115,7 @@ impl RemoteSpec {
                 }
             }
         } else if !self.quiet {
-            eprintln!(
+            crate::output::diagnostic!(
                 "syq: {}: remote download prerequisites unavailable; uploading the verified helper over SSH",
                 self.label()
             );
@@ -2556,6 +2559,7 @@ impl Endpoint {
                                 return Err(e).context("TCP data transport required by test");
                             }
                             let mut g = spec.tcp.lock().unwrap();
+                            let mut warning = None;
                             if let Some(i) = g.as_mut() {
                                 if !i.failed {
                                     i.failed = true;
@@ -2564,9 +2568,13 @@ impl Endpoint {
                                         let congestion_note = tcp_congestion_fallback_note(
                                             info.congestion_control.as_deref(),
                                         );
-                                        eprintln!("syq: {}: data over ssh (TCP port {} stopped answering: {e:#}{congestion_note})", spec.label(), info.port);
+                                        warning = Some(format!("syq: {}: data over ssh (TCP port {} stopped answering: {e:#}{congestion_note})", spec.label(), info.port));
                                     }
                                 }
+                            }
+                            drop(g);
+                            if let Some(warning) = warning {
+                                crate::output::diagnostic!("{warning}");
                             }
                         }
                     }
@@ -3271,6 +3279,56 @@ mod tests {
             .ssh_command(SshConnection::Independent)
             .get_args()
             .any(|arg| arg == OsStr::new("StrictHostKeyChecking=yes")));
+    }
+
+    #[test]
+    fn worker_tcp_fallback_survives_broken_stderr() {
+        if !crate::test_support::with_broken_stderr(
+            "conn::tests::worker_tcp_fallback_survives_broken_stderr",
+        ) {
+            return;
+        }
+        let temporary = crate::test_support::tempdir().unwrap();
+        let marker = temporary.path().join("ssh-attempted");
+        let spec = RemoteSpec {
+            local_process: false,
+            user: None,
+            host: "unused".into(),
+            port: None,
+            // The shell records that fallback was reached, then reports a
+            // missing helper so no retry or real SSH connection is needed.
+            rsh: vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                format!(
+                    "touch {}; exit 127",
+                    shell_words::quote(marker.to_str().unwrap())
+                ),
+            ],
+            syq_path: None,
+            bootstrap_helper: false,
+            restricted_grant: None,
+            helper_install: Default::default(),
+            ssh_multiplexer: None,
+            quiet: false,
+            tcp: std::sync::Arc::new(std::sync::Mutex::new(Some(TcpInfo {
+                addrs: vec!["invalid address".into()], // Fail resolution without DNS or a socket.
+                port: 0,
+                key: None,
+                token: Vec::new(),
+                congestion_control: None,
+                failed: false,
+                failure: None,
+                next: Default::default(),
+            }))),
+            diagnostics: Default::default(),
+        };
+        let endpoint = Endpoint::Remote(spec.clone());
+        assert!(endpoint
+            .connect_with_role(false, ConnectionRole::SourceWorker { roots: Vec::new() })
+            .is_err());
+        assert!(marker.exists(), "worker never attempted SSH fallback");
+        assert!(spec.tcp.lock().unwrap().as_ref().unwrap().failed);
     }
 
     #[test]

--- a/src/janky_cat.rs
+++ b/src/janky_cat.rs
@@ -65,7 +65,7 @@ fn copy_one(
     match copy_slowly(input, output, pace) {
         Ok(()) => Ok(true),
         Err(CopyError::Read(error)) => {
-            eprintln!("syq cat: {}: {error}", Path::new(label).display());
+            crate::output::diagnostic!("syq cat: {}: {error}", Path::new(label).display());
             Ok(false)
         }
         Err(CopyError::Write(error)) => bail!("writing standard output: {error}"),
@@ -120,7 +120,10 @@ pub fn run(arguments: &[OsString]) -> Result<i32> {
                     succeeded &= copy_one(&mut file, operand, &mut output, &mut pace)?;
                 }
                 Err(error) => {
-                    eprintln!("syq cat: {}: {error}", Path::new(operand).display());
+                    crate::output::diagnostic!(
+                        "syq cat: {}: {error}",
+                        Path::new(operand).display()
+                    );
                     succeeded = false;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod identity;
 mod janky_cat;
 mod native_map;
 mod native_rm;
+mod output;
 mod persistence;
 mod private_broker;
 mod progress;
@@ -122,33 +123,35 @@ fn main() {
     }
     if argv.get(1).and_then(|arg| arg.to_str()) == Some("--release-manifest-signing-payload") {
         if argv.len() != 3 {
-            eprintln!("syq: --release-manifest-signing-payload requires one manifest path");
+            crate::output::diagnostic!(
+                "syq: --release-manifest-signing-payload requires one manifest path"
+            );
             std::process::exit(2);
         }
         if let Err(e) = update::write_manifest_signing_payload(std::path::Path::new(&argv[2])) {
-            eprintln!("syq: {e:#}");
+            crate::output::diagnostic!("syq: {e:#}");
             std::process::exit(1);
         }
         return;
     }
     if argv.get(1).and_then(|arg| arg.to_str()) == Some("--restricted-install") {
         if argv.len() != 2 {
-            eprintln!("syq: restricted installer takes no command-line arguments");
+            crate::output::diagnostic!("syq: restricted installer takes no command-line arguments");
             std::process::exit(2);
         }
         if let Err(error) = restricted::remote_install() {
-            eprintln!("syq restricted installer: {error:#}");
+            crate::output::diagnostic!("syq restricted installer: {error:#}");
             std::process::exit(1);
         }
         return;
     }
     if argv.get(1).and_then(|arg| arg.to_str()) == Some("--restricted-revoke") {
         if argv.len() != 2 {
-            eprintln!("syq: restricted revoker takes no command-line arguments");
+            crate::output::diagnostic!("syq: restricted revoker takes no command-line arguments");
             std::process::exit(2);
         }
         if let Err(error) = restricted::remote_revoke() {
-            eprintln!("syq restricted revoker: {error:#}");
+            crate::output::diagnostic!("syq restricted revoker: {error:#}");
             std::process::exit(1);
         }
         return;
@@ -159,11 +162,11 @@ fn main() {
             .and_then(|argument| argument.to_str())
             .and_then(|argument| argument.strip_prefix("--enrollment="));
         if argv.len() != 3 || enrollment.is_none() {
-            eprintln!("syq: restricted receiver requires exactly --enrollment=ID");
+            crate::output::diagnostic!("syq: restricted receiver requires exactly --enrollment=ID");
             std::process::exit(2);
         }
         if let Err(error) = restricted::run_receiver(enrollment.unwrap()) {
-            eprintln!("syq restricted receiver: {error:#}");
+            crate::output::diagnostic!("syq restricted receiver: {error:#}");
             std::process::exit(1);
         }
         return;
@@ -175,7 +178,7 @@ fn main() {
             && argv.get(2).and_then(|arg| arg.to_str()) == Some("--server"));
     if server_mode {
         if let Err(e) = server::run() {
-            eprintln!("syq server: {e:#}");
+            crate::output::diagnostic!("syq server: {e:#}");
             std::process::exit(1);
         }
         return;
@@ -184,7 +187,7 @@ fn main() {
         match janky_cat::run(&argv[2..]) {
             Ok(code) => std::process::exit(code),
             Err(error) => {
-                eprintln!("syq cat: {error:#}");
+                crate::output::diagnostic!("syq cat: {error:#}");
                 std::process::exit(1);
             }
         }
@@ -193,7 +196,7 @@ fn main() {
         match persistence::run(&argv[2..]) {
             Ok(code) => std::process::exit(code),
             Err(error) => {
-                eprintln!("syq persist: {error:#}");
+                crate::output::diagnostic!("syq persist: {error:#}");
                 std::process::exit(1);
             }
         }
@@ -202,7 +205,7 @@ fn main() {
         match completion::run(&argv[2..]) {
             Ok(code) => std::process::exit(code),
             Err(error) => {
-                eprintln!("syq completion: {error:#}");
+                crate::output::diagnostic!("syq completion: {error:#}");
                 std::process::exit(1);
             }
         }
@@ -211,7 +214,7 @@ fn main() {
         match result {
             Ok(code) => std::process::exit(code),
             Err(error) => {
-                eprintln!("syq: {error:#}");
+                crate::output::diagnostic!("syq: {error:#}");
                 std::process::exit(1);
             }
         }
@@ -219,21 +222,21 @@ fn main() {
     let mut args = match cli::Args::parse_args() {
         Ok(a) => a,
         Err(e) => {
-            eprintln!("syq: {e:#}");
+            crate::output::diagnostic!("syq: {e:#}");
             std::process::exit(2);
         }
     };
     args.normalize();
     if args.self_update {
         if let Err(e) = update::self_update() {
-            eprintln!("syq: {e:#}");
+            crate::output::diagnostic!("syq: {e:#}");
             std::process::exit(1);
         }
         return;
     }
     if args.register_standalone_install {
         if let Err(e) = update::register_standalone_install() {
-            eprintln!("syq: {e:#}");
+            crate::output::diagnostic!("syq: {e:#}");
             std::process::exit(1);
         }
         return;
@@ -255,7 +258,7 @@ fn main() {
             std::process::exit(code)
         }
         Err(e) => {
-            eprintln!("syq: {e:#}");
+            crate::output::diagnostic!("syq: {e:#}");
             std::process::exit(1);
         }
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,42 @@
+//! Human output must not change the outcome of a filesystem operation.
+//! These writes can still block; they deliberately do not buffer or drop slow output.
+
+use std::fmt::Arguments;
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+
+pub(crate) fn emit_diagnostic(args: Arguments<'_>) {
+    let _ = writeln!(io::stderr().lock(), "{args}");
+}
+
+pub(crate) fn emit_human_stdout(args: Arguments<'_>) {
+    if let Err(error) = write_stdout(args) {
+        warn_stdout(&error);
+    }
+}
+
+/// Essential output (such as a receipt frame or detach handoff) must let
+/// its caller handle failure. The stdout lock is released before returning.
+pub(crate) fn write_stdout(args: Arguments<'_>) -> io::Result<()> {
+    let mut out = io::stdout().lock();
+    writeln!(out, "{args}").and_then(|()| out.flush())
+}
+
+pub(crate) fn warn_stdout(error: &io::Error) {
+    static WARNED: AtomicBool = AtomicBool::new(false);
+    if !WARNED.swap(true, Relaxed) {
+        emit_diagnostic(format_args!(
+            "syq: warning: could not write human output to stdout: {error}"
+        ));
+    }
+}
+
+macro_rules! diagnostic {
+    ($($arg:tt)*) => { $crate::output::emit_diagnostic(format_args!($($arg)*)) };
+}
+pub(crate) use diagnostic;
+
+macro_rules! human_stdout {
+    ($($arg:tt)*) => { $crate::output::emit_human_stdout(format_args!($($arg)*)) };
+}
+pub(crate) use human_stdout;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -135,18 +135,28 @@ impl Progress {
 
     /// Print a line to stdout, keeping the progress area intact.
     pub fn println(&self, line: &str) {
-        let mut t = self.term.lock().unwrap();
-        self.erase(&mut t);
-        let mut out = std::io::stdout().lock();
-        let _ = writeln!(out, "{line}");
-        let _ = out.flush();
+        let mut term = Some(self.term.lock().unwrap());
+        self.erase(term.as_mut().unwrap());
+        // A redirected stdout cannot disturb the terminal display. Let the
+        // ticker keep running while a slow pipe blocks this printing worker.
+        if !std::io::stdout().is_terminal() {
+            drop(term.take());
+        }
+        let result = {
+            let mut out = std::io::stdout().lock();
+            writeln!(out, "{line}").and_then(|()| out.flush())
+        };
+        drop(term);
+        if let Err(error) = result {
+            crate::output::warn_stdout(&error);
+        }
     }
 
     /// Print a line to stderr (errors and warnings), keeping the progress area intact.
     pub fn eprintln(&self, line: &str) {
         let mut t = self.term.lock().unwrap();
         self.erase(&mut t);
-        eprintln!("{line}");
+        crate::output::diagnostic!("{line}");
     }
 
     pub fn error(&self, line: &str) {
@@ -170,7 +180,7 @@ impl Progress {
         let mut term = self.term.lock().unwrap();
         self.erase(&mut term);
         if self.json {
-            eprintln!(
+            crate::output::diagnostic!(
                 "{}",
                 serde_json::json!({
                     "type": "warning",
@@ -180,13 +190,13 @@ impl Progress {
                 })
             );
         } else {
-            eprintln!("syq: warning: {message}");
+            crate::output::diagnostic!("syq: warning: {message}");
         }
     }
 
     fn erase(&self, t: &mut TermState) {
         if t.lines_drawn > 0 {
-            eprint!("\r\x1b[{}A\x1b[J", t.lines_drawn);
+            let _ = write!(std::io::stderr().lock(), "\r\x1b[{}A\x1b[J", t.lines_drawn);
             t.lines_drawn = 0;
         }
     }
@@ -256,7 +266,7 @@ impl Progress {
                 .is_none_or(|l| now - l >= Duration::from_secs(1))
             {
                 t.last_json = Some(now);
-                eprintln!(
+                crate::output::diagnostic!(
                     "{{\"bytes_done\":{done},\"bytes_total\":{total},\"bytes_unchanged\":{skipped},\"files_done\":{fdone},\"files_total\":{ftotal},\"files_unchanged\":{},\"files_excluded\":{},\"scanned\":{},\"scan_done\":{scan_done},\"rate\":{:.0},\"eta\":{},\"elapsed\":{:.1}}}",
                     self.files_unchanged.load(Relaxed),
                     self.files_excluded.load(Relaxed),

--- a/src/remote_to_remote.rs
+++ b/src/remote_to_remote.rs
@@ -149,9 +149,34 @@ impl Iterator for CapturedFrames<'_> {
 /// other transfers inherit stdout untouched. Frames are decoded one line
 /// at a time and spooled rather than accumulated in memory.
 fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<CapturedReceipt>> {
+    let mut output_error = None;
+    let result = relay_output(stdout, &mut std::io::stdout().lock(), &mut output_error);
+    // Report only after releasing stdout, including when receipt parsing fails.
+    if let Some(error) = output_error {
+        crate::output::warn_stdout(&error);
+    }
+    result
+}
+
+fn relay_output(
+    stdout: impl std::io::Read,
+    out: &mut impl Write,
+    output_error: &mut Option<std::io::Error>,
+) -> Result<Option<CapturedReceipt>> {
     let prefix = crate::receipt::RECEIPT_LINE_PREFIX.as_bytes();
     let mut reader = std::io::BufReader::with_capacity(64 * 1024, stdout);
-    let mut out = std::io::stdout().lock();
+    // A failed human-output sink must not discard the receiver's evidence.
+    // Keep draining and validating receipt frames after the first write error.
+    let mut forward = |bytes: &[u8], flush: bool| {
+        if output_error.is_none() {
+            let result = out
+                .write_all(bytes)
+                .and_then(|()| if flush { out.flush() } else { Ok(()) });
+            if let Err(error) = result {
+                *output_error = Some(error);
+            }
+        }
+    };
     let mut receipt = None;
     // The first bytes of the current line, held only until the prefix
     // decision; then either the receipt payload being collected or nothing.
@@ -189,16 +214,14 @@ fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<CapturedReceipt>> {
                     if head.starts_with(prefix) {
                         capturing = Some(head[prefix.len()..].to_vec());
                     } else {
-                        out.write_all(&head)
-                            .context("relay remote coordinator output")?;
+                        forward(&head, false);
                     }
                     head.clear();
                 }
             } else if let Some(payload) = capturing.as_mut() {
                 payload.extend_from_slice(segment);
             } else {
-                out.write_all(segment)
-                    .context("relay remote coordinator output")?;
+                forward(segment, false);
             }
             if let Some(payload) = capturing.as_mut() {
                 if payload.len() > MAX_RECEIPT_LINE_BYTES {
@@ -209,7 +232,7 @@ fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<CapturedReceipt>> {
                 if let Some(mut payload) = capturing.take() {
                     store_receipt_line(&mut receipt, finish_capture(&mut payload))?;
                 } else {
-                    out.flush().context("relay remote coordinator output")?;
+                    forward(&[], true);
                 }
                 decided = false;
             }
@@ -221,14 +244,13 @@ fn relay_stdout(stdout: impl std::io::Read) -> Result<Option<CapturedReceipt>> {
         if head.starts_with(prefix) {
             capturing = Some(head[prefix.len()..].to_vec());
         } else {
-            out.write_all(&head)
-                .context("relay remote coordinator output")?;
+            forward(&head, false);
         }
     }
     if let Some(mut payload) = capturing.take() {
         store_receipt_line(&mut receipt, finish_capture(&mut payload))?;
     }
-    out.flush().context("relay remote coordinator output")?;
+    forward(&[], true);
     Ok(receipt)
 }
 
@@ -410,7 +432,7 @@ fn settle_captured_receipt(
         // machine just received (the coordinator's own summary was
         // suppressed), so the two can never disagree.
         if !quiet {
-            println!(
+            crate::output::human_stdout!(
                 "syq: receiver-attested: {} files published ({}), {} deleted, {} error(s); receipt {}; {}",
                 terminal.summary.published_files,
                 crate::progress::human(terminal.summary.transferred_bytes),
@@ -424,7 +446,7 @@ fn settle_captured_receipt(
         // stream advertises. Verification complaints reach stderr; they do
         // not fork the exit code away from the terminal record.
         if let Some(message) = settlement_error {
-            eprintln!("syq: {message}");
+            crate::output::diagnostic!("syq: {message}");
         }
         return Ok(outcome.exit_code);
     }
@@ -440,10 +462,10 @@ fn settle_captured_receipt(
                 .map(|problem| format!("; first: {problem}"))
                 .unwrap_or_default()
         );
-        eprintln!("syq: warning: {message}");
+        crate::output::diagnostic!("syq: warning: {message}");
     }
     if verbose {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: encrypted receipt from {dst_host} verified: {} operations, {} final states, {} files published ({}), {} deletions",
             terminal.summary.operations,
             terminal.summary.final_states,
@@ -818,7 +840,7 @@ fn run_remote(
                 grant_digest: Some(prepared.grant_digest),
             });
             if !args.quiet {
-                eprintln!(
+                crate::output::diagnostic!(
                     "syq: using command-restricted destination enrollment {}",
                     prepared.enrollment_id
                 );
@@ -1129,7 +1151,7 @@ fn run_remote(
         )
     };
     if args.peer_auth == PeerAuth::FullAgent {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: warning: --peer-auth full-agent exposes every capability in your SSH agent to {coordinator_host} for this transfer"
         );
     }
@@ -1152,15 +1174,18 @@ fn run_remote(
         }
         // The handoff is the command's result, not chatter: -q trims it to
         // the bare coordinator and log path rather than suppressing it.
-        if args.quiet {
-            println!("{coordinator_target}:{log}");
+        let handoff = if args.quiet {
+            format!("{coordinator_target}:{log}")
         } else {
-            println!("syq: started on {coordinator_target}, log {log}");
-        }
+            format!("syq: started on {coordinator_target}, log {log}")
+        };
+        crate::output::write_stdout(format_args!("{handoff}")).with_context(|| {
+            format!("job started on {coordinator_target}, log {log}, but writing its location to stdout failed")
+        })?;
         return Ok(0);
     }
     if !args.quiet {
-        eprintln!("syq: remote-to-remote: running on {coordinator_host}");
+        crate::output::diagnostic!("syq: remote-to-remote: running on {coordinator_host}");
     }
     let run = || {
         let mut cmd = make_command();
@@ -1505,6 +1530,151 @@ mod tests {
         assert!(!automatic_enrollment_allowed(true, false));
         assert!(!automatic_enrollment_allowed(false, true));
         assert!(!automatic_enrollment_allowed(true, true));
+    }
+
+    #[test]
+    fn relay_output_failure_preserves_verified_receipt_and_rejects_corruption() {
+        use crate::receipt::*;
+        struct FailingOutput {
+            flush_only: bool,
+        }
+        impl Write for FailingOutput {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                if self.flush_only {
+                    Ok(bytes.len())
+                } else {
+                    Err(std::io::ErrorKind::BrokenPipe.into())
+                }
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Err(std::io::ErrorKind::BrokenPipe.into())
+            }
+        }
+        let signing_key = ssh_key::PrivateKey::new(
+            ssh_key::private::Ed25519Keypair::from_seed(&[19; 32]).into(),
+            "output-test",
+        )
+        .unwrap();
+        let (secret, public) = generate_recipient().unwrap();
+        let policy = ReceiptPolicy {
+            required: true,
+            hashed: false,
+            max_records: 32,
+            max_plaintext_bytes: 64 * 1024,
+            delivery: ReceiptDelivery::AttachedEncrypted {
+                suite: HpkeSuite::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+                recipient_public_key: public,
+            },
+        };
+        let enrollment_id = EnrollmentId::random();
+        let request_id = RequestId::fresh(1_900_000_000).unwrap();
+        let grant_digest = [17; 32];
+        let issued = ReceiptStreamWriter::new(&policy)
+            .unwrap()
+            .finish(ReceiptClosure {
+                enrollment_id,
+                request_id,
+                grant_digest,
+                issued_at: 1_900_000_001,
+                policy: policy.clone(),
+                entries_touched: 0,
+                transferred_bytes: 0,
+                signing_key: &signing_key,
+            })
+            .unwrap();
+        let mut encoded = Vec::new();
+        emit_receipt_frames(issued, |frame| {
+            encoded.extend_from_slice(RECEIPT_LINE_PREFIX.as_bytes());
+            encoded.extend_from_slice(
+                base64::engine::general_purpose::STANDARD_NO_PAD
+                    .encode(frame)
+                    .as_bytes(),
+            );
+            encoded.push(b'\n');
+            Ok(())
+        })
+        .unwrap();
+        let expected = ReceiptExpectation {
+            public_key: signing_key.public_key().to_openssh().unwrap(),
+            enrollment_id,
+            request_id,
+            recipient_secret: Some(secret),
+            policy,
+            grant_digest: Some(grant_digest),
+        };
+        for flush_only in [false, true] {
+            // Fail either before the receipt arrives or after it was captured.
+            for human_first in [false, true] {
+                let input = if human_first {
+                    [b"human line\n".as_slice(), &encoded].concat()
+                } else {
+                    [&encoded, b"human line\n".as_slice()].concat()
+                };
+                let mut output_error = None;
+                let mut captured = relay_output(
+                    input.as_slice(),
+                    &mut FailingOutput { flush_only },
+                    &mut output_error,
+                )
+                .unwrap();
+                assert_eq!(output_error.unwrap().kind(), std::io::ErrorKind::BrokenPipe);
+                let file = tempfile::tempfile().unwrap();
+                let writer =
+                    crate::results::ResultsWriter::new(Box::new(file.try_clone().unwrap()));
+                assert_eq!(
+                    settle_receipt(
+                        &expected,
+                        captured.as_mut(),
+                        ReceiptSettlement {
+                            src_host: "source",
+                            dst_host: "destination",
+                            coordinator_exit_code: 0,
+                            results: Some(&writer),
+                            elapsed_ms: 1,
+                            verbose: false,
+                            quiet: false,
+                        }
+                    )
+                    .unwrap(),
+                    0
+                );
+                let mut text = String::new();
+                let mut file = file;
+                file.rewind().unwrap();
+                file.read_to_string(&mut text).unwrap();
+                let result: serde_json::Value =
+                    serde_json::from_str(text.lines().last().unwrap()).unwrap();
+                assert_eq!(result["exit_code"], 0);
+                assert_eq!(result["provenance"], "receiver_attested");
+            }
+        }
+        // Losing human output never disables receipt framing or verification.
+        let invalid = format!("human line\n{RECEIPT_LINE_PREFIX}invalid!\n");
+        assert!(relay_output(
+            invalid.as_bytes(),
+            &mut FailingOutput { flush_only: false },
+            &mut None
+        )
+        .is_err());
+        let mut captured = relay_output(encoded.as_slice(), &mut Vec::new(), &mut None).unwrap();
+        let wrong_expected = ReceiptExpectation {
+            grant_digest: Some([99; 32]),
+            ..expected
+        };
+        assert!(settle_receipt(
+            &wrong_expected,
+            captured.as_mut(),
+            ReceiptSettlement {
+                src_host: "source",
+                dst_host: "destination",
+                coordinator_exit_code: 0,
+                results: None,
+                elapsed_ms: 1,
+                verbose: false,
+                quiet: true,
+            }
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -4241,7 +4241,7 @@ pub(crate) fn dispatch_receiver_command(argv: &[OsString]) -> Option<Result<i32>
         return None;
     }
     let Some(command) = argv.get(2).and_then(|argument| argument.to_str()) else {
-        eprintln!("{RECEIVER_USAGE}");
+        crate::output::diagnostic!("{RECEIVER_USAGE}");
         return Some(Ok(2));
     };
     match command {

--- a/src/results.rs
+++ b/src/results.rs
@@ -589,7 +589,9 @@ impl ResultsWriter {
 
     fn mark_dead(&self, error: &std::io::Error) {
         if !self.dead.swap(true, Relaxed) {
-            eprintln!("syq: warning: --results stream failed ({error}); further records are lost");
+            crate::output::diagnostic!(
+                "syq: warning: --results stream failed ({error}); further records are lost"
+            );
         }
     }
 }
@@ -609,6 +611,22 @@ fn tagged(path: &[u8]) -> serde_json::Value {
 mod tests {
     use super::*;
     use std::sync::Arc;
+
+    #[test]
+    fn failed_results_and_stderr_do_not_panic() {
+        if !crate::test_support::with_broken_stderr(
+            "results::tests::failed_results_and_stderr_do_not_panic",
+        ) {
+            return;
+        }
+        let (reader, writer) = std::os::unix::net::UnixStream::pair().unwrap();
+        drop(reader);
+        let writer = ResultsWriter::new(Box::new(writer));
+        writer.emit_error_classified("first failure", None, None);
+        assert!(writer.is_dead());
+        writer.emit_error_classified("later failure", None, None);
+        assert!(!writer.out.is_poisoned());
+    }
 
     #[derive(Clone, Default)]
     struct Sink(Arc<Mutex<Vec<u8>>>);

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -124,7 +124,7 @@ fn print_summary(args: &Args, progress: &Progress, summary: &RemovalSummary) {
     if summary.entries_failed > 0 {
         details.push(format!("{} errors", commas(summary.entries_failed)));
     }
-    println!(
+    crate::output::human_stdout!(
         "syq: {} {} entries in {}{}",
         if args.dry_run {
             "would remove"

--- a/src/server.rs
+++ b/src/server.rs
@@ -577,7 +577,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
         }
     }
     if debug {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq server{}: {blocks} blocks, {} MiB; waiting for input {:.2}s, handling {:.2}s, writing responses {:.2}s",
             if over_ssh { "" } else { " (tcp)" },
             bytes >> 20,
@@ -913,7 +913,9 @@ fn accept_data_connections(
         if live.fetch_add(1, Relaxed) >= max_live {
             live.fetch_sub(1, Relaxed);
             if debug {
-                eprintln!("syq server (tcp): refusing connection, {max_live} already live");
+                crate::output::diagnostic!(
+                    "syq server (tcp): refusing connection, {max_live} already live"
+                );
             }
             continue; // drop; stream closes
         }
@@ -938,7 +940,7 @@ fn accept_data_connections(
                 descriptor_session,
             ) {
                 if debug {
-                    eprintln!("syq server (tcp {id}): {e:#}");
+                    crate::output::diagnostic!("syq server (tcp {id}): {e:#}");
                 }
             }
             live.fetch_sub(1, Relaxed);

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -2,6 +2,30 @@
 
 use std::path::PathBuf;
 
+/// Run a unit test in a separate process whose stderr reader has gone away.
+/// Keep stdout available for the test harness and assertion diagnostics.
+pub(crate) fn with_broken_stderr(name: &str) -> bool {
+    if std::env::var("SYQ_TEST_BROKEN_STDERR").as_deref() == Ok(name) {
+        return true;
+    }
+    let (reader, writer) = std::os::unix::net::UnixStream::pair().unwrap();
+    drop(reader);
+    let result = std::process::Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", name, "--nocapture"])
+        .env("SYQ_TEST_BROKEN_STDERR", name)
+        .stderr(std::process::Stdio::from(std::os::fd::OwnedFd::from(
+            writer,
+        )))
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stdout)
+    );
+    false
+}
+
 /// The process temporary directory with symlinks resolved.
 ///
 /// macOS places `TMPDIR` under `/var`, a symlink to `/private/var`. Native

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -303,18 +303,18 @@ fn remote_helper_mode(spec: &RemoteSpec, interface: Interface) -> &'static str {
 
 fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
     let diagnostics = spec.diagnostics();
-    eprintln!("syq: {}:", spec.label());
+    crate::output::diagnostic!("syq: {}:", spec.label());
     if let Some(peer) = &diagnostics.peer {
-        eprintln!(
+        crate::output::diagnostic!(
             "  control: connected via {}; remote {}",
             spec.remote_shell_name(),
             peer.platform
         );
         if let Some(version) = crate::conn::openssh_version(&spec.rsh[0]) {
-            eprintln!("  ssh client: {version}");
+            crate::output::diagnostic!("  ssh client: {version}");
         }
         let helper_mode = remote_helper_mode(spec, args.interface);
-        eprintln!("  helper: {} ({helper_mode})", peer.identity);
+        crate::output::diagnostic!("  helper: {} ({helper_mode})", peer.identity);
     }
 
     if let Some(probe) = &diagnostics.tcp_probe {
@@ -331,7 +331,7 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
             } else {
                 ""
             };
-            eprintln!(
+            crate::output::diagnostic!(
                 "  TCP {}{source}: {}",
                 data_address(&candidate.address, probe.port),
                 candidate_status(candidate, fastest)
@@ -339,10 +339,10 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
         }
         let remote = probe.congestion_control.as_deref().unwrap_or("unavailable");
         match &args.tcp_congestion {
-            Some(requested) => eprintln!(
+            Some(requested) => crate::output::diagnostic!(
                 "  congestion control: remote listener {remote}; local data sockets request {requested}"
             ),
-            None => eprintln!("  congestion control: remote listener {remote} (host default)"),
+            None => crate::output::diagnostic!("  congestion control: remote listener {remote} (host default)"),
         }
     }
 
@@ -359,7 +359,9 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
             } else {
                 "plaintext TCP"
             };
-            eprintln!("  transport: {name} {route_state} (reachability preflight passed)");
+            crate::output::diagnostic!(
+                "  transport: {name} {route_state} (reachability preflight passed)"
+            );
         }
         DataTransport::Ssh => {
             let tcp_failure = spec
@@ -370,17 +372,17 @@ fn print_remote_diagnostics(spec: &RemoteSpec, args: &Args) {
                 .and_then(|info| info.failure.clone())
                 .or(diagnostics.tcp_setup_error.clone());
             if args.no_tcp {
-                eprintln!(
+                crate::output::diagnostic!(
                     "  transport: SSH {route_state} ({})",
                     interface_option(args, "--no-tcp", "--syq-no-tcp")
                 );
             } else if let Some(error) = tcp_failure {
-                eprintln!(
+                crate::output::diagnostic!(
                     "  transport: SSH {route_state} (TCP unavailable: {})",
                     one_line(&error)
                 );
             } else {
-                eprintln!("  transport: SSH {route_state}");
+                crate::output::diagnostic!("  transport: SSH {route_state}");
             }
         }
     }
@@ -410,15 +412,15 @@ fn print_transport_diagnostics(args: &Args, src: &Endpoint, dst: &Endpoint) {
         "fixed"
     };
     if !remote {
-        eprintln!("syq: transport: local filesystem");
+        crate::output::diagnostic!("syq: transport: local filesystem");
     }
     if args.dry_run {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: concurrency: a real transfer would start with {} {unit} ({policy}); dry-run starts no workers",
             args.connections
         );
     } else {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: concurrency: starting with {} {unit} ({policy})",
             args.connections
         );
@@ -841,7 +843,7 @@ fn handle_tcp_setup_error(
     if !args.quiet || debug() {
         let congestion_note =
             crate::conn::tcp_congestion_fallback_note(args.tcp_congestion.as_deref());
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: {}: data over ssh (TCP ports {}-{} not reachable: {error:#}{congestion_note}); a Tailscale address or an open port is faster",
             spec.label(),
             ports.0,
@@ -1140,7 +1142,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         // only way here is the operator's explicit --coordinate-at local.
         debug_assert!(args.relay);
         if !args.quiet {
-            eprintln!("syq: remote-to-remote transfer: relaying data through this machine");
+            crate::output::diagnostic!(
+                "syq: remote-to-remote transfer: relaying data through this machine"
+            );
         }
     } else if args.interface != Interface::Rsync && args.coordinate_at != CoordinateAt::Auto {
         bail!("--coordinate-at currently applies only to copies between two remote endpoints");
@@ -1366,7 +1370,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                             }
                             gate.mark_warming(id);
                             if !opts.quiet {
-                                eprintln!(
+                                crate::output::diagnostic!(
                                     "syq: worker {id}: connection setup failed; retrying in {}s ({error:#})",
                                     1 << (failures - 1)
                                 );
@@ -1396,7 +1400,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         fast_batch_files,
                     };
                     if debug() {
-                        eprintln!(
+                        crate::output::diagnostic!(
                             "syq: worker {id} connected in {:.2}s",
                             t0.elapsed().as_secs_f64()
                         );
@@ -1421,7 +1425,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                             }
                             gate.mark_warming(id);
                             if !opts.quiet {
-                                eprintln!(
+                                crate::output::diagnostic!(
                                     "syq: worker {id}: connection dropped; reopening in {}s ({error:#})",
                                     1 << (failures - 1)
                                 );
@@ -1476,7 +1480,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         }
     };
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: control connections up in {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -1510,7 +1514,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         }
     }
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: TCP route probes started at {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -1612,7 +1616,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         _ => (operator_dst_root.clone(), dst_root_entry),
     };
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: destination stat complete at {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -1741,7 +1745,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         None
     };
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: destination selection complete at {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -1935,7 +1939,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         .set(crate::resume::copy_id(&identity))
         .expect("partial identity set once");
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: copy identity complete at {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -2029,7 +2033,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         }
     }
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: destination preflight complete at {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -2047,7 +2051,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             )?;
         }
         if debug() {
-            eprintln!(
+            crate::output::diagnostic!(
                 "syq: {}: tcp data port {:?}",
                 spec.label(),
                 spec.tcp
@@ -2075,7 +2079,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         }
     }
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: data transport setup complete at {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -2106,7 +2110,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     print_transport_diagnostics(&args, &src_ep, &dst_ep);
     if args.verbose >= 2 {
         if let Some(remembered) = remembered_start {
-            eprintln!(
+            crate::output::diagnostic!(
                 "syq: auto-tuning: starting with {remembered} connections remembered for this path"
             );
         }
@@ -2316,7 +2320,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         }
     }
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: payload planning complete at {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -2447,7 +2451,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         None => None,
     };
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: file workers complete at {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -2495,7 +2499,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         st.apply_deferred()?;
     }
     if debug() {
-        eprintln!(
+        crate::output::diagnostic!(
             "syq: deferred metadata complete at {:.2}s",
             t0.elapsed().as_secs_f64()
         );
@@ -2532,11 +2536,14 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                                 break;
                             }
                         };
-                        println!(
+                        if let Err(error) = crate::output::write_stdout(format_args!(
                             "{}{}",
                             crate::receipt::RECEIPT_LINE_PREFIX,
                             base64::engine::general_purpose::STANDARD_NO_PAD.encode(frame)
-                        );
+                        )) {
+                            progress.error(&format!("syq: write receipt: {error}"));
+                            break;
+                        }
                         if terminal {
                             break;
                         }
@@ -2642,7 +2649,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 if final_key.as_deref() == Some(initial_key) {
                     tune::remember(initial_key, policy.settled());
                 } else if debug() {
-                    eprintln!(
+                    crate::output::diagnostic!(
                         "syq: auto-tuning: transport changed during transfer; not updating cache"
                     );
                 }
@@ -2656,7 +2663,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     if !args.quiet && (!aborted || capacity_only_dry_run_abort) && !args.suppress_summary {
         if opts.dry_run {
             if args.verbose > 0 && dry_run_creates_root {
-                println!(
+                crate::output::human_stdout!(
                     "create directory {} (destination missing)",
                     display_directory(&dst_root)
                 );
@@ -2675,7 +2682,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 fresh_capacity_assessment,
             );
         } else if opts.verify_only {
-            println!(
+            crate::output::human_stdout!(
                 "syq: verified {} files, {} differ/missing, {} in {}",
                 commas(progress.files_done.load(Relaxed) + errors),
                 errors,
@@ -2683,7 +2690,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 crate::progress::hms(elapsed)
             );
         } else {
-            println!(
+            crate::output::human_stdout!(
                 "syq: transferred {} files ({}), {} unchanged ({} files), {} dirs created{}{}{}",
                 commas(terminal.files_transferred),
                 human(terminal.bytes_transferred),
@@ -2729,7 +2736,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 matches!(endpoint, Endpoint::Remote(spec) if !spec.local_process && spec.data_transport() == DataTransport::Ssh)
             });
         let tcp_stats = format_tcp_stats(&transport_stats.lock().unwrap(), has_ssh_data);
-        println!(
+        crate::output::human_stdout!(
                 "  scanned entries: {}\n  {files_label}: {}\n  {unchanged_files_label}: {}\n  files excluded: {}\n  {bytes_label}: {}\n  {unchanged_bytes_label}: {}\n  elapsed: {:.2}s\n  connections: {}{}",
                 commas(progress.scanned.load(Relaxed)),
                 commas(progress.files_total.load(Relaxed)),
@@ -3593,35 +3600,37 @@ fn print_dry_run_summary(
     changes: &DryRunChanges,
     capacity: Option<FreshCapacityAssessment>,
 ) {
-    println!("syq: dry-run summary");
+    crate::output::human_stdout!("syq: dry-run summary");
     for (source, mapping) in srcs.iter().zip(mappings) {
-        println!(
+        crate::output::human_stdout!(
             "  mapping: {} -> {} ({})",
             display_plan_source(source, args),
             display_plan_target(dst, &mapping.target, args),
             mapping.semantics
         );
     }
-    println!("  changes: {}", changes.summary());
+    crate::output::human_stdout!("  changes: {}", changes.summary());
 
     match deletes {
-        DeletePlan::Disabled => println!("  deletions: disabled"),
+        DeletePlan::Disabled => crate::output::human_stdout!("  deletions: disabled"),
         DeletePlan::Planned(n) => {
             if let Some(limit) = opts.max_delete.filter(|limit| n > *limit) {
-                println!(
+                crate::output::human_stdout!(
                     "  deletions: {} planned; blocked by --max-delete {limit}",
                     count_label(n, "entry", "entries")
                 );
             } else {
-                println!(
+                crate::output::human_stdout!(
                     "  deletions: {} planned after a successful copy",
                     count_label(n, "entry", "entries")
                 );
             }
         }
-        DeletePlan::Skipped(reason) => println!("  deletions: skipped ({reason})"),
+        DeletePlan::Skipped(reason) => {
+            crate::output::human_stdout!("  deletions: skipped ({reason})")
+        }
     }
-    println!(
+    crate::output::human_stdout!(
         "  logical data: {} in {} needing content work (upper bound); {} in {} with unchanged content",
         human(progress.bytes_total.load(Relaxed)),
         count_label(progress.files_total.load(Relaxed), "file", "files"),
@@ -3644,7 +3653,7 @@ fn print_dry_run_summary(
                 )
             },
         );
-        println!(
+        crate::output::human_stdout!(
             "  capacity: {} logical data required; {} available; {inode_detail} ({})",
             human(capacity.logical_bytes),
             human(capacity.available_bytes),
@@ -3668,7 +3677,7 @@ fn print_dry_run_summary(
     if other > 0 {
         exclusions.push(count_label(other, "other entry", "other entries"));
     }
-    println!(
+    crate::output::human_stdout!(
         "  exclusions: {}",
         if exclusions.is_empty() {
             if opts.ignore.is_empty() {
@@ -3681,7 +3690,7 @@ fn print_dry_run_summary(
         }
     );
 
-    println!("  route: {}", selected_route(src_ep, dst_ep, args));
+    crate::output::human_stdout!("  route: {}", selected_route(src_ep, dst_ep, args));
 }
 
 fn path_has_partial_component(path: &[u8]) -> bool {
@@ -6518,7 +6527,7 @@ impl Worker {
             match item {
                 Item::Exit => {
                     if debug() {
-                        eprintln!(
+                        crate::output::diagnostic!(
                             "syq: worker {} blocked: src recv {:.2}s, dst send {:.2}s, dst ack {:.2}s, idle {:.2}s; small: {} files in {} batches, src {:.2}s, dst send {:.2}s, dst ack {:.2}s, restat {:.2}s, bookkeeping {:.2}s",
                             self.id,
                             self.t[0],

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -261,7 +261,7 @@ pub fn remember(key: &str, connections: usize) {
     };
     if let Err(error) = remember_at(&path, key, connections) {
         if crate::transfer::debug() {
-            eprintln!("syq: tuning cache {}: {error}", path.display());
+            crate::output::diagnostic!("syq: tuning cache {}: {error}", path.display());
         }
     }
 }
@@ -900,7 +900,7 @@ pub fn run(
             last = (meter.bytes(), meter.files());
             sample_start = std::time::Instant::now();
             if crate::transfer::debug() {
-                eprintln!(
+                crate::output::diagnostic!(
                     "syq: tune: {before} -> {requested} workers (direct copy needs userspace transfer)"
                 );
             }
@@ -921,7 +921,7 @@ pub fn run(
             last = (meter.bytes(), meter.files());
             sample_start = std::time::Instant::now();
             if crate::transfer::debug() {
-                eprintln!(
+                crate::output::diagnostic!(
                     "syq: tune: {before} -> {active} workers (state {:?})",
                     policy.state
                 );
@@ -961,7 +961,7 @@ pub fn run(
                 last = (meter.bytes(), meter.files());
                 sample_start = std::time::Instant::now();
                 if crate::transfer::debug() {
-                    eprintln!(
+                    crate::output::diagnostic!(
                         "syq: tune: {before} -> {active} workers (candidate ready, state {:?})",
                         policy.state
                     );
@@ -997,7 +997,7 @@ pub fn run(
                 if let Some(score) = sampler.push(rate) {
                     policy.refresh_warming_baseline(score);
                     if crate::transfer::debug() {
-                        eprintln!(
+                        crate::output::diagnostic!(
                             "syq: tune: refreshed {active}-worker baseline to {:.1} MB/s while {} workers warm",
                             score / 1e6,
                             policy.n
@@ -1081,7 +1081,7 @@ pub fn run(
         if policy.n != before {
             sampler.reset();
             if crate::transfer::debug() {
-                eprintln!(
+                crate::output::diagnostic!(
                     "syq: tune: candidate {before} -> {} workers (measured {:.1} MB/s at {before}, state {:?})",
                     policy.n,
                     score / 1e6,

--- a/src/update.rs
+++ b/src/update.rs
@@ -176,7 +176,7 @@ pub fn after_success(quiet: bool) {
     if release.version <= current {
         return;
     }
-    eprintln!(
+    crate::output::diagnostic!(
         "syq: update {} is available; run `syq --self-update`",
         release.version
     );
@@ -249,7 +249,7 @@ pub(crate) fn verified_current_helper(helper: &TrustedCurrentHelper) -> Result<V
                 });
             }
             Err(error) => {
-                eprintln!(
+                crate::output::diagnostic!(
                     "syq: warning: cached remote helper failed integrity verification ({error}); discarding it"
                 );
                 fs::remove_file(&cache_path).with_context(|| {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -4244,6 +4244,35 @@ exit 22
 }
 
 #[test]
+fn helper_install_and_upload_fallback_survive_broken_stderr() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    setup_release_bootstrap(&t);
+    executable(&t.path("remote-bin/curl"), b"#!/bin/sh\nexit 22\n");
+    write(
+        &t.path("src"),
+        b"helper installed despite missing diagnostics",
+    );
+    let remote = format!("fake:{}", t.s("dst"));
+    let (reader, writer) = std::os::unix::net::UnixStream::pair().unwrap();
+    drop(reader);
+    let output = remote_syq_command(&t, &rsh, &["-a", &t.s("src"), &remote])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(std::os::fd::OwnedFd::from(writer)))
+        .start()
+        .unwrap()
+        .wait_with_output()
+        .unwrap();
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("dst")), read(&t.path("src")));
+    assert_eq!(
+        read(&cached_remote_helper(&t)),
+        read(Path::new(env!("CARGO_BIN_EXE_syq")))
+    );
+}
+
+#[test]
 fn missing_remote_hasher_skips_download_and_uploads_verified_binary() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
@@ -11430,6 +11459,60 @@ fn native_detach_does_not_report_an_immediate_setup_failure_as_started() {
         "immediate setup failure waited for the full readiness timeout"
     );
     assert!(!t.path("dst").exists());
+}
+
+#[test]
+fn native_detach_broken_stdout_reports_running_job_without_panicking() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("src"), b"detached");
+    let (reader, writer) = std::os::unix::net::UnixStream::pair().unwrap();
+    drop(reader);
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--rsh"])
+        .arg(&rsh)
+        .args([
+            "--syq-path",
+            env!("CARGO_BIN_EXE_syq"),
+            "--no-tcp",
+            "-j",
+            "1",
+            "--detach",
+            "--from",
+            "hostA",
+            "--src",
+            &t.s("src"),
+            "--to",
+            "hostB",
+            "--as",
+            &t.s("dst"),
+            "-q",
+        ])
+        .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(std::os::fd::OwnedFd::from(writer)))
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap()
+        .wait_with_output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "{}", stderr_of(&output));
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("job started on hostA, log "), "{stderr}");
+    assert!(
+        stderr.contains("writing its location to stdout failed"),
+        "{stderr}"
+    );
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while fs::read(t.path("dst")).ok().as_deref() != Some(b"detached".as_slice())
+        && std::time::Instant::now() < deadline
+    {
+        eprintln!("waiting for detached job after handoff output failure");
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+    assert_eq!(read(&t.path("dst")), b"detached");
 }
 
 // ----------------------------------------------------------- review round 13

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -1,0 +1,188 @@
+//! Output failures must not replace filesystem outcomes or freeze telemetry.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::os::fd::OwnedFd;
+use std::os::unix::net::UnixStream;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn broken_output() -> Stdio {
+    let (reader, writer) = UnixStream::pair().unwrap();
+    drop(reader);
+    Stdio::from(OwnedFd::from(writer))
+}
+
+fn command(directory: &std::path::Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+    command
+        .current_dir(directory)
+        .env("SYQ_NO_UPDATE_CHECK", "1")
+        .env("XDG_CONFIG_HOME", directory.join("config"))
+        .stdin(Stdio::null());
+    command
+}
+
+fn terminal(path: &std::path::Path) -> serde_json::Value {
+    let text = fs::read_to_string(path).unwrap();
+    serde_json::from_str(text.lines().last().unwrap()).unwrap()
+}
+
+#[test]
+fn closed_human_streams_preserve_copy_and_removal_results() {
+    for broken_stderr in [false, true] {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().canonicalize().unwrap();
+        fs::write(root.join("src"), b"output failure must not lose this").unwrap();
+        for (mode, args, result) in [
+            (
+                "copy",
+                vec!["cp", "--src", "src", "--as", "dst", "-v", "--progress-json"],
+                "copy.json",
+            ),
+            (
+                "remove",
+                vec!["rm", "dst", "--progress-json"],
+                "remove.json",
+            ),
+        ] {
+            let output = command(&root)
+                .args(args)
+                .args(["--results", result])
+                .stdout(broken_output())
+                .stderr(if broken_stderr {
+                    broken_output()
+                } else {
+                    Stdio::piped()
+                })
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "{mode}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let record = terminal(&root.join(result));
+            assert_eq!(record["type"], "result");
+            assert_eq!(record["exit_code"], 0);
+            if mode == "copy" {
+                assert_eq!(
+                    fs::read(root.join("dst")).unwrap(),
+                    fs::read(root.join("src")).unwrap()
+                );
+            } else {
+                assert!(!root.join("dst").exists());
+            }
+            if !broken_stderr {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                assert_eq!(
+                    stderr
+                        .matches("could not write human output to stdout")
+                        .count(),
+                    1,
+                    "{stderr}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn closed_stderr_preserves_failure_exit_status() {
+    let directory = tempfile::tempdir().unwrap();
+    let output = command(directory.path())
+        .args([
+            "cp",
+            "--src",
+            "missing",
+            "--as",
+            "dst",
+            "--results",
+            "result.json",
+        ])
+        .stderr(broken_output())
+        .output()
+        .unwrap();
+    let code = output.status.code().unwrap();
+    assert_ne!(code, 0);
+    assert_ne!(code, 101);
+    assert_eq!(
+        terminal(&directory.path().join("result.json"))["exit_code"],
+        code
+    );
+}
+
+#[test]
+fn full_stdout_keeps_results_progress_running() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().canonicalize().unwrap();
+    fs::write(root.join("src"), b"data").unwrap();
+    let (mut reader, mut writer) = UnixStream::pair().unwrap();
+    // Fill the sink before starting syq, then restore blocking writes. A
+    // verbose dry run will block on its first stdout line deterministically.
+    writer.set_nonblocking(true).unwrap();
+    let bytes = [0; 8192];
+    loop {
+        match writer.write(&bytes) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(error) => panic!("fill stdout: {error}"),
+        }
+    }
+    writer.set_nonblocking(false).unwrap();
+    let mut child = command(&root)
+        .args([
+            "cp",
+            "--src",
+            "src",
+            "--as",
+            "dst",
+            "-nv",
+            "--results",
+            "result.json",
+        ])
+        .stdout(Stdio::from(OwnedFd::from(writer)))
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(8);
+    let mut sampled_times = std::collections::BTreeSet::new();
+    let mut last_report = Instant::now();
+    while Instant::now() < deadline {
+        if let Ok(text) = fs::read_to_string(root.join("result.json")) {
+            for line in text.lines() {
+                if let Ok(record) = serde_json::from_str::<serde_json::Value>(line) {
+                    if record["type"] == "progress" {
+                        sampled_times.insert(record["elapsed_ms"].as_u64().unwrap());
+                    }
+                }
+            }
+        }
+        // Three samples span at least two seconds while stdout remains full.
+        if sampled_times.len() >= 3 || child.try_wait().unwrap().is_some() {
+            break;
+        }
+        if last_report.elapsed() >= Duration::from_secs(1) {
+            eprintln!("waiting for progress with full stdout: {sampled_times:?}");
+            last_report = Instant::now();
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    // Release the sink even on a regression, so the child and ticker can exit.
+    let drain = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).unwrap();
+    });
+    let output = child.wait_with_output().unwrap();
+    drain.join().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        sampled_times.len() >= 3,
+        "ticker stalled; last observed samples: {sampled_times:?}"
+    );
+    assert_eq!(terminal(&root.join("result.json"))["exit_code"], 0);
+}


### PR DESCRIPTION
Closed output readers could make copy/removal summaries panic, poison connection state during an SSH fallback warning, or discard a receiver receipt when forwarding human output failed. A full stdout pipe also held the progress display lock and stopped its ticker.

Human diagnostics and copy/removal summaries now use non-panicking writes. Stdout failures attempt one warning without changing the filesystem outcome. TCP fallback releases its state mutex before printing; helper installation retains its serialization. Redirected stdout writes release the display lock so a separate writable progress/results stream can continue.

The receipt relay stops forwarding human output after a local write failure but continues collecting and verifying the receipt. Receipt protocol writes still report errors. Detach returns a handled error if it cannot print the already-running job's location, and attempts to include that location on stderr.

Writes remain synchronous: a slow consumer can still block the worker writing to it. This does not introduce output queues or change the existing results-stream failure policy. Documentation describes these behaviors.

Validation on Linux:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`: 412 unit tests and 383 integration tests passed.
- `scripts/test-real-ssh.sh`: default three-container OpenSSH suite passed, including restricted-receiver and SSH fallback paths.
- `scripts/check-doc-links.py`: 13 files checked, no problems.

New regressions exercise broken stdout/stderr, preserved copy/removal outcomes, failed results-stream diagnostics, worker TCP fallback, helper installation/upload fallback, detach handoff failure, progress with a full stdout stream, and verified receipt settlement after output write/flush failures.
