### PR TITLE
Make shell completion follow command grammar and path policies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,10 @@ outlive its premise and steer later work in the wrong direction.
 
 ## Branch synchronization and handoff
 
+- Open regular pull requests by default. Use a draft only when the user asks
+  or there is a concrete reason to prevent that particular PR from being
+  merged. The user prefers to review ordinary task work without a draft gate.
+
 - Durable task work belongs in commits on the task branch. Changes intended for
   `master` go through a pull request; do not commit them directly on `master` or
   merge task branches from the coordination checkout. Do not merge a pull

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -603,7 +603,8 @@ remote filenames. In native commands, source path options are listed at the
 `--from` endpoint and placement paths at the `--to` endpoint. In `syq rsync`,
 an operand such as `host:dir/fi` is listed on `host`. Files named with spaces,
 newlines, or non-UTF-8 bytes remain single candidates in shells that support
-those names.
+those names. You can press Tab repeatedly while an option such as `--co` or
+a quoted filename is unfinished.
 
 Remote completion uses a normal SSH login in batch mode: it never opens a
 password prompt, starts TCP data listeners, or uses the enrollment key (the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -604,7 +604,18 @@ remote filenames. In native commands, source path options are listed at the
 an operand such as `host:dir/fi` is listed on `host`. Files named with spaces,
 newlines, or non-UTF-8 bytes remain single candidates in shells that support
 those names. You can press Tab repeatedly while an option such as `--co` or
-a quoted filename is unfinished.
+a quoted filename is unfinished. Completion recognizes attached short options
+such as `-Cphotos`, completes comma-separated `--preserve` values, and covers
+`persist`, `receiver`, and nested `help` commands as well as filesystem commands.
+
+Source filenames are listed relative to `--cwd` (`-C`) or beneath `--root`.
+Destination paths use the destination endpoint's working directory. Directory
+arguments such as `--src-dir` and `--into` suggest directories. Native path
+completion follows directory symlinks only with the applicable `--follow`,
+`--follow-src`, or `--follow-dst` option; `--root` still prevents escaping the
+selected root. After a copy's first `--to` or placement argument, completion
+stops suggesting sources. It also omits conflicting options and selectors
+that the selected mapping mode cannot accept.
 
 Remote completion uses a normal SSH login in batch mode: it never opens a
 password prompt, starts TCP data listeners, or uses the enrollment key (the

--- a/scripts/stress-completion.py
+++ b/scripts/stress-completion.py
@@ -4,7 +4,9 @@
 Run after `cargo build --bin syq`:
   python3 scripts/stress-completion.py --syq target/debug/syq --cases 1000 --seed 1
 
-Exercises raw Bash requests, tokenized Bash/Zsh/fish requests, and repeated
+Checks expected candidates for every public command, source bases, selector
+kinds, parser conflicts, source ordering, and symlink policy, then mutates shell
+text. Exercises raw Bash requests, tokenized Bash/Zsh/fish requests, and repeated
 calls to the generated Bash adapter. Every child has a process-group deadline.
 Failures print the seed, case, and exact byte inputs for reproduction. This
 checks the Bash function directly; it does not drive an interactive Readline
@@ -73,19 +75,54 @@ def quote(word):
     return b"'" + word.replace(b"'", b"'\\''") + b"'"
 
 
+def semantic_cases():
+    """Expected values come from fixture meaning, not another completion path."""
+    for command in (b'cp', b'rm', b'map'):
+        for base in ([b'--cwd', b'base'], [b'-C', b'base'], [b'--root', b'base'],
+                     [b'--cwd=base'], [b'--root=base'], [b'-Cbase'], [b'-C=base']):
+            yield [b'syq', command] + base + [b'in'], [b'inner-dir/', b'inside.txt']
+        yield [b'syq', command, b'-Cba'], [b'-Cbase/']
+        for selector in (b'--src-dir', b'--src-dirs', b'--srcs-in'):
+            yield [b'syq', command, b'--cwd', b'base', selector, b'in'], [b'inner-dir/']
+        yield [b'syq', command, b'--root', b'base', b'inner-dir//'], [b'inner-dir//nested.txt']
+        yield [b'syq', command, b'--root', b'base', b'../'], []
+        yield [b'syq', command, b'link/'], []
+        yield [b'syq', command, b'--follow-src', b'link/in'], [b'link/inner-dir/', b'link/inside.txt']
+    yield [b'syq', b'rm', b'--results', b'ba'], [b'base/']
+    yield [b'syq', b'persist', b'status', b'--pscope=ba'], [b'--pscope=base/']
+    yield [b'syq', b'receiver', b'e'], [b'enroll']
+    yield [b'syq', b'receiver', b'enroll', b'--v'], [b'--via']
+    yield [b'syq', b'help', b'receiver', b'e'], [b'enroll']
+    yield [b'syq', b'completion', b'cache', b'f'], [b'forget']
+    yield [b'syq', b'cp', b'--preserve', b'permissions,ow'], [b'permissions,ownership']
+    yield [b'syq', b'rsync', b'--syq-ignore', b'--', b'--d'], [b'--delete', b'--delete-excluded', b'--dry-run']
+    yield [b'syq', b'cp', b'alpha file', b'--into', b'base', b'--as'], []
+    yield [b'syq', b'cp', b'--cwd', b'base', b'--root'], []
+    yield [b'syq', b'cp', b'--mapping', b'manifest', b'a'], []
+    yield [b'syq', b'map', b'--srcs-in', b'base', b'a'], []
+    for destination in (b'--to', b'--into', b'--into-new', b'--into-existing',
+                        b'--as', b'--as-new', b'--as-existing'):
+        for placement in ([destination, b'target'], [destination + b'=target']):
+            for fragment in (b'', b'--src', b'--cwd', b'--root', b'--mapping'):
+                yield [b'syq', b'cp', b'alpha file'] + placement + [fragment], []
+
+
 def cases(rng, count):
-    # These must stay first: the original parser fails at the literal `--`.
+    # Include all command routes and state transitions before random mutation.
+    for words, expected in semantic_cases():
+        yield b' '.join(quote(word) for word in words), words[-1], words, expected
+    # The original parser fails at the literal `--`.
     for fragment in [b'--', b'--co', b'--help', b'-h', b'help', b'--version',
                      b'', b'-', b'--coordinate-at=', b"'", b'"', b'\\']:
-        yield b'syq ' + fragment, fragment, None
-        yield b'syq cp ' + fragment, fragment, None
+        yield b'syq ' + fragment, fragment, None, None
+        yield b'syq cp ' + fragment, fragment, None, None
     for line, fragment in [(b"syq cp 'alpha", b'alpha'),
                            (b'syq cp "alpha', b'alpha'),
                            (b'syq cp alpha\\ ', b'alpha '),
                            (b'FOO=x syq --', b'--'),
                            (b'printf x | syq --', b'--'),
                            (b'syq cp --coordinate-at=sr', b'sr')]:
-        yield line, fragment, None
+        yield line, fragment, None, None
     atoms = [b'-', b'--', b'help', b'co', b'=', b':', b'@', b"'", b'"',
              b'\\', b' ', b'\t', b'\n', b';', b'|', b'&', b'(', b')',
              b'$(touch injected)', b'`touch injected`', 'é'.encode(), b'\xff']
@@ -96,11 +133,11 @@ def cases(rng, count):
         words = rng.choice([[b'syq'], [b'syq', b'cp', b'--'],
                             [b'syq', b'rm', b'--'], [b'syq', b'map', b'--']])
         words = words + [fragment]
-        yield b' '.join(quote(word) for word in words), fragment, words
+        yield b' '.join(quote(word) for word in words), fragment, words, None
         # Also stop midway through shell syntax, as a person typing would.
         line = b'syq cp -- ' + fragment
         cut = rng.randrange(len(line) + 1)
-        yield line[:cut], fragment, None
+        yield line[:cut], fragment, None, None
 
 
 def main():
@@ -120,7 +157,11 @@ def main():
     with tempfile.TemporaryDirectory(prefix='syq-completion-stress-') as directory:
         root = Path(directory)
         (root / 'bin').mkdir()
-        (root / 'bin' / 'syq').symlink_to(syq)
+        # Pin one executable for the whole run: a concurrent cargo build may
+        # replace the supplied path between requests.
+        snapshot = root / 'bin' / 'syq'
+        shutil.copy2(syq, snapshot)
+        syq = snapshot
         # C locale deliberately makes Bash cursor slicing operate on raw bytes.
         env = dict(os.environ, HOME=str(root / 'home'), LC_ALL='C',
                    XDG_CACHE_HOME=str(root / 'cache'), XDG_CONFIG_HOME=str(root / 'config'),
@@ -131,11 +172,17 @@ def main():
         for name in ['alpha file', '--help', "quote'file", 'éclair']:
             (root / name).write_text('fixture')
         (root / 'alpine').mkdir()
+        (root / 'base' / 'inner-dir').mkdir(parents=True)
+        (root / 'base' / 'inside.txt').write_text('inside')
+        (root / 'base' / 'inner-dir' / 'nested.txt').write_text('nested')
+        (root / 'link').symlink_to('base', target_is_directory=True)
         backend = [os.fsencode(syq), b'completion']
-        for number, (line, fragment, words) in enumerate(cases(random.Random(args.seed), args.cases)):
+        for number, (line, fragment, words, semantic_expected) in enumerate(cases(random.Random(args.seed), args.cases)):
             try:
                 data = run(backend + [b'__complete-bash', fragment, b'--', line], env, root)
                 values = records(data)
+                if semantic_expected is not None:
+                    assert sorted(values) == sorted(semantic_expected), (values, semantic_expected)
                 if line == b'syq --':
                     assert b'--help' in values and b'--version' in values, values
                 if line == b'syq cp --co':

--- a/scripts/stress-completion.py
+++ b/scripts/stress-completion.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Reproducible, local-only completion mini-fuzzer (Python standard library).
+
+Run after `cargo build --bin syq`:
+  python3 scripts/stress-completion.py --syq target/debug/syq --cases 1000 --seed 1
+
+Exercises raw Bash requests, tokenized Bash/Zsh/fish requests, and repeated
+calls to the generated Bash adapter. Every child has a process-group deadline.
+Failures print the seed, case, and exact byte inputs for reproduction. This
+checks the Bash function directly; it does not drive an interactive Readline
+session or exercise the Zsh/fish shell adapters or remote connections.
+"""
+
+import argparse
+import os
+from pathlib import Path
+import random
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+
+
+BASH = r'''
+eval "$("$SYQ" completion bash)" || exit
+COMP_LINE=$1
+COMP_POINT=${#COMP_LINE}
+COMP_WORDS=(syq "$2")
+COMP_CWORD=1
+for ((tab=0; tab<3; tab++)); do
+    _syq_complete
+    for candidate in "${COMPREPLY[@]}"; do
+        printf '%s\0' "$candidate"
+    done
+    printf '\0'
+done
+'''
+
+
+def run(argv, env, cwd):
+    child = subprocess.Popen(argv, env=env, cwd=cwd, stdin=subprocess.DEVNULL,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                             start_new_session=True)
+    try:
+        stdout, stderr = child.communicate(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(child.pid, signal.SIGKILL)
+        stdout, stderr = child.communicate()
+        try:
+            os.killpg(child.pid, 0)
+        except ProcessLookupError:
+            pass
+        else:
+            raise AssertionError(f'process group {child.pid} survived timeout cleanup')
+        raise AssertionError(f"timed out: {argv!r}; stderr={stderr!r}") from None
+    assert child.returncode == 0, (argv, child.returncode, stderr)
+    assert not stderr, (argv, stderr)
+    return stdout
+
+
+def records(data, tagged=True):
+    assert not data or data.endswith(b'\0'), data
+    result = data.split(b'\0')[:-1]
+    if tagged:
+        assert all(record[:1] in (b'f', b'p') for record in result), data
+        result = [record[1:] for record in result]
+    assert len(result) == len(set(result)), result
+    return result
+
+
+def quote(word):
+    return b"'" + word.replace(b"'", b"'\\''") + b"'"
+
+
+def cases(rng, count):
+    # These must stay first: the original parser fails at the literal `--`.
+    for fragment in [b'--', b'--co', b'--help', b'-h', b'help', b'--version',
+                     b'', b'-', b'--coordinate-at=', b"'", b'"', b'\\']:
+        yield b'syq ' + fragment, fragment, None
+        yield b'syq cp ' + fragment, fragment, None
+    for line, fragment in [(b"syq cp 'alpha", b'alpha'),
+                           (b'syq cp "alpha', b'alpha'),
+                           (b'syq cp alpha\\ ', b'alpha '),
+                           (b'FOO=x syq --', b'--'),
+                           (b'printf x | syq --', b'--'),
+                           (b'syq cp --coordinate-at=sr', b'sr')]:
+        yield line, fragment, None
+    atoms = [b'-', b'--', b'help', b'co', b'=', b':', b'@', b"'", b'"',
+             b'\\', b' ', b'\t', b'\n', b';', b'|', b'&', b'(', b')',
+             b'$(touch injected)', b'`touch injected`', 'é'.encode(), b'\xff']
+    for _ in range(count):
+        fragment = b''.join(rng.choice(atoms) for _ in range(rng.randrange(9)))
+        # Only local filenames or top-level commands: no generated request can
+        # choose a remote endpoint or operate on the user's filesystem.
+        words = rng.choice([[b'syq'], [b'syq', b'cp', b'--'],
+                            [b'syq', b'rm', b'--'], [b'syq', b'map', b'--']])
+        words = words + [fragment]
+        yield b' '.join(quote(word) for word in words), fragment, words
+        # Also stop midway through shell syntax, as a person typing would.
+        line = b'syq cp -- ' + fragment
+        cut = rng.randrange(len(line) + 1)
+        yield line[:cut], fragment, None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--syq', type=Path, default=Path('target/debug/syq'))
+    parser.add_argument('--seed', type=int, default=1)
+    parser.add_argument('--cases', type=int, default=128,
+                        help='generated cases (each also gets a truncated-line variant)')
+    args = parser.parse_args()
+    if args.cases < 0:
+        parser.error('--cases must be nonnegative')
+    syq = args.syq.resolve(strict=True)
+    bash = shutil.which('bash')
+    if bash is None:
+        parser.error('bash is required')
+    started = time.monotonic()
+    with tempfile.TemporaryDirectory(prefix='syq-completion-stress-') as directory:
+        root = Path(directory)
+        (root / 'bin').mkdir()
+        (root / 'bin' / 'syq').symlink_to(syq)
+        # C locale deliberately makes Bash cursor slicing operate on raw bytes.
+        env = dict(os.environ, HOME=str(root / 'home'), LC_ALL='C',
+                   XDG_CACHE_HOME=str(root / 'cache'), XDG_CONFIG_HOME=str(root / 'config'),
+                   XDG_RUNTIME_DIR=str(root / 'runtime'), SYQ=str(syq),
+                   SYQ_COMPLETION_DEBUG='1', PATH=f'{root / "bin"}:/usr/bin:/bin')
+        env.pop('BASH_ENV', None)
+        env.pop('ENV', None)
+        for name in ['alpha file', '--help', "quote'file", 'éclair']:
+            (root / name).write_text('fixture')
+        (root / 'alpine').mkdir()
+        backend = [os.fsencode(syq), b'completion']
+        for number, (line, fragment, words) in enumerate(cases(random.Random(args.seed), args.cases)):
+            try:
+                data = run(backend + [b'__complete-bash', fragment, b'--', line], env, root)
+                values = records(data)
+                if line == b'syq --':
+                    assert b'--help' in values and b'--version' in values, values
+                if line == b'syq cp --co':
+                    assert b'--coordinate-at' in values, values
+                if words is not None:
+                    for shell in (b'bash', b'zsh', b'fish'):
+                        tokenized = run(backend + [b'__complete', shell,
+                                        str(len(words) - 1).encode(), b'--'] + words, env, root)
+                        assert records(tokenized, shell != b'fish') == values, (shell, tokenized, data)
+                actual = run([os.fsencode(bash), b'--noprofile', b'--norc', b'-c',
+                              BASH.encode(), b'bash', line, fragment], env, root)
+                expected = (b''.join(value + b'\0' for value in values) + b'\0') * 3
+                assert actual == expected, (actual, expected)
+                assert not (root / 'injected').exists(), 'shell text was executed'
+            except (AssertionError, OSError):
+                print(f'FAIL seed={args.seed} case={number} line={line!r} fragment={fragment!r}', flush=True)
+                raise
+            if number % 100 == 0:
+                print(f'seed={args.seed}: {number + 1} cases passed', flush=True)
+        print(f'PASS seed={args.seed}: {number + 1} cases, three Bash calls each, '
+              f'{time.monotonic() - started:.1f}s', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -8,7 +8,7 @@
 
 use crate::cli::{parse_native_endpoint, NativeEndpoint};
 use crate::conn::{Conn, RemoteConn, RemoteSpec, SshMultiplexer};
-use crate::proto::{CompletionEntry, Request, Response};
+use crate::proto::{CompletionEntry, OperatorSymlinkPolicy, Request, Response};
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
@@ -523,8 +523,10 @@ fn candidates(index: usize, words: &[OsString]) -> Result<Vec<Candidate>> {
     };
     let args_before = &words[2..index];
     match command {
-        "completion" => Ok(completion_command_candidates(args_before, current)),
-        "persist" => Ok(persist_candidates(args_before, current)),
+        "completion" | "persist" | "receiver" => {
+            management_candidates(command, args_before, current)
+        }
+        "help" => Ok(help_candidates(args_before, current)),
         "cp" | "rm" | "map" | "rsync" => {
             filesystem_command_candidates(command, args_before, current)
         }
@@ -685,43 +687,119 @@ fn root_candidates(current: &[u8]) -> Vec<Candidate> {
     .collect()
 }
 
-fn completion_command_candidates(args: &[Vec<u8>], current: &[u8]) -> Vec<Candidate> {
-    let values: &[&str] = match args.first().map(Vec::as_slice) {
-        None => &["bash", "zsh", "fish", "cache", "--help", "--help-all"],
-        Some(b"cache") if args.len() == 1 => &["list", "forget", "clear", "--help", "--help-all"],
-        Some(b"cache") if args.get(1).is_some_and(|value| value == b"forget") => {
-            return endpoint_candidates(current, EndpointSyntax::Native, None)
-        }
-        _ => &[],
-    };
-    values
-        .iter()
-        .filter(|value| value.as_bytes().starts_with(current))
-        .map(|value| Candidate::text(value.as_bytes().to_vec()))
+fn public_command(name: &str) -> Option<clap::Command> {
+    match name {
+        "completion" => Some(command_for_help()),
+        "persist" => Some(crate::persistence::command_for_help()),
+        "receiver" => Some(crate::help::receiver()),
+        "--self-update" => Some(crate::help::lifecycle()),
+        _ => crate::cli::command_for_completion(name),
+    }
+}
+
+fn subcommand_candidates(meta: &clap::Command, current: &[u8]) -> Vec<Candidate> {
+    meta.get_subcommands()
+        .filter(|child| !child.is_hide_set())
+        .filter(|child| child.get_name().as_bytes().starts_with(current))
+        .map(|child| Candidate::text(child.get_name().as_bytes().to_vec()))
         .collect()
 }
 
-fn persist_candidates(args: &[Vec<u8>], current: &[u8]) -> Vec<Candidate> {
-    if args.is_empty() {
-        return ["on", "off", "status", "--help", "--help-all"]
+fn help_candidates(args: &[Vec<u8>], current: &[u8]) -> Vec<Candidate> {
+    let Some(first) = args.first() else {
+        let mut values = subcommand_candidates(&crate::help::root(), current);
+        values.retain(|candidate| candidate.value != b"help");
+        if b"--self-update".starts_with(current) {
+            values.push(Candidate::text(b"--self-update".to_vec()));
+        }
+        return values;
+    };
+    let Some(mut meta) = std::str::from_utf8(first).ok().and_then(public_command) else {
+        return Vec::new();
+    };
+    for topic in &args[1..] {
+        let Some(child) = std::str::from_utf8(topic)
+            .ok()
+            .and_then(|topic| meta.find_subcommand(topic))
+            .filter(|child| !child.is_hide_set())
+            .cloned()
+        else {
+            return Vec::new();
+        };
+        meta = child;
+    }
+    let mut values = subcommand_candidates(&meta, current);
+    values.extend(
+        ["--help", "--help-all"]
             .into_iter()
             .filter(|value| value.as_bytes().starts_with(current))
-            .map(|value| Candidate::text(value.as_bytes().to_vec()))
-            .collect();
+            .map(|value| Candidate::text(value.as_bytes().to_vec())),
+    );
+    values
+}
+
+fn management_candidates(
+    command: &str,
+    args: &[Vec<u8>],
+    current: &[u8],
+) -> Result<Vec<Candidate>> {
+    let mut meta = public_command(command).expect("public management command");
+    meta.build();
+    let mut rest = args;
+    while let Some(child) = rest
+        .first()
+        .and_then(|word| std::str::from_utf8(word).ok())
+        .and_then(|word| meta.find_subcommand(word))
+        .filter(|child| !child.is_hide_set())
+        .cloned()
+    {
+        if child.get_name() == "help" {
+            let mut topics = vec![command.as_bytes().to_vec()];
+            topics.extend_from_slice(&args[..args.len() - rest.len()]);
+            topics.extend_from_slice(&rest[1..]);
+            return Ok(help_candidates(&topics, current));
+        }
+        meta = child;
+        rest = &rest[1..];
     }
-    if previous_is(args, &[b"--pscope"]) {
-        return local_path_candidates(current, true);
+    let context = CompletionContext::scan(&meta, rest);
+    if !context.terminated {
+        if let Some((arg, _)) = context.pending {
+            if arg.is_allow_hyphen_values_set() || !current.starts_with(b"-") {
+                return complete_argument(command, &context, &meta, arg, current);
+            }
+        }
+        if let Some((arg, value, prefix)) = attached_value(&meta, current) {
+            let mut values = complete_argument(command, &context, &meta, arg, value)?;
+            for candidate in &mut values {
+                let mut full = prefix.to_vec();
+                full.extend_from_slice(&candidate.value);
+                candidate.value = full;
+            }
+            return Ok(values);
+        }
+        if current.starts_with(b"-") {
+            return Ok(option_candidates(&meta, current)
+                .into_iter()
+                .filter(|candidate| {
+                    option_arg(&meta, &candidate.value)
+                        .is_some_and(|arg| context.allowed(command, &meta, arg))
+                })
+                .collect());
+        }
     }
-    let options: &[&str] = match args.first().map(Vec::as_slice) {
-        Some(b"on") => &["--ephemeral", "--help", "--help-all"],
-        Some(b"off" | b"status") => &["--pscope", "--help", "--help-all"],
-        _ => &[],
-    };
-    options
-        .iter()
-        .filter(|value| value.as_bytes().starts_with(current))
-        .map(|value| Candidate::text(value.as_bytes().to_vec()))
-        .collect()
+    if context.positional_count != 0 {
+        return Ok(Vec::new());
+    }
+    let subcommands = subcommand_candidates(&meta, current);
+    if meta.get_subcommands().any(|child| !child.is_hide_set()) {
+        return Ok(subcommands);
+    }
+    match (command, meta.get_name()) {
+        ("completion", "forget") => Ok(endpoint_candidates(current, EndpointSyntax::Native, None)),
+        ("receiver", "enroll") => Ok(endpoint_candidates(current, EndpointSyntax::Rsync, None)),
+        _ => Ok(Vec::new()),
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -735,7 +813,6 @@ enum ValueCompletion {
     SourcePath { apply_base: bool },
     DestinationPath,
     LocalPath { directories_only: bool },
-    Enum(&'static [&'static str]),
     None,
 }
 
@@ -750,74 +827,306 @@ struct CompletionDirectory {
     confined_root: Option<Vec<u8>>,
 }
 
+/// Parse the completed portion without requiring an otherwise valid command.
+/// Metadata supplies arity, aliases, short clusters, and hyphen-value rules.
+/// Encode values inline in `options` so later lookups never mistake value
+/// bytes for flags or the option terminator.
+#[derive(Default)]
+struct CompletionContext<'a> {
+    options: Vec<Vec<u8>>,
+    present: HashSet<String>,
+    pending: Option<(&'a clap::Arg, usize)>,
+    positional_count: usize,
+    selector_count: usize,
+    terminated: bool,
+}
+
+fn option_arg<'a>(meta: &'a clap::Command, name: &[u8]) -> Option<&'a clap::Arg> {
+    meta.get_arguments().find(|arg| {
+        arg.get_long()
+            .is_some_and(|long| name == format!("--{long}").as_bytes())
+            || arg
+                .get_all_aliases()
+                .unwrap_or_default()
+                .iter()
+                .any(|alias| name == format!("--{alias}").as_bytes())
+            || arg
+                .get_short()
+                .is_some_and(|short| name == format!("-{short}").as_bytes())
+    })
+}
+
+fn option_name(arg: &clap::Arg) -> Vec<u8> {
+    arg.get_long()
+        .map(|long| format!("--{long}"))
+        .unwrap_or_else(|| format!("-{}", arg.get_short().unwrap()))
+        .into_bytes()
+}
+
+fn selector_id(id: &str) -> bool {
+    matches!(
+        id,
+        "src" | "srcs_in" | "src_file" | "src_dir" | "srcs" | "src_files" | "src_dirs"
+    )
+}
+
+impl<'a> CompletionContext<'a> {
+    fn value(&mut self, arg: &'a clap::Arg, value: &[u8], count: usize) {
+        let mut encoded = option_name(arg);
+        encoded.push(b'=');
+        encoded.extend_from_slice(value);
+        self.options.push(encoded);
+        self.selector_count += usize::from(selector_id(arg.get_id().as_str()));
+        let max = arg.get_num_args().map_or(1, |range| range.max_values());
+        self.pending = (count < max).then_some((arg, count));
+    }
+
+    fn scan(meta: &'a clap::Command, args: &[Vec<u8>]) -> Self {
+        let mut context = Self::default();
+        for word in args {
+            if let Some((arg, count)) = context.pending.take() {
+                if arg.is_allow_hyphen_values_set() || !word.starts_with(b"-") || word == b"-" {
+                    context.value(arg, word, count + 1);
+                    continue;
+                }
+            }
+            if context.terminated {
+                context.positional_count += 1;
+                context.selector_count += 1;
+                continue;
+            }
+            if word == b"--" {
+                context.terminated = true;
+                continue;
+            }
+            let mut parsed = Vec::new();
+            if word.starts_with(b"--") {
+                let (name, value) = split_inline_option(word)
+                    .map_or((word.as_slice(), None), |(name, value)| (name, Some(value)));
+                if let Some(arg) = option_arg(meta, name) {
+                    parsed.push((arg, value));
+                }
+            } else if word.starts_with(b"-") && word.len() > 1 {
+                for index in 1..word.len() {
+                    let Some(arg) = option_arg(meta, &[b'-', word[index]]) else {
+                        break;
+                    };
+                    if arg.get_action().takes_values() {
+                        let tail = &word[index + 1..];
+                        parsed.push((
+                            arg,
+                            (!tail.is_empty()).then(|| tail.strip_prefix(b"=").unwrap_or(tail)),
+                        ));
+                        break;
+                    }
+                    parsed.push((arg, None));
+                }
+            }
+            if parsed.is_empty() {
+                if !word.starts_with(b"-") || word == b"-" {
+                    context.positional_count += 1;
+                    context.selector_count += 1;
+                }
+                continue;
+            }
+            for (arg, value) in parsed {
+                context.present.insert(arg.get_id().to_string());
+                if let Some(value) = value {
+                    context.value(arg, value, 1);
+                } else if arg.get_action().takes_values() {
+                    context.pending = Some((arg, 0));
+                } else {
+                    context.options.push(option_name(arg));
+                }
+            }
+        }
+        context
+    }
+
+    fn allowed(&self, command: &str, meta: &clap::Command, arg: &clap::Arg) -> bool {
+        let id = arg.get_id().as_str();
+        if meta.get_groups().any(|group| {
+            !group.clone().is_multiple()
+                && group.get_args().any(|member| member == arg.get_id())
+                && group
+                    .get_args()
+                    .any(|member| member != arg.get_id() && self.present.contains(member.as_str()))
+        }) {
+            return false;
+        }
+        if meta.get_arg_conflicts_with(arg).iter().any(|other| {
+            other.get_id() != arg.get_id() && self.present.contains(other.get_id().as_str())
+        }) || meta.get_arguments().any(|other| {
+            other.get_id() != arg.get_id()
+                && self.present.contains(other.get_id().as_str())
+                && meta
+                    .get_arg_conflicts_with(other)
+                    .iter()
+                    .any(|conflict| conflict.get_id() == arg.get_id())
+        }) {
+            return false;
+        }
+        if command == "cp" {
+            if self.destination_started() && native_copy_source_option(&option_name(arg)) {
+                return false;
+            }
+            if (self.present.contains("mapping") && selector_id(id))
+                || (id == "mapping" && self.selector_count > 0)
+            {
+                return false;
+            }
+        }
+        if command == "map" {
+            if self.present.contains("srcs_in") && (selector_id(id) || id == "as") {
+                // The first pending value still needs completion.
+                if !(id == "srcs_in" && self.selector_count == 0) {
+                    return false;
+                }
+            }
+            if id == "srcs_in" && (self.selector_count > 0 || self.present.contains("as")) {
+                return false;
+            }
+            if id == "as" && self.selector_count > 1 {
+                return false;
+            }
+            if selector_id(id) && self.present.contains("as") && self.selector_count >= 1 {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn destination_started(&self) -> bool {
+        [
+            "to",
+            "into",
+            "into_new",
+            "into_existing",
+            "as",
+            "as_new",
+            "as_existing",
+        ]
+        .iter()
+        .any(|id| self.present.contains(*id))
+    }
+
+    fn sources_allowed(&self, command: &str) -> bool {
+        !(command == "cp" && (self.destination_started() || self.present.contains("mapping"))
+            || command == "map"
+                && (self.present.contains("srcs_in")
+                    || self.present.contains("as") && self.selector_count >= 1))
+    }
+}
+
+/// Return the argument, its value, and the exact prefix to preserve for an
+/// attached value, including short clusters such as `-nvCdir`.
+fn attached_value<'a, 'b>(
+    meta: &'a clap::Command,
+    current: &'b [u8],
+) -> Option<(&'a clap::Arg, &'b [u8], &'b [u8])> {
+    if let Some((name, value)) = split_inline_option(current) {
+        let arg = option_arg(meta, name)?;
+        return arg
+            .get_action()
+            .takes_values()
+            .then_some((arg, value, &current[..name.len() + 1]));
+    }
+    if current.starts_with(b"--") || !current.starts_with(b"-") {
+        return None;
+    }
+    for index in 1..current.len() {
+        let arg = option_arg(meta, &[b'-', current[index]])?;
+        if arg.get_action().takes_values() {
+            let mut start = index + 1;
+            if current.get(start) == Some(&b'=') {
+                start += 1;
+            }
+            return Some((arg, &current[start..], &current[..start]));
+        }
+    }
+    None
+}
+
 fn filesystem_command_candidates(
     command: &str,
     args: &[Vec<u8>],
     current: &[u8],
 ) -> Result<Vec<Candidate>> {
-    let command_meta = crate::cli::command_for_completion(command)
+    let mut meta = crate::cli::command_for_completion(command)
         .ok_or_else(|| anyhow!("missing completion metadata for {command}"))?;
-    let after_double_dash = args.iter().any(|arg| arg == b"--");
-    let copy_destination_started = command == "cp" && native_copy_destination_started(args);
-    if !after_double_dash {
-        if let Some((option, value)) = split_inline_option(current) {
-            if copy_destination_started && native_copy_source_option(option) {
-                return Ok(Vec::new());
-            }
-            if let Some(kind) = value_completion(command, option, &command_meta) {
-                let mut values = complete_value(command, args, value, kind)?;
-                for candidate in &mut values {
-                    let mut prefixed = option.to_vec();
-                    prefixed.push(b'=');
-                    prefixed.extend_from_slice(&candidate.value);
-                    candidate.value = prefixed;
-                }
-                return Ok(values);
+    meta.build();
+    let context = CompletionContext::scan(&meta, args);
+    if !context.terminated {
+        if let Some((arg, _)) = context.pending {
+            if arg.is_allow_hyphen_values_set() || !current.starts_with(b"-") {
+                return complete_argument(command, &context, &meta, arg, current);
             }
         }
-        if let Some(previous) = args.last() {
-            if copy_destination_started && native_copy_source_option(previous) {
-                return Ok(Vec::new());
+        if let Some((arg, value, prefix)) = attached_value(&meta, current) {
+            let mut values = complete_argument(command, &context, &meta, arg, value)?;
+            for candidate in &mut values {
+                let mut full = prefix.to_vec();
+                full.extend_from_slice(&candidate.value);
+                candidate.value = full;
             }
-            if let Some(kind) = value_completion(command, previous, &command_meta) {
-                if command == "rsync" || !current.starts_with(b"-") {
-                    return complete_value(command, args, current, kind);
-                }
-            }
+            return Ok(values);
         }
         if current.starts_with(b"-") {
-            let mut candidates = option_candidates(&command_meta, current);
-            if copy_destination_started {
-                candidates.retain(|candidate| !native_copy_source_option(&candidate.value));
-            }
-            return Ok(candidates);
+            return Ok(option_candidates(&meta, current)
+                .into_iter()
+                .filter(|candidate| {
+                    option_arg(&meta, &candidate.value)
+                        .is_some_and(|arg| context.allowed(command, &meta, arg))
+                })
+                .collect());
         }
     }
-
     match command {
-        "cp" if copy_destination_started => Ok(Vec::new()),
-        "cp" | "rm" | "map" => complete_path_for(command, args, current, true),
-        "rsync" => complete_rsync_operand(args, current),
+        "cp" | "rm" | "map" if context.sources_allowed(command) => {
+            complete_path_for(command, &context.options, current, true)
+        }
+        "rsync" => complete_rsync_operand(&context.options, current),
         _ => Ok(Vec::new()),
     }
 }
 
-fn native_copy_destination_started(args: &[Vec<u8>]) -> bool {
-    const OPTIONS: &[&[u8]] = &[
-        b"--to",
-        b"--into",
-        b"--into-new",
-        b"--into-existing",
-        b"--as",
-        b"--as-new",
-        b"--as-existing",
-    ];
-    args.iter().any(|argument| {
-        OPTIONS.iter().any(|option| {
-            argument == option
-                || (argument.starts_with(option) && argument.get(option.len()) == Some(&b'='))
-        })
-    })
+fn complete_argument(
+    command: &str,
+    context: &CompletionContext<'_>,
+    meta: &clap::Command,
+    arg: &clap::Arg,
+    current: &[u8],
+) -> Result<Vec<Candidate>> {
+    if !context.allowed(command, meta, arg) {
+        return Ok(Vec::new());
+    }
+    if let Some(values) = arg.get_value_parser().possible_values() {
+        let split = arg
+            .get_value_delimiter()
+            .filter(|delimiter| delimiter.is_ascii())
+            .and_then(|delimiter| current.iter().rposition(|byte| *byte == delimiter as u8))
+            .map_or(0, |index| index + 1);
+        return Ok(values
+            .filter(|value| {
+                !value.is_hide_set() && value.get_name().as_bytes().starts_with(&current[split..])
+            })
+            .map(|value| {
+                let mut full = current[..split].to_vec();
+                full.extend_from_slice(value.get_name().as_bytes());
+                Candidate::text(full)
+            })
+            .collect());
+    }
+    let name = option_name(arg);
+    let kind = value_completion(command, &name, meta).unwrap_or(ValueCompletion::None);
+    let mut values = complete_value(command, &context.options, current, kind)?;
+    if matches!(
+        arg.get_id().as_str(),
+        "cwd" | "root" | "srcs_in" | "src_dir" | "src_dirs" | "into" | "into_new" | "into_existing"
+    ) {
+        values.retain(|candidate| candidate.value.ends_with(b"/"));
+    }
+    Ok(values)
 }
 
 fn native_copy_source_option(option: &[u8]) -> bool {
@@ -866,22 +1175,12 @@ fn value_completion(
             b"--pscope" => Some(ValueCompletion::LocalPath {
                 directories_only: true,
             }),
-            b"--coordinate-at" => Some(ValueCompletion::Enum(&["auto", "src", "dst", "local"])),
-            b"--preserve" => Some(ValueCompletion::Enum(&[
-                "permissions",
-                "ownership",
-                "specials",
-            ])),
-            b"--receiver-receipt" => Some(ValueCompletion::Enum(&["sizes", "digests"])),
-            b"--peer-auth" => Some(ValueCompletion::Enum(&[
-                "restricted",
-                "broker",
-                "own-credentials",
-                "full-agent",
-            ])),
             _ => None,
         },
         "rm" => match option {
+            b"--results" => Some(ValueCompletion::LocalPath {
+                directories_only: false,
+            }),
             b"--from" => Some(ValueCompletion::Endpoint(EndpointSyntax::Native)),
             b"-C" | b"--cwd" | b"--root" => Some(ValueCompletion::SourcePath { apply_base: false }),
             b"--src" | b"--srcs-in" | b"--src-file" | b"--src-dir" | b"--srcs" | b"--src-files"
@@ -898,6 +1197,16 @@ fn value_completion(
             b"--as" => Some(ValueCompletion::LocalPath {
                 directories_only: false,
             }),
+            _ => None,
+        },
+        "persist" => match option {
+            b"--pscope" => Some(ValueCompletion::LocalPath {
+                directories_only: true,
+            }),
+            _ => None,
+        },
+        "receiver" => match option {
+            b"--via" => Some(ValueCompletion::Endpoint(EndpointSyntax::Native)),
             _ => None,
         },
         "rsync" => match option {
@@ -947,11 +1256,6 @@ fn complete_value(
         ValueCompletion::LocalPath { directories_only } => {
             Ok(local_path_candidates(current, directories_only))
         }
-        ValueCompletion::Enum(values) => Ok(values
-            .iter()
-            .filter(|value| value.as_bytes().starts_with(current))
-            .map(|value| Candidate::text(value.as_bytes().to_vec()))
-            .collect()),
         ValueCompletion::None => Ok(Vec::new()),
     }
 }
@@ -978,6 +1282,26 @@ fn option_candidates(command: &clap::Command, current: &[u8]) -> Vec<Candidate> 
         .collect()
 }
 
+fn path_policy(command: &str, args: &[Vec<u8>], source: bool) -> OperatorSymlinkPolicy {
+    if command == "rsync" {
+        return OperatorSymlinkPolicy::TrustedOwner;
+    }
+    if contains_option(args, b"--follow")
+        || contains_option(
+            args,
+            if source {
+                b"--follow-src"
+            } else {
+                b"--follow-dst"
+            },
+        )
+    {
+        OperatorSymlinkPolicy::FollowAll
+    } else {
+        OperatorSymlinkPolicy::Refuse
+    }
+}
+
 fn complete_path_for(
     command: &str,
     args: &[Vec<u8>],
@@ -988,12 +1312,30 @@ fn complete_path_for(
         return complete_source_path(command, args, current, true);
     }
     let Some(endpoint_text) = find_option_value(args, b"--to") else {
-        return Ok(local_path_candidates_at(current, false, None));
+        return Ok(local_path_candidates_at(
+            current,
+            false,
+            None,
+            path_policy(command, args, false),
+        ));
     };
     let Some(endpoint) = parse_native_endpoint(Some(endpoint_text))? else {
-        return Ok(local_path_candidates_at(current, false, None));
+        return Ok(local_path_candidates_at(
+            current,
+            false,
+            None,
+            path_policy(command, args, false),
+        ));
     };
-    remote_path_candidates(command, args, endpoint, current, Vec::new(), None)
+    remote_path_candidates(
+        command,
+        args,
+        endpoint,
+        current,
+        Vec::new(),
+        None,
+        path_policy(command, args, false),
+    )
 }
 
 fn complete_source_path(
@@ -1004,15 +1346,38 @@ fn complete_source_path(
 ) -> Result<Vec<Candidate>> {
     let base = if apply_base { source_base(args) } else { None };
     if command == "map" {
-        return Ok(local_path_candidates_at(current, false, base));
+        return Ok(local_path_candidates_at(
+            current,
+            false,
+            base,
+            path_policy(command, args, true),
+        ));
     }
     let Some(endpoint_text) = find_option_value(args, b"--from") else {
-        return Ok(local_path_candidates_at(current, false, base));
+        return Ok(local_path_candidates_at(
+            current,
+            false,
+            base,
+            path_policy(command, args, true),
+        ));
     };
     let Some(endpoint) = parse_native_endpoint(Some(endpoint_text))? else {
-        return Ok(local_path_candidates_at(current, false, base));
+        return Ok(local_path_candidates_at(
+            current,
+            false,
+            base,
+            path_policy(command, args, true),
+        ));
     };
-    remote_path_candidates(command, args, endpoint, current, Vec::new(), base)
+    remote_path_candidates(
+        command,
+        args,
+        endpoint,
+        current,
+        Vec::new(),
+        base,
+        path_policy(command, args, true),
+    )
 }
 
 fn source_base(args: &[Vec<u8>]) -> Option<SourceBase<'_>> {
@@ -1034,9 +1399,18 @@ fn complete_rsync_operand(args: &[Vec<u8>], current: &[u8]) -> Result<Vec<Candid
         }
         let mut wrapper = authority.to_vec();
         wrapper.push(b':');
-        return remote_path_candidates("rsync", args, endpoint, path, wrapper, None);
+        return remote_path_candidates(
+            "rsync",
+            args,
+            endpoint,
+            path,
+            wrapper,
+            None,
+            OperatorSymlinkPolicy::TrustedOwner,
+        );
     }
-    let mut candidates = local_path_candidates_at(current, false, None);
+    let mut candidates =
+        local_path_candidates_at(current, false, None, OperatorSymlinkPolicy::TrustedOwner);
     candidates.extend(endpoint_candidates(
         current,
         EndpointSyntax::Rsync,
@@ -1078,6 +1452,7 @@ fn remote_path_candidates(
     current: &[u8],
     wrapper: Vec<u8>,
     base: Option<SourceBase<'_>>,
+    symlink_policy: OperatorSymlinkPolicy,
 ) -> Result<Vec<Candidate>> {
     if has_explicit_rsh(command, args) {
         return Ok(Vec::new());
@@ -1123,6 +1498,7 @@ fn remote_path_candidates(
                     directory_for_thread,
                     root_for_thread,
                     prefix_for_thread,
+                    symlink_policy,
                 );
                 (result, Some(connection))
             }
@@ -1198,12 +1574,14 @@ fn list_remote_entries(
     directory: Vec<u8>,
     confined_root: Option<Vec<u8>>,
     prefix: Vec<u8>,
+    symlink_policy: OperatorSymlinkPolicy,
 ) -> Result<Vec<CompletionEntry>> {
     match connection.call(Request::ListDir {
         directory,
         confined_root,
         prefix: prefix.clone(),
         limit: MAX_DIRECTORY_CANDIDATES,
+        symlink_policy,
     })? {
         Response::DirectoryEntries { entries, .. } => validate_completion_entries(entries, &prefix),
         Response::EndpointError(error) => Err(crate::conn::endpoint_error(error)),
@@ -1234,13 +1612,19 @@ fn validate_completion_entries(
 }
 
 fn local_path_candidates(current: &[u8], directories_only: bool) -> Vec<Candidate> {
-    local_path_candidates_at(current, directories_only, None)
+    local_path_candidates_at(
+        current,
+        directories_only,
+        None,
+        OperatorSymlinkPolicy::FollowAll,
+    )
 }
 
 fn local_path_candidates_at(
     current: &[u8],
     directories_only: bool,
     base: Option<SourceBase<'_>>,
+    symlink_policy: OperatorSymlinkPolicy,
 ) -> Vec<Candidate> {
     if current == b"~" && !matches!(base, Some(SourceBase::Root(_))) {
         return std::env::var_os("HOME")
@@ -1254,16 +1638,14 @@ fn local_path_candidates_at(
     let Some(directory) = apply_path_base(base, &directory) else {
         return Vec::new();
     };
-    if let Some(root) = directory.confined_root.as_deref() {
-        let Ok(root) = std::fs::canonicalize(crate::fsops::resolve(root)) else {
-            return Vec::new();
-        };
-        let Ok(resolved) = std::fs::canonicalize(crate::fsops::resolve(&directory.path)) else {
-            return Vec::new();
-        };
-        if !resolved.starts_with(root) {
-            return Vec::new();
-        }
+    if crate::fsops::check_completion_directory(
+        &directory.path,
+        directory.confined_root.as_deref(),
+        symlink_policy,
+    )
+    .is_err()
+    {
+        return Vec::new();
     }
     let mut entries = Vec::new();
     let Ok(items) = std::fs::read_dir(crate::fsops::resolve(&directory.path)) else {
@@ -1279,7 +1661,12 @@ fn local_path_candidates_at(
         };
         let is_directory = file_type.is_dir()
             || (file_type.is_symlink()
-                && std::fs::metadata(item.path()).is_ok_and(|metadata| metadata.is_dir()));
+                && crate::fsops::check_completion_directory(
+                    item.path().as_os_str().as_bytes(),
+                    directory.confined_root.as_deref(),
+                    symlink_policy,
+                )
+                .is_ok());
         if directories_only && !is_directory {
             continue;
         }
@@ -1344,8 +1731,7 @@ fn root_relative_directory_is_safe(directory: &[u8]) -> bool {
     let mut depth = 0usize;
     for component in directory.split(|byte| *byte == b'/') {
         match component {
-            b"" => return false,
-            b"." => {}
+            b"" | b"." => {}
             b".." if depth == 0 => return false,
             b".." => depth -= 1,
             _ => depth += 1,
@@ -1627,13 +2013,6 @@ fn contains_option(args: &[Vec<u8>], option: &[u8]) -> bool {
     option_arguments(args).any(|argument| argument == option)
 }
 
-fn previous_is(args: &[Vec<u8>], options: &[&[u8]]) -> bool {
-    !args.iter().any(|argument| argument == b"--")
-        && args
-            .last()
-            .is_some_and(|previous| options.iter().any(|option| previous == *option))
-}
-
 fn option_arguments(args: &[Vec<u8>]) -> impl Iterator<Item = &[u8]> {
     args.iter()
         .map(Vec::as_slice)
@@ -1899,11 +2278,6 @@ mod tests {
         );
         assert!(!has_explicit_rsh("cp", &args));
         assert!(!contains_option(&args, b"--no-bootstrap"));
-        assert!(!previous_is(
-            &[b"--pscope".to_vec(), b"--".to_vec()],
-            &[b"--pscope"]
-        ));
-
         let terminated_value = vec![
             b"--from".to_vec(),
             b"--".to_vec(),

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -161,14 +161,27 @@ impl Candidate {
     }
 }
 
-pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
+fn parse_action(argv: &[OsString]) -> Result<CompletionAction, clap::Error> {
+    // The installed Bash adapter sends exactly REPLACEMENT -- LINE. Both
+    // payloads are arbitrary shell text: even `--`, `--help`, and `help` are
+    // data here. Decode that fixed envelope before clap can interpret them.
+    if let [action, replacement, separator, line] = argv {
+        if action == "__complete-bash" && separator == "--" {
+            return Ok(CompletionAction::CompleteBash {
+                replacement: replacement.clone(),
+                line: line.clone(),
+            });
+        }
+    }
     let mut full_argv = vec![OsString::from("syq completion")];
     full_argv.extend_from_slice(argv);
-    let matches = command_for_help()
-        .try_get_matches_from(full_argv)
-        .unwrap_or_else(|error| error.exit());
-    let command = CompletionCommand::from_arg_matches(&matches)?;
-    match command.action {
+    let matches = command_for_help().try_get_matches_from(full_argv)?;
+    Ok(CompletionCommand::from_arg_matches(&matches)?.action)
+}
+
+pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
+    let action = parse_action(argv).unwrap_or_else(|error| error.exit());
+    match action {
         CompletionAction::Bash => print!("{BASH_ADAPTER}"),
         CompletionAction::Zsh => print!("{ZSH_ADAPTER}"),
         CompletionAction::Fish => print!("{FISH_ADAPTER}"),
@@ -483,8 +496,13 @@ fn write_candidates(shell: CompletionShell, candidates: Vec<Candidate>) -> Resul
 }
 
 fn candidates(index: usize, words: &[OsString]) -> Result<Vec<Candidate>> {
+    // Shells can omit the empty word at the cursor, but an index beyond that
+    // is not a usable request. Do not allocate based on an unchecked index.
+    if index > words.len() {
+        return Ok(Vec::new());
+    }
     let mut words: Vec<Vec<u8>> = words.iter().map(|word| word.as_bytes().to_vec()).collect();
-    while words.len() <= index {
+    if words.len() == index {
         words.push(Vec::new());
     }
     let Some(command_start) = words
@@ -1696,6 +1714,74 @@ mod tests {
         );
         assert_eq!(split_rsync_remote(b"./a:b"), None);
         assert_eq!(split_rsync_remote(b"host::module"), None);
+    }
+
+    #[test]
+    fn bash_request_treats_every_replacement_as_literal_data() {
+        for replacement in ["", "-", "--", "--co", "--help", "-h", "help", "--version"] {
+            let line = format!("syq cp {replacement}");
+            let argv = ["__complete-bash", replacement, "--", &line].map(OsString::from);
+            let action = parse_action(&argv)
+                .unwrap_or_else(|error| panic!("replacement {replacement:?}: {error}"));
+            let CompletionAction::CompleteBash {
+                replacement: parsed,
+                line: parsed_line,
+            } = action
+            else {
+                panic!("wrong action for {replacement:?}");
+            };
+            assert_eq!(parsed, replacement);
+            assert_eq!(parsed_line, line.as_str());
+        }
+    }
+
+    #[test]
+    fn completion_indices_allow_an_omitted_empty_word_but_reject_out_of_range() {
+        let words = [OsString::from("syq")];
+        assert!(values(candidates(1, &words).unwrap()).contains(&b"cp".to_vec()));
+        assert!(candidates(2, &words).unwrap().is_empty());
+        assert!(candidates(usize::MAX, &words).unwrap().is_empty());
+    }
+
+    #[test]
+    fn bash_request_mini_fuzzer_preserves_raw_bytes() {
+        // All non-NUL bytes can occur in argv, including invalid UTF-8. Test
+        // each byte next to syntax that clap and Bash would normally parse.
+        for byte in 1..=255 {
+            for prefix in [
+                b"".as_slice(),
+                b"-",
+                b"--",
+                b"'",
+                b"\"",
+                b"\\",
+                b"a=",
+                b"a:",
+            ] {
+                let mut fragment = prefix.to_vec();
+                fragment.push(byte);
+                let mut line = b"syq cp ".to_vec();
+                line.extend_from_slice(&fragment);
+                let argv = [
+                    OsString::from("__complete-bash"),
+                    OsString::from_vec(fragment.clone()),
+                    OsString::from("--"),
+                    OsString::from_vec(line.clone()),
+                ];
+                let CompletionAction::CompleteBash {
+                    replacement,
+                    line: parsed,
+                } = parse_action(&argv).unwrap()
+                else {
+                    panic!("wrong action for {fragment:?}");
+                };
+                assert_eq!(replacement.as_bytes(), fragment);
+                assert_eq!(parsed.as_bytes(), line);
+                let (index, words) = bash_command_words(parsed.as_bytes());
+                assert!(index < words.len());
+                assert!(words.iter().map(Vec::len).sum::<usize>() <= line.len());
+            }
+        }
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2892,6 +2892,7 @@ mod tests {
                 confined_root: None,
                 prefix: b"mar".to_vec(),
                 limit: 10,
+                symlink_policy: crate::proto::OperatorSymlinkPolicy::Refuse,
             })
             .unwrap();
         assert!(

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -296,6 +296,31 @@ pub fn resolve(p: &[u8]) -> PathBuf {
     PathBuf::from(OsStr::from_bytes(p))
 }
 
+/// Completion follows the same operator-path symlink policy as the command.
+/// Keep the explicit root check even when following symlinks is requested.
+pub(crate) fn check_completion_directory(
+    directory: &[u8],
+    confined_root: Option<&[u8]>,
+    symlink_policy: OperatorSymlinkPolicy,
+) -> Result<()> {
+    let path = resolve(directory);
+    OperatorResolver::resolve_process(
+        path.as_os_str().as_bytes(),
+        symlink_policy,
+        OperatorFinalComponent::Directory,
+        false,
+        &mut Vec::new(),
+    )?;
+    if let Some(root) = confined_root {
+        let root = std::fs::canonicalize(resolve(root))?;
+        let directory = std::fs::canonicalize(path)?;
+        if !directory.starts_with(root) {
+            bail!("completion directory is outside the requested root");
+        }
+    }
+    Ok(())
+}
+
 /// A receiver-side selection retained from the ownership walk until it is
 /// either created or made the connection's working directory. Keeping the fd,
 /// rather than just its identity, closes the post-check pathname race.
@@ -2632,6 +2657,7 @@ impl FsOps {
         confined_root: Option<&[u8]>,
         prefix: &[u8],
         requested_limit: u16,
+        symlink_policy: OperatorSymlinkPolicy,
     ) -> Result<Response> {
         const MAX_COMPLETION_ENTRIES: usize = 1_000;
         if directory.contains(&0)
@@ -2641,13 +2667,7 @@ impl FsOps {
         {
             bail!("invalid completion directory or prefix");
         }
-        if let Some(root) = confined_root {
-            let resolved_root = std::fs::canonicalize(resolve(root))?;
-            let resolved_directory = std::fs::canonicalize(resolve(directory))?;
-            if !resolved_directory.starts_with(&resolved_root) {
-                bail!("completion directory is outside the requested root");
-            }
-        }
+        check_completion_directory(directory, confined_root, symlink_policy)?;
         let limit = usize::from(requested_limit).min(MAX_COMPLETION_ENTRIES);
         if limit == 0 {
             return Ok(Response::DirectoryEntries {
@@ -2673,7 +2693,12 @@ impl FsOps {
             let file_type = item.file_type()?;
             let directory = file_type.is_dir()
                 || (file_type.is_symlink()
-                    && std::fs::metadata(item.path()).is_ok_and(|metadata| metadata.is_dir()));
+                    && check_completion_directory(
+                        item.path().as_os_str().as_bytes(),
+                        confined_root,
+                        symlink_policy,
+                    )
+                    .is_ok());
             entries.push(CompletionEntry { name, directory });
         }
         entries.sort_by(|left, right| left.name.cmp(&right.name));
@@ -5816,7 +5841,14 @@ impl FsOps {
                 confined_root,
                 prefix,
                 limit,
-            } => self.completion_entries(directory, confined_root.as_deref(), prefix, *limit),
+                symlink_policy,
+            } => self.completion_entries(
+                directory,
+                confined_root.as_deref(),
+                prefix,
+                *limit,
+                *symlink_policy,
+            ),
             Request::StatMany {
                 paths,
                 sources,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -590,6 +590,7 @@ pub enum Request {
         confined_root: Option<PathBytes>,
         prefix: PathBytes,
         limit: u16,
+        symlink_policy: OperatorSymlinkPolicy,
     },
     /// Resolve all native removal selectors to endpoint-owned handles before
     /// mutation, then remove through those handles using an endpoint-local

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -13875,6 +13875,89 @@ fn completion_values(output: &[u8]) -> Vec<(u8, Vec<u8>)> {
 }
 
 #[test]
+fn completion_bash_repeated_tabs_accept_option_fragments() {
+    let t = Tmp::new();
+    write(&t.path("--help"), b"literal filename");
+    for (line, fragment, expected) in [
+        ("syq --", "--", "--help"),
+        ("syq --help", "--help", "--help"),
+        ("syq -h", "-h", ""),
+        ("syq help", "help", "help"),
+        ("syq --version", "--version", "--version"),
+        ("syq cp --", "--", "--coordinate-at"),
+        ("syq cp --co", "--co", "--coordinate-at"),
+        ("syq cp --coordinate-at=sr", "sr", "src"),
+        ("syq cp -- --help", "--help", "--help"),
+    ] {
+        let backend = completion_command(&t, &["__complete-bash", fragment, "--", line])
+            .current_dir(t.path(""))
+            .env("SYQ_COMPLETION_DEBUG", "1")
+            .run()
+            .unwrap();
+        assert_output_ok(&backend);
+        assert!(backend.stderr.is_empty(), "{line:?}: {backend:?}");
+        let values = completion_values(&backend.stdout);
+        if !expected.is_empty() {
+            assert!(
+                values.iter().any(|(_, value)| value == expected.as_bytes()),
+                "{line:?}: {values:?}"
+            );
+        }
+        let output = Command::new("bash")
+            .args([
+                "--noprofile",
+                "--norc",
+                "-c",
+                r#"
+eval "$("$SYQ" completion bash)"
+COMP_LINE=$1
+COMP_POINT=${#COMP_LINE}
+COMP_WORDS=(syq "$2")
+COMP_CWORD=1
+for ((tab=0; tab<3; tab++)); do
+    _syq_complete
+    for candidate in "${COMPREPLY[@]}"; do
+        printf '%s\0' "$candidate"
+    done
+    printf '\0'
+done
+"#,
+                "bash",
+                line,
+                fragment,
+            ])
+            .current_dir(t.path(""))
+            .env("SYQ", env!("CARGO_BIN_EXE_syq"))
+            .env("SYQ_COMPLETION_DEBUG", "1")
+            .env("HOME", t.path("home"))
+            .env("XDG_CACHE_HOME", t.path("cache"))
+            .env("XDG_CONFIG_HOME", t.path("config"))
+            .env("XDG_RUNTIME_DIR", t.runtime())
+            .env(
+                "PATH",
+                format!(
+                    "{}:/usr/bin:/bin",
+                    Path::new(env!("CARGO_BIN_EXE_syq"))
+                        .parent()
+                        .unwrap()
+                        .display()
+                ),
+            )
+            .run()
+            .unwrap();
+        assert_output_ok(&output);
+        assert!(output.stderr.is_empty(), "{line:?}: {output:?}");
+        let mut frame = Vec::new();
+        for (_, value) in values {
+            frame.extend(value);
+            frame.push(0);
+        }
+        frame.push(0);
+        assert_eq!(output.stdout, frame.repeat(3), "{line:?}");
+    }
+}
+
+#[test]
 fn completion_adapters_and_local_filename_candidates_are_shell_safe() {
     let t = Tmp::new();
     write(&t.path("alpha file"), b"file");

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -3585,7 +3585,12 @@ fn top_level_rsync_syntax_is_rejected_without_mutation() {
         .run()
         .unwrap();
     assert_eq!(out.status.code(), Some(2));
-    assert!(String::from_utf8_lossy(&out.stderr).contains("syq rsync"));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("unrecognized command or option"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("syq --help"), "{stderr}");
     assert!(!t.path("dst").exists());
 }
 
@@ -13874,6 +13879,245 @@ fn completion_values(output: &[u8]) -> Vec<(u8, Vec<u8>)> {
         .collect()
 }
 
+/// Check meaning as well as framing, against explicit fixture expectations in
+/// every backend format. The expected values never come from another adapter.
+fn assert_completion_candidates(t: &Tmp, words: &[&str], expected: &[&str]) {
+    for shell in ["bash", "zsh", "fish"] {
+        let index = (words.len() - 1).to_string();
+        let mut args = vec!["__complete", shell, &index, "--"];
+        args.extend_from_slice(words);
+        let output = completion_command(t, &args)
+            .current_dir(t.path(""))
+            .env("SYQ_COMPLETION_DEBUG", "1")
+            .run()
+            .unwrap();
+        assert_output_ok(&output);
+        assert!(output.stderr.is_empty(), "{shell} {words:?}: {output:?}");
+        let mut actual: Vec<Vec<u8>> = output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|record| !record.is_empty())
+            .map(|record| {
+                if shell == "fish" {
+                    record.to_vec()
+                } else {
+                    record[1..].to_vec()
+                }
+            })
+            .collect();
+        actual.sort();
+        let mut expected: Vec<Vec<u8>> = expected
+            .iter()
+            .map(|value| value.as_bytes().to_vec())
+            .collect();
+        expected.sort();
+        assert_eq!(actual, expected, "{shell} {words:?}");
+    }
+}
+
+#[test]
+fn completion_source_bases_types_and_symlink_policies_match_operations() {
+    let t = Tmp::new();
+    write(&t.path("base/inside.txt"), b"inside");
+    write(&t.path("base/inner-dir/nested.txt"), b"nested");
+    write(&t.path("outside.txt"), b"outside");
+    std::os::unix::fs::symlink("base", t.path("link")).unwrap();
+    std::os::unix::fs::symlink("../..", t.path("base/escape")).unwrap();
+    for command in ["cp", "rm", "map"] {
+        for base in [
+            vec!["--cwd", "base"],
+            vec!["-C", "base"],
+            vec!["--root", "base"],
+            vec!["--cwd=base"],
+            vec!["--root=base"],
+            vec!["-Cbase"],
+            vec!["-C=base"],
+        ] {
+            let mut words = vec!["syq", command];
+            words.extend(base);
+            words.push("in");
+            assert_completion_candidates(&t, &words, &["inner-dir/", "inside.txt"]);
+        }
+        assert_completion_candidates(&t, &["syq", command, "-Cba"], &["-Cbase/"]);
+        assert_completion_candidates(&t, &["syq", command, "--cwd", ""], &["base/"]);
+        for selector in ["--src-dir", "--src-dirs", "--srcs-in"] {
+            assert_completion_candidates(
+                &t,
+                &["syq", command, "--cwd", "base", selector, "in"],
+                &["inner-dir/"],
+            );
+        }
+        assert_completion_candidates(
+            &t,
+            &["syq", command, "--root", "base", "inner-dir//"],
+            &["inner-dir//nested.txt"],
+        );
+        assert_completion_candidates(&t, &["syq", command, "--root", "base", "../"], &[]);
+        assert_completion_candidates(
+            &t,
+            &["syq", command, "--root", "base", "--follow-src", "escape/"],
+            &[],
+        );
+        assert_completion_candidates(&t, &["syq", command, "link/"], &[]);
+        assert_completion_candidates(
+            &t,
+            &["syq", command, "--follow-src", "link/in"],
+            &["link/inner-dir/", "link/inside.txt"],
+        );
+    }
+    assert_completion_candidates(
+        &t,
+        &["syq", "cp", "-nCbase", "in"],
+        &["inner-dir/", "inside.txt"],
+    );
+    assert_completion_candidates(&t, &["syq", "cp", "--follow-dst", "link/"], &[]);
+    assert_completion_candidates(
+        &t,
+        &["syq", "cp", "--cwd", "base", "inside.txt", "--into", ""],
+        &["base/"],
+    );
+    assert_completion_candidates(&t, &["syq", "cp", "outside.txt", "--into", "link/"], &[]);
+    assert_completion_candidates(
+        &t,
+        &[
+            "syq",
+            "cp",
+            "outside.txt",
+            "--follow-dst",
+            "--into",
+            "link/in",
+        ],
+        &["link/inner-dir/"],
+    );
+    assert_completion_candidates(
+        &t,
+        &[
+            "syq",
+            "cp",
+            "outside.txt",
+            "--into",
+            "base",
+            "--results",
+            "ba",
+        ],
+        &["base/"],
+    );
+    assert_completion_candidates(
+        &t,
+        &["syq", "rm", "--cwd", "base", "--results", "ba"],
+        &["base/"],
+    );
+}
+
+#[test]
+fn completion_covers_public_command_routes_and_parser_value_grammar() {
+    let t = Tmp::new();
+    fs::create_dir(t.path("scope")).unwrap();
+    assert_completion_candidates(
+        &t,
+        &["syq", "receiver", ""],
+        &["enroll", "list", "revoke", "help"],
+    );
+    assert_completion_candidates(&t, &["syq", "receiver", "enroll", "--v"], &["--via"]);
+    assert_completion_candidates(
+        &t,
+        &["syq", "help", ""],
+        &[
+            "cp",
+            "rm",
+            "map",
+            "rsync",
+            "persist",
+            "completion",
+            "receiver",
+            "--self-update",
+        ],
+    );
+    assert_completion_candidates(&t, &["syq", "help", "receiver", "e"], &["enroll"]);
+    assert_completion_candidates(
+        &t,
+        &["syq", "completion", "cache", ""],
+        &["list", "forget", "clear", "help"],
+    );
+    assert_completion_candidates(&t, &["syq", "persist", "o"], &["on", "off"]);
+    for action in ["off", "status"] {
+        assert_completion_candidates(
+            &t,
+            &["syq", "persist", action, "--pscope", "sc"],
+            &["scope/"],
+        );
+        assert_completion_candidates(
+            &t,
+            &["syq", "persist", action, "--pscope=sc"],
+            &["--pscope=scope/"],
+        );
+    }
+    assert_completion_candidates(
+        &t,
+        &["syq", "cp", "--preserve", "permissions,ow"],
+        &["permissions,ownership"],
+    );
+    assert_completion_candidates(
+        &t,
+        &["syq", "cp", "--preserve=permissions,ow"],
+        &["--preserve=permissions,ownership"],
+    );
+    assert_completion_candidates(
+        &t,
+        &["syq", "rsync", "--syq-ignore", "--", "--d"],
+        &["--delete", "--delete-excluded", "--dry-run"],
+    );
+    assert_completion_candidates(
+        &t,
+        &["syq", "rsync", "--syq-ignore", "--files-from", "--d"],
+        &["--delete", "--delete-excluded", "--dry-run"],
+    );
+    assert_completion_candidates(&t, &["syq", "rsync", "--", "--d"], &[]);
+}
+
+#[test]
+fn completion_respects_conflicts_selection_modes_and_source_order() {
+    let t = Tmp::new();
+    write(&t.path("source"), b"source");
+    for destination in [
+        "--to",
+        "--into",
+        "--into-new",
+        "--into-existing",
+        "--as",
+        "--as-new",
+        "--as-existing",
+    ] {
+        let attached = format!("{destination}=target");
+        for arguments in [vec![destination, "target"], vec![attached.as_str()]] {
+            let mut words = vec!["syq", "cp", "source"];
+            words.extend(arguments);
+            words.push("");
+            assert_completion_candidates(&t, &["syq", "cp", "source", "--to", "--src"], &[]);
+            assert_completion_candidates(&t, &words, &[]);
+            for forbidden in ["--src", "--cwd", "--root", "--from", "--mapping", "-C"] {
+                *words.last_mut().unwrap() = forbidden;
+                assert_completion_candidates(&t, &words, &[]);
+            }
+            *words.last_mut().unwrap() = "--dry";
+            assert_completion_candidates(&t, &words, &["--dry-run"]);
+        }
+    }
+    assert_completion_candidates(
+        &t,
+        &["syq", "cp", "source", "--into", "target", "--as"],
+        &[],
+    );
+    assert_completion_candidates(&t, &["syq", "cp", "--cwd", ".", "--root"], &[]);
+    assert_completion_candidates(&t, &["syq", "cp", "--root", ".", "--cwd"], &[]);
+    assert_completion_candidates(&t, &["syq", "cp", "--mapping", "manifest", "--src"], &[]);
+    assert_completion_candidates(&t, &["syq", "cp", "--mapping", "manifest", "s"], &[]);
+    assert_completion_candidates(&t, &["syq", "cp", "source", "--mapping"], &[]);
+    assert_completion_candidates(&t, &["syq", "map", "--srcs-in", ".", "s"], &[]);
+    assert_completion_candidates(&t, &["syq", "map", "source", "--srcs-in"], &[]);
+    assert_completion_candidates(&t, &["syq", "map", "--srcs-in", ".", "--src"], &[]);
+}
+
 #[test]
 fn completion_bash_repeated_tabs_accept_option_fragments() {
     let t = Tmp::new();
@@ -14180,6 +14424,122 @@ printf '%s\n' "${COMPREPLY[@]}""#,
 }
 
 #[test]
+fn remote_completion_obeys_symlink_policy_types_and_literal_option_values() {
+    let t = Tmp::new();
+    fs::create_dir(t.runtime()).unwrap();
+    write(&t.path("remote-home/base/inside.txt"), b"inside");
+    fs::create_dir(t.path("remote-home/base/inner-dir")).unwrap();
+    std::os::unix::fs::symlink("base", t.path("remote-home/link")).unwrap();
+    let ssh = fake_ssh(&t);
+    let binary = env!("CARGO_BIN_EXE_syq");
+    let base = t.s("remote-home/base");
+    let link = format!("{}/in", t.s("remote-home/link"));
+    let attached_base = format!("-C{base}");
+    let remote_link = format!("fake.example:{link}");
+    for (words, expected) in [
+        (
+            vec![
+                "syq",
+                "cp",
+                "--syq-path",
+                binary,
+                "--from",
+                "fake.example",
+                &attached_base,
+                "--src-dir",
+                "in",
+            ],
+            vec!["inner-dir/".to_string()],
+        ),
+        (
+            vec![
+                "syq",
+                "cp",
+                "--syq-path",
+                binary,
+                "--from",
+                "fake.example",
+                &link,
+            ],
+            vec![],
+        ),
+        (
+            vec![
+                "syq",
+                "cp",
+                "--syq-path",
+                binary,
+                "--from",
+                "fake.example",
+                "--follow-src",
+                &link,
+            ],
+            vec![format!("{}ner-dir/", link), format!("{}side.txt", link)],
+        ),
+        (
+            vec![
+                "syq",
+                "cp",
+                "--syq-path",
+                binary,
+                "--to",
+                "fake.example",
+                "--follow-dst",
+                "--into",
+                &link,
+            ],
+            vec![format!("{}ner-dir/", link)],
+        ),
+        // --rsh is the ignore pattern, so this must still perform the normal
+        // remote completion through the test SSH transport.
+        (
+            vec![
+                "syq",
+                "rsync",
+                "--rsync-path",
+                binary,
+                "--syq-ignore",
+                "--rsh",
+                &remote_link,
+            ],
+            vec![
+                format!("{}ner-dir/", remote_link),
+                format!("{}side.txt", remote_link),
+            ],
+        ),
+    ] {
+        let index = (words.len() - 1).to_string();
+        let mut args = vec!["__complete", "bash", &index, "--"];
+        args.extend_from_slice(&words);
+        let output = completion_command(&t, &args)
+            .env_remove("SYQ_COMPLETION_DEBUG")
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+            )
+            .run()
+            .unwrap();
+        assert_output_ok(&output);
+        assert!(output.stderr.is_empty(), "{words:?}: {output:?}");
+        let actual: Vec<Vec<u8>> = completion_values(&output.stdout)
+            .into_iter()
+            .map(|(_, value)| value)
+            .collect();
+        assert_eq!(
+            actual,
+            expected
+                .iter()
+                .map(|value| value.as_bytes().to_vec())
+                .collect::<Vec<_>>(),
+            "{words:?}"
+        );
+    }
+}
+
+#[test]
 fn remote_completion_uses_normal_ssh_and_learns_a_disposable_endpoint() {
     let t = Tmp::new();
     fs::create_dir(t.runtime()).unwrap();
@@ -14339,22 +14699,13 @@ fn remote_completion_uses_normal_ssh_and_learns_a_disposable_endpoint() {
     assert_output_ok(&destination);
     assert_eq!(
         completion_values(&destination.stdout),
-        vec![
-            (
-                b'f',
-                t.path("remote-home/data/name with spaces")
-                    .as_os_str()
-                    .as_encoded_bytes()
-                    .to_vec(),
-            ),
-            (
-                b'p',
-                t.path("remote-home/data/nested/")
-                    .as_os_str()
-                    .as_encoded_bytes()
-                    .to_vec(),
-            ),
-        ]
+        vec![(
+            b'p',
+            t.path("remote-home/data/nested/")
+                .as_os_str()
+                .as_encoded_bytes()
+                .to_vec(),
+        ),]
     );
 
     let remote_operand = format!("fake.example:{path}");


### PR DESCRIPTION
Completion could print a clap error on `syq --<Tab>`, list the wrong directory for `-Cdir`, omit valid filenames, or suggest arguments the command rejects. Make completion follow the public command grammar and path policies while accepting unfinished shell input.

The change covers the original Bash failure and all ten findings from the subsequent audit:

- Decode the existing Bash adapter's fixed request as literal bytes; bound tokenized cursor indices before allocating.
- Read option arity, aliases, short clusters, enum values, delimiters, conflicts, and exclusive groups from clap metadata. Keep option values distinct from flags, including rsync's `--syq-ignore --` and `--syq-ignore --rsh` cases.
- Honor attached `-Cdir` bases, filter directory-only values, complete `rm --results` and attached persistence scopes, and permit repeated separators in confined paths.
- Apply native source/destination symlink opt-ins locally and remotely. The ListDir request now carries the operator symlink policy; root confinement remains enforced.
- Complete receiver management and nested help routes. Suppress source arguments after every destination starter, conflicting placements/bases, and selectors excluded by mapping modes.
- Add expected-candidate integration tests in all three backend formats, fake-SSH coverage, and 127 semantic cases to the seeded stress tool. The tool snapshots its binary so concurrent builds cannot change the executable mid-run.

Document the behavior and the user's preference for regular PRs by default. Also update one stale integration assertion inherited from master to check the current top-level error message, retaining its exit-code and no-mutation checks.

Validation of the changes at `225bd5d`:

- Formatting, Clippy with warnings denied, and `cargo test --bin syq`: passed.
- `cargo test --all-targets`: passed, including 388 local integration tests and all eight completion tests.
- Documentation links: 13 files, no problems.
- `scripts/test-real-ssh.sh`: passed on the clean committed tree at `225bd5d`.
- Seeded stress: seeds 1 and 42 each passed 2,157 cases: 4,314 cases and 12,942 repeated Bash adapter calls total.

The backend tests cover Bash/Zsh/fish candidate formats; the stress tool drives the Bash adapter. Native Zsh/fish interactive sessions and macOS were not run locally. No merge requested or performed.

Branch-status: clean `completion-stress` at `225bd5d`, upstream and GitHub PR head match, regular/open PR, no PR checks registered. Master advanced by two commits during this work; the PR remains mergeable. Latest master `ci`, `rsync-compat`, and `macos` runs all passed at `5d1b2c2`.
