### PR TITLE
Prepare syq 0.3.2

### DIFF
--- a/.github/release-notes/v0.3.2.md
+++ b/.github/release-notes/v0.3.2.md
@@ -1,0 +1,9 @@
+syq 0.3.2 improves SSH startup, small network copies, and shell completion.
+
+- Persistent SSH connections start reliably on macOS, and small updates can stay on the existing control connection to avoid extra connection setup.
+- Remote copies can omit destination placement: `syq cp project --to server` copies into your home directory on the server, and `syq cp --from server project` copies into your current local directory. Local-only copies still require explicit placement.
+- Source-built syq automatically uploads its own helper to compatible SSH hosts, making development builds easier to use remotely.
+- Bash completion handles literal fragments correctly, and completion across supported shells follows command syntax, path policies, and command modes more closely.
+- Documentation now starts with practical tasks and illustrates where copied files go.
+
+Existing commands with explicit destination placement keep their behavior. Commands that previously failed because remote destination placement was omitted now perform the copy using the defaults above. No stored-state migration is introduced by this release; remote helpers continue to require the same build identity as the initiating syq.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Prepare syq 0.3.2 with matching Cargo metadata and curated notes for the merged SSH startup, small-copy, remote placement, source-helper upload, completion, and documentation changes. Dependencies are unchanged.

Validation at 081989c: formatting, locked Clippy across all targets/features, 429 unit tests, the remote default-placement integration test, all eight completion integration tests, documentation links, and the Python API inventory passed. Default real-SSH release certification is running. Full exact-master CI certifications and preflight remain required before tagging.

This preparation changes no interfaces or persisted formats. The notes describe the changed omitted-placement behavior relative to 0.3.1; existing explicit placements are unchanged.
