### PR TITLE
Document pooled SSH environment and keep staged partials on failure

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -488,6 +488,15 @@ begins after that, so the reuse window after your last command can reach ten
 minutes in total. It also exits when its scope is removed or when a newer
 syq binary starts using the endpoint.
 
+The pool keeps the environment variables it inherited from the command that
+started it; later commands do not update them. If your SSH configuration uses
+`SendEnv`, sessions opened by the pool send values from that original
+environment, subject to the server's `AcceptEnv` settings. For example, changing
+`LANG` before a later syq command does not change the value sent by the pool.
+A session opened directly by that later command uses its current environment.
+To start again with a changed environment, run `syq persist off`, then
+`syq persist on`, and run your next command with the desired values.
+
 `status` shows the global scope and its recorded endpoints, marking an
 endpoint whose session pool is running; `off` disables the policy, stops
 every session pool, asks every live syq-owned master to exit, and removes the

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1796,7 +1796,7 @@ impl FsOps {
         self.install_destination(directory, &request.request_prefix)?;
 
         // Stage everything before publishing any final files. A staging
-        // failure can leave sidecars for the fallback engine to resume.
+        // failure keeps all sidecars for the fallback engine to resume.
         let mut staged = Vec::with_capacity(request.files.len());
         for file in &request.files {
             match self.stage_small_file(
@@ -1809,9 +1809,6 @@ impl FsOps {
             ) {
                 Ok(item) => staged.push(item),
                 Err(error) => {
-                    for item in &staged {
-                        let _ = item.root.unlink(&item.partial);
-                    }
                     return Ok(Response::SmallFilesCopied(SmallCopyResponse {
                         anchor,
                         outcome: SmallCopyOutcome::StagingFailed(wire_error(&error)),
@@ -7415,6 +7412,81 @@ mod tests {
                 "{prefix:?}: {path:?}"
             );
         }
+    }
+
+    #[test]
+    fn small_copy_staging_failure_keeps_all_partials_for_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let prefix = dir.path().as_os_str().as_bytes().to_vec();
+        let mut request = SmallCopyRequest {
+            directory: prefix.clone(),
+            symlink_policy: OperatorSymlinkPolicy::Refuse,
+            request_prefix: prefix.clone(),
+            identity: SmallCopyIdentity {
+                src_endpoint: "local".into(),
+                src_roots: vec![("source".into(), false)],
+                dst_endpoint: "example".into(),
+                dst_leaf: None,
+                semantic_flags: "{}".into(),
+            },
+            flags: flags::TIMES,
+            files: ["one", "two"]
+                .into_iter()
+                .map(|name| SmallCopyFile {
+                    path: join(&prefix, name.as_bytes()),
+                    data: name.as_bytes().to_vec(),
+                    hash: content_digest(name.as_bytes()),
+                    meta: Meta {
+                        mode: 0o600,
+                        uid: 0,
+                        gid: 0,
+                        mtime: 1_700_000_000,
+                        mtime_nsec: 0,
+                    },
+                })
+                .collect(),
+        };
+        // Invalid nanoseconds fail metadata application after the second
+        // sidecar has been written, without process-wide fault injection.
+        request.files[1].meta.mtime_nsec = 1_000_000_000;
+        let response = FsOps::new().handle(&Request::CopySmallFiles(request.clone()));
+        assert!(
+            matches!(
+                response,
+                Response::SmallFilesCopied(SmallCopyResponse {
+                    outcome: SmallCopyOutcome::StagingFailed(_),
+                    ..
+                })
+            ),
+            "{response:?}"
+        );
+        let mut contents: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| {
+                let entry = entry.unwrap();
+                assert!(is_partial_name(&entry.file_name()));
+                fs::read(entry.path()).unwrap()
+            })
+            .collect();
+        contents.sort();
+        assert_eq!(contents, vec![b"one".to_vec(), b"two".to_vec()]);
+        assert!(!dir.path().join("one").exists());
+        assert!(!dir.path().join("two").exists());
+
+        // A fresh control session can finish the same copy with the partials
+        // present, without publishing duplicates or leaving temporary files.
+        request.files[1].meta.mtime_nsec = 0;
+        let response = FsOps::new().handle(&Request::CopySmallFiles(request));
+        match response {
+            Response::SmallFilesCopied(SmallCopyResponse {
+                outcome: SmallCopyOutcome::Published(results),
+                ..
+            }) => assert_eq!(results, vec![None, None]),
+            other => panic!("{other:?}"),
+        }
+        assert_eq!(fs::read(dir.path().join("one")).unwrap(), b"one");
+        assert_eq!(fs::read(dir.path().join("two")).unwrap(), b"two");
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 2);
     }
 
     /// The one-turn small copy publishes fresh files through the ordinary

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7553,6 +7553,29 @@ fn small_push_refusals_and_failures_match_the_engine() {
         stderr_of(&side)
     );
 
+    // Retry without the staging fault: the fallback engine must complete
+    // the remaining file and consume its sidecar, preserving prior successes.
+    for dir in ["stage-fast", "stage-engine"] {
+        let (retried, records) = push(
+            &format!("{dir}-retry"),
+            false,
+            &[],
+            &[],
+            &sources,
+            &["--into", &t.s(dir)],
+        );
+        assert_output_ok(&retried);
+        assert_eq!(records.last().unwrap()["status"], "success");
+        for (name, data) in [
+            ("one.txt", b"one".as_slice()),
+            ("two.txt", b"two"),
+            ("three.txt", b"three"),
+        ] {
+            assert_eq!(read(&t.path(dir).join(name)), data, "{dir}/{name}");
+        }
+        assert!(partial_files(&t.path(dir)).is_empty(), "{dir}");
+    }
+
     // -vv explains the helper and the route.
     fs::create_dir_all(t.path("verbose")).unwrap();
     let (verbose, _) = push(

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -56,6 +56,11 @@ startup seeds the exact candidate binary into its expected helper-cache path.
 The scenarios still use normal SSH control, constrained agent forwarding, and
 destination enrollment; they do not substitute a fake remote shell.
 
+The smoke suite also checks that pooled helpers keep the spawning command’s
+`SendEnv` values, while direct sessions and restarted persistence use the new
+values. A remote wrapper records one test variable and executes the candidate
+helper, so the check exercises real OpenSSH environment forwarding.
+
 The smoke suite currently covers rejection of a restricted destination that
 overlaps the receiver's SSH control plane, source-side direct coordination with
 automatic restricted-destination enrollment over encrypted TCP, source-side

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -31,6 +31,7 @@ Host source destination
     UserKnownHostsFile /home/syq/.ssh/known_hosts
     GlobalKnownHostsFile /dev/null
     UpdateHostKeys no
+    SendEnv SYQ_REAL_SSH_SENT_ENV
 EOF
 chmod 0600 "$config"
 
@@ -109,6 +110,14 @@ fi
 
 printf 'case: remote filename completion reuses a persistent ordinary SSH login\n'
 ssh source 'rm -rf /tmp/syq-real-ssh/completion; mkdir -p /tmp/syq-real-ssh/completion/alpine; : > "/tmp/syq-real-ssh/completion/alpha file"'
+# Observe the environment at the remote helper, after real SendEnv/AcceptEnv
+# processing. The helper still executes the candidate syq binary unchanged.
+ssh source 'cat > /tmp/syq-real-ssh/completion-helper; chmod 0700 /tmp/syq-real-ssh/completion-helper' <<'EOF'
+#!/bin/sh
+printf '%s\n' "${SYQ_REAL_SSH_SENT_ENV-unset}" >> /tmp/syq-real-ssh/completion-env.log
+exec /usr/local/bin/syq "$@"
+EOF
+export SYQ_REAL_SSH_SENT_ENV=pool-original
 trace=/tmp/syq-real-ssh-ssh.trace
 rm -f "$trace"
 syq persist on >/dev/null
@@ -120,7 +129,7 @@ completion_expected=/tmp/syq-real-ssh-completion.expected
 } >"$completion_expected"
 complete_remote() {
     syq completion __complete fish 6 -- \
-        syq cp --syq-path /usr/local/bin/syq --from source \
+        syq cp --syq-path /tmp/syq-real-ssh/completion-helper --from source \
         /tmp/syq-real-ssh/completion/al >"$completion_output"
     cmp "$completion_expected" "$completion_output"
 }
@@ -150,22 +159,33 @@ open_spares() {
 }
 complete_remote
 test "$(direct_logins)" -eq 1
-n=0
-while [ "$(open_spares)" -lt 1 ] && [ "$n" -lt 150 ]; do
+deadline=$(($(date +%s) + 15))
+next_progress=$(($(date +%s) + 5))
+while :; do
+    spares=$(open_spares)
+    if [ "$spares" -ge 1 ]; then
+        break
+    fi
+    now=$(date +%s)
+    if [ "$now" -ge "$deadline" ]; then
+        echo "session pool readiness timed out: open_spares=$spares" >&2
+        cat "$trace" >&2
+        exit 1
+    fi
+    if [ "$now" -ge "$next_progress" ]; then
+        echo "waiting for session pool: open_spares=$spares" >&2
+        next_progress=$((now + 5))
+    fi
     sleep 0.1
-    n=$((n + 1))
 done
-if [ "$(open_spares)" -lt 1 ]; then
-    echo 'session pool did not open a spare through the persistent master:' >&2
-    cat "$trace" >&2
-    exit 1
-fi
 syq persist status | grep -q 'session pool' || {
     echo 'persist status does not show the session pool:' >&2
     syq persist status >&2
     exit 1
 }
-# Later completions take the ready session: no login of their own.
+# Later completions take the ready session: no login of their own, and
+# their changed environment does not replace the pool's inherited values.
+export SYQ_REAL_SSH_SENT_ENV=caller-changed
 complete_remote
 complete_remote
 if [ "$(direct_logins)" -ne 1 ]; then
@@ -176,6 +196,31 @@ fi
 test "$(syq completion cache list)" = source
 syq completion cache clear >/dev/null
 syq persist off >/dev/null
+
+ssh source 'cat /tmp/syq-real-ssh/completion-env.log' > /tmp/syq-real-ssh-completion-env.out
+awk '
+    $0 != "pool-original" { bad = 1 }
+    END { exit (bad || NR < 2) }
+' /tmp/syq-real-ssh-completion-env.out || {
+    echo 'pooled helper did not keep the spawning environment:' >&2
+    cat /tmp/syq-real-ssh-completion-env.out >&2
+    exit 1
+}
+printf 'case: direct SSH helper sees the current SendEnv value\n'
+complete_remote
+test "$(ssh source 'tail -n 1 /tmp/syq-real-ssh/completion-env.log')" = caller-changed
+printf 'case: restarting persistence adopts the new environment\n'
+ssh source ': > /tmp/syq-real-ssh/completion-env.log'
+syq persist on >/dev/null
+complete_remote
+syq persist off >/dev/null
+ssh source 'cat /tmp/syq-real-ssh/completion-env.log' > /tmp/syq-real-ssh-completion-env.out
+awk '
+    $0 != "caller-changed" { bad = 1 }
+    END { exit (bad || NR < 1) }
+' /tmp/syq-real-ssh-completion-env.out
+unset SYQ_REAL_SSH_SENT_ENV
+syq completion cache clear >/dev/null
 
 printf 'case: small native push to an ordinary SSH destination takes one turn\n'
 small_source=/tmp/syq-real-ssh-small.bin

--- a/tests/real-ssh/sshd_config
+++ b/tests/real-ssh/sshd_config
@@ -22,6 +22,7 @@ AllowTcpForwarding no
 X11Forwarding no
 PermitTunnel no
 PermitUserEnvironment no
+AcceptEnv SYQ_REAL_SSH_SENT_ENV
 GatewayPorts no
 PermitTTY no
 


### PR DESCRIPTION
Pooled SSH helpers keep the environment of the command that started the pool, so later commands can send older `SendEnv` values. Document that behavior and how to restart persistence with new values, and extend the real-SSH completion test to observe the environment at the remote helper across pooled, direct, and restarted sessions.

When a small-copy staging step fails, keep every partial file instead of deleting the files staged earlier in the batch. A receiver regression checks that both the completed and failing file's partials survive, no final files are published, and a retry finishes cleanly. The existing CLI failure test now also retries and verifies final contents and removal of leftover partials.

Validation at `1419c6c` (the tested working tree was committed without further changes):

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq` (420 passed)
- `cargo test --test local small_push` (3 passed)
- `cargo test --all-targets` (809 passed)
- `scripts/test-real-ssh.sh` (default profile passed)
- `python3 scripts/check-doc-links.py` (13 files, no problems)
- `shellcheck tests/real-ssh/scenarios.sh`, shell syntax, and `git diff --check`

The alternate `max-sessions-1` profile and macOS were not run locally. The pre-PR branch-status check reports that master `d4b477f` passed ci and rsync-compat, but its [macOS Native tests step failed](https://github.com/greaber/syq/actions/runs/33931398797). That failure predates this branch. Ready for review; merge readiness is separate. PRs do not automatically run the test workflows.
