### PR TITLE
docs: link to GitHub Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ It is built for large files, large trees, and fast networks.
 
 [Documentation](https://greaber.github.io/syq/) ·
 [Speed](https://greaber.github.io/syq/speed.html) ·
-[Security](https://greaber.github.io/syq/security.html)
+[Security](https://greaber.github.io/syq/security.html) ·
+[Discussions](https://github.com/greaber/syq/discussions)
 
 ## Install
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@ Syq copies and removes files in parallel, on one machine or over SSH. It can
 resume interrupted copies and transfer directly between servers without
 forwarding your SSH agent.
 
+[Discussions](https://github.com/greaber/syq/discussions)
+
 In published tests, syq copied a folder from Amsterdam to Tokyo
 [5.2× faster than rsync](https://greaber.github.io/syq-bench/#fly-cross-region-memory),
 and 20,000 small files to NFS


### PR DESCRIPTION
Add a Discussions link to the README resource links and documentation landing page so readers can find the community discussions. Validation: documentation link checker passed (14 files, zero problems), git diff --check passed, and GitHub confirms Discussions is enabled. Rust and SSH tests were not run for this Markdown-only change.