### PR TITLE
Upload source-built remote helpers and simplify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Installs into `~/.local/bin` without `sudo`. Or use Homebrew:
 `brew install greaber/tap/syq`. Both install matching remote helpers on first
 use. Update with `syq --self-update` (standalone) or `brew upgrade syq`.
 
-**Cargo and other source builds do not install remote helpers automatically,
-check for release updates, or support self-update.** See the
+Source builds upload themselves to compatible remote hosts, but do not check
+for release updates or support self-update. See the
 [installation guide](https://greaber.github.io/syq/install.html) for source
 builds, remote setup, and shell completion.
 

--- a/README.md
+++ b/README.md
@@ -22,16 +22,14 @@ directory trees on one machine or across a network, built for the jobs where
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/greaber/syq/releases/latest/download/install.sh | sh
 ```
 
-No `sudo` is needed; the binary lands in `~/.local/bin`. Homebrew
-(`brew install greaber/tap/syq`) and Cargo (`cargo install --locked syq`) also
-work. With the installer or Homebrew, syq installs its matching remote helper
-on first use. Cargo builds need a compatible remote `syq`; see the
-[installation guide](https://greaber.github.io/syq/install.html#cargo).
-To use unreleased code, see [installing from `master` or another branch](https://greaber.github.io/syq/install.html#installing-from-master-or-another-branch),
-including how to update and set up matching remote binaries.
+Installs into `~/.local/bin` without `sudo`. Or use Homebrew:
+`brew install greaber/tap/syq`. Both install matching remote helpers on first
+use. Update with `syq --self-update` (standalone) or `brew upgrade syq`.
 
-Bash, Zsh, and fish completion includes remote paths and becomes especially
-fast with `syq persist on`; see the [installation guide](https://greaber.github.io/syq/install.html#shell-completion).
+**Cargo and other source builds do not install remote helpers automatically,
+check for release updates, or support self-update.** See the
+[installation guide](https://greaber.github.io/syq/install.html) for source
+builds, remote setup, and shell completion.
 
 ## Quick start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,9 +121,8 @@ time it connects, one per version, so both ends always run
 matching code. The remote downloads the release directly when it has the tools,
 or the local machine uploads it. Either way the binary is checked against a
 signed release manifest, verified with a public key compiled into your local
-syq, before it runs. This requires an official release build; Cargo and
-checkout builds need a compatible remote `syq`, as
-[Installing](install.md#cargo) explains.
+syq, before it runs. Cargo and checkout builds instead upload their own binary
+to hosts that can run it; see [Installing](install.md#cargo).
 
 **Direct remote-to-remote transfers.** Rsync cannot copy between two remote
 hosts from your laptop. You download and re-upload, at your laptop's bandwidth,

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,37 +1,31 @@
 # Installing syq
 
-Syq runs on Linux and macOS. The local machine needs one of the installation
-paths below. With the standalone installer or Homebrew, syq installs a
-matching copy of itself on remote hosts the first time it connects (see
-[Remote helper bootstrap](#remote-helper-bootstrap)). A Cargo or checkout
-build needs a compatible remote `syq`, as the [Cargo section](#cargo) explains.
+Syq runs on Linux and macOS, on x86-64 and ARM64. Choose an installation method:
+
+| Method | Installs remote helpers automatically | How to update |
+| --- | --- | --- |
+| Standalone installer | Yes | `syq --self-update` |
+| Homebrew | Yes | `brew upgrade syq` |
+| Cargo or Git checkout | No; [set up remote hosts yourself](#remote-hosts-with-source-builds) | Rerun Cargo or rebuild |
+
+**Source builds do not automatically install remote helpers, check for release
+updates, or support `syq --self-update`.** This includes `cargo install syq`
+and builds from release tags. Only standalone installs check for updates.
 
 ## Standalone installer
 
-The standalone installer needs no `sudo` and installs the matching Linux or
-macOS binary in `~/.local/bin`:
+Install the latest release into `~/.local/bin`, without `sudo`:
 
 ```sh
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/greaber/syq/releases/latest/download/install.sh | sh
 ```
 
-That initial shell installer necessarily needs `curl` or `wget` to obtain syq
-before syq exists. The installed syq, and the remote helper installation it
-performs, do not depend on either command.
-
-To inspect it first, download the same URL without piping it to `sh`. Every
-release also has an immutable versioned installer, for example
-`https://github.com/greaber/syq/releases/download/v0.1.8/install.sh`. To choose
-another directory, download the script and run `sh install.sh --bin-dir DIR`
-(or pipe it to `sh -s -- --bin-dir DIR`). The script detects your platform,
-verifies the archive's embedded SHA-256 and size, runs the temporary binary to
-check its version and release identity, and then replaces `syq` atomically.
-Even with `--bin-dir`, either `HOME` or `XDG_CONFIG_HOME` must be set so every
-successful standalone installation can record its install receipt.
+Make sure `~/.local/bin` is on your `PATH`. To inspect the script first or
+choose another directory, download it and run `sh install.sh --bin-dir DIR`.
+The installer verifies the download before replacing the binary. Versioned
+installers are also available on the [releases page](https://github.com/greaber/syq/releases).
 
 ## Homebrew
-
-Homebrew is also supported through the project-owned tap:
 
 ```sh
 brew install greaber/tap/syq
@@ -39,35 +33,30 @@ brew install greaber/tap/syq
 
 ## Cargo
 
-Rust users can instead compile and install the published source package:
+With Rust, Cargo, and a C compiler installed:
 
 ```sh
 cargo install --locked syq
 ```
 
-Cargo installs binaries in `~/.cargo/bin` by default; make sure that directory
-is on your `PATH`. Cargo builds, including the published source package, use
-the [source-build remote setup](#remote-hosts-with-source-builds) below.
+Cargo installs into `~/.cargo/bin` by default. Make sure it is on your `PATH`;
+`command -v syq` shows whether an older installation takes precedence.
+Rerun the command to update. For remote copies, follow
+[Remote hosts with source builds](#remote-hosts-with-source-builds).
 
 ## Installing from master or another branch
-
-To install the latest code on `master`, with Git, Rust, Cargo, and a C compiler
-installed:
 
 ```sh
 cargo install --locked --force --git https://github.com/greaber/syq.git --branch master syq
 ```
 
-Replace `master` with another branch name to try that branch. To install a
-specific commit, replace `--branch master` with `--rev COMMIT_SHA`. Rerun the
-branch command to update; `--force` reinstalls even when the package version
-number has not changed. These are optimized builds, just like
-`cargo build --release`; the word “release” in Cargo's build profile does not
-make them official syq releases.
+Replace `master` with a branch name, or use `--rev COMMIT_SHA` instead of
+`--branch master` to select a commit. Rerun the command to update; `--force`
+reinstalls even when the package version has not changed.
 
-The active Rust toolchain must satisfy the selected revision's `rust-version`
-in `Cargo.toml`. For the exact toolchain pinned by that revision, build from a
-checkout with [rustup](https://rustup.rs/) installed:
+Your Rust toolchain must satisfy that revision's `rust-version` in
+`Cargo.toml`. To use its pinned toolchain, install [rustup](https://rustup.rs/)
+and build from a checkout:
 
 ```sh
 git clone --branch master https://github.com/greaber/syq.git
@@ -75,68 +64,79 @@ cd syq
 cargo install --locked --force --path .
 ```
 
-Rustup selects the version in `rust-toolchain.toml`. You can replace `master`
-in the clone command with another branch, or run `git checkout COMMIT_SHA`
-before installing to select a specific commit. To update a clean branch
+Rustup selects the version in `rust-toolchain.toml`. To update a clean branch
 checkout, run `git pull --ff-only` and repeat the install command. To build
-without installing, use `cargo build --locked --release`; the binary is at
-`target/release/syq`. See [Platform notes](#platform-notes) for macOS build
-prerequisites.
-
-Check which executable your shell selects and record its build identity:
-
-```sh
-command -v syq
-syq --build-identity
-```
-
-Cargo normally installs into `~/.cargo/bin`. An older standalone or Homebrew
-binary earlier on `PATH` can still be the one you run; adjust `PATH` or invoke
-`~/.cargo/bin/syq` explicitly.
+without installing, run `cargo build --locked --release`; the binary is
+`target/release/syq`. On macOS, building also needs the Xcode command-line tools
+(`xcode-select --install`).
 
 ### What changes with an unreleased build
 
-Branch builds can include changes that have not shipped in a release. Use the
-documentation in that checkout when trying another branch; the documentation
-site describes `master`.
-
-`syq --version` reports the package version, which can stay the same across
-many commits. `syq --build-identity` distinguishes them: a clean Git build has
-an identity such as `v0.2.0+dev.0123456789ab`. Local changes add a
-`.dirty.HASH` suffix. Include the full build identity when reporting a problem.
-A source build from a release tag still has a development identity and does
-not match the official release binary. Source archives without Git revision
-metadata get a build-specific identity, so use a Git checkout when building
-matching binaries on different machines.
-
-Source builds do not automatically install remote helpers, check for release
-updates, or support `syq --self-update`. Update them with Cargo or rebuild the
-checkout. To return to an official binary, use the standalone installer or
-Homebrew and check `command -v syq` again so a Cargo binary does not shadow it.
+Use the documentation in the checkout for the branch you are trying.
+`syq --version` shows the package version; `syq --build-identity` identifies
+the build, including its commit and local changes. Include that identity when
+reporting a problem. Cargo's `--release` profile produces an optimized source
+build, not an official release binary.
 
 ### Remote hosts with source builds
 
-Local copies need no extra setup. For remote operations, install a source-built
-`syq` on every participating host. All binaries must report exactly the same
-`syq --build-identity`; matching package versions or branch names are not
-enough. Build the same pinned commit from clean checkouts for each host's
-platform, or copy your binary when it is compatible with the remote platform.
-Local changes affect the identity too, so independently edited checkouts may
-fail the connection handshake.
+Local copies need no extra setup. For remote operations, install `syq` on
+every participating host with **exactly the same `syq --build-identity`**.
+Matching package versions or branch names are not enough, and a source build
+from a release tag does not match the official binary.
 
-Select the remote binary explicitly. For example, after installing it at
-`/home/alice/.cargo/bin/syq` on `server`:
+Build the same pinned commit from clean Git checkouts for each host's platform,
+or copy your binary if it is compatible with the remote platform. Avoid source
+archives without Git metadata when building matching binaries separately:
+they get build-specific identities.
+
+Then select the remote binary explicitly, for example:
 
 ```sh
 ssh server /home/alice/.cargo/bin/syq --build-identity
 syq cp --syq-path /home/alice/.cargo/bin/syq ./data server:/home/alice/data-copy
 ```
 
-Native `syq cp` and remote `syq rm` use `--syq-path PATH`, or `--no-bootstrap`
-when the matching binary is on the non-interactive remote `PATH`. `syq rsync`
-uses `--rsync-path PATH`, or `--syq-no-bootstrap` for the same `PATH` lookup.
-Without these options, source builds cannot use the default managed helper
-installation, even if a matching binary is already installed on the remote.
+| Command | Explicit remote binary | Use the remote `PATH` |
+| --- | --- | --- |
+| `syq cp` or remote `syq rm` | `--syq-path PATH` | `--no-bootstrap` |
+| `syq rsync` | `--rsync-path PATH` | `--syq-no-bootstrap` |
+
+One of these options is required even if a matching binary is already
+installed. The `PATH` option uses the non-interactive SSH session's `PATH`.
+
+## Update checks and self-update
+
+Standalone installs check for updates at most once a day after a successful
+interactive command and print a reminder when one is available. They never
+install an update automatically. Run `syq --self-update` to update.
+
+Set `SYQ_NO_UPDATE_CHECK=1` to disable automatic checks and reminders; explicit
+`syq --self-update` still works. Self-update requires the install receipt at
+`$XDG_CONFIG_HOME/syq/install.json` (normally `~/.config/syq/install.json`)
+to name the running executable.
+
+Update Homebrew with `brew upgrade syq` and source builds with Cargo or a
+rebuild. To switch from source to an official binary, use the standalone
+installer or Homebrew, then check `command -v syq` so a Cargo binary does not
+shadow it.
+
+## Remote helper bootstrap
+
+With the standalone installer or Homebrew, you do not need to install syq on
+remote hosts in advance. On first connection, syq installs its matching helper
+under `~/.cache/syq/helpers/` on the remote host.
+
+Syq verifies the release signature and checksums before installing the helper.
+It tries downloading on the remote host first; if the download fails or the
+required tools are missing, it downloads locally and uploads over SSH. Either your
+machine or the remote host must be able to reach GitHub for the initial
+download. Later connections reuse the cached helper. You can remove the cache;
+syq recreates it when needed.
+
+To manage remote binaries yourself, use the options under
+[Remote hosts with source builds](#remote-hosts-with-source-builds).
+The local and remote build identities must match.
 
 ## Shell completion
 
@@ -161,73 +161,6 @@ Tab on a remote endpoint can take a few seconds if syq must install the remote
 helper there. `syq persist on` makes later completions much faster by keeping
 the authenticated SSH connection, and a ready helper session on it,
 available between commands.
-
-## Update checks and self-update
-
-Standalone installs download and verify one signed release manifest at most
-once a day after a successful interactive command. When a newer release is
-available they print a reminder; updates are never installed as a side effect
-of a copy. Run `syq --self-update` to install the update (`syq --self-update --help`
-explains eligibility and reminders), or set
-`SYQ_NO_UPDATE_CHECK=1` to disable automatic checks and reminders. Explicit
-`syq --self-update` checks still work when that variable is set. The install
-receipt lives at
-`$XDG_CONFIG_HOME/syq/install.json` (normally `~/.config/syq/install.json`) and
-must name the running executable, so a Homebrew or source build never replaces
-itself. Self-update is deliberately limited to standalone installs because a
-package manager must remain the owner of its files. Update Homebrew installs
-with `brew upgrade syq`.
-
-Release binaries are published for Linux x86-64/ARM64 and macOS Apple
-Silicon/Intel. Terminal downloads and Homebrew normally do not attach macOS's
-quarantine attribute, which is why command-line tools installed this way do not
-usually produce Gatekeeper prompts. The binaries are not Developer ID signed
-or notarized by Apple, so a browser download may prompt or be blocked by
-Gatekeeper. Use the terminal installer or Homebrew for the documented
-installation path.
-
-## Remote helper bootstrap
-
-With an official release build, nothing needs to be installed on the remote
-host in advance. Syq installs a helper of exactly its own version, kept on the
-remote under `~/.cache/syq/helpers/`.
-On first use of a version it detects the remote
-platform and checks for a downloader, SHA-256 implementation, and `gzip`. When
-that complete toolchain is available, the remote downloads the matching
-compressed binary and signed manifest from that version's GitHub release. It
-relays the manifest and computed digest over SSH, then waits while the local
-client verifies the manifest signature and compares its expected digest. Only
-an explicit approval from the client lets the remote install the helper
-atomically. This path therefore works even when the local machine cannot reach
-the release host. Later runs execute that exact path without an extra probe
-connection.
-
-If the remote toolchain is unavailable, a tool fails, or the download times
-out or otherwise fails, the local client downloads the archive for that
-platform with its own built-in HTTPS client (rustls) instead. It verifies both the archive and
-decompressed binary, caches the verified binary under
-`$XDG_CACHE_HOME/syq/helpers/` (normally `~/.cache/syq/helpers/`), and uploads it
-through the configured SSH command.
-This fallback does not require a remote downloader, hasher, or decompressor.
-Remote filesystem and installation errors fail immediately because uploading
-the same helper cannot fix them. A completed download with the wrong digest is
-discarded and produces an integrity warning even if the verified upload then
-succeeds.
-
-The helper cache accepts only a verified release binary. To opt out of
-automatic helper installation, install a compatible binary yourself. Native `syq cp` and
-remote `syq rm` use `--syq-path /path/to/syq`, or `--no-bootstrap` when the
-binary is on the non-interactive remote `PATH`; `syq rsync` uses `--rsync-path
-/path/to/syq` or `--syq-no-bootstrap`.
-
-The local client verifies the manifest's embedded Ed25519 signature over its
-normalized JSON form (RFC 8785). A remote download uses `curl` or `wget`, `gzip`,
-and one of `sha256sum`, `shasum`, or `openssl`; those programs are optional
-because missing or unusable tools select verified SSH upload instead. Version
-directories coexist and either helper cache can be removed at any time; syq
-recreates the helper it needs on the next connection. After launch, both sides
-must have the same build identity: the release tag for official binaries, or the
-Git-derived identity when an explicit source-built helper is used.
 
 ## SSH requirements
 
@@ -254,18 +187,13 @@ first on `PATH`; syq picks up whichever `ssh` that resolves to.
 
 ## Platform notes
 
-- **macOS (Apple Silicon / Intel):** build natively on the Mac with
-  `cargo build --release` (needs the Xcode command-line tools, `xcode-select
-  --install`, for the bundled zstd C library). The tool is otherwise pure Rust
-  and uses only POSIX calls; Linux-only optimizations (`fallocate`,
-  glibc `mallopt`) are compiled out automatically. The destination-side
-  same-machine copy fast path is Linux-only; on macOS those copies use the
-  normal path. macOS also cannot hold open a file or directory it may not
-  read, so a copy that Linux completes through an open handle that needs no
-  read permission (for example a mode `000` source file) fails on macOS with
-  a permission error. On
-  macOS, `/tmp`, `/var`, and `/etc` are symlinks into `/private`. Native
-  commands refuse a symlink in a path they are given unless you pass
+Mac binaries are not Developer ID signed or notarized by Apple. Browser
+downloads may trigger Gatekeeper; use the terminal installer or Homebrew.
+
+- **macOS (Apple Silicon / Intel):** copies of unreadable files (for example, mode
+  `000`) can fail where Linux can copy through an open handle. The same-machine
+  copy fast path is Linux-only. On macOS, `/tmp`, `/var`, and `/etc` are
+  symlinks into `/private`. Native commands refuse a symlink in a path they are given unless you pass
   `--follow-src`, `--follow-dst`, or `--follow`, so spell such paths as
   `/private/tmp/...` or pass the follow option.
 - For a manually installed binary that is portable across distributions (for

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,35 +1,29 @@
 # Installing syq
 
-Syq runs on Linux and macOS, on x86-64 and ARM64. Choose an installation method:
-
-| Method | Installs remote helpers automatically | How to update |
-| --- | --- | --- |
-| Standalone installer | Yes | `syq --self-update` |
-| Homebrew | Yes | `brew upgrade syq` |
-| Cargo or Git checkout | No; [set up remote hosts yourself](#remote-hosts-with-source-builds) | Rerun Cargo or rebuild |
-
-**Source builds do not automatically install remote helpers, check for release
-updates, or support `syq --self-update`.** This includes `cargo install syq`
-and builds from release tags. Only standalone installs check for updates.
-
 ## Standalone installer
 
-Install the latest release into `~/.local/bin`, without `sudo`:
+Install the latest release on Linux or macOS (x86-64 or ARM64), without `sudo`:
 
 ```sh
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/greaber/syq/releases/latest/download/install.sh | sh
 ```
 
-Make sure `~/.local/bin` is on your `PATH`. To inspect the script first or
-choose another directory, download it and run `sh install.sh --bin-dir DIR`.
-The installer verifies the download before replacing the binary. Versioned
-installers are also available on the [releases page](https://github.com/greaber/syq/releases).
+The binary goes in `~/.local/bin`; make sure that directory is on your `PATH`.
+To choose another directory, download the script and run
+`sh install.sh --bin-dir DIR`.
+
+Syq installs matching remote helpers on first use. Standalone installs also
+check for updates and print a reminder; run `syq --self-update` to update.
+Set `SYQ_NO_UPDATE_CHECK=1` to disable reminders. Updates are never installed
+automatically.
 
 ## Homebrew
 
 ```sh
 brew install greaber/tap/syq
 ```
+
+Remote helpers are installed automatically. Update with `brew upgrade syq`.
 
 ## Cargo
 
@@ -39,10 +33,10 @@ With Rust, Cargo, and a C compiler installed:
 cargo install --locked syq
 ```
 
-Cargo installs into `~/.cargo/bin` by default. Make sure it is on your `PATH`;
-`command -v syq` shows whether an older installation takes precedence.
-Rerun the command to update. For remote copies, follow
-[Remote hosts with source builds](#remote-hosts-with-source-builds).
+Cargo installs into `~/.cargo/bin`. Rerun the command to update.
+**Source builds do not check for release updates or support `syq --self-update`.**
+For remote operations, they upload their own binary, so the remote must be able
+to run it. A Mac build cannot install a Linux helper this way.
 
 ## Installing from master or another branch
 
@@ -50,93 +44,52 @@ Rerun the command to update. For remote copies, follow
 cargo install --locked --force --git https://github.com/greaber/syq.git --branch master syq
 ```
 
-Replace `master` with a branch name, or use `--rev COMMIT_SHA` instead of
-`--branch master` to select a commit. Rerun the command to update; `--force`
-reinstalls even when the package version has not changed.
+Replace `master` with another branch, or replace `--branch master` with
+`--rev COMMIT_SHA` to test a particular commit. Rerun to update.
 
-Your Rust toolchain must satisfy that revision's `rust-version` in
-`Cargo.toml`. To use its pinned toolchain, install [rustup](https://rustup.rs/)
-and build from a checkout:
+To test local edits, build from your checkout:
 
 ```sh
-git clone --branch master https://github.com/greaber/syq.git
-cd syq
-cargo install --locked --force --path .
+cargo build --locked --release
+./target/release/syq cp ./data --to server --into /tmp
 ```
 
-Rustup selects the version in `rust-toolchain.toml`. To update a clean branch
-checkout, run `git pull --ff-only` and repeat the install command. To build
-without installing, run `cargo build --locked --release`; the binary is
-`target/release/syq`. On macOS, building also needs the Xcode command-line tools
-(`xcode-select --install`).
+No commit or published branch is needed. Syq uploads this build to compatible
+remote hosts automatically. For Linux servers, build and run it on a compatible
+Linux machine. Matching OS and CPU are required; the remote also needs any
+system libraries the binary uses. Syq checks that the uploaded helper runs
+before installing it.
 
-### What changes with an unreleased build
-
-Use the documentation in the checkout for the branch you are trying.
-`syq --version` shows the package version; `syq --build-identity` identifies
-the build, including its commit and local changes. Include that identity when
-reporting a problem. Cargo's `--release` profile produces an optimized source
-build, not an official release binary.
-
-### Remote hosts with source builds
-
-Local copies need no extra setup. For remote operations, install `syq` on
-every participating host with **exactly the same `syq --build-identity`**.
-Matching package versions or branch names are not enough, and a source build
-from a release tag does not match the official binary.
-
-Build the same pinned commit from clean Git checkouts for each host's platform,
-or copy your binary if it is compatible with the remote platform. Avoid source
-archives without Git metadata when building matching binaries separately:
-they get build-specific identities.
-
-Then select the remote binary explicitly, for example:
-
-```sh
-ssh server /home/alice/.cargo/bin/syq --build-identity
-syq cp --syq-path /home/alice/.cargo/bin/syq ./data server:/home/alice/data-copy
-```
-
-| Command | Explicit remote binary | Use the remote `PATH` |
-| --- | --- | --- |
-| `syq cp` or remote `syq rm` | `--syq-path PATH` | `--no-bootstrap` |
-| `syq rsync` | `--rsync-path PATH` | `--syq-no-bootstrap` |
-
-One of these options is required even if a matching binary is already
-installed. The `PATH` option uses the non-interactive SSH session's `PATH`.
-
-## Update checks and self-update
-
-Standalone installs check for updates at most once a day after a successful
-interactive command and print a reminder when one is available. They never
-install an update automatically. Run `syq --self-update` to update.
-
-Set `SYQ_NO_UPDATE_CHECK=1` to disable automatic checks and reminders; explicit
-`syq --self-update` still works. Self-update requires the install receipt at
-`$XDG_CONFIG_HOME/syq/install.json` (normally `~/.config/syq/install.json`)
-to name the running executable.
-
-Update Homebrew with `brew upgrade syq` and source builds with Cargo or a
-rebuild. To switch from source to an official binary, use the standalone
-installer or Homebrew, then check `command -v syq` so a Cargo binary does not
-shadow it.
+Use [rustup](https://rustup.rs/) to select the checkout's pinned Rust toolchain.
+On macOS, building also needs the Xcode command-line tools. `command -v syq`
+shows which installed binary your shell selects; `syq --build-identity` shows
+its source revision and local changes.
 
 ## Remote helper bootstrap
 
-With the standalone installer or Homebrew, you do not need to install syq on
-remote hosts in advance. On first connection, syq installs its matching helper
-under `~/.cache/syq/helpers/` on the remote host.
+On first use, syq installs a matching helper in `~/.cache/syq/helpers/` on the
+remote host. Later connections reuse it.
 
-Syq verifies the release signature and checksums before installing the helper.
-It tries downloading on the remote host first; if the download fails or the
-required tools are missing, it downloads locally and uploads over SSH. Either your
-machine or the remote host must be able to reach GitHub for the initial
-download. Later connections reuse the cached helper. You can remove the cache;
-syq recreates it when needed.
+Official releases download a helper for the remote platform and verify its
+signed manifest. Source builds upload the running executable over SSH; they
+cannot download a matching build for another platform.
 
-To manage remote binaries yourself, use the options under
-[Remote hosts with source builds](#remote-hosts-with-source-builds).
-The local and remote build identities must match.
+### Remote hosts with source builds
+
+If automatic upload cannot work, install a compatible build yourself. Its
+`syq --build-identity` must exactly match the local build: use the same commit
+and source changes. A source build does not match an official release binary.
+
+Choose **one** of these options:
+
+| Command | Specify the remote binary | Find it on the remote `PATH` |
+| --- | --- | --- |
+| `syq cp` or remote `syq rm` | `--syq-path /path/to/syq` | `--no-bootstrap` |
+| `syq rsync` | `--rsync-path /path/to/syq` | `--syq-no-bootstrap` |
+
+An explicit path disables automatic installation by itself. You do not also
+pass `--no-bootstrap`. The `PATH` option uses the non-interactive SSH session's
+`PATH`.
 
 ## Shell completion
 
@@ -164,39 +117,8 @@ available between commands.
 
 ## SSH requirements
 
-Syq runs your own `ssh`, so your configuration, keys, agent, and known hosts
-apply unchanged. Copies between your machine and a remote host need nothing
-special. A copy between two remote machines forwards the constrained agent
-broker (a temporary local SSH agent that signs only for the intended
-destination) to the coordinator, the host that runs the copy, by default.
-This relies on OpenSSH features from release 8.9
-(February 2022):
-the client on your machine and on the coordinator host must be 8.9 or newer,
-and so must the `sshd` on the other remote. Syq checks the two clients it runs
-and stops with a message naming the older one. Ubuntu 22.04, Debian 12, RHEL 9
-with current updates, and macOS 13 or newer qualify; RHEL 8, Ubuntu 20.04, and
-Debian 11 do not. On such hosts pass `--peer-auth own-credentials` and keep credentials
-on the coordinator host, or choose `--peer-auth full-agent` or an
-explicit `--rsh` policy. `syq cp -vv` prints the client version it found.
-
-On macOS, Apple's `ssh` ships without a built-in FIDO provider, so a
-hardware-backed `sk-` key works only with an external `SecurityKeyProvider`
-library configured in `ssh_config`. The simplest route is to install `openssh`
-with Homebrew, which has the provider built in, and put its `bin` directory
-first on `PATH`; syq picks up whichever `ssh` that resolves to.
-
-## Platform notes
-
-Mac binaries are not Developer ID signed or notarized by Apple. Browser
-downloads may trigger Gatekeeper; use the terminal installer or Homebrew.
-
-- **macOS (Apple Silicon / Intel):** copies of unreadable files (for example, mode
-  `000`) can fail where Linux can copy through an open handle. The same-machine
-  copy fast path is Linux-only. On macOS, `/tmp`, `/var`, and `/etc` are
-  symlinks into `/private`. Native commands refuse a symlink in a path they are given unless you pass
-  `--follow-src`, `--follow-dst`, or `--follow`, so spell such paths as
-  `/private/tmp/...` or pass the follow option.
-- For a manually installed binary that is portable across distributions (for
-  example, a host with an older glibc), build a static binary:
-  `RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target x86_64-unknown-linux-gnu`
-  (building for musl also works if `musl-gcc` is installed, which `zstd-sys` needs).
+Syq uses your `ssh` configuration, keys, and known hosts. The default
+[remote-to-remote authentication](remote-to-remote.md) needs OpenSSH 8.9 or
+newer on the local and coordinating hosts, and on the other remote's SSH
+server. Copies between your machine and one remote do not need these newer
+features.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -597,7 +597,8 @@ Connection and listing failures simply produce no candidates; set
 
 The helper syq installs on a remote host serves one bounded, read-only
 directory listing. If the matching helper is absent, the first completion may
-install it through the same signed, verified bootstrap used by a transfer.
+install it through the same [helper installation](install.md#remote-helper-bootstrap)
+used by a transfer: a verified release download or a source-build upload.
 With persistence enabled, completion uses the same per-endpoint SSH control
 connection as later transfers, which removes the repeated login latency. It
 also takes the session pool's ready helper when one is waiting, which makes a

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -28,7 +28,7 @@ rsync meaning (human-readable sizes); use `syq rsync --help` for common help
 or `syq rsync --help-all` for all options.
 
 `syq --self-update --help` explains standalone upgrades and update reminders.
-Homebrew installs use `brew upgrade syq`; see [Installation](install.md#update-checks-and-self-update).
+Homebrew installs use `brew upgrade syq`; see [Installation](install.md#standalone-installer).
 
 ## Native commands
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -827,10 +827,10 @@ const REMOTE_TO_REMOTE_HEADING: &str = "Remote-to-remote transfers";
 
 #[derive(clap::Args, Debug, Default)]
 struct NativeRemoteHelperArgs {
-    /// Use this exact syq executable for ordinary remote helpers, including a remote-to-remote coordinator
+    /// Use this remote syq executable instead of installing a helper
     #[arg(long, value_name = "PATH", conflicts_with = "no_bootstrap")]
     syq_path: Option<String>,
-    /// Require ordinary remote helpers on PATH instead of installing a versioned helper
+    /// Use syq on the remote PATH instead of installing a helper
     #[arg(long)]
     no_bootstrap: bool,
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1460,7 +1460,7 @@ impl RemoteSpec {
 
     /// `limited`: take a connect slot (data connections). The control
     /// connection passes false: everything waits on it, so it must never
-    /// queue behind workers. In managed mode the release helper is installed
+    /// queue behind workers. In managed mode the matching helper is installed
     /// on first use if the remote lacks it.
     pub fn connect_with(&self, compress: bool, limited: bool) -> Result<RemoteConn> {
         let role = if limited {
@@ -2180,10 +2180,8 @@ fn receive_hello(mut conn: RemoteConn, worker: bool) -> Result<RemoteConn> {
 }
 
 impl RemoteSpec {
-    /// Ensure the exact release helper exists in the remote cache.
-    /// Only authorized release assets may populate the managed helper cache.
+    /// Install a matching release asset or upload this source-built executable.
     pub fn install_helper(&self) -> Result<()> {
-        crate::identity::require_release_build()?;
         let mut installed = self.helper_install.lock().unwrap();
         if *installed {
             return Ok(());
@@ -2201,7 +2199,7 @@ impl RemoteSpec {
         }
         self.bootstrap_helper(bootstrap).with_context(|| {
             format!(
-                "could not install the authorized {} helper on {} ({})",
+                "could not install the matching {} helper on {} ({})",
                 remote_helper::helper_identity(),
                 self.label(),
                 target.key
@@ -2259,6 +2257,36 @@ impl RemoteSpec {
     }
 
     fn bootstrap_helper(&self, bootstrap: RemoteBootstrap) -> Result<()> {
+        if !crate::identity::is_release_build() {
+            if Some(bootstrap.target) != Target::local() {
+                bail!(
+                    "cannot automatically install a source-built helper for {} from {}; \
+                     run syq from a compatible host, use an official release, or install a matching \
+                     build on the remote and select it with --syq-path (--rsync-path for syq rsync)",
+                    bootstrap.target.key,
+                    crate::identity::platform()
+                );
+            }
+            // On Linux this refers to the running image even if a rebuild has
+            // replaced or removed its original path.
+            #[cfg(target_os = "linux")]
+            let executable = std::path::PathBuf::from("/proc/self/exe");
+            #[cfg(not(target_os = "linux"))]
+            let executable =
+                std::env::current_exe().context("locate the running syq executable")?;
+            let binary =
+                std::fs::read(&executable).context("read the running syq for helper upload")?;
+            if !self.quiet {
+                crate::output::diagnostic!(
+                    "syq: {}: uploading this source build over SSH",
+                    self.label()
+                );
+            }
+            // The upload script runs the temporary helper and checks its build
+            // identity before renaming it into the cache. OS/CPU agreement alone
+            // does not guarantee compatible dynamic libraries or CPU features.
+            return self.upload_helper(bootstrap.target, &binary);
+        }
         let mut trusted = None;
         if bootstrap.remote_download {
             match self.try_remote_download(bootstrap.target)? {

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -39,7 +39,7 @@ pub fn require_release_build() -> Result<()> {
     )
 }
 
-fn is_release_build() -> bool {
+pub(crate) fn is_release_build() -> bool {
     if env!("SYQ_IS_RELEASE_BUILD") == "1" {
         return true;
     }

--- a/src/remote_helper.rs
+++ b/src/remote_helper.rs
@@ -1,10 +1,10 @@
 //! Release/build-identified remote helper discovery and installation commands.
 //!
 //! Official clients name their exact release; development clients carry a Git
-//! identity but may not populate the managed cache. A cache hit adds no extra
+//! identity and upload their own executable to compatible hosts. A cache hit adds no extra
 //! ssh round trip: the normal remote command computes the target name and execs
 //! the cached binary directly. On a miss, `conn` probes the target and either
-//! authorizes a remote download or uploads a locally verified matching asset.
+//! authorizes a release download or uploads a matching executable.
 
 pub const RELEASE_BASE_URL: &str = "https://github.com/greaber/syq/releases/download";
 pub const HELPER_MISSING_EXIT: i32 = 125;
@@ -255,7 +255,7 @@ trap - EXIT HUP INT TERM"#,
     )
 }
 
-/// Install a locally verified, uncompressed helper received on standard input.
+/// Install a verified release asset or the client executable over authenticated SSH.
 /// This path deliberately needs no remote downloader, hasher, or decompressor.
 pub fn upload_script(target: Target) -> String {
     let release = cache_key();
@@ -282,7 +282,7 @@ if ! chmod 700 "$tmp"; then
     exit {install_failed_exit}
 fi
 got=$("$tmp" --version 2>/dev/null) || {{
-    echo "syq: uploaded helper cannot run on this host" >&2
+    echo "syq: uploaded helper cannot run on this host; use a build compatible with its system libraries and CPU" >&2
     exit {install_failed_exit}
 }}
 [ "$got" = {expected_version} ] || {{

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -4407,24 +4407,83 @@ exit 23
 }
 
 #[test]
-fn development_build_refuses_managed_remote_bootstrap() {
+fn development_build_uploads_itself_and_reuses_cached_helper() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
-
-    write(&t.path("src"), b"offline");
+    executable(
+        &t.path("remote-bin/curl"),
+        b"#!/bin/sh\necho unexpected-download >> \"$FAKE_CURL_LOG\"\nexit 1\n",
+    );
+    write(&t.path("src"), b"offline source build");
     let remote = format!("fake:{}", t.s("dst"));
     let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
-    assert!(!out.status.success(), "bootstrap unexpectedly succeeded");
-    assert!(!t.path("dst").exists());
-    assert!(!t.path("remote-home/.cache/syq/helpers").exists());
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), b"offline source build");
+    assert_eq!(
+        read(&cached_remote_helper(&t)),
+        read(Path::new(env!("CARGO_BIN_EXE_syq")))
+    );
+    assert!(!t.path("curl.log").exists());
+    assert!(!cached_local_helper(&t).exists());
+
+    write(&t.path("rsh.log"), b"");
+    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
+    assert_output_ok(&out);
+    let log = fs::read_to_string(t.path("rsh.log")).unwrap();
+    assert!(
+        !log.contains("syq-helper-target:"),
+        "cache hit probed: {log}"
+    );
+    assert!(!log.contains(".upload"), "cache hit uploaded: {log}");
+}
+
+#[test]
+fn development_build_rejects_cross_platform_upload() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    let other_os = if cfg!(target_os = "linux") {
+        "Darwin"
+    } else {
+        "Linux"
+    };
+    executable(
+        &t.path("remote-bin/uname"),
+        format!("#!/bin/sh\ncase \"$1\" in -s) echo {other_os};; -m) echo x86_64;; esac\n")
+            .as_bytes(),
+    );
+    write(&t.path("src"), b"must not copy");
+    let remote = format!("fake:{}", t.s("dst"));
+    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
+    assert!(!out.status.success());
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains(
-            "managed remote bootstrap is only available from an official syq release build"
-        ),
+        stderr.contains("cannot automatically install a source-built helper"),
         "{stderr}"
     );
-    assert!(!stderr.contains("uploading"), "{stderr}");
+    assert!(stderr.contains("--syq-path"), "{stderr}");
+    assert!(!t.path("dst").exists());
+    assert!(!t.path("remote-home/.cache/syq/helpers").exists());
+}
+
+#[test]
+fn development_build_does_not_install_an_unrunnable_upload() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    // Model a host on which the uploaded binary cannot execute.
+    executable(&t.path("remote-bin/chmod"), b"#!/bin/sh\nexit 0\n");
+    write(&t.path("src"), b"must not copy");
+    let remote = format!("fake:{}", t.s("dst"));
+    let out = remote_syq(&t, &rsh, &["-a", &t.s("src"), &remote]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("uploaded helper cannot run on this host"),
+        "{stderr}"
+    );
+    assert!(!t.path("dst").exists());
+    let helper = cached_remote_helper(&t);
+    assert!(!helper.exists());
+    assert_eq!(fs::read_dir(helper.parent().unwrap()).unwrap().count(), 0);
 }
 
 #[test]

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -51,10 +51,9 @@ internal Docker network: no ports are published and no real SSH configuration,
 agent, keys, homes, or remote hosts are used. The destination service alone gets
 `NET_ADMIN`, solely to install the test's port-specific firewall rule.
 
-Managed bootstrap rejects unpublished development identities, so endpoint
-startup seeds the exact candidate binary into its expected helper-cache path.
-The scenarios still use normal SSH control, constrained agent forwarding, and
-destination enrollment; they do not substitute a fake remote shell.
+Endpoint helper caches start empty. The suite copies a file to each endpoint
+using the source build, exercising automatic executable upload over real SSH
+before the remaining scenarios reuse those helpers.
 
 The smoke suite also checks that pooled helpers keep the spawning command’s
 `SendEnv` values, while direct sessions and restarted persistence use the new

--- a/tests/real-ssh/entrypoint.sh
+++ b/tests/real-ssh/entrypoint.sh
@@ -1,20 +1,6 @@
 #!/bin/sh
 set -eu
 
-seed_helper() {
-    identity=$(syq --build-identity)
-    case "$(uname -m)" in
-        x86_64) target=linux-x86_64 ;;
-        aarch64) target=linux-aarch64 ;;
-        *)
-            echo "unsupported real-SSH test architecture: $(uname -m)" >&2
-            exit 1
-            ;;
-    esac
-    helper="/home/syq/.cache/syq/helpers/${identity}-release/${target}/syq"
-    install -D -m 0755 -o syq -g syq /usr/local/bin/syq "$helper"
-}
-
 endpoint() {
     test -r /run/lab/authorized_keys
     install -d -m 0700 -o syq -g syq /home/syq/.ssh
@@ -28,7 +14,6 @@ endpoint() {
             --dport "$SYQ_REAL_SSH_BLOCKED_TCP_PORT" \
             -j REJECT --reject-with tcp-reset
     fi
-    seed_helper
     /usr/sbin/sshd -t -f /etc/ssh/sshd_config
     if [ -n "${SYQ_REAL_SSH_EXPECT_MAX_SESSIONS:-}" ]; then
         effective_max_sessions=$(

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -108,6 +108,16 @@ if [ -z "$ssh_release" ] || [ "$ssh_major" -lt 8 ] || { [ "$ssh_major" -eq 8 ] &
     exit 1
 fi
 
+printf 'case: source build uploads itself over real SSH to empty helper caches\n'
+printf 'development helper upload\n' > /tmp/dev-helper-upload.txt
+for host in source destination; do
+    ssh "$host" 'test ! -e "$HOME/.cache/syq/helpers"'
+    syq cp /tmp/dev-helper-upload.txt --to "$host" --into /tmp
+    ssh "$host" 'cmp /tmp/dev-helper-upload.txt /dev/stdin' < /tmp/dev-helper-upload.txt
+done
+# The completion scenario expects to discover only its own endpoint.
+syq completion cache clear >/dev/null
+
 printf 'case: remote filename completion reuses a persistent ordinary SSH login\n'
 ssh source 'rm -rf /tmp/syq-real-ssh/completion; mkdir -p /tmp/syq-real-ssh/completion/alpine; : > "/tmp/syq-real-ssh/completion/alpha file"'
 # Observe the environment at the remote helper, after real SendEnv/AcceptEnv


### PR DESCRIPTION
Source builds currently refuse automatic remote-helper installation, making a local edit require manual installation on every test host. They now upload the running executable over SSH when the remote OS and CPU match, validate that it runs and reports the expected build identity, and cache it for later connections. This works without committing or publishing a branch. Cross-platform attempts explain how to use a compatible host or an explicitly installed helper; official releases retain signed artifact downloads.

The installation guide is reduced from 274 to 124 lines and focuses on installing, updating, and testing builds. It explicitly distinguishes `--syq-path PATH` from `--no-bootstrap`: either selects an existing helper, and an explicit path needs no additional flag. README and CLI help are aligned.

[Rendered installation preview](https://cdna-morris-begin-controversial.trycloudflare.com/install.html) (temporary public tunnel, serving this branch).

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq` and `cargo test --all-targets`
- `scripts/test-real-ssh.sh`: empty-cache uploads to both endpoints, then the existing completion, persistence, direct-transfer, restricted-receiver, and TCP fallback scenarios
- Documentation links, mdBook build, shellcheck, and whitespace checks

Rust and real-SSH checks passed at d0d53e7; ee0570a only corrects a documentation anchor, with documentation checks passing. Tests exercise upload/cache reuse without downloads, cross-platform rejection, and cleanup of an unrunnable helper. Linux was tested; native macOS execution and the alternate max-sessions-1 SSH profile were not run. Initial SSH fixture failures (incorrect copy syntax and completion endpoint state left by the new setup) were corrected before the successful runs.

Branch-status output before opening:

```text
Worktree: /home/grant/repos/syq/.worktrees/dev-helper-upload
Branch:   dev-helper-upload at ee0570a (clean)
Upstream: none
Master:   1704425 from refs/heads/master (branch is ahead 3, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      2903fd8  https://github.com/greaber/syq/actions/runs/33964392587
  rsync-compat.yml success      2903fd8  https://github.com/greaber/syq/actions/runs/33964392563
  macos.yml        success      2903fd8  https://github.com/greaber/syq/actions/runs/33964392707

Pull request: none for dev-helper-upload
```
