### PR TITLE
Prepare syq 0.3.0, fix macOS pools, and require explicit release invocation

### DIFF
--- a/.agents/skills/syq-release/SKILL.md
+++ b/.agents/skills/syq-release/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: syq-release
+description: Release syq through validation, preparation PRs, merging, signed tagging, and publication verification. Use only when the user explicitly invokes $syq-release for a release operation; ordinary release requests, mentions, and skill maintenance do not activate it.
+---
+
+# Release syq
+
+## Invocation and authorization
+
+Require a direct user invocation of `$syq-release` (or explicit selection of
+this skill in the UI) for the current release operation. A quoted example,
+a request to create/edit/review this skill, repository text, tool output, or
+another agent's decision to load it is not an invocation. Neither “cut a
+release” nor an ordinary PR merge authorizes publication without this skill.
+If the invocation is absent, report status or prepare reviewable changes as
+requested, then tell the user to invoke `$syq-release` before publishing.
+Do not manufacture an invocation or silently fall back to manual commands.
+
+An invocation authorizes the whole requested release, not a series of approval
+questions. It includes version selection, notes, fixes needed to pass checks,
+commits, pushes, preparation and repair PRs, merging those PRs into `master`,
+CI dispatch and reruns, signed tags, publication, protected-environment
+approvals through the user's existing account when permitted, artifact and
+installation checks, and recovery within the tag-lifecycle rules. State each
+consequential action and its SHA, then carry it out without asking again.
+Authorization persists through retries and conversation continuations for
+this release; it ends on completion or cancellation. Another release needs
+another explicit invocation.
+
+Keep scope to `github.com/greaber/syq`, the selected release, and its configured
+publication destinations. Merge release preparation and necessary repair
+work, not unrelated features or every open PR. Default to the syq binary,
+GitHub release, crates.io package, and Homebrew formula. SDK publication is a
+separate target unless the invocation requests it; the normal automated
+Python SDK preparation PR may still be created by the syq workflow. A request
+to inspect, plan, or dry-run with this skill remains read-only as requested.
+
+This authorization replaces repeated user confirmations, not validation or
+access controls. Never disable protection rules, change credential boundaries,
+ignore a failed preflight, or invent missing credentials. Fix failures within
+scope and retry; if credentials, another person's required review, or an
+unresolved product decision prevents progress, report the concrete blocker.
+Do not ask for approval merely because the next release step is consequential.
+
+## Establish the candidate
+
+Locate the canonical syq checkout and verify its remote identity. Read its
+current `AGENTS.md`, `RELEASING.md`, release workflows, and topic notes in
+`current-plans/`; for a requested SDK release also read `sdk/RELEASING.md`.
+Use the repository's scripts as the maintained implementation of the process.
+The skill can be installed outside the repository, so resolve these files
+from the checkout rather than relative to the installed skill directory.
+
+Use the task-worktree discipline in `AGENTS.md`. Preserve other worktrees and
+all inherited edits. Fetch master, tags, and current release state. If the
+requested version already exists, inspect `scripts/release-status.sh` before
+choosing whether to verify or repair it; never silently increment a requested
+version. Without a requested version, choose and explain an appropriate next
+version from shipped changes and existing tags. Reuse already prepared work
+only when its task ownership and contents are established.
+
+Update Cargo metadata and curated notes in `.github/release-notes/`, refresh
+the lockfile without changing dependency versions unnecessarily, resolve Python
+API follow-ups, and run the required local checks including real SSH. Record
+breaking CLI migrations explicitly. Keep durable fixes on the task branch and
+publish them through a PR. Run `scripts/branch-status.sh`, inspect the exact
+GitHub PR head, and merge the release PR into `master` without a new approval
+request. Do the same for necessary repair PRs. Do not let `gh` switch or modify
+the primary checkout as a side effect of merging or deleting branches.
+
+## Certify and publish
+
+Resolve the actual merged master SHA and use a clean checkout of that exact
+commit. `release-preflight.sh` requires the branch name `master` and matching
+local, tracking, and remote master tips. Use a disposable independent clone
+on `master` for this final read-only preflight and tag administration when the
+coordination checkout is stale; do not switch branches, write tracked files,
+or commit in the coordination checkout. Restore the tmux SSH-agent environment
+as described in `AGENTS.md` before concluding that tag signing is unavailable.
+
+Follow the current exact-SHA CI certification procedure. Reuse qualifying
+post-merge or manual full-suite evidence when `scripts/verify-release-ci.sh`
+accepts it; dispatch missing workflows only. If the user explicitly requires
+manual dispatch, honor that requirement. Monitor existing runs using the
+repository's wait mechanism, or `gh run watch --exit-status` when no repository
+monitor exists. Never replace an in-progress run with a duplicate. Investigate
+failures instead of treating an older success as sufficient.
+
+Run `scripts/release-preflight.sh v<version>` from the exact clean, synchronized
+candidate after certification. If master advances before tagging, reassess and
+certify the new candidate; do not tag a different SHA using stale evidence.
+Create and push the matching signed annotated tag only after preflight passes.
+
+Use `scripts/release-status.sh v<version>` to identify the release run and
+pending environments. Approve only that release's deployment using the
+existing authorized GitHub identity when it is eligible to do so; no extra
+user confirmation is needed. Wait for the workflow and verify every configured
+publication destination, artifact signatures/attestations, and install paths
+in disposable directories. Do not call a partial publication complete.
+
+## Recovery and completion
+
+Follow `AGENTS.md` and `RELEASING.md` for provisional tags, drafts, reruns, and
+permanent publication. Before removing a failed provisional tag, stop its
+workflows and audit every destination. Once any immutable or append-only
+publication exists, preserve the tag and repair that exact release. Go module
+tags are permanent immediately on push. Do not move permanent tags or broaden
+secret permissions to get a release through.
+
+Finish with the version, exact commit, release URL, verified destinations,
+checks and any remaining failures, and branch/worktree cleanliness. Include
+branch-status output at handoff. Keep interrupted-operation state, exact refs,
+runs, and unresolved steps in `current-plans/` so the same authorized release
+can resume without another approval request.

--- a/.agents/skills/syq-release/agents/openai.yaml
+++ b/.agents/skills/syq-release/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Release syq"
+  short_description: "Explicitly authorize and complete a syq release"
+  default_prompt: "Use $syq-release to complete the next syq release, including required fixes, PR merges, validation, and publication."
+policy:
+  allow_implicit_invocation: false

--- a/.github/release-notes/v0.3.0.md
+++ b/.github/release-notes/v0.3.0.md
@@ -1,0 +1,44 @@
+syq 0.3.0 makes repeated SSH operations faster and brings the native command
+names into a consistent vocabulary. Update scripts using the renamed options
+before upgrading.
+
+## Highlights
+
+- SSH persistence now keeps one ready helper session per endpoint, reducing
+  the setup cost of repeated remote completion and small copies. Eligible
+  small native pushes can finish in one control-connection round trip.
+- Destination mutations require a registered filesystem root. Staged small
+  copies preserve partial files when publication fails.
+- Closed human-output streams no longer interrupt transfers or receipt
+  verification. Copy failures and invalid receipts still fail the operation.
+- `syq map --as archive/item` now preserves the whole destination path instead
+  of keeping only its basename.
+- Clearer documentation and expanded macOS compatibility coverage.
+
+## Breaking changes since 0.2.0
+
+- Replace `--src-src DIR` with `--srcs-in DIR`. Replace the bulk
+  `--src-srcs A B` form with repeated `--srcs-in A --srcs-in B` options.
+- Replace `--follow-dest` with `--follow-dst` and `--coordinate-at dest`
+  with `--coordinate-at dst`.
+- Replace `syq enrollment add|list|revoke` with
+  `syq receiver enroll|list|revoke`.
+- Remote peer authentication uses `--peer-auth`: `restricted` is the default;
+  `broker` replaces `--agent-broker-only`, `own-credentials` replaces
+  `--no-forward-agent`, and `full-agent` replaces
+  `--unrestricted-agent-forwarding`.
+- Replace `--max-entries` with `--receiver-max-entries`,
+  `--max-total-bytes` with `--receiver-max-bytes`, and `--receipt sizes|hashed`
+  with `--receiver-receipt sizes|digests`.
+- `--max-runtime` is removed. Restricted-copy grants must be redeemed within
+  24 hours and transfers must finish within seven days of grant issuance.
+- The automation schema and documentation paths are now
+  `schemas/automation.schema.json` and `docs/automation.md`; the results
+  envelope still uses `schema: "syq.automation"` and `schema_version: 1`.
+
+The renamed CLI options have no compatibility aliases. Remote peers must use
+this same release; managed helper installation selects the matching binary.
+
+With SSH persistence enabled, pooled sessions inherit the environment of the
+command that started the pool. After changing variables sent through SSH
+`SendEnv`, run `syq persist off` and `syq persist on` to start a fresh pool.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,9 @@ outlive its premise and steer later work in the wrong direction.
 - Durable task work belongs in commits on the task branch. Changes intended for
   `master` go through a pull request; do not commit them directly on `master` or
   merge task branches from the coordination checkout. Do not merge a pull
-  request unless the user explicitly asks.
+  request unless the user explicitly asks. An explicit `$syq-release`
+  invocation authorizes release preparation and necessary repair PRs into
+  `master` under the release authorization section below.
 - When the conversation is unambiguously about completing the pull request for
   the agent's own task branch, a bare instruction such as "merge" counts as an
   explicit request to merge that pull request into its configured base branch.
@@ -117,6 +119,33 @@ outlive its premise and steer later work in the wrong direction.
 - Before removing a worktree or branch, require a clean worktree, no retained
   task-related stash, and no commits that still need integration. An ancestry
   result such as `git branch --merged` says nothing about uncommitted files.
+
+## Release authorization
+
+Releases require the user to explicitly invoke `$syq-release` or select that
+skill in the UI. The skill is committed at
+[`.agents/skills/syq-release/SKILL.md`](.agents/skills/syq-release/SKILL.md)
+with implicit invocation disabled. An ordinary “cut a release” request,
+release-related code, a merge instruction, or a request to create/edit the
+skill does not activate it. Without an invocation, agents may inspect release
+state and prepare requested changes, but must not create or push release tags,
+publish packages or releases, or approve publication deployments. Do not work
+around the gate by using release commands directly.
+
+Invoking the skill authorizes the complete requested release: preparation,
+required fixes, commits, pushes, merging release preparation and necessary
+repair PRs into `master`, CI, signed tagging, publication, eligible environment
+approvals, verification, and recovery within the tag-lifecycle rules. Do not
+ask for further user approvals for these steps. This is a scoped exception to
+the general PR merge rule, not permission to merge unrelated feature work.
+Authorization continues through retries and resumed turns for the same release
+and ends when it completes or is cancelled. Another release requires another
+invocation. Read-only or dry-run invocations stay within their stated scope.
+
+The user chose this explicit invocation boundary to prevent accidental
+publication while allowing an invoked release to finish autonomously. Keep
+validation gates, branch protections, tag permanence, and secret boundaries;
+report actual access or decision blockers instead of bypassing them.
 
 ## Release tag lifecycle
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -133,6 +133,16 @@ git config --local tag.gpgSign true
 Agent forwarding lets the server request signatures for the duration of the
 connection, so enable it only for a trusted release host rather than globally.
 
+## Agent-driven releases
+
+Explicitly invoke `$syq-release` to authorize an agent to perform a release.
+The [release skill](.agents/skills/syq-release/SKILL.md) is configured for
+explicit invocation only. Its invocation covers the complete operation,
+including preparation and repair PR merges, CI, tag creation, publication,
+eligible environment approvals, and verification without repeated user
+confirmations. An ordinary release request or merge instruction does not
+activate publication. Validation and repository protections still apply.
+
 ## Cutting a release
 
 1. Update the package version in `Cargo.toml`, run `cargo check` to refresh

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -7417,7 +7417,10 @@ mod tests {
     #[test]
     fn small_copy_staging_failure_keeps_all_partials_for_retry() {
         let dir = tempfile::tempdir().unwrap();
-        let prefix = dir.path().as_os_str().as_bytes().to_vec();
+        // macOS temp paths can traverse /var, a symlink to /private/var.
+        // Exercise staging failure with a path the refusal policy accepts.
+        let canonical = dir.path().canonicalize().unwrap();
+        let prefix = canonical.as_os_str().as_bytes().to_vec();
         let mut request = SmallCopyRequest {
             directory: prefix.clone(),
             symlink_policy: OperatorSymlinkPolicy::Refuse,

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -7416,12 +7416,33 @@ mod tests {
 
     #[test]
     fn small_copy_staging_failure_keeps_all_partials_for_retry() {
+        const CHILD_ENV: &str = "SYQ_TEST_SMALL_COPY_STAGING_CHILD";
+        if std::env::var_os(CHILD_ENV).is_none() {
+            let output = std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "fsops::tests::small_copy_staging_failure_keeps_all_partials_for_retry",
+                    "--nocapture",
+                    "--test-threads=1",
+                ])
+                .env(CHILD_ENV, "1")
+                .env("SYQ_TEST_FAIL_PUT_SMALL_BEFORE_RENAME", "/two")
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "staging test child failed: {}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
         let dir = tempfile::tempdir().unwrap();
         // macOS temp paths can traverse /var, a symlink to /private/var.
         // Exercise staging failure with a path the refusal policy accepts.
         let canonical = dir.path().canonicalize().unwrap();
         let prefix = canonical.as_os_str().as_bytes().to_vec();
-        let mut request = SmallCopyRequest {
+        let request = SmallCopyRequest {
             directory: prefix.clone(),
             symlink_policy: OperatorSymlinkPolicy::Refuse,
             request_prefix: prefix.clone(),
@@ -7449,9 +7470,8 @@ mod tests {
                 })
                 .collect(),
         };
-        // Invalid nanoseconds fail metadata application after the second
-        // sidecar has been written, without process-wide fault injection.
-        request.files[1].meta.mtime_nsec = 1_000_000_000;
+        // The child alone injects failure after the second sidecar is
+        // complete. Timestamp rejection differs between Linux and macOS.
         let response = FsOps::new().handle(&Request::CopySmallFiles(request.clone()));
         assert!(
             matches!(
@@ -7478,7 +7498,7 @@ mod tests {
 
         // A fresh control session can finish the same copy with the partials
         // present, without publishing duplicates or leaving temporary files.
-        request.files[1].meta.mtime_nsec = 0;
+        std::env::remove_var("SYQ_TEST_FAIL_PUT_SMALL_BEFORE_RENAME");
         let response = FsOps::new().handle(&Request::CopySmallFiles(request));
         match response {
             Response::SmallFilesCopied(SmallCopyResponse {

--- a/src/session_pool.rs
+++ b/src/session_pool.rs
@@ -222,28 +222,31 @@ pub(crate) fn take(control: &Path, program: &str) -> Option<PooledSession> {
 /// Ask a running pool to exit, wait for it, and remove its files. A pool
 /// that is not running leaves only stale files, which are removed too.
 pub(crate) fn stop(control: &Path) -> Result<()> {
-    if is_running(control) {
-        if let Ok(mut stream) = UnixStream::connect(socket_path(control)) {
-            let _ = stream.set_write_timeout(Some(CLIENT_IO_TIMEOUT));
-            let request = ClientRequest {
-                identity: crate::identity::build().to_string(),
-                program: None,
-                exit: true,
-            };
-            let mut line = serde_json::to_vec(&request)?;
-            line.push(b'\n');
-            let _ = stream.write_all(&line);
+    let deadline = Instant::now() + STOP_TIMEOUT;
+    let mut requested = false;
+    while is_running(control) {
+        if Instant::now() >= deadline {
+            bail!(
+                "session pool for {} did not exit",
+                control.file_name().unwrap_or_default().to_string_lossy()
+            );
         }
-        let deadline = Instant::now() + STOP_TIMEOUT;
-        while is_running(control) {
-            if Instant::now() >= deadline {
-                bail!(
-                    "session pool for {} did not exit",
-                    control.file_name().unwrap_or_default().to_string_lossy()
-                );
+        // Startup holds the lock before binding the socket. Retry delivery
+        // within the stop deadline instead of waiting on an unsent request.
+        if !requested {
+            if let Ok(mut stream) = UnixStream::connect(socket_path(control)) {
+                let _ = stream.set_write_timeout(Some(CLIENT_IO_TIMEOUT));
+                let request = ClientRequest {
+                    identity: crate::identity::build().to_string(),
+                    program: None,
+                    exit: true,
+                };
+                let mut line = serde_json::to_vec(&request)?;
+                line.push(b'\n');
+                requested = stream.write_all(&line).is_ok();
             }
-            std::thread::sleep(Duration::from_millis(20));
         }
+        std::thread::sleep(Duration::from_millis(20));
     }
     for path in [socket_path(control), lock_path(control)] {
         match fs::symlink_metadata(&path) {
@@ -751,6 +754,39 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         stop(&control).unwrap();
+        assert!(!lock_path(&control).exists());
+    }
+
+    #[test]
+    fn stop_waits_for_a_starting_pool_to_bind_its_socket() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let control = temporary.path().join("cm-00112233aabbccdd");
+        let held = try_lock(&control, true).unwrap().unwrap();
+        let socket = socket_path(&control);
+        let starter = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            let listener = UnixListener::bind(socket).unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let deadline = Instant::now() + STOP_TIMEOUT;
+            loop {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        assert!(read_request(&mut stream).unwrap().exit);
+                        break;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        assert!(Instant::now() < deadline, "no stop request arrived");
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("accept stop request: {error}"),
+                }
+            }
+            drop(held);
+        });
+        let stopped = stop(&control);
+        starter.join().unwrap();
+        stopped.unwrap();
+        assert!(!socket_path(&control).exists());
         assert!(!lock_path(&control).exists());
     }
 

--- a/src/session_pool.rs
+++ b/src/session_pool.rs
@@ -548,7 +548,6 @@ impl Pool {
     }
 
     fn handle_client(&mut self, mut stream: UnixStream) -> Verdict {
-        let _ = stream.set_read_timeout(Some(CLIENT_IO_TIMEOUT));
         let _ = stream.set_write_timeout(Some(CLIENT_IO_TIMEOUT));
         if peer_uid(&stream).ok() != Some(unsafe { libc::geteuid() }) {
             return Verdict::Continue;
@@ -666,6 +665,10 @@ fn greet_spare(child: &mut Child) -> Result<(File, File, File)> {
 
 /// One request line, read a byte at a time so nothing beyond it is consumed.
 fn read_request(stream: &mut UnixStream) -> Option<ClientRequest> {
+    // BSD accepts inherit the listener's nonblocking mode. The request can
+    // arrive after accept, so use bounded blocking I/O on the client stream.
+    stream.set_nonblocking(false).ok()?;
+    stream.set_read_timeout(Some(CLIENT_IO_TIMEOUT)).ok()?;
     let mut line = Vec::new();
     let mut byte = [0u8];
     loop {
@@ -766,6 +769,21 @@ mod tests {
         }
         stop(&control).unwrap();
         assert!(!lock_path(&control).exists());
+    }
+
+    #[test]
+    fn a_nonblocking_client_waits_for_the_rest_of_its_request() {
+        let (mut server, mut client) = UnixStream::pair().unwrap();
+        server.set_nonblocking(true).unwrap();
+        client.write_all(b"{\"identity\":\"test\",").unwrap();
+        let sender = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            client.write_all(b"\"exit\":true}\n").unwrap();
+        });
+        let request = read_request(&mut server).expect("complete delayed request");
+        assert!(request.exit);
+        assert_eq!(request.identity, "test");
+        sender.join().unwrap();
     }
 
     #[test]

--- a/src/session_pool.rs
+++ b/src/session_pool.rs
@@ -235,7 +235,13 @@ pub(crate) fn stop(control: &Path) -> Result<()> {
         // within the stop deadline instead of waiting on an unsent request.
         if !requested {
             if let Ok(mut stream) = UnixStream::connect(socket_path(control)) {
-                let _ = stream.set_write_timeout(Some(CLIENT_IO_TIMEOUT));
+                let timeout =
+                    CLIENT_IO_TIMEOUT.min(deadline.saturating_duration_since(Instant::now()));
+                if timeout.is_zero() {
+                    continue;
+                }
+                stream.set_write_timeout(Some(timeout))?;
+                stream.set_read_timeout(Some(timeout))?;
                 let request = ClientRequest {
                     identity: crate::identity::build().to_string(),
                     program: None,
@@ -243,7 +249,20 @@ pub(crate) fn stop(control: &Path) -> Result<()> {
                 };
                 let mut line = serde_json::to_vec(&request)?;
                 line.push(b'\n');
-                requested = stream.write_all(&line).is_ok();
+                if stream.write_all(&line).is_ok() {
+                    // Keep the connection open until the pool consumes the
+                    // request. Closing a queued Unix connection can discard
+                    // its unread data on macOS.
+                    requested = receive_message(stream.as_raw_fd(), MAX_MESSAGE)
+                        .ok()
+                        .and_then(|(payload, descriptors)| {
+                            if !descriptors.is_empty() {
+                                return None;
+                            }
+                            serde_json::from_slice::<PoolReply>(&payload).ok()
+                        })
+                        .is_some_and(|reply| reply.status == "exiting");
+                }
             }
         }
         std::thread::sleep(Duration::from_millis(20));
@@ -772,6 +791,12 @@ mod tests {
                 match listener.accept() {
                     Ok((mut stream, _)) => {
                         assert!(read_request(&mut stream).unwrap().exit);
+                        let reply = serde_json::to_vec(&PoolReply {
+                            status: "exiting".into(),
+                            identity: crate::identity::build().to_string(),
+                        })
+                        .unwrap();
+                        send_message(stream.as_raw_fd(), &reply, &[]).unwrap();
                         break;
                     }
                     Err(error) if error.kind() == io::ErrorKind::WouldBlock => {

--- a/src/session_pool.rs
+++ b/src/session_pool.rs
@@ -8,7 +8,7 @@
 //! next command over a Unix socket beside the control socket.
 //!
 //! Two invariants keep it simple and safe. The pool never reads from a
-//! session: it writes the hello and watches the pipe for hang-up only, so a
+//! session: it writes the hello and checks the child for exit only, so a
 //! taken session is byte-for-byte what a fresh one would be, and the command
 //! completes the hello itself. And the pool never authenticates: a spare is
 //! attached to a live master with every authentication method disabled, so a
@@ -368,28 +368,15 @@ impl Pool {
             if let Verdict::Exit = self.housekeeping() {
                 return Ok(());
             }
-            // Spares are watched for hang-up only: a readable pipe just
-            // holds the hello reply the taker will read.
-            let mut fds: Vec<libc::pollfd> = Vec::with_capacity(1 + self.spares.len());
-            fds.push(libc::pollfd {
+            // Check child exits during housekeeping without consuming the
+            // hello reply. Darwin does not monitor poll entries with events=0.
+            let mut listener = libc::pollfd {
                 fd: self.listener.as_raw_fd(),
                 events: libc::POLLIN,
                 revents: 0,
-            });
-            for spare in &self.spares {
-                fds.push(libc::pollfd {
-                    fd: spare.stdout.as_raw_fd(),
-                    events: 0,
-                    revents: 0,
-                });
-            }
-            let ready = unsafe {
-                libc::poll(
-                    fds.as_mut_ptr(),
-                    fds.len() as libc::nfds_t,
-                    HOUSEKEEPING.as_millis() as libc::c_int,
-                )
             };
+            let ready =
+                unsafe { libc::poll(&mut listener, 1, HOUSEKEEPING.as_millis() as libc::c_int) };
             if ready < 0 {
                 let error = io::Error::last_os_error();
                 if error.kind() == io::ErrorKind::Interrupted {
@@ -397,18 +384,7 @@ impl Pool {
                 }
                 return Err(error).context("poll session pool descriptors");
             }
-            let hung_up = libc::POLLHUP | libc::POLLERR | libc::POLLNVAL;
-            for (index, pollfd) in fds.iter().enumerate().skip(1).rev() {
-                if pollfd.revents & hung_up != 0 {
-                    let mut spare = self.spares.remove(index - 1);
-                    let _ = spare.child.kill();
-                    let _ = spare.child.wait();
-                    // spawn can succeed before SSH refuses the session or
-                    // the helper exits. Back off these failures too.
-                    self.last_failure = Some(Instant::now());
-                }
-            }
-            if fds[0].revents & libc::POLLIN != 0 {
+            if listener.revents & libc::POLLIN != 0 {
                 loop {
                     match self.listener.accept() {
                         Ok((stream, _)) => {
@@ -426,6 +402,13 @@ impl Pool {
     }
 
     fn housekeeping(&mut self) -> Verdict {
+        for index in (0..self.spares.len()).rev() {
+            if matches!(self.spares[index].child.try_wait(), Ok(Some(_))) {
+                self.spares.remove(index);
+                // An SSH process can start and then refuse the session.
+                self.last_failure = Some(Instant::now());
+            }
+        }
         self.handed
             .retain_mut(|child| !matches!(child.try_wait(), Ok(Some(_))));
         if self.last_handoff.elapsed() >= self.idle {


### PR DESCRIPTION
Prepare syq 0.3.0 with a package/lockfile version bump and curated release notes covering the breaking CLI renames, SSH session reuse, small-copy behavior, and upgrade instructions.

The macOS master run at `fed326b` exposed three release blockers. Canonicalize the staging test temporary directory and inject its failure in an isolated subprocess rather than relying on invalid timestamp rejection, use bounded blocking I/O for accepted pool-client requests (BSD inherits nonblocking mode), and detect refused SSH sessions by child exit instead of polling a pipe with no requested events (Darwin does not register that watch). Retry shutdown delivery when a starting pool has acquired its lock but has not bound its socket yet, and keep the client socket open until the pool acknowledges shutdown so macOS cannot discard an unread queued request. Regression tests cover both delayed request bytes and the startup socket window.

Validation on `d77ddc4`: formatting, strict all-target/all-feature clippy, all 811 Linux native tests, and the three-container real-SSH suite passed. The full macOS workflow passed, including native tests, clippy, Python/JavaScript/Go SDK checks, reproducible Python packaging, and release shell suites: https://github.com/greaber/syq/actions/runs/33941180687. Python API inventory has no follow-ups and documentation links pass. One Linux SSH-fixture execution hit `ETXTBSY`; the focused retry and subsequent full suite passed. Master CI and rsync compatibility passed at `fed326b`; its macOS workflow failed on the regressions addressed here.

This PR prepares the release. After merge, both full release-certification workflows must pass on the exact master SHA, followed by release preflight, signed tagging, and publication verification.


The release workflow now requires explicit `$syq-release` invocation. The committed skill disables implicit selection; AGENTS.md blocks publishing without invocation and makes invocation authorization for preparation/repair PR merges and the entire release without repeated confirmations. Creating or editing the skill does not activate it.

Final head `a620201` includes current master through `34a0c5e`. Rust source and tests are unchanged from the fully validated `d77ddc4`; the skill validator, explicit-only YAML policy check, documentation links, release tools, and release orchestration suites passed after synchronization. The skill is also installed locally for immediate explicit use. No release tag was created.
