### PR TITLE
Trim README to benefits and project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,8 @@ It is built for large files, large trees, and fast networks.
 - **Gitignore-style filters**, programmable file placement, and JSON results.
 
 [Documentation](https://greaber.github.io/syq/) ·
-[Speed](https://greaber.github.io/syq/speed.html) ·
-[Security](https://greaber.github.io/syq/security.html) ·
+[Benchmarks](https://greaber.github.io/syq-bench/) ·
 [Discussions](https://github.com/greaber/syq/discussions)
-
-## Install
-
-```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/greaber/syq/releases/latest/download/install.sh | sh
-```
-
-Linux and macOS; no `sudo` needed. Installs into `~/.local/bin`.
-Homebrew and shell setup are covered in the
-[installation guide](https://greaber.github.io/syq/install.html).
-
-## Try it
-
-```sh
-syq cp project --to server --into /backup        # copy as /backup/project
-syq cp --dry-run --srcs-in project --into backup # preview a contents copy
-syq rsync -av server:data/ ./data/               # familiar rsync syntax
-syq cp --from hostA --srcs-in big --to hostB --into big
-syq rm old-output                               # parallel recursive removal
-```
-
-Rsync mode is the most stable interface; native commands are experimental.
-Syq uses its own protocol and does not implement every rsync feature. See
-[rsync compatibility](https://greaber.github.io/syq/rsync-compat.html).
 
 ## Developing syq
 


### PR DESCRIPTION
Keep the README focused on the benefits teaser, direct links to documentation, benchmarks and discussions, and the existing Developing and License sections. Remove duplicated installation/examples and the outdated claim that native commands are experimental while rsync mode is most stable.

Validation: documentation link checker passed (14 files, zero problems); git diff --check passed. Rust and SSH tests were not run for this README-only change. Branch status at ea36e6e: clean; latest reported master ci, rsync-compat and macos runs are in progress at 5ac0ee0.
