### PR TITLE
Reuse completed full-suite CI when cutting a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,3 +357,18 @@ jobs:
           (needs.scope.outputs.full_suite != 'true' ||
            needs.macos_intel.result == 'success')
         run: echo 'Required macOS validation succeeded.'
+
+  # A skipped certificate cannot certify successful selective stubs.
+  release-certification:
+    needs: [scope, rust, sdks, linux-arm64, macos]
+    if: >-
+      needs.scope.outputs.full_suite == 'true' &&
+      needs.scope.outputs.native == 'true' &&
+      needs.scope.outputs.python_sdk == 'true' &&
+      needs.scope.outputs.javascript_sdk == 'true' &&
+      needs.scope.outputs.go_sdk == 'true' &&
+      needs.scope.outputs.linux_arm64 == 'true' &&
+      needs.scope.outputs.macos == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Every release validation suite in this workflow succeeded.'

--- a/.github/workflows/rsync-compat.yml
+++ b/.github/workflows/rsync-compat.yml
@@ -121,3 +121,13 @@ jobs:
           needs.scope.outputs.conformance == 'true' &&
           needs.conformance_platforms.result == 'success'
         run: echo 'Selected rsync conformance succeeded.'
+
+  # A skipped certificate cannot certify successful selective stubs.
+  release-certification:
+    needs: [scope, conformance]
+    if: >-
+      needs.scope.outputs.full_suite == 'true' &&
+      needs.scope.outputs.conformance == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Every release validation suite in this workflow succeeded.'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,14 +120,16 @@ outlive its premise and steer later work in the wrong direction.
 
 ## Release tag lifecycle
 
-- Before pushing a syq release tag, run
-  explicit `workflow_dispatch` runs of both `ci.yml` and `rsync-compat.yml` on
-  the exact clean, synchronized `master` commit, wait for both to succeed, and
-  then run `scripts/release-preflight.sh v<version>` from that same commit.
-  Treat any failure as a blocker rather than pushing the tag to discover
-  whether the release workflow starts. Use
-  `scripts/release-status.sh v<version>` after the push to correlate the exact
-  tag, workflow, approvals, and publication destinations.
+- Before pushing a syq release tag, require successful full-suite runs of both
+  `ci.yml` and `rsync-compat.yml` on the exact clean, synchronized `master`
+  commit. Reuse post-merge or manual runs when `scripts/verify-release-ci.sh`
+  accepts their full-suite certificates; dispatch only workflows missing that
+  evidence and wait for them to succeed. Then run
+  `scripts/release-preflight.sh v<version>` from that same commit. Treat any
+  failure as a blocker rather than pushing the tag to discover whether the
+  release workflow starts. Use `scripts/release-status.sh v<version>` after
+  the push to correlate the exact tag, workflow, approvals, and publication
+  destinations.
 - Except for Go module tags, treat a release tag as provisional until its
   release workflow connects it to permanent published state. If an attempt is
   abandoned before that boundary, remove the failed tag locally and remotely

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -150,21 +150,34 @@ connection, so enable it only for a trusted release host rather than globally.
    exercises all three coordinator placements across isolated source and
    destination containers and does not contact real remote hosts.
 
-2. Once the release commit is the exact `master` tip, explicitly dispatch both
-   full validation workflows on it. Selective push checks are insufficient for
-   a release candidate because an unaffected job may have completed with a
-   successful stub. A manual run selects every native, SDK, conformance, ARM,
-   and macOS suite; the release gates require the latest manual run of each
-   workflow on the exact candidate SHA to succeed:
+2. Once the release commit is the exact `master` tip, check for existing full
+   validation on that commit before starting any more tests:
 
    ```sh
    candidate=$(git rev-parse master)
+   scripts/verify-release-ci.sh greaber/syq "$candidate"
+   ```
+
+   A successful post-merge run is reusable. Each workflow records a
+   `release-certification` job only when all its release suites were selected
+   and passed. Green selective runs with skipped suites do not qualify. The
+   verifier requires the latest push or manual run of each workflow on the
+   exact SHA, from this repository's `master`, to succeed and carry that
+   certificate in its current attempt. Runs made before certificates were
+   introduced need a fresh manual run.
+
+   If evidence is missing, dispatch only the workflow that needs it (both
+   commands are shown here):
+
+   ```sh
    gh workflow run ci.yml --ref master
    gh workflow run rsync-compat.yml --ref master
    ```
 
-   After both runs complete, verify their exact-SHA certification and run the
-   read-only preflight before creating the tag:
+   If the latest run is still running, wait for it instead of starting a copy.
+   A failed latest run must be investigated and repaired or rerun; an older
+   success does not override it. Manual runs select every suite. After the
+   needed runs succeed, repeat verification and run the read-only preflight:
 
    ```sh
    scripts/verify-release-ci.sh greaber/syq "$candidate"
@@ -173,8 +186,8 @@ connection, so enable it only for a trusted release host rather than globally.
 
    It requires the exact clean, synchronized `master` tip; no pending Python
    API follow-ups; matching Cargo metadata; successful `rust`, `sdks`,
-   `macos`, `linux-arm64`, and `conformance` checks on that SHA; the two full
-   manual workflow certifications; an SSH tag-signing key registered with
+   `macos`, `linux-arm64`, and `conformance` checks on that SHA; the two full-suite
+   workflow certifications; an SSH tag-signing key registered with
    GitHub; the selected-Actions allowlist; the protected `release` environment,
    tag policy, variables, and secret names; and absence of the tag or version
    from GitHub, crates.io, and the Homebrew tap. It makes no local or remote
@@ -195,7 +208,7 @@ connection, so enable it only for a trusted release host rather than globally.
    directly targets the workflow commit, that this commit is reachable
    from protected `master`, that the `rust`, `sdks`, `macos`, `linux-arm64`,
    and `conformance` checks all succeeded on that exact commit, and that both
-   full manual workflow certifications succeeded. It then builds
+   full-suite workflow certifications succeeded. It then builds
    static GNU Linux x86-64/ARM64
    binaries and native macOS Apple Silicon/Intel binaries, embeds an Ed25519
    signature over the manifest's RFC 8785 canonical JSON, verifies the exact
@@ -275,8 +288,8 @@ unique concurrency group, including while it is pending, because a later push
 may affect a different subsystem and therefore cannot safely replace the
 earlier push's selected suites. Failures are repaired in follow-up changes; they
 do not retroactively gate unrelated merges. A release candidate must still have
-successful, exact-SHA manual runs of both workflows. Release preflight and tag
-verification require the stable `rust`, `sdks`, `linux-arm64`, `macos`, and
+successful, exact-SHA full-suite certificates from both workflows. Release
+preflight and tag verification require the stable `rust`, `sdks`, `linux-arm64`, `macos`, and
 `conformance` evidence names and reject selective stubs.
 
 The checked-in classifier uses each push's exact diff. Documentation-only

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -347,6 +347,10 @@ EOF
 cat >"$preflight_bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [ "$1" = api ] && [ "${2:-}" = --paginate ]; then
+  shift 3
+  set -- api "$@"
+fi
 case "$1:$2" in
   repo:view) printf 'greaber/syq\n' ;;
   secret:list) printf '[{"name":"SYQ_RELEASE_SIGNING_KEY_PEM_B64"},{"name":"HOMEBREW_TAP_DEPLOY_KEY"}]\n' ;;
@@ -355,7 +359,8 @@ case "$1:$2" in
   api:*)
     case " $* " in
       *'/commits/'*'/check-runs'*) printf '%s\n' "$SYQ_TEST_CHECKS_JSON" ;;
-      *'/actions/workflows/'*'/runs?'*) printf '%s\n' "$SYQ_TEST_WORKFLOW_RUNS_JSON" ;;
+      *'/attempts/'*'/jobs?'*) printf '[{"jobs":[{"name":"release-certification","status":"completed","conclusion":"success"}]}]\n' ;;
+      *'/actions/workflows/'*'/runs?'*) printf '[%s]\n' "$SYQ_TEST_WORKFLOW_RUNS_JSON" ;;
       *'/actions/permissions/selected-actions '*) printf '%s\n' "$SYQ_TEST_SELECTED_ACTIONS_JSON" ;;
       *'/actions/permissions '*) printf '{"enabled":true,"allowed_actions":"selected","sha_pinning_required":true}\n' ;;
       *'/deployment-branch-policies '*) printf '{"branch_policies":[{"name":"v*","type":"tag"}]}\n' ;;
@@ -377,7 +382,7 @@ EOF
 chmod 755 "$preflight_bin/git" "$preflight_bin/gh" "$preflight_bin/curl"
 checks_json=$(jq -cn '{check_runs:["rust","sdks","macos","linux-arm64","conformance"] | map({name:.,conclusion:"success"})}')
 workflow_runs_json=$(jq -cn --arg head "$preflight_head" '{workflow_runs:[{
-  id:601,event:"workflow_dispatch",head_sha:$head,status:"completed",
+  head_branch:"master",head_repository:{full_name:"greaber/syq"},id:601,event:"workflow_dispatch",head_sha:$head,status:"completed",
   conclusion:"success",run_number:1,run_attempt:1}]}')
 selected_json=$(jq -cn '{github_owned_allowed:true,verified_allowed:false,
   patterns_allowed:["rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18"]}')
@@ -409,7 +414,7 @@ if (cd "$preflight_repo" && env "${preflight_env[@]}" \
   echo 'preflight unexpectedly accepted missing full release CI' >&2
   exit 1
 fi
-grep -F 'has no workflow_dispatch run' "$work/failure.out" >/dev/null
+grep -F 'has no push or workflow_dispatch run on master' "$work/failure.out" >/dev/null
 if (cd "$preflight_repo" && env "${preflight_env[@]}" \
   SYQ_TEST_EXISTING_CRATE_VERSION=9.9.9 \
   "$script_dir/release-preflight.sh" v9.9.9) >"$work/failure.out" 2>&1; then

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -180,12 +180,17 @@ fakebin="$work/fakebin"
 mkdir "$fakebin"
 cat > "$fakebin/gh" <<'EOF'
 #!/bin/sh
+if [ "$1" = api ] && [ "${2:-}" = --paginate ]; then
+  shift 3
+  set -- api "$@"
+fi
 case "$1:$2" in
   api:*/git/ref/tags/*) printf '%s\n' "$SYQ_TEST_REF_JSON" ;;
   api:*/git/tags/*) printf '%s\n' "$SYQ_TEST_TAG_JSON" ;;
   api:*/compare/*) printf '%s\n' "$SYQ_TEST_COMPARE_JSON" ;;
   api:*/check-runs*) printf '%s\n' "$SYQ_TEST_CHECKS_JSON" ;;
-  api:*/actions/workflows/*/runs?*) printf '%s\n' "$SYQ_TEST_WORKFLOW_RUNS_JSON" ;;
+  api:*/attempts/1/jobs?*) printf '%s\n' "${SYQ_TEST_CI_JOBS_JSON:-}" ;;
+  api:*/actions/workflows/*/runs?*) printf '[%s]\n' "$SYQ_TEST_WORKFLOW_RUNS_JSON" ;;
   release:download)
     shift 2
     destination=
@@ -214,8 +219,9 @@ checks_json=$(jq -cn '{check_runs:[
   {id:2,name:"rust",started_at:"2026-01-01T00:01:00Z",status:"completed",conclusion:"success"},
   {name:"macos",status:"completed",conclusion:"success"},
   {name:"verify signed release tag",status:"in_progress",conclusion:null}]}')
+export SYQ_TEST_CI_JOBS_JSON='[{"jobs":[{"name":"release-certification","status":"completed","conclusion":"success"}]}]'
 workflow_runs_json=$(jq -cn --arg commit "$commit" '{workflow_runs:[{
-  id:701,event:"workflow_dispatch",head_sha:$commit,status:"completed",
+  head_branch:"master",head_repository:{full_name:"greaber/syq"},id:701,event:"workflow_dispatch",head_sha:$commit,status:"completed",
   conclusion:"success",run_number:1,run_attempt:1}]}')
 SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
   SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$checks_json" \
@@ -224,16 +230,48 @@ SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
 
 SYQ_TEST_WORKFLOW_RUNS_JSON="$workflow_runs_json" PATH="$fakebin:$PATH" \
   "$script_dir/verify-release-ci.sh" greaber/syq "$commit" >/dev/null
-expect_failure 'has no workflow_dispatch run' env \
+expect_failure 'has no push or workflow_dispatch run on master' env \
   SYQ_TEST_WORKFLOW_RUNS_JSON='{"workflow_runs":[]}' PATH="$fakebin:$PATH" \
   "$script_dir/verify-release-ci.sh" greaber/syq "$commit"
 failed_workflow_runs=$(jq -cn --arg commit "$commit" '{workflow_runs:[
-  {id:701,event:"workflow_dispatch",head_sha:$commit,status:"completed",
+  {head_branch:"master",head_repository:{full_name:"greaber/syq"},id:701,event:"workflow_dispatch",head_sha:$commit,status:"completed",
    conclusion:"success",run_number:1,run_attempt:1},
-  {id:702,event:"workflow_dispatch",head_sha:$commit,status:"completed",
+  {head_branch:"master",head_repository:{full_name:"greaber/syq"},id:702,event:"workflow_dispatch",head_sha:$commit,status:"completed",
    conclusion:"failure",run_number:2,run_attempt:1}]}')
 expect_failure 'is completed/failure' env \
   SYQ_TEST_WORKFLOW_RUNS_JSON="$failed_workflow_runs" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-ci.sh" greaber/syq "$commit"
+
+# Reuse only exact-commit, own-repository master runs with full evidence.
+push_runs=$(jq '.workflow_runs[].event = "push"' <<<"$workflow_runs_json")
+SYQ_TEST_WORKFLOW_RUNS_JSON="$push_runs" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-ci.sh" greaber/syq "$commit" >/dev/null
+for conclusion in skipped failure cancelled null; do
+  jobs=$(jq -cn --arg conclusion "$conclusion" \
+    '[{jobs:[{name:"release-certification",status:"completed",conclusion:$conclusion}]}]')
+  expect_failure 'lacks successful full-suite' env \
+    SYQ_TEST_CI_JOBS_JSON="$jobs" SYQ_TEST_WORKFLOW_RUNS_JSON="$push_runs" \
+    PATH="$fakebin:$PATH" "$script_dir/verify-release-ci.sh" greaber/syq "$commit"
+done
+expect_failure 'lacks successful full-suite' env \
+  SYQ_TEST_CI_JOBS_JSON='[{"jobs":[]}]' SYQ_TEST_WORKFLOW_RUNS_JSON="$push_runs" \
+  PATH="$fakebin:$PATH" "$script_dir/verify-release-ci.sh" greaber/syq "$commit"
+for mutation in '.head_sha = "wrong"' '.head_branch = "feature"' \
+  '.head_repository.full_name = "someone/syq"' '.event = "pull_request"'; do
+  untrusted=$(jq ".workflow_runs[] |= ($mutation)" <<<"$push_runs")
+  expect_failure 'has no push or workflow_dispatch run on master' env \
+    SYQ_TEST_WORKFLOW_RUNS_JSON="$untrusted" PATH="$fakebin:$PATH" \
+    "$script_dir/verify-release-ci.sh" greaber/syq "$commit"
+done
+
+pending_runs=$(jq '.workflow_runs[0].status = "in_progress" | .workflow_runs[0].conclusion = null' <<<"$push_runs")
+expect_failure 'is in_progress/pending' env \
+  SYQ_TEST_WORKFLOW_RUNS_JSON="$pending_runs" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-ci.sh" greaber/syq "$commit"
+# A retry cannot borrow the first attempt's successful certificate.
+retry_runs=$(jq '.workflow_runs[0].run_attempt = 2' <<<"$push_runs")
+expect_failure '/attempts/2/jobs' env \
+  SYQ_TEST_WORKFLOW_RUNS_JSON="$retry_runs" PATH="$fakebin:$PATH" \
   "$script_dir/verify-release-ci.sh" greaber/syq "$commit"
 
 lightweight=$(jq -cn --arg sha "$commit" '{object:{type:"commit",sha:$sha}}')

--- a/scripts/verify-release-ci.sh
+++ b/scripts/verify-release-ci.sh
@@ -20,22 +20,34 @@ command -v gh >/dev/null || die 'release CI verification needs gh'
 command -v jq >/dev/null || die 'release CI verification needs jq'
 
 for workflow in ci.yml rsync-compat.yml; do
-  runs=$(gh api \
-    "repos/$repository/actions/workflows/$workflow/runs?event=workflow_dispatch&head_sha=$commit&per_page=100")
-  latest=$(jq -c --arg commit "$commit" '
-    [.workflow_runs[]? |
-      select(.head_sha == $commit and .event == "workflow_dispatch")] |
+  runs=$(gh api --paginate --slurp \
+    "repos/$repository/actions/workflows/$workflow/runs?head_sha=$commit&per_page=100")
+  latest=$(jq -c --arg commit "$commit" --arg repository "$repository" '
+    [.[].workflow_runs[]? |
+      select(.head_sha == $commit and .head_branch == "master"
+        and .head_repository.full_name == $repository
+        and (.event == "workflow_dispatch" or .event == "push"))] |
     sort_by([(.run_number // 0), (.run_attempt // 0)]) |
     last // empty
   ' <<<"$runs")
   [ -n "$latest" ] \
-    || die "full release CI workflow $workflow has no workflow_dispatch run on $commit"
+    || die "full release CI workflow $workflow has no push or workflow_dispatch run on master on $commit"
   status=$(jq -r '.status // "unknown"' <<<"$latest")
   conclusion=$(jq -r '.conclusion // "pending"' <<<"$latest")
   if [ "$status" != completed ] || [ "$conclusion" != success ]; then
     die "latest full release CI workflow $workflow is $status/$conclusion on $commit"
   fi
   run_id=$(jq -er .id <<<"$latest")
+  # A green selective workflow can contain successful stubs. Require the
+  # certificate from this exact attempt, never a job from an earlier attempt.
+  attempt=$(jq -er .run_attempt <<<"$latest")
+  jobs=$(gh api --paginate --slurp \
+    "repos/$repository/actions/runs/$run_id/attempts/$attempt/jobs?per_page=100")
+  jq -e '
+    [.[].jobs[]? | select(.name == "release-certification")] |
+    length == 1 and all(.[]; .status == "completed" and .conclusion == "success")
+  ' <<<"$jobs" >/dev/null \
+    || die "workflow $workflow run $run_id attempt $attempt lacks successful full-suite release-certification on $commit; dispatch this workflow on master"
   printf 'Full release CI: %s run %s succeeded on %s.\n' \
     "$workflow" "$run_id" "$commit"
 done


### PR DESCRIPTION
A release currently repeats full CI even when the same commit already passed every release suite after merge. Add a full-suite certificate to ci and rsync-compat, and let preflight and tag verification reuse the latest successful master push or manual run on the exact release SHA.

Selective runs cannot certify a release. Verification checks the head repository, branch, commit, latest run status, and certificate from the exact run attempt. Older runs without certificates require a manual run. Update maintainer instructions to check existing evidence before dispatching more tests.

Validation at cdbbee5: release tooling and orchestration tests, pinned actionlint, shellcheck on changed scripts, and git diff --check passed. No Rust source changed; the Rust baseline and real-SSH suite were not run. Live GitHub execution of the new certificate jobs remains unverified.

Branch status: release-speed at cdbbee5, clean, ahead of master fed326b by one commit. Master ci and rsync-compat passed at fed326b; macos failed (run 33935564035), so branch-status exited 1. This draft does not resolve that existing failure or modify the release in progress.
