### PR TITLE
Add remote copy path defaults and clarify CLI help

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -72,6 +72,25 @@ resolution, known-host lookup, automatic enrollment, and later enrollment
 reuse. A local path containing `:` stays local because native mode never
 guesses endpoints from path text.
 
+A **placement** specifies the destination path and how to use it. `--into DIR`
+puts selected names inside a directory (`foo` becomes `DIR/foo`); `--as PATH`
+copies one named object to that exact path. The `-new` and `-existing` variants
+also require the destination to be absent or present.
+
+For remote copies, omitting placement defaults to `--into .` at the destination:
+
+```sh
+syq cp foo --to j5        # copy foo into your home directory on j5
+syq cp --from j5 foo      # copy foo from j5's home into your local current directory
+```
+
+With both `--from` and `--to`, the default is the destination host's home
+directory. `--cwd` changes only the source base, not this destination default.
+`--prune` always requires an explicit placement, even for remote copies.
+Matching destination files may be overwritten; use `--dry-run` to preview a copy.
+Local-only copies still require a placement option; bare paths always select
+sources, so `syq cp foo bar` does not treat `bar` as a destination.
+
 In `cp`, finish the source specification before starting the destination. The
 source endpoint, `--cwd` or `--root`, every positional or `--src*` selector,
 and `--mapping` must all appear before the first `--to` or placement option.
@@ -268,7 +287,7 @@ destination changes, with guidance to reduce selectors or `--connections`.
 syq promises no particular minimum limit; the transports and the files
 already open in the invoking environment count against the same limit.
 
-Placement is always explicit:
+Placement options choose the destination path and how to use it:
 
 | Placement | Mapping | Destination precondition |
 |---|---|---|

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -446,7 +446,7 @@ impl Args {
                 Ok(args)
             },
             _ => bail!(
-                "expected a command (`cp`, `rm`, `map`, `rsync`, `persist`, `completion`, or `receiver`); rsync-shaped syntax now starts with `syq rsync`"
+                "unrecognized command or option {command:?}; run `syq --help` for commands and standalone options such as `--self-update`"
             ),
         }
     }
@@ -899,7 +899,7 @@ struct NativeCopyFields {
     suppress_summary: bool,
     #[command(flatten)]
     selection: NativeSelectionArgs,
-    /// Target endpoint ([USER@]HOST[:PORT]); omitted means local
+    /// Destination endpoint ([USER@]HOST[:PORT]); without --into/--as, copy into its home directory
     #[arg(long, value_name = "ENDPOINT")]
     to: Option<String>,
     /// Follow symlinks in directly supplied destination paths
@@ -948,10 +948,10 @@ struct NativeSizeSelectionArgs {
 #[command(
     name = "syq cp",
     version,
-    about = "Copy files and directories locally or over SSH.\n\nDirectories are copied recursively, symlinks as symlinks, and modification times\nare preserved. Destination-only objects remain unless --prune is selected.\nSource arguments must precede destination arguments.",
-    before_help = "Examples:\n  syq cp photos --into backup\n  syq cp --srcs-in photos --to nas --into /backup/photos\n  syq cp report.txt --as report-backup.txt",
-    long_about = "Copy selected objects with explicit endpoint and placement syntax.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files. By default, destination-only objects remain in place. --prune removes them from mapped directory scopes after copying, while protecting ignored and size-excluded paths. The source endpoint, source base, selectors, and --mapping must precede the first --to or placement option; other options may follow the destination. Attach path and pattern option values beginning with `-` by using `=`, for example --src-dir=-. The spelling --mapping - retains its conventional stdin meaning.",
-    override_usage = "syq cp [OPTIONS] SOURCE... PLACEMENT"
+    about = "Copy files and directories locally or over SSH.\n\nDirectories are copied recursively, symlinks as symlinks, and modification times\nare preserved. Destination-only objects remain unless --prune is selected.\nPlacement chooses where names go: --into DIR gives DIR/name; --as PATH\nuses that exact path. Without placement, --to copies into the remote home;\n--from without --to copies into the local current directory. Local-only copies\nand --prune require placement. Matching destination files may be overwritten.\nSource arguments must precede destination arguments.",
+    before_help = "Examples:\n  syq cp foo --to j5\n  syq cp foo --from j5\n  syq cp photos --into backup\n  syq cp --srcs-in photos --to nas --into /backup/photos\n  syq cp report.txt --as report-backup.txt",
+    long_about = "Copy files and directories locally or over SSH.\n\nPlacement specifies the destination path and how to use it: --into DIR puts selected names inside DIR (foo becomes DIR/foo); --as PATH copies one named object to that exact path. The -new and -existing variants also require the destination to be absent or present.\n\nWith --to and no placement, copy into the remote home directory: syq cp foo --to j5. With --from and no --to or placement, copy into the local current directory: syq cp --from j5 foo. Both default to --into . at the destination. Local-only copies and --prune require a placement option. Matching destination files may be overwritten.\n\nNative copies recurse, copy symlinks as symlinks, and preserve modification times by default. Use --preserve to add permissions, ownership, or special files. By default, destination-only objects remain in place. --prune removes them from mapped directory scopes after copying, while protecting ignored and size-excluded paths. The source endpoint, source base, selectors, and --mapping must precede the first --to or placement option; other options may follow the destination. Attach path and pattern option values beginning with `-` by using `=`, for example --src-dir=-. The spelling --mapping - retains its conventional stdin meaning.",
+    override_usage = "syq cp [OPTIONS] SOURCE... [PLACEMENT]"
 )]
 struct NativeCopyCommand {
     #[command(flatten)]
@@ -1254,8 +1254,12 @@ fn parse_native_copy(argv: &[OsString]) -> Result<Args> {
         .find_map(|(path, placement, existence)| path.map(|path| (path, placement, existence)))
     {
         Some((path, placement, existence)) => (Some(path), placement, existence),
+        None if prune => bail!("--prune requires an explicit placement, such as --into DIR"),
+        None if copy.to.is_some() || copy.selection.from.is_some() => {
+            (Some(OsString::from(".")), Placement::Into, Existence::Any)
+        }
         None => bail!(
-            "syq cp requires one of --into, --into-new, --into-existing, --as, --as-new, or --as-existing"
+            "local-only syq cp requires one of --into, --into-new, --into-existing, --as, --as-new, or --as-existing"
         ),
     };
     if placement == Placement::As && mapping.is_some() {
@@ -2568,6 +2572,39 @@ mod tests {
                 "{error}"
             );
         }
+    }
+
+    #[test]
+    fn native_remote_copy_default_placement_and_prune_guard() {
+        use super::Existence;
+        use std::ffi::OsString;
+        for argv in [
+            vec!["foo", "--to", "j5"],
+            vec!["foo", "--from", "j5"],
+            vec!["--from", "j5", "foo"],
+            vec!["--from", "j5", "foo", "--to", "j6"],
+            vec!["--from", "j5", "--mapping", "manifest"],
+        ] {
+            let argv = argv.into_iter().map(OsString::from).collect::<Vec<_>>();
+            let args = parse_native_copy(&argv).unwrap();
+            assert_eq!(args.placement, Placement::Into);
+            assert_eq!(args.target_existence, Existence::Any);
+            assert_eq!(args.locations.last().unwrap().path, b".");
+            let mut pruning = argv;
+            // Mapping has a separate clap-level conflict with --prune.
+            if pruning.iter().any(|arg| arg == "--mapping") {
+                continue;
+            }
+            pruning.push(OsString::from("--prune"));
+            let error = parse_native_copy(&pruning).unwrap_err().to_string();
+            assert!(
+                error.contains("--prune requires an explicit placement"),
+                "{error}"
+            );
+            pruning.extend(["--into", "."].map(OsString::from));
+            assert!(parse_native_copy(&pruning).unwrap().delete);
+        }
+        assert!(parse_native_copy(&[OsString::from("foo")]).is_err());
     }
 
     #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7728,6 +7728,64 @@ fn native_rm_endpoint_conflicts_have_the_same_local_and_remote_classification() 
 }
 
 #[test]
+fn native_remote_copy_omitted_placement_uses_destination_base() {
+    let t = Tmp::new();
+    let ssh = fake_ssh(&t);
+    // Real SSH starts commands in the remote user's home directory.
+    let script = fs::read_to_string(&ssh)
+        .unwrap()
+        .replace("exec /bin/sh -c", "cd \"$HOME\" || exit 1\nexec /bin/sh -c");
+    executable(&ssh, script.as_bytes());
+    fs::create_dir_all(t.path("remote-home")).unwrap();
+    fs::create_dir_all(t.path("local-dest")).unwrap();
+    // Exercise both the small-copy optimization and the full engine.
+    for engine in [false, true] {
+        let name = if engine { "engine" } else { "small" };
+        write(&t.path(&format!("sources/{name}")), b"uploaded");
+        let run = |args: &[&str]| {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+            command
+                .current_dir(t.path("local-dest"))
+                .args([
+                    "cp",
+                    "--syq-path",
+                    env!("CARGO_BIN_EXE_syq"),
+                    "--no-tcp",
+                    "-q",
+                ])
+                .args(args)
+                .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+                .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+                .env("FAKE_RSH_LOG", t.path("rsh.log"))
+                .env(
+                    "PATH",
+                    format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+                );
+            if engine {
+                command.env("SYQ_TEST_DISABLE_SMALL_COPY", "1");
+            }
+            let output = command.run().unwrap();
+            assert!(output.status.success(), "{}", stderr_of(&output));
+        };
+        run(&["-C", &t.s("sources"), name, "--to", "fake.example"]);
+        assert_eq!(read(&t.path(&format!("remote-home/{name}"))), b"uploaded");
+        run(&[name, "--from", "fake.example"]);
+        assert_eq!(read(&t.path(&format!("local-dest/{name}"))), b"uploaded");
+        write(
+            &t.path(&format!("remote-home/tree-{name}/child")),
+            b"contents",
+        );
+        run(&[
+            "--from",
+            "fake.example",
+            "--srcs-in",
+            &format!("tree-{name}"),
+        ]);
+        assert_eq!(read(&t.path("local-dest/child")), b"contents");
+    }
+}
+
+#[test]
 fn native_copy_supports_all_six_placements() {
     let t = Tmp::new();
     for source in [
@@ -7820,6 +7878,23 @@ fn native_selectors_support_bulk_mixing_and_late_modifiers() {
 }
 
 #[test]
+fn unknown_root_option_reports_standalone_options_and_help() {
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .arg("--self-updat")
+        .run()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let error = stderr_of(&output);
+    assert!(
+        error.contains("unrecognized command or option \"--self-updat\""),
+        "{error}"
+    );
+    assert!(error.contains("--self-update"), "{error}");
+    assert!(error.contains("syq --help"), "{error}");
+    assert!(!error.contains("rsync-shaped"), "{error}");
+}
+
+#[test]
 fn native_rejects_positional_destinations_implicit_verbs_and_compat_flags() {
     let positional = native_syq(&["cp", "foo", "bar", "dst"]);
     assert!(!positional.status.success());
@@ -7834,14 +7909,14 @@ fn native_rejects_positional_destinations_implicit_verbs_and_compat_flags() {
         .run()
         .unwrap();
     assert_eq!(implicit.status.code(), Some(2));
-    assert!(String::from_utf8_lossy(&implicit.stderr).contains("expected a command"));
+    assert!(String::from_utf8_lossy(&implicit.stderr).contains("unrecognized command or option"));
 
     let removed = Command::new(env!("CARGO_BIN_EXE_syq"))
         .args(["cp-prune", "source", "--into", "dest"])
         .run()
         .unwrap();
     assert_eq!(removed.status.code(), Some(2));
-    assert!(String::from_utf8_lossy(&removed.stderr).contains("expected a command"));
+    assert!(String::from_utf8_lossy(&removed.stderr).contains("unrecognized command or option"));
 
     for args in [
         ["cp", "-a", "source", "--into", "dest"].as_slice(),


### PR DESCRIPTION
Remote copies currently reject an omitted destination path, and copy help leaves “placement” unexplained. `syq cp foo --to j5` now defaults to the remote home directory, while `syq cp foo --from j5` defaults to the local current directory. Both lower to `--into .`; local-only copies and `--prune` still require explicit placement.

Common and full help explain `--into` versus `--as`, show the shorthand, and state that matching destination files may be overwritten. The reference documents the same behavior. Unknown root arguments now report an unrecognized command or option and point to help and `--self-update`, without the rsync migration message.

Validation at 9291056:
- Passed formatting, all-target/all-feature Clippy with warnings denied, and all 423 binary unit tests.
- Passed 116 `native_` integration tests plus the root-option diagnostic regression. The new transfer test covers pushes, pulls, source bases, contents selections, and both small-copy and full-engine paths in disposable directories.
- Passed common/full help checks, `-h`/`--help` equality, documentation links, and diff whitespace checks.
- Passed the default isolated three-container real-SSH suite on the copy implementation before the final root-diagnostic and test-fixture edits.
- Full `cargo test --all-targets` and cross-platform suites were not run locally; the change is confined to CLI parsing, diagnostics, and documentation.

Branch status before opening: placement-defaults at 9291056, clean, one commit ahead of local master 1704425. Latest post-merge ci.yml, rsync-compat.yml, and macos.yml runs all succeeded at 2903fd8. PRs do not trigger automated test workflows in this repository. Ready for review; not merged.
