### PR TITLE
Complete the docs audit after the documentation rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/greaber/syq/releases/la
 
 No `sudo` is needed; the binary lands in `~/.local/bin`. Homebrew
 (`brew install greaber/tap/syq`) and Cargo (`cargo install --locked syq`) also
-work. Remote hosts need nothing installed in advance.
+work. With the installer or Homebrew, syq installs its matching remote helper
+on first use. Cargo builds need a compatible remote `syq`; see the
+[installation guide](https://greaber.github.io/syq/install.html#cargo).
 
 Bash, Zsh, and fish completion includes remote paths and becomes especially
 fast with `syq persist on`; see the [installation guide](https://greaber.github.io/syq/install.html#shell-completion).

--- a/design/performance.md
+++ b/design/performance.md
@@ -1,0 +1,103 @@
+# Performance measurements and tuning rationale
+
+This note preserves measurement provenance and implementation detail that was
+removed from the user-facing speed guide on 2026-09-05. The measurements are
+historical observations, not new benchmark runs. The tuning description is a
+snapshot of `master` at `87c63e7`; the code in `src/tune.rs` and
+`src/transfer.rs` defines current behavior.
+
+## Path-safety measurements, 2026-09-04
+
+The descriptor-rooted implementation was measured separately on 2026-09-04,
+comparing the pre-confinement revision `0382c06` with a build of the Linux
+`openat2` implementation later committed as `e4de953` on top of master
+`37ab73a` (benchmarked binary SHA-256 prefix `4e2687350003`). Each campaign
+used 32 connections, checksum verification, a 100,000-file mixed-depth tree
+holding 100 MiB, and both tool orderings. File pages were evicted where
+possible, but dentry and inode caches remained warm.
+
+On local ext4, the rooted build took 3.27–3.32 s median by ordering versus
+2.17–2.22 s before confinement, a 47–53% increase on a deliberately short,
+metadata-heavy workload. A shallow 100,000-file tree increased by 12–18%, and
+the sub-second no-change case showed no stable difference. The absolute
+mixed-tree cost was about 1.1 seconds per 100,000 files.
+
+On a same-datacenter NFSv4 mount, five local-to-NFS fresh-copy samples had
+combined medians of 46.45 s rooted and 44.05 s before confinement; the sample
+ranges overlapped widely (41.19–50.96 s and 38.43–52.58 s). The NFS-to-local
+campaign had the same 8.93 s combined median for both builds. A destination
+no-change campaign did not expose a rooted penalty. NFS metadata probes varied
+from 552 to 1,264 files/s during these runs, so the measurements rule out a
+large consistent regression in this setup rather than a small one. They are
+not a performance guarantee for other servers, mount options, cache states, or
+tree shapes.
+
+## Small-file SSH connection reuse
+
+On a long path (262 ms), a fresh 2,000-file / 8 MiB tree over
+`--syq-no-tcp` took 11.29 s in two verified runs after fresh-small-file workers
+began reusing the authenticated control connection, versus 16.85 s with eight
+independently authenticated worker connections. Larger and mixed workloads
+still use independent SSH connections so they keep multi-flow throughput.
+
+This measurement is preserved from the speed guide at `87c63e7`. Reuse applies
+to new files no larger than one transfer block under the default SSH command,
+with no nonzero bandwidth limit. The comparison above was recorded before
+this documentation follow-up; it was not rerun for it.
+
+## Sequential NFS writer comparison
+
+The speed guide at `87c63e7` recorded a fresh 4 GiB `/raid` to asynchronous NFS
+copy taking 21.44 seconds with 32 range writers. With one sequential writer
+on the destination, the median was 9.93 seconds versus 10.94 seconds for `cp`
+(two interleaved runs). The reverse NFS-to-local copy reached 1.13 GiB/s with
+parallel range reads. These are historical measurements, not a promise for
+other mounts; an explicit fixed worker count above one disables the sequential
+fallback described by the comparison.
+
+## Connection-tuning measurements and rationale
+
+Useful progress (the high-water mark of logically completed bytes, plus a small
+credit per completed file so small-file trees count) is sampled every 2.5 s.
+Recovery can retract uncertain bytes, and retransmitting those same bytes does
+not inflate the rate the auto-tuner measures. A count has been *measured*
+only once two
+consecutive samples agree within 10 %, so a burst that gets throttled or a link
+still ramping up is waited out (up to 20 s) rather than credited to the last
+change. The first probe is a 1.3× step up (8→10, not 8→16). A step up is kept
+only when the smaller count is more than 5 % below the best recent measurement;
+a step down is kept when it stays within 5 %. Thus acceptance directly follows
+the objective: the smallest measured count within 5 % of the best observed
+speed, from 1 through 64. A successful move keeps exploring in the same
+direction. A failed move returns to the last good count and records a bound, so
+later probes refine untested integers: if 10→13 helps and 13→17 is flat, syq
+stays at 13 and can later try 11 rather than immediately falling back to 10.
+
+In steady state, evidence in the upward and downward directions ages and backs
+off independently. A direction is first eligible again after 6 stable
+measurements (about 30 seconds at minimum); repeated failures double only that
+direction's delay, up to 4 minutes at the minimum sampling rate. When both
+directions are equally informative, syq deterministically probes up first:
+most connection/throughput curves are concave or saturating, so an extra
+connection usually loses less transfer speed than removing a useful one. This
+is a starting assumption, not a rule: measured collapse aborts a probe early,
+and independent backoff lets downward evidence win.
+
+Upward candidates connect in the background while the current workers keep
+copying; their stable rate refreshes the comparison baseline, while connection
+setup time itself is not scored. A probe starts only when the activity remaining
+at the observed rate is estimated to last through a complete measurement, so a
+slow path is not rejected by a fixed byte threshold and a very fast tail is not
+mistaken for evidence. After a decision, surplus connections and their reader
+threads are closed instead of keeping the largest pool ever tried. At one
+active connection syq keeps exactly one ready spare so the important 1→2 probe
+remains cheap. A dropped data connection is reopened with bounded exponential
+backoff; ranges whose acknowledgement or final rename into place is uncertain
+are safely requeued. Transfers shorter than a measurement or two just run with the
+starting count. The progress line shows the current count
+(`16 conn`), and `--stats` reports the path it took
+(`connections: auto: settled at 16 (path 16, peak 16)`).
+
+Counts are persisted only for copies with a remote endpoint. Local filesystem
+paths, including mounted NFS, do not produce a cache key. Failed, short,
+fixed-count, and mixed-transport runs do not update the cache.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -13,7 +13,7 @@
 # Performance
 
 - [Speed](speed.md)
-- [Server tuning](server-tuning.md)
+- [Server setup](server-tuning.md)
 
 # Trust
 
@@ -22,4 +22,4 @@
 
 # Compatibility
 
-- [Rsync compatibility record](rsync-compat.md)
+- [Rsync compatibility](rsync-compat.md)

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -45,9 +45,9 @@ The results stream is always written on the machine you invoke syq from. A
 local removal and a removal over plain SSH both send each entry's outcome back
 to that machine. The restricted receiver (the command-restricted receiver, a
 forced command on hostB that syq installs when you enroll a destination)
-deliberately rejects native removal: the signed grants it accepts currently
-authorize copy writes only, and no permission or limit for deletion is
-inferred from them.
+rejects native removal: a signed grant authorizes the changes of one copy,
+including that copy's `--prune` deletions under an explicit `--max-delete`
+ceiling. There is no grant form for `syq rm`.
 
 For a remote-to-remote copy there are two ways to fill the stream. Through the
 restricted receiver, the stream is **receiver-attested**: built from hostB's
@@ -78,8 +78,11 @@ immediately. If writing the stream itself fails, syq warns once on
 stderr and stops writing; the consumer detects this as a missing
 terminal record. Argument and usage errors exit `2` with no stream at
 all: a consumer constructs its own argv, so a usage error is a
-consumer bug and gets no JSON. Every run that gets past argument
-parsing emits a terminal record, fatal setup failures included.
+consumer bug and gets no JSON. If the stream cannot be opened (the results
+file already exists, or the descriptor is closed or read-only), syq exits `1`
+with no stream. Once the stream is open, a completed run emits a terminal
+record, fatal setup failures included, provided the stream stays writable.
+A crash or interruption can also leave it incomplete.
 
 ## Record envelope
 
@@ -160,8 +163,7 @@ counted in the terminal record only. Metadata-only updates (permissions,
 ownership, or times reconciled on an otherwise unchanged object, that is,
 an unchanged file, directory, symlink, or special file) are not reported
 per operation in v1: a live run emits no record for them, while a dry run
-does emit a `metadata_differs` trace for the same situation. Closing that
-asymmetry with a metadata result action is a candidate additive extension.
+does emit a `metadata_differs` trace for the same situation.
 
 Copy streams use `trace` and `operation_result`; removal streams use the next
 three record types instead.
@@ -228,8 +230,8 @@ an `object` that is `{"state": "absent"}`, an observation failure
 (`state`, `code`, `message`), or `{"state": "present"}` with `kind`
 (the receiver's precise vocabulary: `dir`, `file`, `symlink`, `fifo`,
 `socket`, `character_device`, `block_device`, `other`), `size`,
-`metadata` (mode/uid/gid/mtime), and, under `--receiver-receipt digests`, a
-`digest` (`{"algorithm": "blake3", "value": <hex>}`), plus
+`metadata` (`mode`, `uid`, `gid`, `mtime`, `mtime_nsec`, `rdev`), and, under
+`--receiver-receipt digests`, a `digest` (`{"algorithm": "blake3", "value": <hex>}`), plus
 `symlink_target` where applicable. Final states are what a verifier
 audits: they describe the tree hostB ended with, not what the transfer
 said it did.

--- a/docs/composability.md
+++ b/docs/composability.md
@@ -57,8 +57,9 @@ Several guarantees make the plan more than a printout:
 - **`--dry-run` and `--syq-verify-only` are read-only by construction.** For a
   remote-to-remote copy through the restricted receiver (the command-restricted
   receiver, a forced command on hostB that syq installs when you enroll a
-  destination), the signed grant that authorizes the copy marks them read-only,
-  and the receiver rejects every write even if the sending host attempts one.
+  destination), the signed grant marks a dry run read-only, and the receiver
+  rejects every write even if the sending host attempts one. Verification-only
+  is an rsync-mode option; it cannot run between two remote endpoints.
 
 What a plan does not give you is a transaction. A filesystem cannot make a
 change to several files all-or-nothing: permissions can change or a disk can
@@ -94,9 +95,10 @@ or a stream can express too:
   them, any tool that edits JSON can reshape a transfer, and syq checks the
   whole manifest for conflicting destinations before a byte moves:
 
-  ```sh
+  ```bash
+  set -o pipefail
   syq map --srcs-in photos \
-    | jq 'select(.kind == "file")
+    | jq -c 'select(.kind == "file")
           | .dst.value = (.mtime | gmtime | strftime("%Y/%m")) + "/" + .dst.value' \
     | syq cp --mapping - -C photos --to nas --into /archive
   ```
@@ -137,10 +139,14 @@ or a stream can express too:
   hostA reported, each record marked `"provenance": "receiver_attested"`,
   while the data flows directly between the hosts; without an enrollment, the
   run fails unless `--coordinate-at local` explicitly routes the data through
-  your machine. Failed operation records carry `src`, `dst`, and `kind`, so
-  once the terminal record says the run finished, a retry manifest is one
-  filter away. The [mappings guide](mappings.md#machine-readable-results) has
-  that filter, including the terminal-record check. This is what an exit code
+  your machine. A remote-to-remote dry run with `--results` always needs
+  `--coordinate-at local`, because only that coordinator produces the trace
+  stream. Failed mapping entries carry `src`, `dst`, and `kind`; failed
+  implicit ancestor directories can lack `src` and are non-retryable. Ordinary
+  copy and deletion records have no `src`. Once the terminal record says the
+  mapping run finished, a retry manifest is one filter away. The
+  [mappings guide](mappings.md#machine-readable-results) has that filter,
+  including the terminal-record check. This is what an exit code
   cannot express: which entries failed, and whether a retry could help.
 
 ## Reruns converge

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,10 +54,11 @@ degree with speed and composability. It is mainly a replacement for `cp`, not
 `rm` or `mv`, but `cp` is the command that most needed replacing, and rsync's
 `--delete` adds mirroring, which the classical commands never had.
 
-Syq aims to do most of what rsync does while doing better on all four counts.
-Today its biggest strengths are speed and secure remote-to-remote transfers.
-Its composability story is still developing but is arguably already ahead of
-rsync's. On filesystem hardening, rsync, and especially [its security
+Syq's biggest strengths are speed and secure remote-to-remote transfers.
+Its composability comes from planning before acting: a dry run reports what
+would change, mappings let a program choose placement, and a results stream
+reports each operation's outcome. On filesystem hardening, rsync, and
+especially [its security
 design](https://github.com/RsyncProject/rsync/blob/v3.5.0/SECURITY.md), has
 been a great teacher; native `cp` and `rm` now follow the same design, and the
 remaining differences are documented rather than hidden.
@@ -120,7 +121,9 @@ time it connects, one per version, so both ends always run
 matching code. The remote downloads the release directly when it has the tools,
 or the local machine uploads it. Either way the binary is checked against a
 signed release manifest, verified with a public key compiled into your local
-syq, before it runs.
+syq, before it runs. This requires an official release build; Cargo and
+checkout builds need a compatible remote `syq`, as
+[Installing](install.md#cargo) explains.
 
 **Direct remote-to-remote transfers.** Rsync cannot copy between two remote
 hosts from your laptop. You download and re-upload, at your laptop's bandwidth,

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,10 +1,10 @@
 # Installing syq
 
 Syq runs on Linux and macOS. The local machine needs one of the installation
-paths below; remote hosts need nothing installed in advance, because the first
-time syq connects to a remote host it installs the remote helper there, a copy
-of syq of the matching version (see [Remote helper
-bootstrap](#remote-helper-bootstrap)).
+paths below. With the standalone installer or Homebrew, syq installs a
+matching copy of itself on remote hosts the first time it connects (see
+[Remote helper bootstrap](#remote-helper-bootstrap)). A Cargo or checkout
+build needs a compatible remote `syq`, as the [Cargo section](#cargo) explains.
 
 ## Standalone installer
 
@@ -21,7 +21,7 @@ performs, do not depend on either command.
 
 To inspect it first, download the same URL without piping it to `sh`. Every
 release also has an immutable versioned installer, for example
-`https://github.com/greaber/syq/releases/download/v0.1.0/install.sh`. To choose
+`https://github.com/greaber/syq/releases/download/v0.1.8/install.sh`. To choose
 another directory, download the script and run `sh install.sh --bin-dir DIR`
 (or pipe it to `sh -s -- --bin-dir DIR`). The script detects your platform,
 verifies the archive's embedded SHA-256 and size, runs the temporary binary to
@@ -69,7 +69,7 @@ the line for your shell to its startup file:
 # Bash (~/.bashrc)
 eval "$(syq completion bash)"
 
-# Zsh (~/.zshrc)
+# Zsh (~/.zshrc), after `autoload -Uz compinit && compinit`
 source <(syq completion zsh)
 ```
 
@@ -101,15 +101,16 @@ with `brew upgrade syq`.
 Release binaries are published for Linux x86-64/ARM64 and macOS Apple
 Silicon/Intel. Terminal downloads and Homebrew normally do not attach macOS's
 quarantine attribute, which is why command-line tools installed this way do not
-usually produce Gatekeeper prompts. A binary downloaded through a browser may;
-browser-oriented distribution would need Apple Developer ID signing and
-notarization in addition to this terminal-first path.
+usually produce Gatekeeper prompts. The binaries are not Developer ID signed
+or notarized by Apple, so a browser download may prompt or be blocked by
+Gatekeeper. Use the terminal installer or Homebrew for the documented
+installation path.
 
 ## Remote helper bootstrap
 
-The remote side of a copy runs the remote helper, but nothing needs to be
-installed or configured there first. An official release build runs a helper
-of exactly its own version, kept on the remote under `~/.cache/syq/helpers/`.
+With an official release build, nothing needs to be installed on the remote
+host in advance. Syq installs a helper of exactly its own version, kept on the
+remote under `~/.cache/syq/helpers/`.
 On first use of a version it detects the remote
 platform and checks for a downloader, SHA-256 implementation, and `gzip`. When
 that complete toolchain is available, the remote downloads the matching
@@ -153,9 +154,9 @@ Git-derived identity when an explicit source-built helper is used.
 Syq runs your own `ssh`, so your configuration, keys, agent, and known hosts
 apply unchanged. Copies between your machine and a remote host need nothing
 special. A copy between two remote machines forwards the constrained agent
-broker (a temporary stand-in for your ssh agent that holds no keys and passes
-on only signing requests for that copy) to the coordinator, the host that runs
-the copy, by default, and that relies on OpenSSH features from release 8.9
+broker (a temporary local SSH agent that signs only for the intended
+destination) to the coordinator, the host that runs the copy, by default.
+This relies on OpenSSH features from release 8.9
 (February 2022):
 the client on your machine and on the coordinator host must be 8.9 or newer,
 and so must the `sshd` on the other remote. Syq checks the two clients it runs

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -43,9 +43,10 @@ One JSON object per line (NDJSON):
   removes any ambiguity: mapping a file and mapping a directory
   (non-recursively; entries are never recursive) are different
   operations. If the object at `src` (an object is a file, directory,
-  symlink, or special file) is not the declared kind, that entry fails,
-  exactly as if `src` did not exist. Without `kind`, the entry maps
-  whatever is there.
+  symlink, or special file) is not the declared kind, that entry fails and
+  the run continues. Its result is `conflict` with `retryable: "no"`; a missing
+  source instead produces `io` / `not_found` with `retryable: "unknown"`.
+  Without `kind`, the entry maps whatever is there.
 - `size`, `mtime` (optional, informational): emitted by `syq map` for
   transforms to filter on; execution ignores them. Unknown keys are
   rejected, so a typo cannot be silently dropped.
@@ -236,11 +237,12 @@ those farms fall short, see [use-cases/link-farms.md](https://github.com/greaber
 - `syq map` accepts the same local selectors as native `cp`, including the
   typed selectors `--src-file`/`--src-dir`, plus `--as PATH` (which emits the
   single selected path at `PATH`, honoring the whole path rather than only
-  its last component). Those selectors are validated exactly as native `cp`
-  validates them; see "Emitting a mapping" for the complete list.
-- What is preserved follows the native default (the equivalent of rsync's
-  `-rlt`). There is no per-entry setting: what is preserved and how files
-  are compared stay the same for the whole run.
+  its last component). Source types and follow options work as in native
+  `cp`; named map selectors also need to stay inside their source base, as
+  described below. See "Emitting a mapping" for the complete list.
+- Preservation follows the native default (the equivalent of rsync's
+  `-rlt`) unless you add `--preserve`. What is preserved and how files are
+  compared stay the same for the whole run; there is no per-entry setting.
 - An entry claims exactly one object. A `dir` entry claims the
   directory itself, without its contents.
 - The command-line path naming a manifest, the `-C`/`--root` source base, and the
@@ -271,10 +273,13 @@ those farms fall short, see [use-cases/link-farms.md](https://github.com/greaber
   swap cannot change which tree is emitted. With `--follow-src`, a named
   selector's emitted `src` comes from the same step-by-step walk that opened
   the handle, not from a second `realpath` lookup.
-- `-C` is only a base for resolving paths: selectors typed on the command line
-  may contain `.` and `..` and may resolve outside it. `--root` is mutually
-  exclusive with `-C` and keeps those selectors inside the selected root
-  directory, whose open handle syq keeps for the whole run. A mapping emitted
+- `-C` is a base for resolving paths: selectors may contain `.` and `..`.
+  Named `syq map` selectors must still be relative and resolve inside that
+  base, because their emitted `src` paths are relative to it. A contents
+  selector (`--srcs-in DIR`) can point anywhere; its entries are relative to
+  `DIR` itself. `--root` is mutually exclusive with `-C` and keeps every
+  selector inside the selected root directory, whose open handle syq keeps
+  for the whole run. A mapping emitted
   from a contents selector is relative to the selected directory, so the
   `syq cp` that consumes it must use that directory as its source base. These
   rules for command-line paths do not relax the strict manifest format
@@ -283,12 +288,12 @@ those farms fall short, see [use-cases/link-farms.md](https://github.com/greaber
   a symlink maps as a symlink, and a destination path that would traverse a
   symlink inside the destination container fails that entry. Resolve links before
   emitting the manifest if you want the files they point to instead.
-- `kind: "special"` asserts the source's type; it does not override the
-  fixed `-rlt` preservation default, which copies no special files. Such an
+- `kind: "special"` asserts the source's type; it does not by itself enable
+  copying special files. Under the default preservation settings, such an
   entry is excluded by rule, like a file under `--min-size`: the run still
-  succeeds and the entry is only counted among the excluded files in the
-  summary. Filter with `jq -c 'select(.kind != "special")'` to drop such
-  entries up front.
+  succeeds and the entry is counted among the excluded files in the summary.
+  Pass `--preserve=specials` to copy it, or filter with
+  `jq -c 'select(.kind != "special")'` to drop such entries up front.
 - A mapping does not define a destination area to prune (there is no rule for
   which paths would count as destination-only), so `--mapping` cannot be
   combined with `--prune`.
@@ -329,14 +334,10 @@ terminal status other than `success` or `partial` means some entries may
 never have been resolved.
 
 The results stream is always written on the machine you invoke syq from.
-For a remote-to-remote copy through the restricted receiver (the
-command-restricted receiver, a forced command on hostB that syq installs
-when you enroll a destination), the stream is receiver-attested: built
-from hostB's signed receipt rather than from what hostA reported, with
-each record marked `"provenance":"receiver_attested"`, while the data
-flows directly between the two hosts. Without an enrollment the run fails
-unless `--coordinate-at local` explicitly routes the data through your
-machine. `--results` cannot be combined with `--detach`, because the
+A mapping copy requires one local endpoint; `--mapping` refuses two remote
+endpoints. General remote-to-remote results, including receiver-attested
+streams, are covered in [Automation results](automation.md#the-channel).
+`--results` cannot be combined with `--detach`, because the
 caller would no longer be attached for the complete stream and its
 terminal record. A named file is created fresh inside its parent
 directory, which syq opens first and keeps open; an existing entry is
@@ -345,8 +346,9 @@ the link's resolved target, so replacing the link later cannot redirect
 the output. Use an inherited `--results-fd` when the caller needs another
 kind of output, such as a pipe or socket.
 
-Failed operation records carry `src`, `dst`, and `kind`, so a retry
-manifest is one filter away:
+Failed records for entries in the mapping carry `src`, `dst`, and `kind`,
+so a retry manifest is one filter away. A failed implicit ancestor directory
+has no `src` and is marked `retryable: "no"`; the filter below skips it:
 
 ```bash
 set -o pipefail
@@ -364,10 +366,9 @@ jq -cs 'if (.[-1].type? // "") != "result"
 
 The jq program first checks the stream's terminal record: a results
 file without one is from a run that did not finish (a crash, a kill),
-and a terminal status other than `success` or `partial` (an `aborted`
-incomplete receipt or a `refused` run) means queued entries were never
-resolved or their receipt records may be missing. In both cases, entries
-may have no records at all, so a retry manifest built from
+and a terminal status other than `success` or `partial` means the run stopped
+early, for example on a manifest error after the stream opened. In either
+case, entries may have no records at all, so a retry manifest built from
 what is there would look complete while it is not. With the
 terminal record present, the filter is what an exit code cannot
 express: which entries failed, and whether a retry could help.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -19,7 +19,8 @@ syq cp project --to server --into /backup       # named object → /backup/proje
 syq cp --srcs-in project --to server --into /app # project contents → /app
 syq cp --from server --cwd /data --src a --src b --into ./data
 syq cp --from server:2222 data --to backup:2200 --into /archive
-syq cp --from server data --to backup --coordinate-at dst --into /archive
+# Pull using credentials already on backup for server:
+syq cp --from server data --to backup --coordinate-at dst --peer-auth own-credentials --into /archive
 syq cp --src-file report --src-dir assets --into /backup
 syq cp --src-files a.txt b.txt --src-dirs images fonts --into /archive
 syq cp report --to server --as-new /reports/final
@@ -58,9 +59,14 @@ follow the placement. This rule makes every bare path's role clear and applies
 equally to local and remote copies.
 
 `--cwd DIR`/`-C DIR` changes where relative source selectors are resolved at
-the source endpoint. Copy selectors may be absolute and then ignore `--cwd`.
-Removal selectors are always relative; native `rm` rejects a leading slash and
-any `.` or `..` component.
+the source endpoint. For `cp` and `rm`, selectors may be absolute, or use
+`.` and `..` to resolve outside that base. `--cwd` changes where resolution
+starts; it does not confine a selection. `syq map` needs named selectors to be
+relative and resolve inside the base so it can emit relative source paths.
+A contents selector (`--srcs-in DIR`) may point outside the base instead.
+With `--root DIR` in place of `--cwd`, all three commands require relative
+selectors that stay beneath `DIR`; absolute paths, `~` paths, and `..` that
+would leave it are refused before anything changes.
 
 Bare paths and repeatable `--src PATH` select named objects (an object is a
 file, directory, symlink, or special file). A named directory keeps its
@@ -88,7 +94,7 @@ selected object rather than something to traverse, so a symlink there is
 copied as the link itself, not followed. A directory-required selector such as
 `--srcs-in` or `--src-dir` cannot use a symlink as its selected directory by
 default. `--follow-src` permits this traversal only in source paths you name,
-including `--cwd`, `rm --root`, and source selectors. `cp --follow-dst`
+including `--cwd`, `--root`, and source selectors. `cp --follow-dst`
 permits it only in the destination placement path. `--follow` is the umbrella:
 it enables both directions and also permits traversal in the control paths
 read by the coordinator (the process that runs the copy; for a
@@ -348,8 +354,7 @@ native copy may also use `--max-size SIZE` or `--min-size SIZE` to skip regular
 source files outside that inclusive range. Those files remain part of the
 source population, so `--prune` protects any corresponding destination paths.
 A remote-to-remote copy on the restricted path refuses `--min-size` and
-refuses `--max-size` with `--prune`, as described below. There, the restricted
-receiver independently enforces the signed total-size ceiling, the signed
+refuses `--max-size` with `--prune`. The restricted receiver independently enforces the signed total-size ceiling, the signed
 filters, and the signed choice between writing through partial files and
 writing in place. On a direct remote-to-remote copy through that receiver,
 `cp` also accepts the receiver ceilings `--receiver-max-entries N` and
@@ -377,9 +382,9 @@ structured outcomes from the endpoint, but the restricted receiver rejects
 native removal because its signed grants authorize copy changes only.
 `--mapping` cannot be combined with `--prune` because mapping manifests define
 no region to prune; `--results` covers `--prune` runs, including their
-removals. `--max-delete` requires
-`--prune`; `rm` additionally accepts `--root` plus its endpoint-side
-removal semantics.
+removals. `--max-delete` requires `--prune`. `cp`, `rm`, and `map` all accept
+`--root DIR` in place of `--cwd` to confine selectors beneath `DIR`. For `rm`,
+that directory also bounds the removal itself.
 
 Native `cp` exposes the remote runtime and transport controls
 directly: `--rsh COMMAND`, `--syq-path PATH`, `--no-bootstrap`, `--no-tcp`,
@@ -401,8 +406,9 @@ filename, and data is never routed through this machine implicitly.
 `--coordinate-at src` explicitly selects a direct push, `--coordinate-at dst`
 selects a direct pull, in which the destination host opens the SSH connection
 to the source host, and `--coordinate-at local` explicitly selects a relay
-through this machine. `--coordinate-at` is rejected for copies that do not have two remote
-endpoints.
+through this machine. The explicit values `src`, `dst`, and `local` are
+rejected for copies without two remote endpoints; `auto` is accepted
+everywhere.
 
 The default push (`--peer-auth restricted`) authenticates to the destination
 through the agent broker, which signs only for that destination, and writes
@@ -567,7 +573,7 @@ syq map --srcs-in photos \
   | syq cp --mapping - -C photos --to nas --into /pub
 ```
 
-`syq map` is local and destination-independent. Its options are `-C`,
+`syq map` is local and destination-independent. Its options are `-C` or `--root`,
 `--follow-src`/`--follow`, the source-selector family, and `--as PATH` for
 placing the single selected top-level object at `PATH`. Copy destinations,
 filtering, transfer policy, execution
@@ -608,9 +614,9 @@ names make clear that an rsync installation will not accept them.
 | Option | Meaning |
 |---|---|
 | `-a`, `--archive` | Same as `-rlptgoD` |
-| `-r` `-l` `-p` `-t` `-g` `-o` `-D` | Recursive; symlinks as symlinks; perms; mtimes; group; owner; devices and specials |
-| `-v`, `-vv` | `-v` lists files as they complete; for copies, `-vv` also explains remote helpers, candidate TCP addresses, the planned transport, and initial concurrency |
-| `-q` | Errors only |
+| `-r`/`--recursive`, `-l`/`--links`, `-p`/`--perms`, `-t`/`--times`, `-g`/`--group`, `-o`/`--owner`, `-D` | Recursive; symlinks as symlinks; perms; mtimes; group; owner; devices and specials |
+| `-v`/`--verbose`, `-vv` | `-v` lists files as they complete; for copies, `-vv` also explains remote helpers, candidate TCP addresses, the planned transport, and initial concurrency |
+| `-q`, `--quiet` | Errors only |
 | `-z`, `--compress` / `--no-compress` | Enable (the default) or disable zstd compression in syq's protocol; this is not `ssh -C` |
 | `-n`, `--dry-run` | Resolve mappings and transport, estimate transfers/exclusions/deletions; change nothing |
 | `--syq-connections N` | Syq extension: parallel data connections (default: auto-tuned, see [Speed](speed.md#how-many-connections)) |
@@ -645,7 +651,8 @@ names make clear that an rsync installation will not accept them.
 | `--files-from FILE` | Copy only the listed paths (relative to the one source directory; see below) |
 | `--from0` | `--files-from` entries are NUL-separated |
 | `--insecure-links` | Follow symlinks in the paths you name on this machine regardless of ownership, and walk source directories by path name, through symlinked parents; never applied to a remote endpoint, as in rsync |
-| `-h` | No-op for rsync compatibility; sizes are always human-readable. Use `--help` for help |
+| `-h`, `--human-readable` | No-op for rsync compatibility; sizes are always human-readable. Use `--help` for help |
+| `-V`, `--version` | Print the version |
 
 Like rsync, `-q` suppresses all non-error output: progress, summaries,
 notices, and `-v` file listings are hidden. Copy failures are still written to
@@ -1136,7 +1143,7 @@ each entry's destination path, use a native mapping instead (see
 ## Not implemented (on purpose, for now)
 
 [rsync-compat.md](rsync-compat.md) tracks rsync compatibility in full: what matches, what
-differs and why, what's missing, and the open issues. The short version:
+differs and why, and what's missing. The short version:
 
 - rsync filter rules (`--exclude`/`--include`/`--filter`); use the
   `--syq-ignore` extension (gitignore syntax) instead.

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -209,25 +209,13 @@ The signed publication policy distinguishes writing to a partial file and
 renaming it into place from `--inplace`; an in-place write opens and writes the
 final file relative to the open handle of the enrolled directory and cannot
 silently switch back to the partial-file method.
-The policy for objects that already exist at the destination is signed and
-enforced by the receiver. It can tell the receiver to create only: every
-creation and publication then refuses to replace anything, metadata or content
-changes to any non-directory that existed before the transfer are refused, and
-existing directories are reused, as in any copy. It can instead tell the
-receiver to update only: the receiver then refuses to create any object and
-ties each update to the object it observed, so an existing object cannot
-change type. These are policies inside the grant rather than options you type:
-the native commands do not have rsync mode's `--ignore-existing` and
-`--existing`, and rsync mode cannot run a remote-to-remote copy. What you can
-type is the placement: `--into-new`/`--as-new` and
-`--into-existing`/`--as-existing` travel as a signed precondition on the
-destination directory, checked against the enrolled directory when the grant
-is redeemed. `--inplace` is refused together with `--as-new` on this path,
-because an in-place write opens the final pathname directly and can neither
-refuse to replace nor be tied to an observed object.
-The native commands have no equivalent of rsync mode's `--update` (skip files
-that are newer on the destination), and the restricted path would refuse it
-anyway: it compares against source modification times that only hostA reports.
+
+Native placement options `--into-new`/`--as-new` and
+`--into-existing`/`--as-existing` are signed into the grant and checked against
+the enrolled destination when the grant is redeemed. `--inplace` is refused
+with `--as-new`: writing directly to the final path cannot guarantee that the
+copy will never replace an existing entry.
+
 `--mapping` and `--min-size` are refused because the receiver cannot check
 them independently of hostA.
 `--max-size` is enforced as a signed per-file limit, but is refused together
@@ -240,29 +228,20 @@ Deletion through the receiver (`cp --prune`) requires an explicit
 inside the scope is always stated on the command line rather than defaulting
 to a hundred million; `--max-delete 0` signs a grant that forbids deletion
 outright. The other signed ceilings default to 100 million entries and 8 TiB of
-file data; native `--receiver-max-entries` and `--receiver-max-bytes` lower them for one
-transfer, which bounds what a redeemed grant is worth to hostA. Every grant also
-carries two deadlines: hostA must start the transfer within 24 hours of the
-grant being issued, and the transfer must finish within 7 days of it.
+file data. `--receiver-max-entries` and `--receiver-max-bytes` replace those
+limits for one transfer and can increase or decrease them, within the allowed
+ranges. What hostA can do is bounded by these limits, whether you use the
+defaults or set your own. Every grant also carries two deadlines: hostA must
+start within 24 hours of issue and finish within 7 days of issue.
 
 `--dry-run` is read-only in a way hostA cannot override: the signed grant
 marks it read-only and the receiver rejects every mutation even if hostA sends
-one. (The native commands have no equivalent of rsync mode's
-`--syq-verify-only`.) A dry run uses an existing enrollment but does not
-install one; run `syq receiver enroll` first when previewing a new destination.
-A destination directory that is itself a symlink is also refused on this path;
-enroll the directory the link points to, so that the signed pathname and the
-opened directory identify the same object.
+one. A dry run uses an existing enrollment but does not install one; run
+`syq receiver enroll` first when previewing a new destination.
 
-One rsync-shaped edge case is handled conservatively inside the grant. In
-rsync's operand spelling, a named directory source such as `hostA:dir` lands
-either inside the destination or exactly at it, depending on whether the
-destination already exists; the grant authorizes only the reading where the
-destination is an existing directory, so if it does not exist, creating
-children at the exact-path reading is denied. The native commands avoid the
-ambiguity because `--as` and `--into` state the placement explicitly, and
-rsync mode cannot run a remote-to-remote copy in any case; create the
-destination directory first if that distinction ever matters.
+Enrollment never follows a destination-root symlink. Enroll the directory the
+link points to so the signed pathname and the opened directory identify the
+same object.
 
 ## Enrollment lifecycle
 

--- a/docs/rsync-compat.md
+++ b/docs/rsync-compat.md
@@ -1,119 +1,46 @@
 # rsync compatibility
 
-`syq rsync` is rsync mode: the syq command that accepts rsync's command line.
-This page records how far that goes: what behaves the same, what differs and
-why, what rsync has that syq doesn't, and the open issues. `README.md` and the
-other documents under `docs/` are the user-facing contract; when they and this
-page disagree, one of them needs fixing.
+`syq rsync` accepts rsync's command line for local copies, pushes, and pulls.
+This page describes which behaviors match, which differ, and which options
+are unavailable. See the [command reference](reference.md#rsync-compatibility)
+for the accepted options.
 
-Each entry says whether it was **measured** (run against upstream rsync 3.5.0
-at commit `7c20b077`, cross-checked with 3.2.7 where the version matters) or
-is **believed** (from documentation or memory, not yet tested). A raw run of
-the upstream rsync test suite is not a compatibility score: most of its
-failures come from unsupported options, protocol internals, daemon mode, or
-its harness. The automated matrix therefore reports raw observations alongside
-our product position on each behavior instead of reducing them to a percentage.
-
-Categories:
-
-- **Compatible**: same observable behavior.
-- **Compatible subset or approximation**: the common case agrees, but a
-  documented edge case, output detail, or implementation limit differs. Exact
-  emulation may be disproportionate to the compatibility value, but the
-  approximation must not hide failure or introduce unexpected data loss.
-- **Intentional divergence**: syq knowingly behaves differently, for
-  safety, product architecture, or another documented reason.
-- **Syq extension**: something rsync does not have. Every such long option
-  uses a `--syq-` name so scripts can tell it will not work with rsync.
-- **Not implemented**: rsync has it, syq doesn't yet, or the behavior belongs
-  only in syq's native mode.
-- **Open issues**: known gaps we intend to close, or decisions still to make.
-
-## Automated upstream test ledger
-
-`tests/rsync-compat/` turns the upstream audit into a repeatable CI check:
-
-```sh
-python3 scripts/rsync-compat.py
-```
-
-Use `--area security` for the focused security slice. Run it once as a
-non-root user and once as root: the root pass adds the foreign-owner symlink
-cases that a non-root user cannot construct. This selects security-classified
-tests from the same matrix; upstream does not provide a separate set of
-security tests.
-
-The manifest fixes rsync at commit `7c20b077` and defines one program under
-test, syq's rsync mode. Its configured `rsync`
-argument routes every upstream invocation through that subcommand without
-changing upstream test calls. `inventory.tsv` names all 351 tests at that
-commit; changing the commit without classifying every added or removed test is
-an error. The classifications deliberately distinguish:
-
-- relevant unmodified and adapted conformance tests;
-- user-visible features syq does not implement;
-- rsync daemon, wire-protocol, restricted-wrapper, build, and internal tests
-  that syq does not need to pass; and
-- an explicit unassessed category for future updates of that commit
-  (currently empty).
-
-Each runnable entry records a raw observation baseline separately from its
-product position: compatible, unimplemented, intentional divergence, undecided
-policy, or unresolved test claim. CI fails when the observation changes in
-either direction until it is reviewed, but an expected test failure is not
-misreported as a harness crash. Runner completeness and output parsing are
-checked independently. All 351 tests at that commit are classified: 38 are
-runnable, 130 require unsupported user-facing features, and 183 exercise
-rsync's own internals, protocol, daemon, or restricted wrapper. There are no
-unassessed tests. The runnable sources produce 40 independently reported
-scenarios. CI runs 36 scenarios as a non-root user, then those scenarios plus
-four root-only circumstances as root, and publishes JSON, Markdown, static
-HTML, and raw-log matrices rather than a headline score.
-
-The generated `tests/rsync-compat/LEDGER.md` is the readable per-test record;
-CI rejects it if it drifts from the manifest and inventory. An adapted test
-names a patch under `tests/rsync-compat/adaptations/`. Patches may translate an
-incidental implementation detail, such as where syq keeps its partial files,
-or isolate a supported scenario from an aggregate upstream test, but must
-preserve the behavior the test claims to check. Their provenance is visible in
-the matrix, including whether they alter an invocation, fixture, or tested
-subset. Git validates both the forward and reverse path sets before the exact
-patch bytes are applied, so adaptations cannot modify rsync sources or the
-runner outside `testsuite/`.
+**Measured** means compared with upstream rsync 3.5.0 at commit `7c20b077`,
+with 3.2.7 also checked where the version matters. **Believed** means based on
+upstream documentation rather than a direct comparison. The
+[test documentation](https://github.com/greaber/syq/tree/master/tests/rsync-compat)
+contains the test inventory and instructions for running it.
 
 ## Compatible
 
-The **Test** column names the function in `tests/local.rs` that checks the
-behavior; an entry without one is only believed, not covered by a test.
-
-| Behavior | Status | Test |
-|---|---|---|
-| Path rules: `src` copies the directory, `src/` its contents; a single file lands as `dest/file` when `dest` is a directory; several sources need a directory destination | measured | `trailing_slash_copies_contents`, `dir_into_existing_dir`, `dir_into_missing_dest_creates_basename`, `single_file_into_existing_dir`, `single_file_to_new_name`, `multiple_sources_require_dir_dest` |
-| Quick check: size + mtime; without `-t` every file is re-sent | measured | `updates_changed_file_and_skips_symlink_only_when_same`, `skip_reconciles_mode` |
-| `--delete` scope: only inside the directories being synced; a single-file source deletes nothing | measured | `delete_only_inside_directories_the_sources_map_onto`, `delete_with_nested_roots_deletes_once` |
-| Ignored/excluded paths are protected from deletion by default; `--delete-excluded` lifts that | measured | `delete_removes_extras_and_protects_ignored`, `delete_nested_roots_keep_their_own_anchored_ignores`, `delete_excluded_removes_ignored_destination_paths` |
-| A directory that can't be emptied because of protected content is reported and left (rsync: `cannot delete non-empty directory`; syq: `not deleting keep/: it holds ignored paths`) | measured | `delete_removes_extras_and_protects_ignored` |
-| Deletion is skipped when listing the source hit errors (rsync: `IO error encountered -- skipping file deletion`) | measured; see "Compatible subsets or approximations" 1 for the transfer-time case | `delete_is_skipped_when_the_source_scan_has_errors`, `unreadable_source_root_disables_delete` |
-| Files the source has but a rule skips (`-u`, `--existing`, `--ignore-existing`, `--max-size`/`--min-size`, symlinks without `-l`, specials without `-D`) are not deleted, even when the destination entry is a non-empty directory | measured on 3.2.7 and 3.5.0 (an earlier README claim that rsync deletes a `--max-size` casualty was wrong) | `delete_never_removes_paths_the_source_has_but_skips`, `delete_leaves_directory_contents_under_a_skipped_source_path`, `size_limits_filter_files_and_protect_them_from_delete`, `delete_keeps_partials_of_filtered_files` |
-| `-u`/`--update`: a destination regular file with a newer mtime is left alone | measured for regular files; see "Compatible subsets or approximations" for symlinks/devices | `update_skips_files_newer_on_the_destination` |
-| `--existing` / `--ignore-existing`, including `--existing` covering directories | measured | `ignore_existing_and_existing`, `existing_never_creates_the_destination_root`, `existing_leaves_a_file_where_a_source_directory_would_go`, `existing_dry_run_lists_no_missing_directories`, `existing_opens_up_readonly_dirs_even_after_a_symlinked_dir` |
-| `--max-size` / `--min-size` on regular files only; `K`/`M`/`G` suffixes | measured | `size_limits_filter_files_and_protect_them_from_delete`, `bad_size_limits_fail_before_anything_connects` |
-| `--files-from` baseline: paths relative to one source; implied parents created; a plain listed directory is copied without its contents unless `-r` is given explicitly (`-a` doesn't count); `--from0`; `-` reads stdin; blank entries and entries starting with `#` or `;` dropped in both separator modes (literal names remain reachable as `./#name` and `./;name`) | measured; entry *parsing* has gaps, open issue 1 | `files_from_copies_listed_paths_with_their_parents`, `files_from_treats_hash_and_semicolon_entries_as_comments`, `files_from_creates_listed_and_implied_dirs_without_r`, `files_from_repeats_and_late_listed_dirs_across_chunks`, `files_from_root_may_be_a_symlink_and_root_lines_are_rejected` |
-| `--delete-after` / `--delete-delay` accepted as synonyms of `--delete` (they describe what syq does) | by construction | `delete_after_and_delay_are_synonyms` |
-| `--max-delete N` exists and exits 25 when it trips | believed (exit code matches rsync); see "Intentional divergences" for positive-limit semantics | `max_delete_refuses_everything_past_the_limit` |
-| `--max-delete=0` reports destination-only entries without deleting them; `--max-delete=-1` is accepted as the historical synonym; without `--delete` the option has no effect | measured for syq; rsync behavior documented upstream | `max_delete_refuses_everything_past_the_limit` |
-| A destination symlink named on the command line is followed when owned by root or by the receiving process's effective uid; a component owned by anyone else is refused | measured, including absolute and relative root/cross-uid cases | `symlink_destination_is_followed`, `destination_root_symlink_preserves_target_metadata_for_both_spellings`, `existing_updates_through_a_destination_root_symlink_to_a_dir`, `foreign_owned_destination_root_symlink_is_refused` |
-| A symlink to a directory found *inside* the destination tree is replaced with a real directory; only the argument itself is followed (rsync without `-K`) | measured | `in_tree_destination_symlink_is_replaced_not_followed`, `existing_does_not_write_through_a_destination_symlink_dir` |
-| `-P`, `-h`, `--partial`, `--numeric-ids`, `-V` accepted as no-ops/aliases; common unsupported flags are rejected with an explanation | by construction | `rsync_compat_noops_are_accepted`, `unsupported_rsync_flags_explain_themselves` |
-| `-B` and `--block-size` select syq's transfer/hash block size | by construction | `checksum_repairs_silent_corruption` |
-| A remote source and remote destination are refused before connecting, as by rsync | by construction | `rsync_rejects_remote_to_remote` |
-| Source entries whose names look like syq's partial files (`.name.syq-part.<id>`) are copied as data like any other file (with one warning); only the exact case where a source path equals the partial file this copy would use for another file is refused, before anything is written | by construction (the check before anything is written, from PR #7) | `sidecar_named_source_directory_is_payload`, `delete_treats_sidecar_patterned_files_as_ordinary_extras`, `partial_named_symlink_is_a_symlink_not_a_leftover` |
+| Behavior | Status |
+|---|---|
+| Path rules: `src` copies the directory, `src/` its contents; a single file lands as `dest/file` when `dest` is a directory; several sources need a directory destination | measured |
+| Quick check: size + mtime; without `-t` every file is re-sent | measured |
+| `--delete` scope: only inside the directories being synced; a single-file source deletes nothing | measured |
+| Ignored/excluded paths are protected from deletion by default; `--delete-excluded` lifts that | measured |
+| A directory that can't be emptied because of protected content is reported and left (rsync: `cannot delete non-empty directory`; syq: `not deleting keep/: it holds ignored paths`) | measured |
+| Deletion is skipped when listing the source hit errors (rsync: `IO error encountered -- skipping file deletion`) | measured; see "Compatible subsets or approximations" 1 for the transfer-time case |
+| Files the source has but a rule skips (`-u`, `--existing`, `--ignore-existing`, `--max-size`/`--min-size`, symlinks without `-l`, specials without `-D`) are not deleted, even when the destination entry is a non-empty directory | measured on 3.2.7 and 3.5.0 |
+| `-u`/`--update`: a destination regular file with a newer mtime is left alone | measured for regular files; see "Compatible subsets or approximations" for symlinks/devices |
+| `--existing` / `--ignore-existing`, including `--existing` covering directories | measured |
+| `--max-size` / `--min-size` on regular files only; `K`/`M`/`G` suffixes | measured |
+| `--files-from` baseline: paths relative to one source; implied parents created; a plain listed directory is copied without its contents unless `-r` is given explicitly (`-a` doesn't count); `--from0`; `-` reads stdin; blank entries and entries starting with `#` or `;` dropped in both separator modes (literal names remain reachable as `./#name` and `./;name`) | measured; see [file-list parsing differences](#file-list-parsing-and-help) |
+| `--delete-after` / `--delete-delay` accepted as synonyms of `--delete` (they describe what syq does) | by construction |
+| `--max-delete N` exists and exits 25 when it trips | believed (exit code matches rsync); see "Intentional divergences" for positive-limit semantics |
+| `--max-delete=0` reports destination-only entries without deleting them; `--max-delete=-1` is accepted as the historical synonym; without `--delete` the option has no effect | measured for syq; rsync behavior documented upstream |
+| A destination symlink named on the command line is followed when owned by root or by the receiving process's effective uid; a component owned by anyone else is refused | measured, including absolute and relative root/cross-uid cases |
+| A symlink to a directory found *inside* the destination tree is replaced with a real directory; only the argument itself is followed (rsync without `-K`) | measured |
+| `-P`, `-h`, `--partial`, `--numeric-ids`, `-V` accepted as no-ops/aliases; common unsupported flags are rejected with an explanation | by construction |
+| `-B` and `--block-size` select syq's transfer/hash block size | by construction |
+| A remote source and remote destination are refused before connecting, as by rsync | by construction |
+| Source entries whose names look like syq's partial files (`.name.syq-part.<id>`) are copied as data like any other file (with one warning); only the exact case where a source path equals the partial file this copy would use for another file is refused, before anything is written | by construction |
 
 ## Intentional divergences
 
 Each item records the current reason syq does otherwise. Safety is one reason;
 architecture and disproportionate implementation cost can also justify a
-narrow divergence. If the reasoning stops holding, move the item.
+narrow divergence.
 
 1. **`--delete` runs after the transfer, always; no `--delete-before` /
    `--delete-during`.** rsync defaults to delete-during. syq's rule means a run
@@ -124,26 +51,21 @@ narrow divergence. If the reasoning stops holding, move the item.
    and others not. The cost is that space is never
    freed before writing. We consider "the transfer failed after it already
    deleted destination-only files" a worse outcome than "ran out of space."
-   *Tests: `delete_with_inplace_replacing_many_symlinks`,
-   `delete_removes_only_this_jobs_orphaned_sidecars`.*
 2. **A positive `--max-delete N` deletes *nothing* past the limit.** rsync
    deletes the first N and then stops. A safety cap that leaves the destination
    in a partially-deleted state is not much of a safety cap; syq refuses
    outright, says so, and exits 25 like rsync. Zero already means delete
-   nothing in both programs. *Test:
-   `max_delete_refuses_everything_past_the_limit`.*
-3. **`--files-from` follows symlinked implied parents and creates them as real
-   directories on the destination**, and refuses a listed symlink together with
-   a path through it. rsync's behavior here is version-sensitive (measured:
-   3.2.7 followed the parent and copied through it; 3.5 created the implied
-   directory, then refused the open with `ELOOP`). Either way, sending the
-   parent as a symlink would make a later write go *through* a destination
-   symlink to wherever it points, which is how a file list could redirect
-   writes outside the destination. Listing `data/foo` means "I want `foo`
-   under `data`"; syq does that and nothing else. *Tests:
-   `files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs`,
-   `files_from_leaves_no_ancestors_behind_on_a_bad_chain`,
-   `files_from_symlink_conflict_is_order_independent`.*
+   nothing in both programs.
+3. **`--files-from` refuses a source parent that is a symlink.** That entry
+   fails with exit 23 and leaves no implied directory at the destination;
+   other valid entries still copy. A listed symlink together with a path
+   through it is refused. Rsync's behavior depends on the version: 3.2.7
+   followed the parent, while 3.5 created an implied directory and then
+   refused the open. Syq refuses before creating that directory. On a local
+   source, `--insecure-links` allows the parent to be followed and creates it
+   as a real destination directory. A remote source always refuses traversal
+   through symlinked parents; the flag is never sent to it.
+
 4. **Two distinct sources mapping onto one destination file is an error.**
    Measured rsync silently keeps the first. Silent last-writer-wins (or
    first-writer-wins) on a collision is data loss with no message; syq refuses
@@ -151,12 +73,6 @@ narrow divergence. If the reasoning stops holding, move the item.
    scanning while keeping the original source count for placement. Naming
    the destination file itself as one of the sources is a conflict too, not a
    licence for the other source to overwrite it.
-   *Tests: `duplicate_destination_rejected`,
-   `exactly_repeated_sources_are_deduplicated_without_changing_placement`,
-   `dir_vs_file_destination_collision_rejected`,
-   `cross_source_collision_is_detected_before_any_change`,
-   `copy_onto_itself_among_sources_is_order_independent`,
-   `three_claimants_are_validated_as_a_group`.*
 
 5. **`--ignore-existing` keeps an existing non-directory even where the
    source maps a directory.** rsync exempts directories from the flag ("this
@@ -165,7 +81,6 @@ narrow divergence. If the reasoning stops holding, move the item.
    make room for a source directory. Under a flag whose whole meaning is
    "what exists is authoritative", that is unrecoverable data loss; syq keeps
    the file and skips the mapped directory with its subtree, with a notice.
-   *Test: `ignore_existing_keeps_a_file_where_a_source_directory_maps`.*
 
 ## Syq extensions
 
@@ -189,7 +104,7 @@ rejected because itemized output is not implemented.
 
 `--syq-verify-only` applies `-u`, size limits, `--existing`, and
 `--ignore-existing` to the scope it compares; it checks exactly what the
-corresponding copy would select. *Test: `verify_only_checks_the_filtered_scope`.*
+corresponding copy would select.
 
 ## Compatible subsets or approximations
 
@@ -198,25 +113,21 @@ corresponding copy would select. *Test: `verify_only_checks_the_filtered_scope`.
    otherwise look like one whose contents vanished. A read failure *during
    transfer* does not disable deletion: the failed file still counts as
    present on the source, so it is never treated as destination-only, and the
-   set of destination-only paths is unaffected. *Tests:
-   `unreadable_source_root_disables_delete`,
-   `delete_is_skipped_when_the_source_scan_has_errors`.*
+   set of destination-only paths is unaffected.
 2. **`-u` applies to regular files only.** rsync also compares mtimes for
-   symlinks and devices (believed, not measured). Low impact; could be
-   aligned. Deliberately, a *type change* replaces regardless of mtimes:
-   a source directory still replaces a newer destination file (as in
+   symlinks and devices (believed, not measured). A *type change* replaces
+   regardless of mtimes: a source directory still replaces a newer destination
+   file (as in
    rsync): `-u` is about not regressing newer file content, not about
    protecting whatever exists; that stronger promise is
    `--ignore-existing`'s (see "Intentional divergences" 5).
 3. **`--files-from` cannot combine with `--syq-ignore`/
    `--syq-ignore-from` or `--delete`.** Rsync allows filters and deletion with
    a file list. These are explicit restrictions rather than silent semantic
-   choices. Filters over a file list are a plausible later addition; deletion
-   scope under a file list is genuinely ambiguous and rsync's semantics for it
-   are murky. *Test:
-   `files_from_rejections_and_stdin`.*
+   choices. Syq does not apply filters to a file list or derive a deletion
+   region from it.
 4. **Deletions are executed over the SSH control connection** in batches of
-   1000 (the receiving side deletes a batch in parallel), not spread over
+   1000 (the destination deletes a batch in parallel), not spread over
    syq's TCP data connections. rsync has one connection anyway; this is a
    note about syq's own model.
 5. **`--rsync-path PATH` must name syq, not rsync.** The standard spelling and
@@ -230,13 +141,12 @@ corresponding copy would select. *Test: `verify_only_checks_the_filtered_scope`.
 ## Not implemented
 
 rsync features syq doesn't have. The common ones are rejected with a one-line
-explanation (`src/cli.rs`, `reject_unsupported_rsync_flags`) so a pasted rsync
-command says what to change.
+explanation so a pasted rsync command says what to change.
 
 - `--delete-before`, `--delete-during`, `--force`: see "Intentional
   divergences" 1; these are refused rather than pending.
-- `-H`/`--hard-links`: needs cross-file ordering in a scheduler that has
-  none today.
+- `-H`/`--hard-links`: separate source names are copied independently; hard
+  links between them are not preserved.
 - `-L`/`--copy-links`, `--copy-unsafe-links`, `-k`/`--copy-dirlinks`,
   `-K`/`--keep-dirlinks`. The first three would widen what the copy reads by
   following symlinks found inside the source; the last follows an existing
@@ -259,14 +169,16 @@ command says what to change.
 - Remote-to-remote transfer is deliberately absent from `syq rsync`, matching
   rsync itself; use native `syq cp` or `syq cp --prune`.
 
-## Open issues
+## File-list parsing and help
 
-1. **The remaining `--files-from` entry parsing doesn't match rsync's**
-   (measured on 3.2.7 and 3.5.0). Finish the related path rules as one change:
-   normalize `..` and clamp it at the source root instead of rejecting;
-   preserve a trailing slash (`dir/` selects the directory's immediate
-   children without `-r`, `dir` only the directory); accept `.`/`/` as the root
-   entry (children without `-r`); add `-0` as an alias of `--from0`.
-2. **`-h` alone should print help**, as rsync does, while staying
-   `--human-readable` inside a cluster (`-avh`). Essentially free.
-3. **`-u` for symlinks/devices**: measure rsync, then align or record.
+`--files-from` parsing differs from rsync's in these cases, measured against
+3.2.7 and 3.5.0:
+
+- A `..` component is rejected rather than clamped at the source root.
+- A trailing slash is stripped: `dir/` and `dir` select the same thing.
+  Rsync's `dir/` selects the directory's immediate children without `-r`.
+- `.` and `/` are rejected rather than treated as entries selecting the root.
+- Use `--from0` for NUL-separated input; `-0` is not accepted.
+
+Unlike rsync, `-h` alone does not print help; use `--help`. Within an option
+cluster such as `-avh`, it is the same human-readable no-op.

--- a/docs/security.md
+++ b/docs/security.md
@@ -144,7 +144,7 @@ What is different from rsync, or weaker:
   specific limits, but the protocol between the two sides has not been fuzzed
   the way rsync's has.
 
-### How confinement is verified
+### How path safety is tested
 
 Syq's tests for this behavior do not rely on scheduler timing. After syq has
 selected or opened a path, the test pauses it at that point, renames the
@@ -226,9 +226,11 @@ protects.
 
 For the duration of a transfer, syq starts a temporary agent-protocol socket
 locally (the constrained agent broker, or the broker for short) and forwards
-*that* to hostA instead of your real agent. The broker holds no private keys;
-it forwards signing requests to your real agent (or to the enrollment key
-below) only after validating the exact path the request is
+*that* to hostA instead of your real agent. With `--peer-auth broker`, it
+passes signing requests to your real agent without holding that agent's keys.
+On the default restricted path, it loads the dedicated enrollment private key
+from local state and signs with it; that key never goes to hostA. In both
+cases, the broker signs only after validating the exact path the request is
 for:
 
 ```text
@@ -304,8 +306,9 @@ Ignore rules, `--inplace`, preservation, the policy for objects that already
 exist at the destination, and placement preconditions are signed into the
 grant and enforced by the receiver on its own. Deletion through the receiver
 requires an explicit `--max-delete`, and the `--receiver-max-entries` and
-`--receiver-max-bytes` options lower the signed ceilings for one transfer, so
-what a redeemed grant is worth to hostA is always bounded on the command line.
+`--receiver-max-bytes` options replace the default limits for one transfer.
+They can increase or decrease them within the allowed ranges. HostA's
+authority is bounded by the defaults or the values you choose.
 Behavior the receiver cannot check independently of hostA is refused rather
 than trusted: `--mapping`, `--min-size`, sending data unencrypted or through
 ssh instead of over TCP data connections, and several others (the
@@ -314,7 +317,7 @@ is in the remote-to-remote guide). `--dry-run` is marked read-only in the
 grant, and the receiver rejects every mutation under it even if hostA sends
 one.
 
-### Layer 4: the rooted receiver
+### Layer 4: staying inside the destination directory
 
 Every destination scan, stat, hash, partial-file operation, metadata change,
 write, and deletion the receiver performs happens relative to the open handle

--- a/docs/server-tuning.md
+++ b/docs/server-tuning.md
@@ -1,15 +1,15 @@
-# Server performance tuning
+# Server setup
 
 This page is about setting up a server (its firewall, sshd, and sysctl
 settings) so syq can run fast on it. That is separate from syq's own
 auto-tuner, which adjusts the connection count during a copy without any
 change to the host. syq does not require a specially configured server. It
-installs the remote helper (a copy of syq that syq installs on the remote host
-the first time it connects) automatically, encrypts its TCP data connections
-by default, falls back to ssh when a TCP listener cannot be reached, and
-adjusts its connection count while a copy runs. Start with the defaults and
-change the host only when a representative transfer shows a specific
-bottleneck.
+installs a matching remote helper automatically when using an official
+release build, encrypts its TCP data connections by default, and adjusts its
+connection count while a copy runs. If TCP cannot be reached, syq falls back
+to ssh, except with the restricted receiver, which requires encrypted TCP
+and fails instead. Start with the defaults and change the host only when a
+representative transfer shows a specific bottleneck.
 
 This is deliberately a guide, not an installer. Firewall policy, ssh capacity,
 kernel versions, network paths, and storage differ too much for one script to
@@ -48,7 +48,8 @@ transfer. The default TCP records are encrypted with a key exchanged through
 ssh. The helper listens on that port over both IPv4 and IPv6, so a firewall
 rule must allow whichever family the client will use. If no advertised
 address and port is reachable, syq reports the fallback once and carries data
-over separate ssh sessions instead.
+over ssh instead. A restricted remote-to-remote copy requires encrypted TCP
+and fails instead of falling back.
 
 Allow the chosen port range only from clients or trusted networks that need it.
 For example, an administrator using ufw could adapt one of these rules:
@@ -67,8 +68,9 @@ per-transfer token and is encrypted unless `--syq-tcp-plain` was requested.
 Trade-offs:
 
 - A reachable TCP path avoids ssh's per-channel flow-control and cipher-process
-  limits. Fresh-small-file workers using default ssh reuse the authenticated
-  control connection; larger and mixed SSH workloads start independent data
+  limits. A job made only of new small files, using default ssh with no
+  bandwidth limit, reuses the authenticated control connection. Larger or
+  mixed workloads and bandwidth-limited copies use independent SSH data
   processes so they can use multiple flows and cipher processes.
 - A firewall exception increases reachable attack surface. A private LAN, VPN,
   or narrowly scoped source rule is preferable to a public allow rule.
@@ -81,9 +83,10 @@ Trade-offs:
 
 This setting matters when data falls back to independent ssh connections. It
 limits concurrent *unauthenticated* ssh connections; it does not limit
-established sessions, fresh-small-file workers multiplexed over default ssh, or
-workers using the TCP data path. syq already retries shed connections and
-reduces the number of simultaneous handshakes, so the default is functional but
+established sessions, small-file workers sharing the control connection
+(which a nonzero `--bwlimit` disables), or workers using the TCP data path.
+Syq already retries shed connections and reduces the number of simultaneous
+handshakes, so the default is functional but
 can make connection setup slower.
 
 Inspect the effective value rather than assuming the distribution default:
@@ -270,8 +273,8 @@ drops with `ip -s link` and the vendor's tools.
   destinations keep the adaptive parallel path. NFS mount choices such as
   `nconnect` are client and server policy; see the
   [NFS notes](speed.md#nfs) and test with disposable data.
-- Compression trades network bytes for CPU. Compare with and without `-z` when
-  either the link or CPU is near saturation.
+- Compression trades network bytes for CPU and is on by default. Compare the
+  default with `--no-compress` when either the link or CPU is near saturation.
 - `--bwlimit` is the appropriate control when the goal is coexistence with
   other traffic, not maximum benchmark throughput.
 

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -3,7 +3,7 @@
 Syq was born of frustration with how slow existing tools are on modern
 hardware and networks. This document lists what makes syq fast in rough order
 of importance, collects the measurements recorded so far, says when
-parallelism does not help, and then documents each mechanism in detail. The
+parallelism does not help, and explains the controls you can adjust. The
 [How it works](reference.md#how-it-works) section of the reference explains
 the partial file, the queue, and the final rename into place that these
 mechanisms sit on; [Server setup](server-tuning.md) covers optional changes to
@@ -25,9 +25,10 @@ table](reference.md#compatibility-options)).
    huge file stays parallel to its last byte. Deletion and native `rm` run in
    parallel too. Without `-j`, the auto-tuner adjusts the connection count
    while the copy runs and ends on the smallest count within 5 % of the best
-   measured rate (one worker is a valid answer for a spinning disk), and
-   remembers that count per path and transport as the next run's starting
-   point. See [How many connections](#how-many-connections).
+   measured rate (one worker is a valid answer for a spinning disk). Copies
+   with a remote endpoint remember that count per path and transport for the
+   next run; local copies, including mounted NFS paths, do not. See
+   [How many connections](#how-many-connections).
 2. **A TCP data path beside ssh.** OpenSSH caps each channel at a 2 MB window,
    which is roughly 2 MB per round trip (about 7 MB/s at 265 ms), and caps each
    process at a few hundred MB/s of cipher work. Syq keeps ssh for
@@ -35,11 +36,12 @@ table](reference.md#compatibility-options)).
    carrying AES-256-GCM records keyed through the ssh session. It advertises
    every IPv4 and IPv6 address the remote has, prefers the fastest that
    answers, and spreads connections across NICs of comparable speed. If no port is reachable it says
-   so once and falls back to ssh data connections. See [TCP data
+   so once and falls back to ssh data connections. The restricted receiver
+   requires encrypted TCP and fails instead of falling back. See [TCP data
    connections](#tcp-data-connections).
-3. **Kernel and server-side copies on one machine.** Same-machine copies use
-   the kernel copy (`copy_file_range`), which becomes a reflink where the filesystem supports it
-   or an in-kernel copy otherwise, and on NFS 4.2 makes the server copy the
+3. **Kernel and server-side copies on one machine.** On Linux, same-machine
+   copies use `copy_file_range`, which becomes a reflink where the filesystem
+   supports it or an in-kernel copy otherwise, and on NFS 4.2 makes the server copy the
    file without moving bytes through the client. See [Same-machine
    copies](#same-machine-copies-copy_file_range-and-nfs).
 4. **Block-level resume with no state file.** The partial file *is* the state.
@@ -51,16 +53,17 @@ table](reference.md#compatibility-options)).
    pipelined whole-file requests in batches instead of one round trip per
    file. Workers connect while the source is still being scanned, address
    probes run while the control connection prepares the destination, and a
-   transfer of nothing but fresh small files over ssh reuses the authenticated
-   control connection instead of paying a handshake per worker.
-6. **Compression that costs nothing when it cannot help.** Remote transfers
+   transfer of only new small files over default ssh, with no bandwidth limit,
+   reuses the authenticated control connection instead of paying a handshake
+   per worker.
+6. **Compression without expanding data.** Remote transfers
    try zstd level 1 on each piece of data they send, sending the compressed
    form only when it is smaller, so archives, media, and encrypted data are not expanded on the
    wire. `--no-compress` skips the attempt when CPU is scarcer than bandwidth.
 7. **ssh used well when ssh must carry data.** Syq asks for `aes128-gcm` first,
    which on AES-NI hardware is faster per stream than OpenSSH's default
-   ChaCha20; it disables connection multiplexing on purpose, since multiplexed
-   channels share one cipher process; it brings up control connections first
+   ChaCha20; it gives large-file data workers independent connections so they
+   can use separate cipher processes; it brings up control connections first
    and up to 32 handshakes at a time; and it halves its concurrency when sshd's
    `MaxStartups` sheds a connection. `syq persist on` keeps one authenticated
    control connection per host alive for five minutes between commands, so a
@@ -93,9 +96,8 @@ faster](#when-rsync-or-cp-is-faster).
 
 ## Measurements so far
 
-These figures come from the development machines named in the sections below,
-not from a controlled benchmark suite, and most compare against `cp` rather
-than rsync. Use [syq-bench](https://github.com/greaber/syq-bench) to measure
+These figures come from development machines rather than a controlled
+benchmark suite, and most compare against `cp` rather than rsync. Use [syq-bench](https://github.com/greaber/syq-bench) to measure
 your own workloads against rsync and cp.
 
 | Workload | syq | Comparison |
@@ -112,33 +114,15 @@ your own workloads against rsync and cp.
 | 262 ms path, fresh 2,000-file / 8 MiB tree over `--no-tcp` | 11.29 s | 16.85 s with independent worker handshakes |
 | 20 Gbit LAN, two 160-core hosts, `-j8` into tmpfs | 1.2–1.3 GiB/s | one ssh stream 450–550 MB/s |
 
-### Path-confinement cost
+### Cost of path safety
 
-syq opens each selected directory once and keeps that handle open for the
-whole run, so later work is relative to the handle and renaming the path
-cannot redirect it. The cost of working this way was measured separately on
-2026-09-04, comparing a build from before that change with the Linux
-`openat2` implementation of it. Each campaign used 32 connections, checksum
-verification, a 100,000-file mixed-depth tree holding 100 MiB, and both tool
-orderings. File pages were evicted where possible, but dentry and inode
-caches remained warm.
-
-On local ext4, the open-handle build took 3.27–3.32 s median by ordering
-versus 2.17–2.22 s before the change, a 47–53% increase on a deliberately short,
-metadata-heavy workload. A shallow 100,000-file tree increased by 12–18%, and
-the sub-second no-change case showed no stable difference. The absolute
-mixed-tree cost was about 1.1 seconds per 100,000 files.
-
-On a same-datacenter NFSv4 mount, five local-to-NFS fresh-copy samples had
-combined medians of 46.45 s with open handles and 44.05 s before the change; the sample
-ranges overlapped widely (41.19–50.96 s and 38.43–52.58 s). The NFS-to-local
-campaign had the same 8.93 s combined median for both builds. A destination
-no-change campaign did not show a penalty for the open-handle build. NFS
-metadata probes varied
-from 552 to 1,264 files/s during these runs, so the measurements rule out a
-large consistent regression in this setup rather than a small one. They are
-not a performance guarantee for other servers, mount options, cache states, or
-tree shapes.
+Syq keeps open directory handles so a renamed path cannot redirect a copy.
+On a deliberately short, metadata-heavy local ext4 workload, this added about
+1.1 seconds per 100,000 files: a 47–53% increase. A shallow tree increased by
+12–18%. NFS measurements showed no large consistent penalty, but varied too
+much to rule out a small one. These results depend on the filesystem, tree,
+and cache state; the [measurement note](https://github.com/greaber/syq/blob/master/design/performance.md#path-safety-measurements-2026-09-04)
+records the builds, method, and sample ranges.
 
 ## When rsync or cp is faster
 
@@ -153,10 +137,11 @@ tree shapes.
   insertion is resent. Delta transfer also makes the destination side read its
   whole old copy, which on a network filesystem can cost more than it saves. Most
   large files are never modified in place; measure your own workload.
-- **Short copies.** Connection setup (one ssh handshake per connection, about
-  0.3 s on a LAN and seconds across continents) and the auto-tuner's probes
-  need a transfer long enough to amortize them. Syq starts at a remembered or sensible count and
-  only opens more once they have been shown to pay.
+- **Short copies.** Connection setup and the auto-tuner's probes need a
+  transfer long enough to pay for them. Each independent ssh connection costs
+  a handshake, about 0.3 s on a LAN and seconds across continents. Small-file
+  jobs that share the control connection avoid worker handshakes. Syq starts
+  at a remembered or default count and opens more only when they help.
 - **When the disk is the limit.** On a 20 Gbit LAN with `-j8`, syq reached
   1.2–1.3 GiB/s into tmpfs, while writes to the destination's ext4 NVMe capped
   everything, rsync included, at about 600 MB/s. Check the disk before blaming
@@ -176,15 +161,17 @@ These options buy speed by giving something up; the default is the safe side.
 - `--connections N` fixes the connection count and disables the auto-tuner;
   `--bwlimit` caps throughput to be polite on a shared link.
 
-The rest of this document describes each mechanism in detail.
+The following sections explain the connection and filesystem controls.
 
 ## When parallelism helps
 
 - **ssh CPU**: one ssh process tops out at a few hundred MB/s of cipher/MAC
   work. N processes scale roughly linearly. Multiplexed channels over one
   connection wouldn't help (same TCP stream, same single encrypting process),
-  so syq passes `-o ControlMaster=no -o ControlPath=none` for its connections
-  on purpose.
+  so large-file data workers get independent SSH connections. A job made
+  only of new files no larger than one block, with no bandwidth limit, shares
+  the control connection instead: its bottleneck is latency. An explicit
+  `--rsh` owns the connection policy.
 - **WAN**: several TCP flows beat one against per-flow window and loss limits.
 - **High-latency filesystems** (NFS, FUSE, object-backed): many small files
   are latency-bound; parallel stat and I/O hide it. The scan is parallel too.
@@ -195,203 +182,94 @@ The rest of this document describes each mechanism in detail.
 
 ## How many connections
 
-Without an explicit connection count, the auto-tuner adjusts the number of
-workers while a copy runs instead of guessing. On a data path it has measured
-before, it starts at the count it last finished on for that path; otherwise it
-starts with 16 when every remote endpoint has a reachable TCP data path, 8
-over ssh, or, when both ends are local, 16 if the process has at most two CPUs
-available and 32 otherwise. This uses the CPU
-affinity or container limit reported by the OS; the lower count remains large
-enough to overlap filesystem latency. A single same-machine file eligible for
-the whole-file path or the kernel copy starts with one worker because extra
-loopback connections cannot help; finding a partial file, or a kernel copy the
-filesystem does not support, immediately restores the usual local starting
-count of 16 or 32.
-Remembered results are keyed only by the directional endpoint path and
-transport (TCP and ssh learn separately), not by RTT, workload, filesystem or
-other volatile telemetry. A stale hint only costs the auto-tuner a probe or two. The
-cache is
-`$XDG_CACHE_HOME/syq/tuning.json` (normally
-`~/.cache/syq/tuning.json`; set `SYQ_TUNING_CACHE` to override it or to an
-empty value to disable it). An explicit connection count, dry runs, verification, short runs
-that compare no counts, failed/aborted copies, and runs whose TCP path falls
-back to ssh after workers start do not update it; the last case may contain
-mixed-transport measurements that are not representative of either pure path.
+Without `--connections`, syq adjusts the worker count while a copy runs. For a
+remote path it has measured, it starts with the count it last finished on.
+Otherwise it starts with 16 over TCP, 8 over ssh, or, for local copies, 16 when
+the process has at most two CPUs available and 32 otherwise. A job made only
+of new small files, with no bandwidth limit, starts no more workers than it
+has batches. A single local file starts with one worker when the kernel or
+sequential destination writer can copy it directly; finding a partial file or
+an unsupported shortcut restores the normal local starting count.
 
-Useful progress (the high-water mark of logically completed bytes, plus a small
-credit per completed file so small-file trees count) is sampled every 2.5 s.
-Recovery can retract uncertain bytes, and retransmitting those same bytes does
-not inflate the rate the auto-tuner measures. A count has been *measured*
-only once two
-consecutive samples agree within 10 %, so a burst that gets throttled or a link
-still ramping up is waited out (up to 20 s) rather than credited to the last
-change. The first probe is a 1.3× step up (8→10, not 8→16). A step up is kept
-only when the smaller count is more than 5 % below the best recent measurement;
-a step down is kept when it stays within 5 %. Thus acceptance directly follows
-the objective: the smallest measured count within 5 % of the best observed
-speed, from 1 through 64. A successful move keeps exploring in the same
-direction. A failed move returns to the last good count and records a bound, so
-later probes refine untested integers: if 10→13 helps and 13→17 is flat, syq
-stays at 13 and can later try 11 rather than immediately falling back to 10.
+The auto-tuner looks for the smallest count from 1 through 64 whose measured
+rate is within 5% of the best it has seen. It makes modest changes, waits for
+the rate to stabilize, and keeps a change only when the measurement justifies
+it. New connections open while existing workers keep copying; surplus
+connections close after a decision. Short transfers may finish before a
+comparison is possible. The progress line shows the current count (`16 conn`),
+and `--stats` reports its path (`connections: auto: settled at 16 (path 16, peak 16)`).
 
-In steady state, evidence in the upward and downward directions ages and backs
-off independently. A direction is first eligible again after 6 stable
-measurements (about 30 seconds at minimum); repeated failures double only that
-direction's delay, up to 4 minutes at the minimum sampling rate. When both
-directions are equally informative, syq deterministically probes up first:
-most connection/throughput curves are concave or saturating, so an extra
-connection usually loses less transfer speed than removing a useful one. This
-is a starting assumption, not a rule: measured collapse aborts a probe early,
-and independent backoff lets downward evidence win.
+Successful copies with a remote endpoint remember their count by directional
+path and transport in `$XDG_CACHE_HOME/syq/tuning.json` (normally
+`~/.cache/syq/tuning.json`). Set `SYQ_TUNING_CACHE` to another path, or to an
+empty value to disable the cache. Local copies, including mounted NFS paths,
+never use it. Dry runs, verification, fixed-count runs, short runs that compare
+no counts, failed copies, and copies that fall back from TCP to ssh after
+workers start do not update it. A stale entry costs the next run a probe or two.
 
-Upward candidates connect in the background while the current workers keep
-copying; their stable rate refreshes the comparison baseline, while connection
-setup time itself is not scored. A probe starts only when the activity remaining
-at the observed rate is estimated to last through a complete measurement, so a
-slow path is not rejected by a fixed byte threshold and a very fast tail is not
-mistaken for evidence. After a decision, surplus connections and their reader
-threads are closed instead of keeping the largest pool ever tried. At one
-active connection syq keeps exactly one ready spare so the important 1→2 probe
-remains cheap. A dropped data connection is reopened with bounded exponential
-backoff; ranges whose acknowledgement or final rename into place is uncertain
-are safely requeued. Transfers shorter than a measurement or two just run with the
-starting count. The progress line shows the current count
-(`16 conn`), and `--stats` reports the path it took
-(`connections: auto: settled at 16 (path 16, peak 16)`).
+On a 265 ms path from Germany to Japan, TCP data connections reached 1 Gbit
+line rate at 8–13 connections. Over ssh, tuning reached about 110 MB/s around
+30 seconds after connecting, compared with 44 MB/s for a fixed eight workers.
+The [engineering note](https://github.com/greaber/syq/blob/master/design/performance.md)
+has the detailed tuning rules and the small-file SSH comparison.
 
-Measured from a 1 Gbit box in Germany to a host in Japan (265 ms): over TCP
-data connections it ends up around 8–13 at line rate; over ssh data
-connections (where each stream is capped by OpenSSH's 2 MB window) it
-reaches line rate (~110 MB/s, where a fixed eight workers managed 44) about 30 s
-after the connections are up.
-
-On the same kind of long path (262 ms), a fresh 2,000-file / 8 MiB tree over
-`--syq-no-tcp` took 11.29 s in two verified runs after fresh-small-file workers
-began reusing the authenticated control connection, versus 16.85 s with eight
-independently authenticated worker connections. Larger and mixed workloads
-still use independent SSH connections so they keep multi-flow throughput.
-
-Native `-j N`/`--connections N`, or compatibility
-`--syq-connections N`, fixes the count and disables the auto-tuner. Use it
-when you know better (for example, one worker for a spinning disk that must
-not be read in parallel) or to be polite on a shared link.
+`-j N`/`--connections N` (`--syq-connections N` under `syq rsync`) fixes the
+count and disables tuning. One worker can help on a spinning disk; use
+`--bwlimit` when the goal is to cap throughput on a shared link.
 
 ## TCP data connections
 
-ssh caps every stream at a few hundred MB/s of cipher CPU, and its 2 MB
-per-channel flow-control window caps a stream at roughly `2 MB / RTT` on long
-links (≈7 MB/s at 265 ms). So by default (unless `--syq-no-tcp`) syq keeps ssh for
-authentication and control only and moves the data over separate TCP
-connections: the remote opens a listener on a port from `--syq-tcp-ports` (default
-47600-47699), and the data connections are plain TCP sockets carrying
-AES-256-GCM records keyed by a secret exchanged over the ssh session
-(`--syq-tcp-plain` skips the encryption on trusted networks; `--syq-no-tcp` sends data over the ssh connection instead). If the port can't be
-reached (a firewall, typically), syq says so once and falls back to ssh data
-connections, so the default is always safe.
+SSH's per-channel window and cipher CPU can limit throughput on long or fast
+links. By default, syq uses SSH for authentication and control and separate
+TCP sockets for file data. The remote listens on one port from `--tcp-ports`
+(default 47600–47699); AES-256-GCM encrypts the data with a secret exchanged
+through SSH. `--tcp-plain` skips encryption on trusted networks; `--no-tcp`
+sends the data through SSH. If no TCP route is reachable, syq reports that once
+(silenced by `-q`) and falls back to SSH. A restricted remote-to-remote copy
+requires encrypted TCP and fails instead of falling back.
 
-The listener accepts IPv4 and IPv6 on the same port, and the remote advertises
-its global addresses of both families: the address your ssh session arrived
-on first, then private-network addresses, then public ones, then overlay
-addresses such as Tailscale, with faster NICs first within each group.
-Link-local IPv6 addresses (`fe80::`) and addresses on virtual interfaces such
-as docker bridges are not advertised. syq also tries the name you gave ssh,
-which is what works when the remote sits behind NAT or port forwarding. Every
-distinct address is probed once, in parallel, for one second; on an IPv6-only
-private network such as a cloud provider's internal mesh the IPv6 address is
-the one that answers.
+The listener accepts IPv4 and IPv6. Syq considers the address your SSH session
+arrived on, private-network addresses, public addresses, and overlay addresses
+such as Tailscale, preferring faster interfaces within each group. It excludes
+link-local IPv6 and virtual interfaces such as Docker bridges, and also tries
+the SSH hostname for hosts behind NAT or port forwarding. It probes candidates
+in parallel for one second each and uses the best that answers. When several
+interfaces of comparable speed answer, it spreads connections across paths
+within 2x of the fastest, so a slow path does not drag down the transfer.
 
-On Linux, `--syq-tcp-congestion ALGO` requests a congestion-control algorithm for
-both ends of every TCP data connection. The connecting socket is
-configured before `connect`, and the remote listener is configured before its
-port is advertised, so accepted sockets inherit the same algorithm. This is a
-per-socket override: syq does not change sysctls, load kernel modules, or alter
-queueing disciplines. Without the option, every socket keeps its host's
-default. An explicit override that either kernel rejects is a fatal error with
-the affected host and kernel error; syq never silently substitutes another
-algorithm. If the TCP route itself is unreachable, the normal warned SSH
-fallback still applies and says that the requested algorithm is not used by
-the SSH fallback.
+On Linux, `--tcp-congestion ALGO` selects the algorithm for both ends of every
+TCP data connection. It changes only those sockets, without modifying sysctls
+or loading modules. The algorithm must be registered on both hosts and
+allowed for the syq process. If either kernel rejects it, the copy fails with
+the host and error. If the TCP route is unreachable, the usual SSH fallback
+reports that the algorithm is no longer in use. The restricted receiver
+refuses this option because its signed grant does not carry that setting.
+See [Server setup](server-tuning.md) for prerequisites and firewall examples.
 
-The algorithm must be registered on both Linux hosts and available to the syq
-process. Unprivileged processes may choose only entries in
-`net.ipv4.tcp_allowed_congestion_control`; inspect host prerequisites and qdisc
-state as described in [server-tuning.md](server-tuning.md). Congestion control
-is sender-side, so setting it only on a download server does not also select it
-for uploads from a client. syq can cover both directions because it owns the
-data socket on each endpoint.
+With `--stats`, syq reports the kernel's socket counters from both ends:
+congestion-control algorithm, retransmissions, RTT, congestion window,
+delivery rate, window-limited time, and ECN marks. Unsupported fields are
+labeled unavailable; SSH data connections expose none of these counters to syq.
 
-With `--stats`, copies over TCP data connections also report the kernel counters available on
-both socket ends: the effective congestion-control algorithm, retransmitted
-packets and bytes (a packet-loss signal), current/minimum RTT, congestion window
-and delivery rate, receive-window and send-buffer limited time, and ECN CE
-deliveries. These are for diagnosis only and do not affect which remembered
-connection count syq starts from. Unsupported fields are labeled unavailable rather than displayed as
-zero. SSH does not expose per-data-connection TCP counters to syq, so the
-statistics say they are unavailable when the data transport is SSH.
-
-The remote advertises every address it has (the one your ssh session arrived
-on first, then private LAN, then public, then CGNAT/Tailscale); the client
-adds the name it reached ssh through (the only address that works for a
-host behind NAT or port forwarding) ahead of the overlay ones, tries them
-all, and prefers the best that answers. If none answers it says so and uses
-ssh (silenced by `-q`). When several NICs of
-comparable speed are reachable (e.g. an 8-rail RoCE fabric), syq spreads its
-data connections across all of them (multipath); it keeps only paths within
-2x of the fastest, so it never drags a fast transfer down by mixing in a slow
-link. Every candidate still gets its complete bounded probe window, but those
-independent probes run while the control connection prepares the destination.
-When the destination is not the command-restricted receiver, each destination
-worker takes over the open handle for its destination directory as part of its
-authenticated hello (this is the cost of handing open directory handles to
-worker processes), and the destination side reports ready only after that
-handoff succeeds. Single-homed hosts and laptops use the one best path,
-unchanged. With ufw:
-
-```sh
-sudo ufw allow from 192.0.2.0/24  to any port 47600:47699 proto tcp   # example LAN
-sudo ufw allow from 203.0.113.5   to any port 47600:47699 proto tcp   # a specific client
-```
-
-Use `-vv` to see the route planned for the real transfer. For each remote
-endpoint seen by the active coordinator (the host that runs the copy) it
-reports the identity and platform of the authenticated remote helper (a copy
-of syq that syq installs on the remote host the first time it connects), every
-TCP address syq considered, reachability and advertised link speed, why a
-reachable address was or was not selected by the check that runs before
-anything is written, the resulting planned TCP/ssh transport, and the initial
-connection count. Workers authenticate their data connections after this report; if TCP
-then fails, syq prints its normal data-over-ssh fallback notice. `-v` alone
-keeps its existing file-listing behavior.
-
-`-vv --dry-run` only observes: it reports the same control connection,
-remote helper startup, TCP listener, address probes, and fallback decision that plain
-`--dry-run` already performs. It does not open an authenticated data connection
-or start transfer workers, and verbosity does not change dry-run's success or
-failure. The reported route is therefore a plan for a real transfer, not a
-claim that a worker data connection was completed.
-
-Native remote-to-remote copies work the same way: the coordinator on hostA
-connects to hostB's listener. Diagnostics are relative to that active
-coordinator. If both endpoints name hostA, `-vv` reports a local filesystem
-route there.
-
-No special server setup is required. For a measurement-first checklist of
-optional firewall, sshd, TCP, and host-network changes, including their
-trade-offs and rollback considerations, see [Server
-setup](server-tuning.md).
+Use `-vv` to inspect the planned route: helper identity and platform,
+candidate addresses and their reachability, the chosen TCP or SSH transport,
+and the initial connection count. Under `--dry-run`, the same probes run but
+no authenticated data connection opens. A remote-to-remote report is relative
+to the coordinator, normally the source host; `--coordinate-at dst` reverses
+the direction. If both endpoints name the same host, the report describes a
+local filesystem route there.
 
 ## Defaults chosen for network filesystems
 
-Small files are read and written in pipelined batches, but every non-`--inplace`
-write still finishes with an atomic rename. When both ends are local, the
-auto-tuner starts with 16 workers on a process limited to one or two CPUs, and 32 otherwise;
-an all-new small-file job starts no more workers than it has batches. This costs
-one rename per file on NFS, but avoids exposing incomplete final-named files.
+Small files are read and written in pipelined batches. Unless you choose
+`--inplace`, each file is written to a partial file and renamed into place.
+That costs a rename per file on NFS but avoids exposing an incomplete file
+under its final name.
 `--inplace` is the explicit space/safety tradeoff.
 
 ## Same-machine copies (copy_file_range and NFS)
 
-When source and destination are on the same machine, syq copies each file with
+On Linux, when source and destination are on the same machine, syq tries
 `copy_file_range(2)` instead of streaming bytes through userspace: the kernel
 does a reflink or a straight in-kernel copy, and on NFS 4.2 the *server* copies
 the file internally (no client round trip). Measured: a single 8 GB file
@@ -404,8 +282,8 @@ write contention and needless transport framing and hashing. NFS-to-NFS copies,
 other source filesystem types, synchronous NFS destinations, an explicit fixed
 worker count above one, and unsupported non-NFS destinations keep the
 parallel, hash-resumable streaming path.
-`-c`, any existing partial file, and `--bwlimit` disable that destination-side
-shortcut.
+`--hash`, any existing partial file, and a nonzero `--bwlimit` disable that
+destination-side shortcut.
 Small new bandwidth-limited files that fit in one paced transfer block still
 use the pipelined whole-file request described in the
 [How it works](reference.md#how-it-works) section.
@@ -413,49 +291,17 @@ use the pipelined whole-file request described in the
 ## NFS
 
 Local↔NFS copies are a local-to-local syq run
-(`syq cp --connections 16 /raid/x --into /mnt/nfs`)
+(`syq cp /raid/x --into /mnt/nfs`)
 and benefit from parallelism across files and on reads: measured on a 20 Gbit
 NFSv4.2 mount, reads of one 4 GB file reached 858 MiB/s with eight workers vs ~400 MB/s
 for `cp`, and 20,000 small files were written in 28 s vs 72 s for `cp -r`.
 Writes from a recognized local disk filesystem into one asynchronous NFS inode
 are instead written one at a time on the destination side, automatically,
 when the kernel cannot copy them itself.
-On a fresh 4 GiB `/raid`→NFS copy, that changed syq from 21.44 s with 32 range
-writers to a 9.93 s median with one sequential writer on the destination
-side, versus a
-10.94 s median for `cp` (two interleaved runs). Synchronous destinations and
+On a fresh 4 GiB `/raid`→NFS copy, that writer reached a 9.93 s median,
+versus 10.94 s for `cp` (two interleaved runs). Synchronous destinations and
 NFS sources keep the adaptive parallel path; the reciprocal NFS→`/raid` copy
 reached 1.13 GiB/s with parallel range reads.
 Separate files still run concurrently and have reached ~650 MB/s in aggregate.
 Mounting with `nconnect=8` (NFS 4.1+; needs an unmount/mount, not a remount) can
 add headroom for those concurrent files and other NFS traffic.
-
-## Performance notes
-
-- syq asks ssh for `aes128-gcm@openssh.com` first (falling back to the usual
-  ciphers). On x86 with AES-NI that is noticeably faster per stream than
-  OpenSSH's default chacha20-poly1305.
-- Each connection costs one ssh handshake (~0.3 s on a LAN, several seconds
-  across continents). The control connections always come up first
-  (everything waits on them; only then do data connections start), up to 32
-  at a time, and if the
-  server sheds one (sshd's `MaxStartups`, default 10, randomly rejects
-  sessions beyond 10 being set up at once), syq halves that number for the
-  rest of the run and retries. Raising `MaxStartups` can reduce setup time for
-  independent ssh data connections; fresh-small-file workers using default ssh
-  reuse the authenticated control connection instead. A higher limit increases
-  the resources available to unauthenticated clients; see
-  [Server setup](server-tuning.md).
-  The auto-tuner starts at 16 for TCP data, or 8 for ssh data, and only opens more
-  once they have been shown to pay.
-- The default direct remote-to-remote path (the restricted path) uses one
-  enrollment-key authentication for the hostB control connection, then
-  encrypted token-authenticated TCP workers.
-- Measured on two 160-core hosts on a 20 Gbit LAN: a single ssh stream tops out
-  around 450–550 MB/s; `syq rsync --syq-connections 8` into tmpfs reached
-  ~1.2–1.3 GiB/s (the raw
-  multi-stream ssh ceiling), while writes to the destination's ext4 NVMe capped
-  everything, rsync included, at ~600 MB/s. Check the disk before blaming the
-  network.
-- `SYQ_DEBUG=1` prints connect times and where each worker and each remote
-  helper spent its time (blocked on reads, pipe writes, acks; waiting, handling).

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -3,11 +3,10 @@
 This directory contains the Python client for syq. It invokes the syq
 executable rather than inventing a second transfer implementation, and it
 implements synchronous and asyncio clients for typed
-`cp` (including `prune=True`) and `map` against syq's versioned machine
-interfaces. Commands without an automation result stream, currently including
-`rm`, remain available through raw `run`. The executable remains authoritative
-for argument semantics,
-filesystem behavior, exit status, and safety checks.
+`cp` (including `prune=True`), `rm`, and `map` against syq's machine
+interfaces. Other commands and modes, such as a detached remote-to-remote
+copy, remain available through raw `run`. The executable remains authoritative
+for argument semantics, filesystem behavior, exit status, and safety checks.
 
 The Python-native surface is documented in
 [`python/NATIVE_API.md`](python/NATIVE_API.md).

--- a/tests/rsync-compat/LOCAL-TESTS.md
+++ b/tests/rsync-compat/LOCAL-TESTS.md
@@ -1,0 +1,94 @@
+# Local compatibility test references
+
+The [user guide](../../docs/rsync-compat.md) describes behavior. This file maps
+those claims to tests in [`tests/local.rs`](../local.rs), alongside the
+upstream suite's [generated ledger](LEDGER.md). A test reference is evidence
+for its named behavior, not a score for compatibility as a whole.
+
+## Compatible behaviors
+
+| Behavior | Status | Test |
+|---|---|---|
+| Path rules: `src` copies the directory, `src/` its contents; a single file lands as `dest/file` when `dest` is a directory; several sources need a directory destination | measured | `trailing_slash_copies_contents`, `dir_into_existing_dir`, `dir_into_missing_dest_creates_basename`, `single_file_into_existing_dir`, `single_file_to_new_name`, `multiple_sources_require_dir_dest` |
+| Quick check: size + mtime; without `-t` every file is re-sent | measured | `updates_changed_file_and_skips_symlink_only_when_same`, `skip_reconciles_mode` |
+| `--delete` scope: only inside the directories being synced; a single-file source deletes nothing | measured | `delete_only_inside_directories_the_sources_map_onto`, `delete_with_nested_roots_deletes_once` |
+| Ignored/excluded paths are protected from deletion by default; `--delete-excluded` lifts that | measured | `delete_removes_extras_and_protects_ignored`, `delete_nested_roots_keep_their_own_anchored_ignores`, `delete_excluded_removes_ignored_destination_paths` |
+| A directory that can't be emptied because of protected content is reported and left (rsync: `cannot delete non-empty directory`; syq: `not deleting keep/: it holds ignored paths`) | measured | `delete_removes_extras_and_protects_ignored` |
+| Deletion is skipped when listing the source hit errors (rsync: `IO error encountered -- skipping file deletion`) | measured; see "Compatible subsets or approximations" 1 for the transfer-time case | `delete_is_skipped_when_the_source_scan_has_errors`, `unreadable_source_root_disables_delete` |
+| Files the source has but a rule skips (`-u`, `--existing`, `--ignore-existing`, `--max-size`/`--min-size`, symlinks without `-l`, specials without `-D`) are not deleted, even when the destination entry is a non-empty directory | measured on 3.2.7 and 3.5.0 | `delete_never_removes_paths_the_source_has_but_skips`, `delete_leaves_directory_contents_under_a_skipped_source_path`, `size_limits_filter_files_and_protect_them_from_delete`, `delete_keeps_partials_of_filtered_files` |
+| `-u`/`--update`: a destination regular file with a newer mtime is left alone | measured for regular files; see "Compatible subsets or approximations" for symlinks/devices | `update_skips_files_newer_on_the_destination` |
+| `--existing` / `--ignore-existing`, including `--existing` covering directories | measured | `ignore_existing_and_existing`, `existing_never_creates_the_destination_root`, `existing_leaves_a_file_where_a_source_directory_would_go`, `existing_dry_run_reports_no_missing_directory_changes`, `existing_opens_up_readonly_dirs_even_after_a_symlinked_dir` |
+| `--max-size` / `--min-size` on regular files only; `K`/`M`/`G` suffixes | measured | `size_limits_filter_files_and_protect_them_from_delete`, `bad_size_limits_fail_before_anything_connects` |
+| `--files-from` baseline: paths relative to one source; implied parents created; a plain listed directory is copied without its contents unless `-r` is given explicitly (`-a` doesn't count); `--from0`; `-` reads stdin; blank entries and entries starting with `#` or `;` dropped in both separator modes (literal names remain reachable as `./#name` and `./;name`) | measured; see [file-list parsing differences](../../docs/rsync-compat.md#file-list-parsing-and-help) | `files_from_copies_listed_paths_with_their_parents`, `files_from_treats_hash_and_semicolon_entries_as_comments`, `files_from_creates_listed_and_implied_dirs_without_r`, `files_from_repeats_and_late_listed_dirs_across_chunks`, `files_from_root_may_be_a_symlink_and_root_lines_are_rejected` |
+| `--delete-after` / `--delete-delay` accepted as synonyms of `--delete` (they describe what syq does) | by construction | `delete_after_and_delay_are_synonyms` |
+| `--max-delete N` exists and exits 25 when it trips | believed (exit code matches rsync); see "Intentional divergences" for positive-limit semantics | `max_delete_refuses_everything_past_the_limit` |
+| `--max-delete=0` reports destination-only entries without deleting them; `--max-delete=-1` is accepted as the historical synonym; without `--delete` the option has no effect | measured for syq; rsync behavior documented upstream | `max_delete_refuses_everything_past_the_limit` |
+| A destination symlink named on the command line is followed when owned by root or by the receiving process's effective uid; a component owned by anyone else is refused | measured, including absolute and relative root/cross-uid cases | `symlink_destination_is_followed`, `destination_root_symlink_preserves_target_metadata_for_both_spellings`, `existing_updates_through_a_destination_root_symlink_to_a_dir`, `foreign_owned_destination_root_symlink_is_refused` |
+| A symlink to a directory found *inside* the destination tree is replaced with a real directory; only the argument itself is followed (rsync without `-K`) | measured | `in_tree_destination_symlink_is_replaced_not_followed`, `existing_does_not_write_through_a_destination_symlink_dir` |
+| `-P`, `-h`, `--partial`, `--numeric-ids`, `-V` accepted as no-ops/aliases; common unsupported flags are rejected with an explanation | by construction | `rsync_compat_noops_are_accepted`, `unsupported_rsync_flags_explain_themselves` |
+| `-B` and `--block-size` select syq's transfer/hash block size | by construction | `checksum_repairs_silent_corruption` |
+| A remote source and remote destination are refused before connecting, as by rsync | by construction | `rsync_rejects_remote_to_remote` |
+| Source entries whose names look like syq's partial files (`.name.syq-part.<id>`) are copied as data like any other file (with one warning); only the exact case where a source path equals the partial file this copy would use for another file is refused, before anything is written | by construction | `sidecar_named_source_directory_is_payload`, `delete_treats_sidecar_patterned_files_as_ordinary_extras`, `partial_named_symlink_is_a_symlink_not_a_leftover` |
+
+## Focused regression tests
+
+### Deletion after transfer
+
+*Tests: `delete_with_inplace_replacing_many_symlinks`,
+   `delete_removes_only_this_jobs_orphaned_sidecars`.*
+
+### Deletion ceiling
+
+*Test:
+   `max_delete_refuses_everything_past_the_limit`.*
+
+### Symlinked file-list parents
+
+*Tests:
+   `files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs`,
+   `files_from_leaves_no_ancestors_behind_on_a_bad_chain`,
+   `files_from_symlink_conflict_is_order_independent`.*
+
+### Destination conflicts
+
+*Tests: `duplicate_destination_rejected`,
+   `exactly_repeated_sources_are_deduplicated_without_changing_placement`,
+   `dir_vs_file_destination_collision_rejected`,
+   `cross_source_collision_is_detected_before_any_change`,
+   `copy_onto_itself_among_sources_is_order_independent`,
+   `three_claimants_are_validated_as_a_group`.*
+
+### Keeping existing entries
+
+*Test: `ignore_existing_keeps_a_file_where_a_source_directory_maps`.*
+
+### Verification scope
+
+*Test: `verify_only_checks_the_filtered_scope`.*
+
+### Source listing failure
+
+*Tests:
+   `unreadable_source_root_disables_delete`,
+   `delete_is_skipped_when_the_source_scan_has_errors`.*
+
+### File-list option restrictions
+
+*Test:
+   `files_from_rejections_and_stdin`.*
+
+## Review tasks
+
+These questions were moved from the public guide on 2026-09-05, against
+`master` at `87c63e7`. They are review tasks, not promises to change behavior.
+Keep the public guide's current limitations accurate if a decision changes.
+
+- Review the `--files-from` path rules together: rejection of `..`, stripped
+  trailing slashes, refusal of `.` and `/` entries, and the missing `-0` alias.
+- Decide whether `-h` alone should print help while remaining a
+  human-readable no-op in an option cluster.
+- Measure rsync's `-u` behavior for symlinks and devices, then choose whether
+  to align or document the difference. Syq currently checks regular files only.
+
+Common unsupported flags are rejected by `reject_unsupported_rsync_flags` in
+`src/cli.rs`; the public guide need not expose that implementation detail.

--- a/tests/rsync-compat/README.md
+++ b/tests/rsync-compat/README.md
@@ -2,7 +2,11 @@
 
 This directory tracks what selected upstream rsync tests tell us about SYQ's
 rsync-compatible command surface. It is both a regression suite and a reviewable
-map of compatibility work. It is not an overall compatibility score.
+map of compatibility work. It is not an overall compatibility score: many
+upstream tests exercise unsupported options, rsync's wire protocol, daemon,
+or internal helpers. The [public compatibility guide](../../docs/rsync-compat.md)
+describes user-visible behavior; [LOCAL-TESTS.md](LOCAL-TESTS.md) links its
+claims to local integration tests and records unresolved review questions.
 
 Run it from the repository root:
 
@@ -116,7 +120,10 @@ keg-only OpenSSL cannot make macOS configuration depend on undeclared flags.
 
 ## Inventory, observations, and product positions
 
-`inventory.tsv` names every test at the pinned commit. Updating the pin without
+`inventory.tsv` names every test at the pinned commit. At the current pin,
+all 351 are classified: 38 runnable sources, 130 unsupported user features,
+and 183 tests of rsync internals, protocol, daemon, or restricted wrappers.
+None are unassessed. Updating the pin without
 classifying every added or removed test is an error. Its classifications are:
 
 - `conformance`: a relevant upstream test used without modification.


### PR DESCRIPTION
Several guides still contradict the current CLI: the composability pipeline emits multiline JSON that mapping input refuses, removal paths are described as more restricted than they are, results startup failures promise a stream that cannot exist, and the SDK overview omits typed `rm`. This updates those claims and carries the remaining applicable documentation corrections from #177 into the rewritten guides.

The follow-up also corrects release-only helper installation, the installer URL and zsh initialization, mapping and receiver behavior, and performance guidance. It shortens the speed and rsync pages, keeps user-visible compatibility limitations in the public guide, and moves test-maintenance details and benchmark provenance into committed maintainer notes. Current command names and the rework's plain wording are preserved.

This PR changes documentation only. Authentication validation, Python API renames, internal code cleanup, persistence status, enrollment housekeeping, and the finish deadline remain separate from this follow-up.

Validation:

- `python3 scripts/check-doc-links.py`: 13 files, no problems.
- `mdbook build`: passed with v0.5.4, downloaded locally and verified against the SHA-256 pinned in `pages.yml`.
- `cargo test --test local mappings_md -- --nocapture`: 5 passed.
- `cargo test --test local files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs -- --exact`: 1 passed.
- `cargo test --test local cwd_may_escape_while_root_confines`: 3 passed.
- `cargo test --test local native_cp_results_fd_refusals -- --exact`: 1 passed.
- Extracted the corrected composability pipeline from the edited Markdown, adapted only the destination to a disposable local directory, and verified the resulting date-based path and file contents.
- Checked all 61 Rust function references in the moved compatibility test notes against the source; all exist.
- `git diff --check`: passed.

The full Rust baseline, full integration suite, real-SSH suite, Python suite, and performance benchmarks were not run for this documentation-only change. PRs do not start automated test workflows; the latest `ci`, `rsync-compat`, and `macos` runs on master all passed at `87c63e7`.
