### PR TITLE
Prepare syq 0.3.1 release

### DIFF
--- a/.github/release-notes/v0.3.1.md
+++ b/.github/release-notes/v0.3.1.md
@@ -1,0 +1,8 @@
+syq 0.3.1 makes command-line help easier to navigate and strengthens release validation.
+
+- Command help now starts with examples and commonly used options. Use `--help-all` for the complete reference, or `syq help receiver enroll` to navigate nested commands.
+- `syq --self-update --help` explains standalone upgrades and update reminders. Shell completion continues to include options omitted from common help.
+- Dry-run help now clarifies that requested results files and remote helper caches may still be written; source and destination copy data remain unchanged.
+- Releases now require full Apple Silicon macOS certification, validate source-package bytes before publication, and smoke-test the generated installer with the actual Linux binary.
+
+No copy-command migration is required from 0.3.0. Help output has changed; scripts that inspect help should use `--help-all` when they need every option. In rsync mode, `-h` still means human-readable sizes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Prepare syq 0.3.1 with clearer command help, complete option references via `--help-all`, and stronger release validation. Update Cargo metadata without changing dependency versions and add curated notes describing the help-output change.

Validation at 21340cadac8d702c25d5584c84f314f0ab699396: cargo check, formatting, locked strict all-target/all-feature Clippy, 422 unit tests, four CLI-help integration tests, Python API synchronization, documentation links, and default three-container real-SSH release certification passed. Full cross-platform certification follows on the merged master commit before tagging.
