### PR TITLE
Add progressive CLI help and fix help inconsistencies

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -167,7 +167,8 @@ available between commands.
 Standalone installs download and verify one signed release manifest at most
 once a day after a successful interactive command. When a newer release is
 available they print a reminder; updates are never installed as a side effect
-of a copy. Run `syq --self-update` to install the update, or set
+of a copy. Run `syq --self-update` to install the update (`syq --self-update --help`
+explains eligibility and reminders), or set
 `SYQ_NO_UPDATE_CHECK=1` to disable automatic checks and reminders. Explicit
 `syq --self-update` checks still work when that variable is set. The install
 receipt lives at

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,6 +9,27 @@ transfers](remote-to-remote.md), [Security](security.md), and
 authoritative where this document and the binary disagree; please report the
 disagreement.
 
+## Command-line help
+
+`syq --help` lists commands and top-level options. For each command, `-h`
+and `--help` show the same examples and commonly used options; `--help-all`
+shows the complete option reference, grouped by purpose. For example:
+
+```sh
+syq cp --help
+syq cp --help-all
+syq help receiver enroll
+```
+
+Small management commands show the same options at both levels. Every common
+help page points to its full reference. Options omitted from common help still
+work and remain available in shell completion. In rsync mode, `-h` keeps its
+rsync meaning (human-readable sizes); use `syq rsync --help` for common help
+or `syq rsync --help-all` for all options.
+
+`syq --self-update --help` explains standalone upgrades and update reminders.
+Homebrew installs use `brew upgrade syq`; see [Installation](install.md#update-checks-and-self-update).
+
 ## Native commands
 
 A native command starts with an operation and keeps endpoints, selectors,
@@ -665,7 +686,7 @@ names make clear that an rsync installation will not accept them.
 | `-v`/`--verbose`, `-vv` | `-v` lists files as they complete; for copies, `-vv` also explains remote helpers, candidate TCP addresses, the planned transport, and initial concurrency |
 | `-q`, `--quiet` | Errors only |
 | `-z`, `--compress` / `--no-compress` | Enable (the default) or disable zstd compression in syq's protocol; this is not `ssh -C` |
-| `-n`, `--dry-run` | Resolve mappings and transport, estimate transfers/exclusions/deletions; change nothing |
+| `-n`, `--dry-run` | Resolve mappings and transport, estimate transfers/exclusions/deletions; leave source and destination data unchanged |
 | `--syq-connections N` | Syq extension: parallel data connections (default: auto-tuned, see [Speed](speed.md#how-many-connections)) |
 | `--bwlimit RATE` | Limit aggregate file-data throughput (bare rate is KiB/s; `0` disables) |
 | `-B SIZE`, `--block-size SIZE` | Transfer and hash block size (default 4M) |
@@ -773,9 +794,10 @@ Identical to rsync:
 
 ### Previewing a copy
 
-`-n` / `--dry-run` connects to the endpoints and scans both sides, but creates,
-updates, and deletes nothing. Its concise summary, printed before anything
-would be written, makes path placement, intended changes, logical work, and
+`-n` / `--dry-run` connects to the endpoints and scans both sides without
+creating, updating, or deleting copy data. Requested `--results` files are
+still written, and remote connections may install helpers or update caches.
+Its concise summary makes path placement, intended changes, logical work, and
 the selected data route explicit before a real copy:
 
 ```text

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,9 +44,7 @@ pub enum SourceSelection {
 /// Endpoint that owns the transfer coordinator for a native copy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
 pub enum CoordinateAt {
-    /// Run locally unless both endpoints are remote, then use the source
-    /// endpoint (delegated path operands travel encoded, so any filename
-    /// works).
+    /// Run locally unless both endpoints are remote, then run at the source.
     #[default]
     Auto,
     /// Run the coordinator at the source endpoint.
@@ -61,7 +59,8 @@ pub enum CoordinateAt {
 #[command(
     name = "syq rsync",
     version,
-    about = "Parallel copy with an rsync-shaped interface",
+    about = "Copy using rsync-compatible syntax.\n\nA trailing source slash copies directory contents; without it, copy the named\ndirectory. Source and destination cannot both be remote; use syq cp for that.\n-h means human-readable sizes, as in rsync. Use --help for help.",
+    before_help = "Examples:\n  syq rsync -a photos/ backup/\n  syq rsync -av photos/ nas:/backup/photos/\n  syq rsync -av nas:photos/ backup/",
     disable_help_flag = true,
     override_usage = "syq rsync [OPTIONS] SRC... DEST\n       syq rsync [OPTIONS] [USER@]HOST:SRC... DEST\n       syq rsync [OPTIONS] SRC... [USER@]HOST:DEST"
 )]
@@ -197,7 +196,7 @@ pub struct Args {
     #[arg(long, overrides_with = "compress")]
     pub no_compress: bool,
     /// Resolve mappings and transport, then estimate transfers, exclusions, and deletions;
-    /// change nothing
+    /// leave source and destination data unchanged (remote helper setup may write cache files)
     #[arg(short = 'n', long)]
     pub dry_run: bool,
     /// No-op accepted for rsync compatibility (sizes are always human-readable)
@@ -423,11 +422,11 @@ impl Args {
             bail!("command name is not valid UTF-8");
         };
         match command {
-            "rsync" => Self::parse_rsync(&argv[1..], false),
+            "rsync" => Self::parse_rsync(&argv[1..]),
             "cp" => parse_native(&argv[1..], Interface::NativeCp),
             "rm" => parse_native(&argv[1..], Interface::NativeRm),
             "map" => parse_native(&argv[1..], Interface::NativeMap),
-            "--help" | "-h" => {
+            "--help" | "-h" | "--help-all" => {
                 print_root_help();
                 std::process::exit(0);
             }
@@ -437,28 +436,33 @@ impl Args {
             }
             // Installation lifecycle switches remain top-level. Internal
             // helper switches are handled in main.
-            "--self-update" | "--register-standalone-install" => Self::parse_rsync(&argv, true),
+            "--self-update" | "--register-standalone-install" => {
+                let matches = crate::help::lifecycle().try_get_matches_from(
+                    std::iter::once(OsString::from("syq")).chain(argv)
+                ).unwrap_or_else(|error| error.exit());
+                let mut args = native_engine_defaults();
+                args.self_update = matches.get_flag("self_update");
+                args.register_standalone_install = matches.get_flag("register_standalone_install");
+                Ok(args)
+            },
             _ => bail!(
                 "expected a command (`cp`, `rm`, `map`, `rsync`, `persist`, `completion`, or `receiver`); rsync-shaped syntax now starts with `syq rsync`"
             ),
         }
     }
 
-    fn parse_rsync(argv: &[OsString], allow_lifecycle: bool) -> Result<Args> {
-        if !allow_lifecycle
-            && argv
-                .iter()
-                .filter_map(|argument| argument.to_str())
-                .any(|argument| {
-                    matches!(argument, "--self-update" | "--register-standalone-install")
-                })
+    fn parse_rsync(argv: &[OsString]) -> Result<Args> {
+        if argv
+            .iter()
+            .filter_map(|argument| argument.to_str())
+            .any(|argument| matches!(argument, "--self-update" | "--register-standalone-install"))
         {
             bail!("installation lifecycle options are top-level syq options, not rsync options");
         }
         reject_unsupported_rsync_flags(argv)?;
         let mut full_argv = vec![OsString::from("syq rsync")];
         full_argv.extend(argv.iter().cloned());
-        let matches = Args::command()
+        let matches = crate::help::filesystem(Args::command())
             .try_get_matches_from(full_argv)
             .unwrap_or_else(|error| error.exit());
         let args = Args::from_arg_matches(&matches)?;
@@ -608,9 +612,10 @@ fn ordered_ignore_lines(
 }
 
 fn print_root_help() {
-    println!(
-        "Parallel endpoint-aware filesystem operations\n\nUsage: syq <COMMAND> [OPTIONS]\n       syq --self-update\n\nCommands:\n  cp           Copy selected objects, optionally pruning target-only objects\n  rm           Remove explicitly selected object trees\n  map          Print a local source selection as an NDJSON mapping\n  rsync        Use the rsync-shaped command surface\n  persist      Manage reusable SSH control connections\n  completion   Generate shell completion and manage its disposable local cache\n  receiver     Manage command-restricted receiver enrollments (enroll, list, revoke)\n\nRun `syq <COMMAND> --help` for command-specific help."
-    );
+    crate::help::root().print_help().unwrap_or_else(|error| {
+        crate::output::diagnostic!("syq: {error}");
+        std::process::exit(1);
+    });
 }
 
 /// Clap metadata for the public filesystem command surfaces. The dynamic
@@ -618,10 +623,10 @@ fn print_root_help() {
 /// spelling and hidden flags in one place.
 pub(crate) fn command_for_completion(name: &str) -> Option<clap::Command> {
     match name {
-        "rsync" => Some(Args::command()),
-        "cp" => Some(NativeCopyCommand::command()),
-        "rm" => Some(NativeRmCommand::command()),
-        "map" => Some(NativeMapCommand::command()),
+        "rsync" => Some(crate::help::filesystem(Args::command())),
+        "cp" => Some(crate::help::filesystem(NativeCopyCommand::command())),
+        "rm" => Some(crate::help::filesystem(NativeRmCommand::command())),
+        "map" => Some(crate::help::filesystem(NativeMapCommand::command())),
         _ => None,
     }
 }
@@ -720,7 +725,7 @@ struct NativeRmSelectionArgs {
 
 #[derive(clap::Args, Debug)]
 struct NativeOperationalArgs {
-    /// Resolve and preview the operation without changing anything
+    /// Preview without changing copy/removal data; requested results files are still written
     #[arg(short = 'n', long)]
     dry_run: bool,
     /// Increase verbosity
@@ -729,7 +734,7 @@ struct NativeOperationalArgs {
     /// Suppress non-error messages
     #[arg(short = 'q', long)]
     quiet: bool,
-    /// Use a fixed number of parallel connections/workers
+    /// Fix parallel connections/workers (copies otherwise tune automatically)
     #[arg(short = 'j', long = "connections", value_name = "N")]
     connections: Option<usize>,
     /// Show progress even when stderr is not a terminal
@@ -777,8 +782,8 @@ struct NativeCopyOperationalArgs {
     /// Securely open and read gitignore-style patterns from raw-byte FILE (repeatable; stacks in command-line order)
     #[arg(long, value_name = "FILE")]
     ignore_from: Vec<OsString>,
-    /// Preserve additional metadata (permissions, ownership, or specials; repeatable/comma-separated)
-    #[arg(long, value_name = "ATTRIBUTE", value_delimiter = ',')]
+    /// Preserve permissions or ownership, or copy special files (repeatable/comma-separated)
+    #[arg(long, value_name = "FEATURE", value_delimiter = ',')]
     preserve: Vec<NativePreserve>,
     /// Update destination files directly, using no full-sized staging file; interruption can leave them incomplete
     #[arg(long)]
@@ -873,8 +878,11 @@ struct NativeRemoteArgs {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 enum NativePreserve {
+    /// Preserve permission bits
     Permissions,
+    /// Preserve owner and group IDs
     Ownership,
+    /// Copy device nodes and special files
     Specials,
 }
 
@@ -940,9 +948,10 @@ struct NativeSizeSelectionArgs {
 #[command(
     name = "syq cp",
     version,
-    about = "Copy selected objects with explicit endpoint and placement syntax",
+    about = "Copy files and directories locally or over SSH.\n\nDirectories are copied recursively, symlinks as symlinks, and modification times\nare preserved. Destination-only objects remain unless --prune is selected.\nSource arguments must precede destination arguments.",
+    before_help = "Examples:\n  syq cp photos --into backup\n  syq cp --srcs-in photos --to nas --into /backup/photos\n  syq cp report.txt --as report-backup.txt",
     long_about = "Copy selected objects with explicit endpoint and placement syntax.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files. By default, destination-only objects remain in place. --prune removes them from mapped directory scopes after copying, while protecting ignored and size-excluded paths. The source endpoint, source base, selectors, and --mapping must precede the first --to or placement option; other options may follow the destination. Attach path and pattern option values beginning with `-` by using `=`, for example --src-dir=-. The spelling --mapping - retains its conventional stdin meaning.",
-    override_usage = "syq cp [OPTIONS] [--src PATH | --srcs-in DIR | --src-file PATH | --src-dir DIR | PATH]... PLACEMENT"
+    override_usage = "syq cp [OPTIONS] SOURCE... PLACEMENT"
 )]
 struct NativeCopyCommand {
     #[command(flatten)]
@@ -1018,9 +1027,10 @@ fn validate_native_copy_argument_order(matches: &clap::ArgMatches) -> Result<()>
 #[command(
     name = "syq map",
     version,
-    about = "Print a local source selection as an NDJSON mapping",
-    long_about = "Print a local source selection as an NDJSON mapping.\n\nOne JSON object per line: tagged src and dst paths (src relative to the source base, dst relative to a future target container), the object kind, and size/mtime for regular files. Emission is local and read-only. Names must be valid UTF-8. Attach path option values beginning with `-` by using `=`, for example --src-dir=-.",
-    override_usage = "syq map [OPTIONS] [--src PATH | --srcs-in DIR | --src-file PATH | --src-dir DIR | PATH]..."
+    about = "Print source-to-destination mappings as NDJSON.\n\nScan local sources and write one JSON object per line for later cp --mapping.\n--as changes placement relative to that copy's destination directory.\nNamed selectors must be relative (use -C for the source base).\n--srcs-in must be the only selector; --as requires one named object.\nNames must be valid UTF-8. No destination is contacted.",
+    before_help = "Examples:\n  syq map --srcs-in photos\n  syq map photos --as archive/photos > mapping.ndjson\n  syq cp --mapping mapping.ndjson --into backup",
+    long_about = "Print source-to-destination mappings as NDJSON.\n\nScan local sources for later cp --mapping. Named selectors must be relative (use -C for the source base). --srcs-in must be the only selector; --as requires one named object and changes its placement relative to the future destination directory.\n\nOne JSON object per line: tagged src and dst paths (src relative to the source base, dst relative to a future target container), the object kind, and size/mtime for regular files. Emission is local and read-only. Names must be valid UTF-8. Attach path option values beginning with `-` by using `=`, for example --src-dir=-.",
+    override_usage = "syq map [OPTIONS] PATH...\n       syq map [OPTIONS] --srcs-in DIR"
 )]
 struct NativeMapCommand {
     #[command(flatten)]
@@ -1034,9 +1044,10 @@ struct NativeMapCommand {
 #[command(
     name = "syq rm",
     version,
-    about = "Remove endpoint-resolved object trees without following symlinks by default",
-    long_about = "Remove endpoint-resolved object trees without following symlinks by default.\n\nAttach path option values beginning with `-` by using `=`, for example --src-dir=-.",
-    override_usage = "syq rm [OPTIONS] [--src PATH | --srcs-in DIR | --src-file PATH | --src-dir DIR | PATH]..."
+    about = "Remove selected files and directory trees.\n\nDirectories are removed recursively. --srcs-in removes their contents instead.\nBy default, selected symlinks are removed as links and path symlinks are refused.",
+    before_help = "Examples:\n  syq rm --dry-run old-backup\n  syq rm old-backup\n  syq rm --from nas --srcs-in /backup/old",
+    long_about = "Remove selected files and directory trees. Directories are removed recursively; --srcs-in removes their contents instead. By default, selected symlinks are removed as links and path symlinks are refused.\n\nAttach path option values beginning with `-` by using `=`, for example --src-dir=-.",
+    override_usage = "syq rm [OPTIONS] PATH...\n       syq rm [OPTIONS] --srcs-in DIR"
 )]
 struct NativeRmCommand {
     #[command(flatten)]
@@ -1183,7 +1194,7 @@ fn decode_delegated_operands(copy: &mut NativeCopyFields) -> Result<()> {
 fn parse_native_copy(argv: &[OsString]) -> Result<Args> {
     let mut full_argv = vec![OsString::from("syq cp")];
     full_argv.extend_from_slice(argv);
-    let matches = NativeCopyCommand::command()
+    let matches = crate::help::filesystem(NativeCopyCommand::command())
         .try_get_matches_from(full_argv)
         .unwrap_or_else(|error| error.exit());
     validate_native_copy_argument_order(&matches)?;
@@ -1360,7 +1371,7 @@ fn parse_native_copy(argv: &[OsString]) -> Result<Args> {
 fn parse_native_map(argv: &[OsString]) -> Result<Args> {
     let mut full_argv = vec![OsString::from("syq map")];
     full_argv.extend_from_slice(argv);
-    let matches = NativeMapCommand::command()
+    let matches = crate::help::filesystem(NativeMapCommand::command())
         .try_get_matches_from(full_argv)
         .unwrap_or_else(|error| error.exit());
     let mut parsed = NativeMapCommand::from_arg_matches(&matches)?;
@@ -1431,7 +1442,7 @@ fn parse_native_map(argv: &[OsString]) -> Result<Args> {
 fn parse_native_rm(argv: &[OsString]) -> Result<Args> {
     let mut full_argv = vec![OsString::from("syq rm")];
     full_argv.extend_from_slice(argv);
-    let matches = NativeRmCommand::command()
+    let matches = crate::help::filesystem(NativeRmCommand::command())
         .try_get_matches_from(full_argv)
         .unwrap_or_else(|error| error.exit());
     let mut parsed = NativeRmCommand::from_arg_matches(&matches)?;

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -10,7 +10,7 @@ use crate::cli::{parse_native_endpoint, NativeEndpoint};
 use crate::conn::{Conn, RemoteConn, RemoteSpec, SshMultiplexer};
 use crate::proto::{CompletionEntry, Request, Response};
 use anyhow::{anyhow, bail, Context, Result};
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::ffi::{CString, OsString};
@@ -81,7 +81,10 @@ enum CacheAction {
     /// List learned endpoint suggestions, most recently used first
     List,
     /// Forget one exact native endpoint spelling
-    Forget { endpoint: String },
+    Forget {
+        /// Endpoint to forget: [USER@]HOST[:PORT], e.g. alice@nas:2222
+        endpoint: String,
+    },
     /// Remove all learned endpoint suggestions
     Clear,
 }
@@ -161,7 +164,10 @@ impl Candidate {
 pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
     let mut full_argv = vec![OsString::from("syq completion")];
     full_argv.extend_from_slice(argv);
-    let command = CompletionCommand::try_parse_from(full_argv).unwrap_or_else(|error| error.exit());
+    let matches = command_for_help()
+        .try_get_matches_from(full_argv)
+        .unwrap_or_else(|error| error.exit());
+    let command = CompletionCommand::from_arg_matches(&matches)?;
     match command.action {
         CompletionAction::Bash => print!("{BASH_ADAPTER}"),
         CompletionAction::Zsh => print!("{ZSH_ADAPTER}"),
@@ -649,7 +655,9 @@ fn root_candidates(current: &[u8]) -> Vec<Candidate> {
         "persist",
         "completion",
         "receiver",
+        "help",
         "--help",
+        "--help-all",
         "--version",
         "--self-update",
     ]
@@ -661,8 +669,8 @@ fn root_candidates(current: &[u8]) -> Vec<Candidate> {
 
 fn completion_command_candidates(args: &[Vec<u8>], current: &[u8]) -> Vec<Candidate> {
     let values: &[&str] = match args.first().map(Vec::as_slice) {
-        None => &["bash", "zsh", "fish", "cache", "--help"],
-        Some(b"cache") if args.len() == 1 => &["list", "forget", "clear", "--help"],
+        None => &["bash", "zsh", "fish", "cache", "--help", "--help-all"],
+        Some(b"cache") if args.len() == 1 => &["list", "forget", "clear", "--help", "--help-all"],
         Some(b"cache") if args.get(1).is_some_and(|value| value == b"forget") => {
             return endpoint_candidates(current, EndpointSyntax::Native, None)
         }
@@ -677,7 +685,7 @@ fn completion_command_candidates(args: &[Vec<u8>], current: &[u8]) -> Vec<Candid
 
 fn persist_candidates(args: &[Vec<u8>], current: &[u8]) -> Vec<Candidate> {
     if args.is_empty() {
-        return ["on", "off", "status", "--help"]
+        return ["on", "off", "status", "--help", "--help-all"]
             .into_iter()
             .filter(|value| value.as_bytes().starts_with(current))
             .map(|value| Candidate::text(value.as_bytes().to_vec()))
@@ -687,8 +695,8 @@ fn persist_candidates(args: &[Vec<u8>], current: &[u8]) -> Vec<Candidate> {
         return local_path_candidates(current, true);
     }
     let options: &[&str] = match args.first().map(Vec::as_slice) {
-        Some(b"on") => &["--ephemeral", "--help"],
-        Some(b"off" | b"status") => &["--pscope", "--help"],
+        Some(b"on") => &["--ephemeral", "--help", "--help-all"],
+        Some(b"off" | b"status") => &["--pscope", "--help", "--help-all"],
         _ => &[],
     };
     options
@@ -1657,6 +1665,10 @@ end
 complete -c syq -f -a '(__syq_complete)'
 "#;
 
+pub(crate) fn command_for_help() -> clap::Command {
+    crate::help::configure(CompletionCommand::command())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1859,6 +1871,11 @@ mod tests {
         let command = crate::cli::command_for_completion("cp").unwrap();
         let options = values(option_candidates(&command, b"--coor"));
         assert_eq!(options, vec![b"--coordinate-at".to_vec()]);
+        assert_eq!(
+            values(option_candidates(&command, b"--help-a")),
+            vec![b"--help-all".to_vec()]
+        );
+        assert!(values(root_candidates(b"--help-a")).contains(&b"--help-all".to_vec()));
     }
 
     #[test]

--- a/src/help.rs
+++ b/src/help.rs
@@ -1,0 +1,254 @@
+//! Help presentation built from the same commands used for parsing/completion.
+use clap::{Arg, ArgAction, Command};
+
+/// Short and long flag spellings intentionally select the same view. Only
+/// --help-all expands the reference; hide_short_help never hides completion.
+pub(crate) fn configure(command: Command) -> Command {
+    let name = command.get_name().to_owned();
+    configure_at(command, &name)
+}
+
+fn configure_at(mut command: Command, path: &str) -> Command {
+    for child in command.get_subcommands_mut() {
+        *child = configure_at(child.clone(), &format!("{path} {}", child.get_name()));
+    }
+    let rsync = path == "syq rsync";
+    command = command.disable_help_flag(true);
+    let mut help = Arg::new("help")
+        .long("help")
+        .action(ArgAction::HelpShort)
+        .help("Show common usage and options")
+        .help_heading("Help and version");
+    if !rsync {
+        help = help.short('h');
+    }
+    if command.get_arguments().any(|arg| arg.get_id() == "help") {
+        command = command.mut_arg("help", |_| help);
+    } else {
+        command = command.arg(help);
+    }
+    if command.get_version().is_some() {
+        command = command.disable_version_flag(true);
+        let version = Arg::new("version")
+            .short('V')
+            .long("version")
+            .action(ArgAction::Version)
+            .help("Print version")
+            .help_heading("Help and version");
+        command = if command.get_arguments().any(|arg| arg.get_id() == "version") {
+            command.mut_arg("version", |_| version)
+        } else {
+            command.arg(version)
+        };
+    }
+    command
+        .arg(
+            Arg::new("help_all")
+                .long("help-all")
+                .action(ArgAction::HelpLong)
+                .help("Show all options and details")
+                .help_heading("Help and version"),
+        )
+        .after_help(format!("All options and details: {path} --help-all"))
+        .after_long_help("Documentation: https://greaber.github.io/syq/")
+}
+
+/// Presentation metadata references parser IDs, never a separate option list.
+/// Unclassified public options remain visible in the complete reference.
+pub(crate) fn filesystem(command: Command) -> Command {
+    let rsync = command.get_name() == "syq rsync";
+    let map = command.get_name() == "syq map";
+    let rm = command.get_name() == "syq rm";
+    let command = command.mut_args(|arg| {
+        if arg.is_hide_set() {
+            return arg;
+        }
+        let id_owned = arg.get_id().to_string();
+        let id = id_owned.as_str();
+        let common = if rsync {
+            matches!(
+                id,
+                "paths"
+                    | "archive"
+                    | "dry_run"
+                    | "verbose"
+                    | "quiet"
+                    | "checksum"
+                    | "ignore"
+                    | "delete"
+                    | "bwlimit"
+                    | "help"
+                    | "version"
+            )
+        } else {
+            matches!(
+                id,
+                "sources"
+                    | "srcs_in"
+                    | "from"
+                    | "cwd"
+                    | "to"
+                    | "into"
+                    | "as"
+                    | "dry_run"
+                    | "verbose"
+                    | "quiet"
+                    | "ignore"
+                    | "preserve"
+                    | "hash"
+                    | "prune"
+                    | "help"
+                    | "version"
+            ) || (rm && id == "root")
+        };
+        let heading = match id {
+            "sources" | "paths" | "src" | "srcs_in" | "src_file" | "src_dir" | "src_files"
+            | "src_dirs" | "srcs" | "from" | "cwd" | "root" | "follow" | "follow_src" => {
+                "Sources and selection"
+            }
+            "to" | "into" | "into_new" | "into_existing" | "as" | "as_new" | "as_existing"
+            | "follow_dst" => "Destination placement",
+            "results" | "results_fd" | "progress" | "no_progress" | "progress_json" | "stats" => {
+                "Progress and results"
+            }
+            "connections" | "connections_opt" | "block_size" | "bwlimit" => "Performance",
+            "rsh" | "syq_path" | "no_bootstrap" | "no_tcp" | "tcp_plain" | "tcp_ports"
+            | "tcp_congestion" | "pscope" | "compress" | "no_compress" => "SSH and transport",
+            "coordinate_at"
+            | "detach"
+            | "peer_auth"
+            | "receiver_max_entries"
+            | "receiver_max_bytes"
+            | "receiver_receipt" => "Remote-to-remote transfers",
+            "help" | "version" => "Help and version",
+            "dry_run" | "verbose" | "quiet" => "Preview and output",
+            _ => "Copy policy and filtering",
+        };
+        let mut arg = arg.hide_short_help(!common).help_heading(heading);
+        // Shared parser fields need command-specific explanations.
+        if rm && id == "syq_path" {
+            arg = arg.help("Use this exact syq executable on the remote removal endpoint");
+        } else if rm && matches!(id, "follow" | "follow_src") {
+            arg = arg.help("Follow symlinks in supplied source paths; remove the selected target, leaving the link");
+        } else if rm && id == "verbose" {
+            arg = arg.help("List removed paths");
+        } else if id == "verbose" && !map {
+            arg = arg.help("List files with -v; explain helpers and transport with -vv");
+        }
+        arg
+    });
+    configure(command)
+}
+
+pub(crate) fn root() -> Command {
+    configure(Command::new("syq")
+        .about("Copy files and directories locally or over SSH")
+        .override_usage("syq <COMMAND> [OPTIONS]\n       syq --self-update")
+        .before_help("Examples:\n  syq cp photos --into backup\n  syq cp --srcs-in photos --to nas --into /backup/photos\n  syq map photos --as archive/photos")
+        .arg(Arg::new("version").short('V').long("version").action(ArgAction::Version).help("Print version"))
+        .version(env!("CARGO_PKG_VERSION"))
+        .arg(Arg::new("self_update").long("self-update").action(ArgAction::SetTrue)
+            .help("Install the newest signed release (standalone installs); Homebrew: brew upgrade syq"))
+        .disable_help_subcommand(true)
+        .subcommand(Command::new("cp").about("Copy files and directories, optionally removing destination-only files"))
+        .subcommand(Command::new("rm").about("Remove selected files and directory trees"))
+        .subcommand(Command::new("map").about("Print source-to-destination mappings as NDJSON"))
+        .subcommand(Command::new("rsync").about("Copy using rsync-compatible syntax"))
+        .subcommand(Command::new("persist").about("Manage reusable SSH connections and helper sessions"))
+        .subcommand(Command::new("completion").about("Generate shell completion and manage cached endpoint suggestions"))
+        .subcommand(Command::new("receiver").about("Enroll, list, or revoke command-restricted receivers"))
+        .subcommand(Command::new("help").about("Show help for a command, e.g. syq help cp")))
+}
+
+pub(crate) fn lifecycle() -> Command {
+    configure(Command::new("syq")
+        .about("Install the newest signed syq release")
+        .override_usage("syq --self-update")
+        .before_help("Standalone (curl installer) installs: syq --self-update\nHomebrew installs: brew upgrade syq\nSource builds: rebuild or reinstall.\n\nStandalone installs show new-version reminders at most daily after successful\nfilesystem commands when stderr is a terminal and quiet mode is off. Set\nSYQ_NO_UPDATE_CHECK to disable reminders; explicit self-update still works.\nUpdates verify signed release metadata and never install as a side effect of copying.")
+        .arg(Arg::new("self_update").long("self-update").action(ArgAction::SetTrue).exclusive(true)
+            .help("Update the executable registered by the standalone installer"))
+        .arg(Arg::new("register_standalone_install").long("register-standalone-install")
+            .action(ArgAction::SetTrue).exclusive(true).hide(true)))
+        .after_help("All options and details: syq --self-update --help-all")
+}
+
+/// Receiver management shares a parser-backed help surface with other commands.
+pub(crate) fn receiver() -> Command {
+    let via = || {
+        Arg::new("via")
+            .long("via")
+            .value_name("ENDPOINT")
+            .help("Retry through this SSH jump host if the direct management connection fails")
+    };
+    configure(
+        Command::new("syq receiver")
+            .about("Manage command-restricted receiver enrollments")
+            .subcommand_required(true)
+            .subcommand(
+                Command::new("enroll")
+                    .about("Enroll a destination's existing parent, or refresh its receiver")
+                    .arg(
+                        Arg::new("target")
+                            .required(true)
+                            .value_name("[USER@]HOST:DESTINATION")
+                            .help("Remote destination, e.g. alice@nas:/backup/photos"),
+                    )
+                    .arg(via()),
+            )
+            .subcommand(Command::new("list").about("List local active and pending enrollments"))
+            .subcommand(
+                Command::new("revoke")
+                    .about("Remove the forced key and per-enrollment state from both machines")
+                    .arg(
+                        Arg::new("id")
+                            .required(true)
+                            .value_name("ENROLLMENT-ID")
+                            .help("Enrollment ID printed by syq receiver list"),
+                    )
+                    .arg(via()),
+            ),
+    )
+}
+
+/// Only the explicit `syq help ...` route uses this topic lookup. Transfer
+/// operands are never searched for help-like strings.
+pub(crate) fn show_topic(topics: &[std::ffi::OsString]) -> anyhow::Result<()> {
+    let mut topics = topics
+        .iter()
+        .map(|s| {
+            s.to_str()
+                .ok_or_else(|| anyhow::anyhow!("help topic is not UTF-8"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let full = topics.last() == Some(&"--help-all");
+    if full || matches!(topics.last(), Some(&"--help" | &"-h")) {
+        topics.pop();
+    }
+    let mut command = match topics.first().copied() {
+        None => root(),
+        Some("persist") => crate::persistence::command_for_help(),
+        Some("completion") => crate::completion::command_for_help(),
+        Some("receiver") => receiver(),
+        Some("--self-update") => lifecycle(),
+        Some(name) => crate::cli::command_for_completion(name)
+            .ok_or_else(|| anyhow::anyhow!("unknown help topic {name:?}"))?,
+    };
+    for topic in topics.iter().skip(1) {
+        let parent = command
+            .get_bin_name()
+            .unwrap_or(command.get_name())
+            .to_owned();
+        command = command
+            .find_subcommand(topic)
+            .filter(|child| !child.is_hide_set())
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("unknown help topic {topic:?}"))?
+            .bin_name(format!("{parent} {topic}"));
+    }
+    if full {
+        command.print_long_help()?;
+    } else {
+        command.print_help()?;
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod delegation;
 mod descriptor_broker;
 pub mod enrollment;
 mod fsops;
+mod help;
 mod identity;
 mod janky_cat;
 mod native_map;
@@ -118,6 +119,13 @@ fn main() {
     raise_nofile();
     fsops::capture_process_umask();
     let argv: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    if argv.get(1).and_then(|arg| arg.to_str()) == Some("help") {
+        if let Err(error) = help::show_topic(&argv[2..]) {
+            crate::output::diagnostic!("syq: {error:#}");
+            std::process::exit(2);
+        }
+        return;
+    }
     if argv.get(1).and_then(|arg| arg.to_str()) == Some("--build-identity") {
         println!("{}", identity::build());
         return;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -6,7 +6,7 @@
 
 use crate::cli::Args;
 use anyhow::{bail, Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 use std::ffi::{OsStr, OsString};
 use std::fs::{File, OpenOptions};
@@ -24,8 +24,8 @@ const SCOPE_MARKER_CONTENT: &[u8] = b"syq persistence scope\n";
 #[derive(Parser, Debug)]
 #[command(
     name = "syq persist",
-    about = "Manage reusable SSH control connections",
-    long_about = "Manage reusable SSH control connections. The durable setting applies to later syq transfer commands. An ephemeral scope is isolated from that setting and is selected by passing its printed path back with --pscope."
+    about = "Manage reusable SSH connections and helper sessions",
+    long_about = "Manage reusable SSH connections and helper sessions. The durable setting applies to later syq transfer commands. An ephemeral scope is isolated from that setting and is selected by passing its printed path back with --pscope."
 )]
 struct PersistCommand {
     #[command(subcommand)]
@@ -124,7 +124,10 @@ pub(crate) fn completion_endpoints(explicit_scope: Option<&Path>) -> Result<Vec<
 pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
     let mut full_argv = vec![OsString::from("syq persist")];
     full_argv.extend_from_slice(argv);
-    let command = PersistCommand::try_parse_from(full_argv).unwrap_or_else(|error| error.exit());
+    let matches = command_for_help()
+        .try_get_matches_from(full_argv)
+        .unwrap_or_else(|error| error.exit());
+    let command = PersistCommand::from_arg_matches(&matches)?;
     match command.action {
         PersistAction::On { ephemeral: true } => {
             let scope = create_ephemeral_scope()?;
@@ -718,6 +721,10 @@ fn master_exit_command(socket: &Path, record: &EndpointRecord) -> Command {
     }
     command.arg("--").arg(&record.host);
     command
+}
+
+pub(crate) fn command_for_help() -> clap::Command {
+    crate::help::configure(PersistCommand::command())
 }
 
 #[cfg(test)]

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -4221,45 +4221,26 @@ fn decode_receiver_command(original: &str) -> Result<Vec<u8>> {
     Ok(envelope)
 }
 
-fn management_via(arguments: &[OsString]) -> Result<Option<SshEndpoint>> {
-    if arguments.is_empty() {
-        return Ok(None);
-    }
-    if arguments.len() != 2 || arguments[0] != "--via" {
-        bail!("expected optional --via [USER@]HOST");
-    }
-    Ok(Some(SshEndpoint::parse(
-        arguments[1]
-            .to_str()
-            .context("--via endpoint is not UTF-8")?,
-    )?))
-}
-
-const RECEIVER_USAGE: &str = "Usage: syq receiver <COMMAND>\n\nManage command-restricted receiver enrollments.\n\nCommands:\n  enroll  Enroll a remote destination, or refresh an existing enrollment\n  list    List local enrollments\n  revoke  Remove an enrollment from both machines\n\nRun `syq receiver <COMMAND> --help` for command-specific help.";
-
 /// `syq receiver enroll|list|revoke`: the receiver enrollment system is one
-/// subcommand with its verbs beneath it. `argv[1]` is `enrollment`.
+/// subcommand with its verbs beneath it.
 pub(crate) fn dispatch_receiver_command(argv: &[OsString]) -> Option<Result<i32>> {
     if argv.get(1)?.to_str()? != "receiver" {
         return None;
     }
-    let Some(command) = argv.get(2).and_then(|argument| argument.to_str()) else {
-        crate::output::diagnostic!("{RECEIVER_USAGE}");
-        return Some(Ok(2));
+    let matches = crate::help::receiver()
+        .try_get_matches_from(
+            std::iter::once(OsString::from("syq receiver")).chain(argv[2..].iter().cloned()),
+        )
+        .unwrap_or_else(|error| error.exit());
+    let (command, options) = matches.subcommand().expect("subcommand required");
+    let via = || -> Result<Option<SshEndpoint>> {
+        options
+            .get_one::<String>("via")
+            .map(|value| SshEndpoint::parse(value))
+            .transpose()
     };
     match command {
-        "--help" | "-h" => {
-            println!("{RECEIVER_USAGE}");
-            Some(Ok(0))
-        }
         "list" => Some((|| {
-            if argv.get(3).is_some_and(|argument| argument == "--help") {
-                println!("Usage: syq receiver list\n\nList local command-restricted receiver enrollments.");
-                return Ok(0);
-            }
-            if argv.len() != 3 {
-                bail!("usage: syq receiver list");
-            }
             let active = load_local_enrollments()?;
             let active_ids = active
                 .iter()
@@ -4288,16 +4269,9 @@ pub(crate) fn dispatch_receiver_command(argv: &[OsString]) -> Option<Result<i32>
             Ok(0)
         })()),
         "enroll" => Some((|| {
-            if argv.get(3).is_some_and(|argument| argument == "--help") {
-                println!(
-                    "Usage: syq receiver enroll [USER@]HOST:DESTINATION [--via [USER@]HOST]\n\nEnroll a command-restricted receiver for DESTINATION's existing parent, or refresh an existing enrollment's receiver."
-                );
-                return Ok(0);
-            }
-            if argv.len() < 4 {
-                bail!("usage: syq receiver enroll [USER@]HOST:DESTINATION [--via [USER@]HOST]");
-            }
-            let target = argv[3].to_str().context("enrollment target is not UTF-8")?;
+            let target = options
+                .get_one::<String>("target")
+                .expect("target required");
             let location = Location::parse(target)?;
             let host = location
                 .host
@@ -4305,7 +4279,7 @@ pub(crate) fn dispatch_receiver_command(argv: &[OsString]) -> Option<Result<i32>
                 .context("enrollment target must be remote")?;
             let requested = std::str::from_utf8(&location.path)
                 .context("enrollment destination is not UTF-8")?;
-            let via = management_via(&argv[4..])?;
+            let via = via()?;
             let policy =
                 crate::agent_broker::resolve_host_policy("ssh", location.user.as_deref(), host)?;
             let (metadata, _, destination) = enroll(
@@ -4325,17 +4299,8 @@ pub(crate) fn dispatch_receiver_command(argv: &[OsString]) -> Option<Result<i32>
             Ok(0)
         })()),
         "revoke" => Some((|| {
-            if argv.get(3).is_some_and(|argument| argument == "--help") {
-                println!(
-                    "Usage: syq receiver revoke ENROLLMENT-ID [--via [USER@]HOST]\n\nRemove the forced key and per-enrollment state from both machines."
-                );
-                return Ok(0);
-            }
-            if argv.len() < 4 {
-                bail!("usage: syq receiver revoke ENROLLMENT-ID [--via [USER@]HOST]");
-            }
-            let id = EnrollmentId::parse(argv[3].to_str().context("enrollment ID is not UTF-8")?)?;
-            let via = management_via(&argv[4..])?;
+            let id = EnrollmentId::parse(options.get_one::<String>("id").expect("ID required"))?;
+            let via = via()?;
             let active = load_local_enrollments()?
                 .into_iter()
                 .find(|(metadata, _)| metadata.id == id);
@@ -4392,9 +4357,7 @@ pub(crate) fn dispatch_receiver_command(argv: &[OsString]) -> Option<Result<i32>
             println!("revoked {id} from {}", target.label());
             Ok(0)
         })()),
-        other => Some(Err(anyhow::anyhow!(
-            "unknown receiver command {other:?}\n{RECEIVER_USAGE}"
-        ))),
+        _ => unreachable!("receiver subcommand validated by clap"),
     }
 }
 

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -1,0 +1,178 @@
+//! Public help must be useful without invoking filesystem or update operations.
+use std::process::{Command, Output};
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(args)
+        .env("NO_COLOR", "1")
+        .env("SYQ_NO_UPDATE_CHECK", "1")
+        .output()
+        .unwrap()
+}
+
+fn help(args: &[&str]) -> String {
+    let output = run(args);
+    assert!(
+        output.status.success(),
+        "{args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty(), "{args:?}: {:?}", output.stderr);
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn short_and_long_help_spellings_are_identical_at_every_public_level() {
+    for path in [
+        vec![],
+        vec!["cp"],
+        vec!["rm"],
+        vec!["map"],
+        vec!["--self-update"],
+        vec!["persist"],
+        vec!["persist", "on"],
+        vec!["persist", "off"],
+        vec!["persist", "status"],
+        vec!["completion"],
+        vec!["completion", "bash"],
+        vec!["completion", "zsh"],
+        vec!["completion", "fish"],
+        vec!["completion", "cache"],
+        vec!["completion", "cache", "list"],
+        vec!["completion", "cache", "forget"],
+        vec!["completion", "cache", "clear"],
+        vec!["receiver"],
+        vec!["receiver", "enroll"],
+        vec!["receiver", "list"],
+        vec!["receiver", "revoke"],
+    ] {
+        let page = |flag| {
+            let mut args = path.clone();
+            args.push(flag);
+            help(&args)
+        };
+        let short = page("-h");
+        assert_eq!(short, page("--help"), "{path:?}");
+        assert!(short.contains("--help-all"), "{path:?}");
+        assert!(!page("--help-all").is_empty());
+    }
+}
+
+#[test]
+fn full_reference_reveals_specialized_options_without_exposing_internal_switches() {
+    for (command, common, advanced) in [
+        ("cp", "--into", "--coordinate-at"),
+        ("rm", "--srcs-in", "--results-fd"),
+        ("map", "--as", "--src-files"),
+        ("rsync", "--archive", "--syq-tcp-ports"),
+    ] {
+        let short = help(&[command, "--help"]);
+        let full = help(&[command, "--help-all"]);
+        assert!(short.contains(common));
+        assert!(!short.contains(advanced), "{short}");
+        assert!(full.contains(advanced), "{full}");
+        assert!(short.lines().count() < full.lines().count());
+        for internal in [
+            "--delegated-operands-b64",
+            "--suppress-summary",
+            "--register-standalone-install",
+            "--server",
+        ] {
+            assert!(!full.contains(internal), "{command}: {internal}");
+        }
+    }
+}
+
+#[test]
+fn lifecycle_and_root_help_describe_the_real_commands() {
+    let root = help(&["--help"]);
+    for option in ["--help", "--help-all", "--version", "--self-update"] {
+        assert!(root.contains(option));
+    }
+    assert!(root.contains("source-to-destination mappings"));
+    let update = help(&["--self-update", "--help"]);
+    for term in [
+        "Standalone",
+        "brew upgrade syq",
+        "SYQ_NO_UPDATE_CHECK",
+        "signed",
+    ] {
+        assert!(update.contains(term));
+    }
+    assert!(!update.contains("--archive"));
+    assert!(!update.contains("syq rsync"));
+    assert!(!run(&["--self-update", "unexpected"]).status.success());
+    for path in [
+        vec!["cp"],
+        vec!["receiver", "enroll"],
+        vec!["persist", "on"],
+        vec!["completion", "cache", "forget"],
+    ] {
+        let mut direct = path.clone();
+        direct.push("--help");
+        let mut topic = vec!["help"];
+        topic.extend(path);
+        assert_eq!(help(&direct), help(&topic));
+    }
+    assert!(!run(&["help", "unknown"]).status.success());
+}
+
+#[test]
+fn help_like_operands_are_data_and_rsync_h_remains_human_readable() {
+    let temp = tempfile::tempdir().unwrap();
+    let dir = temp.path().canonicalize().unwrap();
+    for name in ["--help", "--help-all", "-h"] {
+        std::fs::write(dir.join(name), b"file data").unwrap();
+        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .current_dir(&dir)
+            .args(["cp", &format!("--src={name}"), "--as", "copied", "-q"])
+            .env("SYQ_NO_UPDATE_CHECK", "1")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(std::fs::read(dir.join("copied")).unwrap(), b"file data");
+        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .current_dir(&dir)
+            .args(["map", "--", name])
+            .env("SYQ_NO_UPDATE_CHECK", "1")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("\"dst\""));
+    }
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .current_dir(&dir)
+        .args(["rsync", "-h", "copied", "rsync-copy"])
+        .env("SYQ_NO_UPDATE_CHECK", "1")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(std::fs::read(dir.join("rsync-copy")).unwrap(), b"file data");
+    // A detached option value is also not a help request when the grammar permits it.
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .current_dir(&dir)
+        .args([
+            "rsync",
+            "--syq-ignore",
+            "--help-all",
+            "copied",
+            "filtered-copy",
+        ])
+        .env("SYQ_NO_UPDATE_CHECK", "1")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(dir.join("filtered-copy").exists());
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3027,7 +3027,7 @@ fn receiver_is_one_subcommand_with_its_verbs_beneath_it() {
     assert!(String::from_utf8_lossy(&bare.stderr).contains("Usage: syq receiver"));
     let bogus = run(&["receiver", "rotate"]);
     assert!(!bogus.status.success());
-    assert!(String::from_utf8_lossy(&bogus.stderr).contains("unknown receiver command"));
+    assert!(String::from_utf8_lossy(&bogus.stderr).contains("unrecognized subcommand"));
     for verb in ["enroll", "list", "revoke"] {
         let verb_help = run(&["receiver", verb, "--help"]);
         assert!(verb_help.status.success(), "{verb}");
@@ -12441,13 +12441,22 @@ fn native_map_refusals() {
 #[test]
 fn native_map_exposes_only_manifest_shaping_options() {
     let help = Command::new(env!("CARGO_BIN_EXE_syq"))
-        .args(["map", "--help"])
+        .args(["map", "--help-all"])
         .run()
-        .expect("run syq map --help");
+        .expect("run syq map --help-all");
     assert_output_ok(&help);
     let help = String::from_utf8(help.stdout).expect("map help is UTF-8");
+    // Examples may mention downstream cp options; inspect option declarations.
+    let declarations = help
+        .lines()
+        .filter(|line| line.starts_with("  -") || line.starts_with("      --"))
+        .collect::<Vec<_>>()
+        .join("\n");
     for option in ["--cwd", "--follow", "--src", "--srcs-in", "--as"] {
-        assert!(help.contains(option), "map help omitted {option}:\n{help}");
+        assert!(
+            declarations.contains(option),
+            "map help omitted {option}:\n{help}"
+        );
     }
     for option in [
         "--from",
@@ -12479,7 +12488,7 @@ fn native_map_exposes_only_manifest_shaping_options() {
         "--receiver-receipt",
     ] {
         assert!(
-            !help.contains(option),
+            !declarations.contains(option),
             "map help unexpectedly exposed {option}:\n{help}"
         );
     }


### PR DESCRIPTION
CLI help previously mixed common workflows with every specialized option, omitted root option descriptions, and displayed rsync help for `syq --self-update --help`. `-h` and `--help` now show the same examples and common options; `--help-all` shows the complete reference grouped by purpose. `syq rsync -h` retains its rsync meaning.

The change adds `syq help COMMAND` navigation, gives self-update its own parser and upgrade guidance, and makes receiver help consistent through parser-backed command metadata. It clarifies map placement and selector restrictions, dry-run side effects, removal helper wording, and persistence. Specialized options remain available in completion. Documentation and regression tests cover the help levels and help-like filenames.

Validation: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --bin syq`, `cargo test --all-targets` (815 tests), `scripts/test-real-ssh.sh`, and `python3 scripts/check-doc-links.py` passed. The map option-inventory test now checks option declarations in full help, allowing examples to mention downstream copy options.

Branch status at `ee4640b`: clean, one commit ahead of local master `5837d18`. Latest post-merge master workflows `ci`, `rsync-compat`, and `macos` all succeeded at `d124d81`. PRs do not trigger automated test workflows in this repository.
