### PR TITLE
Move docs controls into the existing site header

### DIFF
--- a/theme/README.md
+++ b/theme/README.md
@@ -19,7 +19,10 @@ keeps its own committed assets and builds independently; neither site fetches
 styles or fonts from the other at build time or in the browser.
 
 `docs.css` is the mdBook adapter: prose, code, tables, sidebar, toolbar and
-anchor offsets. `docs.js` adds the current-site marker.
+anchor offsets. `docs.js` adds the current-site marker and moves the existing search, theme and
+sidebar controls into the shared header, preserving mdBook listeners and shortcuts.
+Print and edit links appear below the article; the duplicate title and GitHub
+shortcut no longer need a separate toolbar row. Search opens only when requested.
 The header is a supported partial; the full mdBook template and scripts remain
 upstream so search, chapter navigation, keyboard shortcuts and code copying
 continue to receive mdBook fixes. The built-in light/rust preferences use the
@@ -35,12 +38,17 @@ The font stylesheet uses mdBook's resource helper to resolve hashed font
 filenames. syq-bench embeds the same resources as data URIs. Do not replace the
 resource placeholders with literal paths: those break mdBook's asset hashing.
 
-The toolbar stays sticky below the shared header during both forward and backward
-scrolling. Its offset rule deliberately matches mdBook's sticky/hover selectors
-and overrides inline scroll offsets. When upgrading mdBook, check `reference.html`
-at 390, 820 and 1440 pixels: scroll down several screens, reverse direction, hover
-the toolbar, hide/show the sidebar, and use search and theme controls without
-returning to the top. Also check reload at a saved scroll position.
+With JavaScript enabled, the original toolbar and hover placeholder are hidden,
+and the page margin no longer compensates for that placeholder. Header controls
+remain fixed while scrolling. Without JavaScript, the native toolbar remains
+available below the header for sidebar and page links; its sticky offset still
+overrides mdBook's default. Mobile chapter drawers start below the shared header.
+
+When upgrading mdBook, check 320/390/620/760/820/1440px layouts, navigation and
+control overlap, initial headings and fragment offsets, search via click and `/`,
+themes via mouse/keyboard, chapter toggling, scrolled reload, print/edit links,
+and navigation without JavaScript. The adapter moves upstream nodes rather than
+forking the book template or replacing the control implementations.
 
 The oversized side-of-page chapter arrows are hidden; sidebar links and the
 end-of-page navigation provide the chapter routes.

--- a/theme/docs.css
+++ b/theme/docs.css
@@ -100,3 +100,31 @@ a:focus-visible,button:focus-visible,label:focus-visible {outline:2px solid var(
 
 /* Chapter navigation is in the sidebar and at the end of each page. */
 .nav-wide-wrapper{display:none}
+
+/* mdBook controls share the site header after docs.js moves their existing nodes.
+   Keep the native toolbar as a functional fallback when JavaScript is disabled. */
+.docs-compact-header #mdbook-menu-bar,
+.docs-compact-header #mdbook-menu-bar-hover-placeholder {display:none}
+.docs-compact-header .page {margin-block-start:0}
+.docs-controls {position:relative;display:flex;align-items:center;gap:2px;margin:0 0 0 auto;flex:none;color:var(--muted)}
+.docs-controls .icon-button,.docs-controls>label {display:flex;align-items:center;justify-content:center;width:42px;height:44px;cursor:pointer}
+.docs-controls .fa-svg {font-size:18px;line-height:1;padding:0}
+.docs-controls .icon-button:hover,.docs-controls>label:hover {color:var(--syq)}
+.docs-controls .theme-popup {top:48px;left:auto;right:0;font-size:14px}
+.docs-controls .theme-popup .theme {padding:5px 20px}
+.docs-compact-header :target {scroll-margin-top:calc(var(--site-header-height) + 24px)}
+.docs-page-actions {display:flex;gap:24px;flex-wrap:wrap;margin-top:48px;padding-top:20px;border-top:1px solid var(--line);font:14px/1.5 var(--display)}
+@media(max-width:760px) {
+  :root.docs-compact-header {--site-header-height:108px}
+  .docs-compact-header .site-header {display:grid;grid-template-columns:1fr auto;grid-template-rows:44px auto;align-content:center;gap:4px 16px}
+  .docs-compact-header .site-wordmark {grid-column:1;grid-row:1}
+  .docs-compact-header .site-nav {grid-column:1/-1;grid-row:2}
+  .docs-controls {grid-column:2;grid-row:1}
+}
+@media(max-width:619px) {
+  .docs-compact-header .sidebar {top:var(--site-header-height)}
+}
+@media(max-width:480px) {
+  .docs-compact-header .site-nav {font-size:14px;gap:8px}
+}
+@media print {.docs-page-actions{display:none}}

--- a/theme/docs.js
+++ b/theme/docs.js
@@ -1,4 +1,25 @@
 (() => {
 // The header markup is shared verbatim with syq-bench.
 document.querySelector('.site-nav [data-site="docs"]').setAttribute('aria-current', 'page');
+
+// Move the existing nodes so mdBook keeps its listeners, labels and shortcuts.
+const controls = document.querySelector('#mdbook-menu-bar .left-buttons');
+controls.classList.add('docs-controls');
+document.querySelector('.site-header').append(controls);
+
+const pageActions = document.createElement('nav');
+pageActions.className = 'docs-page-actions';
+pageActions.setAttribute('aria-label', 'Page tools');
+for (const [selector, label] of [
+  ['#print-button', 'Print this book'],
+  ['#git-edit-button', 'Edit this page'],
+]) {
+  const link = document.querySelector(selector)?.closest('a');
+  if (link) {
+    link.textContent = label;
+    pageActions.append(link);
+  }
+}
+document.querySelector('.content main').append(pageActions);
+document.documentElement.classList.add('docs-compact-header');
 })();


### PR DESCRIPTION
The docs currently reserve a second, 50px toolbar row below the shared site header. Move mdBook's existing search, theme and sidebar controls into that header, and place print/edit links below the article. Hide the duplicate title/GitHub toolbar and correct its placeholder margin so the first heading stays below the header. Search input appears only when requested.

Existing control nodes retain mdBook listeners, accessibility attributes and keyboard shortcuts. Narrow screens arrange the controls beside the wordmark with site links below. JavaScript-disabled navigation retains the native toolbar fallback. Shared branding assets and benchmark styling are unchanged.

Validation at `50c3c12` (clean, pushed): mdBook 0.5.4 build; 15-file documentation link check; JS syntax and whitespace checks. Chromium at 320/390/620/760/820/1440 px checked no control overlap, visible first heading, no extra toolbar row, scrolled theme/search/sidebar actions, `/` shortcut, page-specific edit/print links, and no horizontal overflow. Native no-JS sidebar fallback and public mobile search also pass. No Rust or benchmark suites run for this docs-only presentation change.

Branch status:

```text
Worktree: /home/grant/repos/syq-bench/.worktrees/docs-header-controls
Branch:   docs-header-controls at 50c3c12 (clean)
Upstream: origin/docs-header-controls (ahead 0, behind 0)
Master:   4c02593 from refs/heads/master (branch is ahead 3, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      4c02593  https://github.com/greaber/syq/actions/runs/33988320296
  rsync-compat.yml success      4c02593  https://github.com/greaber/syq/actions/runs/33988320204
  macos.yml        success      4c02593  https://github.com/greaber/syq/actions/runs/33988320233

Pull request: #230 https://github.com/greaber/syq/pull/230
  base master, open, review none, merge state clean
  GitHub head 50c3c12: matches local 50c3c12
  checks: none registered yet
```
