### PR TITLE
Add an interactive local and SSH benchmark script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,12 @@ jobs:
           (needs.scope.outputs.native == 'true' &&
            needs.scope.outputs.full_suite == 'true')
         run: scripts/test-installer.sh
+      - name: Test interactive benchmark
+        if: >-
+          needs.scope.outputs.tooling == 'true' ||
+          (needs.scope.outputs.native == 'true' &&
+           needs.scope.outputs.full_suite == 'true')
+        run: python3 scripts/test-try-benchmark.py
       - name: Test release tooling
         if: >-
           needs.scope.outputs.tooling == 'true' ||

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -124,6 +124,8 @@ jobs:
           test -z "$(gofmt -l .)"
           go vet ./...
           go test ./...
+      - name: Test interactive benchmark with system Bash
+        run: python3 scripts/test-try-benchmark.py
       - name: Release shell suites
         run: |
           status=0

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,6 +18,35 @@ Installs into `~/.local/bin` without `sudo`. Make sure that directory is on your
 brew install greaber/tap/syq
 ```
 
+## Try a benchmark
+
+Compare syq with rsync on your own machines, or with rsync and cp locally:
+
+```sh
+curl --proto '=https' --tlsv1.2 -fLsS https://raw.githubusercontent.com/greaber/syq/master/scripts/try-benchmark.sh | bash
+```
+
+The script asks whether to copy locally, send to an SSH host, or fetch from
+one; which workloads to try; the test size; and where to put temporary files.
+You can choose another disk or an NFS mount for a local comparison. No
+syq-bench installation is needed. If syq is missing, it offers to run the
+normal installer locally.
+
+It needs Bash, rsync, OpenSSL, and standard Unix utilities on your machine.
+SSH tests also need SSH access and rsync on the remote machine. Use an SSH
+config alias for custom ports or IPv6 addresses. No remote system packages are
+installed; syq performs its usual remote helper setup.
+
+The quick test copies a 64 MiB file and 1,024 files of 8 KiB each. Each tool
+runs three times. Temporary test files are removed on success; after a failed
+or interrupted SSH test, the script prints the remote scratch directory for
+you to check and remove. It never uses your existing files as test data.
+
+To inspect the script first, download it with curl's `-o try-benchmark.sh`,
+then run `bash try-benchmark.sh`. Use `--help` for repeatable command-line
+options, including `--yes` to use defaults without questions and `--install`
+to install syq if missing. See [how to interpret the comparison](speed.md#quick-comparison).
+
 ## Updates
 
 Use `syq --self-update` for a standalone installation, or `brew upgrade syq`

--- a/docs/install.md
+++ b/docs/install.md
@@ -38,9 +38,9 @@ config alias for custom ports or IPv6 addresses. No remote system packages are
 installed; syq performs its usual remote helper setup.
 
 The quick test copies a 64 MiB file and 1,024 files of 8 KiB each. Each tool
-runs three times. Temporary test files are removed on success; after a failed
-or interrupted SSH test, the script prints the remote scratch directory for
-you to check and remove. It never uses your existing files as test data.
+runs three times. Temporary test files are removed on success, failure, or Ctrl-C. If SSH is
+unreachable during cleanup, the script prints the remote scratch path for
+you to remove later. It never uses your existing files as test data.
 
 To inspect the script first, download it with curl's `-o try-benchmark.sh`,
 then run `bash try-benchmark.sh`. Use `--help` for repeatable command-line

--- a/docs/install.md
+++ b/docs/install.md
@@ -44,6 +44,11 @@ runs three times. Temporary test files are removed on success, failure, or Ctrl-
 unreachable during cleanup, the script prints the remote scratch path for
 you to remove later. It never uses your existing files as test data.
 
+The transcript includes the exact syq build, the commands being timed, each
+verified trial, and the mean, minimum and maximum elapsed times. Keep that
+output when sharing a surprising result; differences smaller than the trial
+variation may not indicate a speed advantage.
+
 To inspect the script first, download it with curl's `-o try-benchmark.sh`,
 then run `bash try-benchmark.sh`. Use `--help` for repeatable command-line
 options, including `--yes` to use defaults without questions and `--install`

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,6 +33,8 @@ syq-bench installation is needed. If syq is missing, it offers to run the
 normal installer locally.
 
 It needs Bash, rsync, OpenSSL, and standard Unix utilities on your machine.
+Terminal runs also need Perl to keep SSH prompts available while allowing
+immediate cancellation.
 SSH tests also need SSH access and rsync on the remote machine. Use an SSH
 config alias for custom ports or IPv6 addresses. No remote system packages are
 installed; syq performs its usual remote helper setup.

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -43,8 +43,9 @@ These copy the same regular files and request permissions and modification
 times; the tools still differ in compression, integrity checks, and filesystem
 optimizations. Syq prints its transfer statistics.
 
-Generation, a small syq helper warm-up, and POSIX `cksum` comparisons are
-outside the timer. A failed command or content check stops the comparison.
+Generation, a single 14-byte syq setup copy, and POSIX `cksum` comparisons are
+outside the timer. The setup copy prepares the helper and exercises transfer
+setup; it is labeled separately and does not print a throughput result. A failed command or content check stops the comparison.
 Caches are not flushed, so this is a cache-friendly test rather than a cold
 disk benchmark. Times include process startup and buffered writes, without
 waiting for durable storage. Small tests can mostly measure startup costs;

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -36,7 +36,10 @@ copy remotely. Sizes are quick (64 MiB and 8 MiB), medium (1 GiB and 32 MiB),
 and large (8 GiB and 128 MiB), for the large-file and small-file workloads.
 
 Data comes from a fixed AES-CTR byte stream, making it reproducible and
-hard to compress. Every trial has an empty destination. The script rotates
+hard to compress. Every trial has an empty, pre-created destination; interrupted trials are
+never resumed. On Ctrl-C the script stops its local workers, moves remote
+scratch out of the transfer path, and deletes its temporary data. If SSH
+is unavailable, it reports the remote path for later cleanup. The script rotates
 tool order and reports each elapsed time and the mean for each tool. It uses
 syq's defaults with permissions preserved, `rsync -rpt`, and local `cp -pR`.
 These copy the same regular files and request permissions and modification

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -18,6 +18,40 @@ commands, and measured limitations. Use
 [syq-bench on your own machines](https://greaber.github.io/syq-bench/reproduce.html)
 to compare settings and track performance over time.
 
+## Quick comparison
+
+The [interactive benchmark](install.md#try-a-benchmark) gives you a small
+comparison without installing a benchmark package. After downloading the
+script, you can repeat the same choices explicitly:
+
+```sh
+bash try-benchmark.sh --yes --mode push --host server --workload both --size medium --rounds 3
+bash try-benchmark.sh --yes --mode local --source-dir /data --dest-dir /mnt/nfs --workload small
+```
+
+Scratch parents must already exist. For SSH tests, `--dest-dir` is the remote
+scratch parent, including when pulling; `--source-dir` is always the local
+scratch parent. Budget roughly twice the selected data size locally and one
+copy remotely. Sizes are quick (64 MiB and 8 MiB), medium (1 GiB and 32 MiB),
+and large (8 GiB and 128 MiB), for the large-file and small-file workloads.
+
+Data comes from a fixed AES-CTR byte stream, making it reproducible and
+hard to compress. Every trial has an empty destination. The script rotates
+tool order and reports each elapsed time and the mean for each tool. It uses
+syq's defaults with permissions preserved, `rsync -rpt`, and local `cp -pR`.
+These copy the same regular files and request permissions and modification
+times; the tools still differ in compression, integrity checks, and filesystem
+optimizations. Syq prints its transfer statistics.
+
+Generation, a small syq helper warm-up, and POSIX `cksum` comparisons are
+outside the timer. A failed command or content check stops the comparison.
+Caches are not flushed, so this is a cache-friendly test rather than a cold
+disk benchmark. Times include process startup and buffered writes, without
+waiting for durable storage. Small tests can mostly measure startup costs;
+local filesystem cloning can favor cp. Results do not predict every workload,
+and syq may be slower. Use the full published benchmark methodology for more
+controlled measurements.
+
 ## When rsync or cp is faster
 
 - **Tiny jobs:** setup can cost more than the copy. [`syq persist on`](install.md#keep-connections-open) avoids

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Exercise the standalone script, including piped prompts and failure cleanup.
+
+Remote tests here fake only SSH and syq; rsync still runs its real client/server
+protocol. tests/real-ssh additionally exercises real syq over real OpenSSH.
+"""
+import os
+from pathlib import Path
+import pty
+import select
+import shlex
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+
+SCRIPT = Path(__file__).resolve().with_name('try-benchmark.sh')
+FAKE_SYQ = r'''#!/usr/bin/env python3
+import os, pathlib, shutil, subprocess, sys, time
+args=sys.argv[1:]
+if args == ['--version']:
+    print('syq test double'); sys.exit(0)
+src=pathlib.Path(args[args.index('--srcs-in')+1])
+dst=pathlib.Path(args[args.index('--into')+1])
+if src.name == 'probe' and os.environ.get('BENCH_TEST_ASK'):
+    print('Credentials:', flush=True)
+    with open('/dev/tty') as terminal:
+        if terminal.readline().strip() != 'test': sys.exit(4)
+mode=os.environ.get('BENCH_TEST_FAILURE', '') if src.name != 'probe' else ''
+if mode == 'fail': sys.exit(23)
+if mode == 'hang':
+    child=subprocess.Popen(['sleep','300'])
+    pathlib.Path(os.environ['BENCH_TEST_PID']).write_text(str(child.pid))
+    child.wait(); sys.exit(1)
+shutil.copytree(src,dst,dirs_exist_ok=True)
+if mode == 'corrupt':
+    next(dst.iterdir()).write_bytes(b'bad')
+'''
+FAKE_SSH = '''#!/usr/bin/env bash
+set -eu
+while [[ $1 == -o ]]; do shift 2; done
+shift
+exec /bin/sh -c "$*"
+'''
+
+
+class BenchmarkTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix='syq-benchmark-test-')
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.bin = self.root / 'bin'
+        self.bin.mkdir()
+        for name, content in [('syq', FAKE_SYQ), ('ssh', FAKE_SSH)]:
+            path = self.bin / name
+            path.write_text(content)
+            path.chmod(0o755)
+        self.scratch = self.root / "scratch with 'quotes' and $dollar"
+        self.scratch.mkdir()
+        self.sentinel = self.scratch / 'keep-me'
+        self.sentinel.write_text('existing user data')
+        # Do not accidentally discover a developer's installed syq during the
+        # missing-install test. All other commands use the host's real tools.
+        for name in ['bash', 'rsync', 'openssl', 'dd', 'split', 'cksum', 'cmp',
+                     'awk', 'mktemp', 'mkdir', 'rm', 'cat', 'ps', 'sleep', 'sed',
+                     'cp', 'python3', 'sh']:
+            executable = shutil.which(name)
+            if executable is None:
+                self.fail(f'Missing test prerequisite: {name}')
+            (self.bin / name).symlink_to(executable)
+        self.env = dict(os.environ, PATH=str(self.bin))
+
+    def invoke(self, *args, env=None):
+        return subprocess.run(
+            ['/bin/bash', str(SCRIPT), '--yes', '--source-dir', str(self.scratch),
+             '--dest-dir', str(self.scratch), '--rounds', '1', '--workload', 'large', *args],
+            env=env or self.env, capture_output=True, text=True, timeout=60,
+        )
+
+    def assert_clean(self):
+        self.assertEqual(self.sentinel.read_text(), 'existing user data')
+        self.assertEqual(list(self.scratch.iterdir()), [self.sentinel])
+
+    def test_local_both_and_rotation(self):
+        result = self.invoke('--workload', 'both', '--rounds', '3')
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        lines = [line for line in result.stdout.splitlines() if line.startswith('large: ')]
+        self.assertEqual([line.split()[1].rstrip(',') for line in lines],
+                         ['syq', 'rsync', 'cp', 'rsync', 'cp', 'syq', 'cp', 'syq', 'rsync'])
+        self.assertIn('small cp', result.stdout)
+        self.assert_clean()
+
+    def test_push_and_pull_quoted_paths(self):
+        for mode in ['push', 'pull']:
+            with self.subTest(mode=mode):
+                result = self.invoke('--mode', mode, '--host', 'test-host')
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertNotIn('large cp', result.stdout)
+                self.assert_clean()
+
+    def test_failures_do_not_report_success(self):
+        for failure in ['fail', 'corrupt']:
+            with self.subTest(failure=failure):
+                result = self.invoke(env=dict(self.env, BENCH_TEST_FAILURE=failure))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn('Results (mean', result.stdout)
+                self.assert_clean()
+
+    def test_remote_failure_retains_only_owned_scratch(self):
+        result = self.invoke('--mode', 'push', '--host', 'test-host',
+                             env=dict(self.env, BENCH_TEST_FAILURE='fail'))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('Remote scratch preserved', result.stderr)
+        self.assertEqual(len(list(self.scratch.glob('syq-bench.*'))), 1)
+        self.assertEqual(self.sentinel.read_text(), 'existing user data')
+
+    def test_install_is_opt_in_and_uses_official_installer(self):
+        template = self.bin / 'syq-template'
+        (self.bin / 'syq').rename(template)
+        home = self.root / 'home'
+        env = dict(self.env, HOME=str(home))
+        result = self.invoke(env=env)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(home.exists())
+        self.assert_clean()
+        installer = '#!/bin/sh\nset -eu\nmkdir -p "$HOME/.local/bin"\ncp ' + shlex.quote(str(template)) + ' "$HOME/.local/bin/syq"\n'
+        curl = self.bin / 'curl'
+        curl.write_text('#!/usr/bin/env python3\nimport pathlib, sys\n'
+                        'assert "https://github.com/greaber/syq/releases/latest/download/install.sh" in sys.argv\n'
+                        'pathlib.Path(sys.argv[sys.argv.index("-o")+1]).write_text(' + repr(installer) + ')\n')
+        curl.chmod(0o755)
+        result = self.invoke('--install', env=env)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue((home / '.local/bin/syq').is_file())
+        self.assert_clean()
+
+    def test_bad_options_before_scratch(self):
+        for args in [('--mode', 'invalid'), ('--rounds', '0'), ('--size', 'huge'),
+                     ('--mode', 'push', '--host', '-oProxyCommand=bad')]:
+            result = self.invoke(*args)
+            self.assertNotEqual(result.returncode, 0)
+            self.assert_clean()
+
+    def test_interruption_stops_child_and_cleans(self):
+        pidfile = self.root / 'child.pid'
+        proc = subprocess.Popen(
+            ['/bin/bash', str(SCRIPT), '--yes', '--source-dir', str(self.scratch),
+             '--dest-dir', str(self.scratch), '--workload', 'large', '--rounds', '1'],
+            env=dict(self.env, BENCH_TEST_FAILURE='hang', BENCH_TEST_PID=str(pidfile)),
+            stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True,
+        )
+        try:
+            deadline = time.monotonic() + 15
+            while not pidfile.exists() and time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    self.fail(f'Exited before hang: {proc.stderr.read()}')
+                time.sleep(0.05)
+            self.assertTrue(pidfile.exists(), 'No child PID within 15 seconds')
+            proc.send_signal(signal.SIGTERM)
+            _, errors = proc.communicate(timeout=10)
+            self.assertEqual(proc.returncode, 143, errors)
+            pid = int(pidfile.read_text())
+            # A reparented zombie is stopped; do not mistake it for a live worker.
+            state = subprocess.run(['ps', '-o', 'stat=', '-p', str(pid)], capture_output=True, text=True)
+            self.assertTrue(not state.stdout.strip() or state.stdout.strip().startswith('Z'), state.stdout)
+            self.assert_clean()
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+            if pidfile.exists():
+                try:
+                    os.kill(int(pidfile.read_text()), signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+    def test_piped_script_reads_answers_from_terminal(self):
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.chdir(self.scratch)
+            os.execvpe('/bin/bash', ['/bin/bash', '-c', f'cat {shlex.quote(str(SCRIPT))} | /bin/bash'], dict(self.env, BENCH_TEST_ASK='1'))
+        output = b''
+        prompts_answered = 0
+        # All five default answers are read from /dev/tty, not the script pipe.
+        os.write(fd, b'\n' * 5)
+        deadline = time.monotonic() + 45
+        try:
+            while time.monotonic() < deadline:
+                if select.select([fd], [], [], 0.2)[0]:
+                    try:
+                        data = os.read(fd, 65536)
+                    except OSError:
+                        break
+                    if not data:
+                        break
+                    output += data
+                    if output.count(b'Credentials:') > prompts_answered:
+                        os.write(fd, b'test\n')
+                        prompts_answered += 1
+            else:
+                self.fail(f'Interactive run timed out; last output: {output[-2000:]!r}')
+            _, status = os.waitpid(pid, 0)
+            self.assertEqual(os.waitstatus_to_exitcode(status), 0, output.decode())
+            self.assertIn(b'Results (mean', output)
+            self.assert_clean()
+        finally:
+            os.close(fd)
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -20,7 +20,7 @@ SCRIPT = Path(__file__).resolve().with_name('try-benchmark.sh')
 FAKE_SYQ = r'''#!/usr/bin/env python3
 import os, pathlib, shutil, subprocess, sys, time
 args=sys.argv[1:]
-if args == ['--version']:
+if args in (['--version'], ['--build-identity']):
     print('syq test double'); sys.exit(0)
 src=pathlib.Path(args[args.index('--srcs-in')+1])
 dst=pathlib.Path(args[args.index('--into-existing')+1])
@@ -93,6 +93,33 @@ class BenchmarkTests(unittest.TestCase):
         self.assertEqual([line.split()[1].rstrip(',') for line in lines],
                          ['syq', 'rsync', 'cp', 'rsync', 'cp', 'syq', 'cp', 'syq', 'rsync'])
         self.assertIn('small cp', result.stdout)
+        self.assertIn('syq: syq test double', result.stdout)
+        self.assertEqual(result.stdout.count('Command:'), 18)
+        self.assertIn('Command: syq cp --preserve=permissions', result.stdout)
+        # Each reported mean must agree with the untimed per-trial records;
+        # range columns show the variability hidden by a mean alone.
+        import re
+        trials = {}
+        current = None
+        for line in result.stdout.splitlines():
+            match = re.match(r'(large|small): (syq|rsync|cp), trial', line)
+            if match:
+                current = tuple(match.groups())
+            match = re.match(r'Verified contents; elapsed ([0-9.]+) seconds', line)
+            if match:
+                trials.setdefault(current, []).append(float(match[1]))
+        summaries = 0
+        for line in result.stdout.splitlines():
+            fields = line.split()
+            if len(fields) == 6 and tuple(fields[:2]) in trials:
+                summaries += 1
+                values = trials[tuple(fields[:2])]
+                self.assertAlmostEqual(float(fields[2]), sum(values)/len(values), delta=0.00051)
+                self.assertEqual(float(fields[3]), min(values))
+                self.assertEqual(float(fields[4]), max(values))
+                self.assertEqual(int(fields[5]), len(values))
+        self.assertEqual(summaries, 6)
+
         self.assertEqual(result.stdout.count('Preparing syq with a 14-byte setup copy'), 1)
         self.assertEqual(result.stdout.count('test double: copy statistics'), 6)
         self.assertIn('Setup complete.', result.stdout)

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -68,7 +68,7 @@ class BenchmarkTests(unittest.TestCase):
         # missing-install test. All other commands use the host's real tools.
         for name in ['bash', 'rsync', 'openssl', 'dd', 'split', 'cksum', 'cmp',
                      'awk', 'mktemp', 'mkdir', 'rm', 'cat', 'ps', 'sleep', 'sed',
-                     'cp', 'mv', 'python3', 'sh']:
+                     'cp', 'mv', 'python3', 'sh', 'perl']:
             executable = shutil.which(name)
             if executable is None:
                 self.fail(f'Missing test prerequisite: {name}')
@@ -198,6 +198,12 @@ class BenchmarkTests(unittest.TestCase):
                     pass
 
     def test_keyboard_ctrl_c_cleans_remote_scratch(self):
+        self.check_terminal_interruption(keyboard=True)
+
+    def test_terminal_sigterm_cleans_remote_scratch(self):
+        self.check_terminal_interruption(keyboard=False)
+
+    def check_terminal_interruption(self, *, keyboard):
         pidfile = self.root / 'ctrl-c-child.pid'
         pid, fd = pty.fork()
         if pid == 0:
@@ -211,7 +217,10 @@ class BenchmarkTests(unittest.TestCase):
         try:
             while time.monotonic() < deadline:
                 if pidfile.exists() and not interrupted:
-                    os.write(fd, b'\x03')
+                    if keyboard:
+                        os.write(fd, b'\x03')
+                    else:
+                        os.kill(pid, signal.SIGTERM)
                     interrupted = True
                 if select.select([fd], [], [], 0.1)[0]:
                     try:
@@ -222,10 +231,13 @@ class BenchmarkTests(unittest.TestCase):
                         break
                     output += data
             else:
-                self.fail(f'Ctrl-C timed out; last output: {output[-2000:]!r}')
+                self.fail(f'Terminal cancellation timed out; last output: {output[-2000:]!r}')
             _, status = os.waitpid(pid, 0)
             self.assertTrue(interrupted)
-            self.assertEqual(os.waitstatus_to_exitcode(status), 130, output.decode())
+            self.assertEqual(os.waitstatus_to_exitcode(status), 130 if keyboard else 143, output.decode())
+            child = int(pidfile.read_text())
+            state = subprocess.run(['ps', '-o', 'stat=', '-p', str(child)], capture_output=True, text=True)
+            self.assertTrue(not state.stdout.strip() or state.stdout.strip().startswith('Z'), state.stdout)
             self.assertIn(b'Cleaning up remote benchmark files', output)
             self.assert_clean()
         finally:

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -35,6 +35,7 @@ if mode == 'hang':
     pathlib.Path(os.environ['BENCH_TEST_PID']).write_text(str(child.pid))
     child.wait(); sys.exit(1)
 shutil.copytree(src,dst,dirs_exist_ok=True)
+if '--quiet' not in args: print('test double: copy statistics')
 if mode == 'corrupt':
     next(dst.iterdir()).write_bytes(b'bad')
 '''
@@ -90,6 +91,9 @@ class BenchmarkTests(unittest.TestCase):
         self.assertEqual([line.split()[1].rstrip(',') for line in lines],
                          ['syq', 'rsync', 'cp', 'rsync', 'cp', 'syq', 'cp', 'syq', 'rsync'])
         self.assertIn('small cp', result.stdout)
+        self.assertEqual(result.stdout.count('Preparing syq with a 14-byte setup copy'), 1)
+        self.assertEqual(result.stdout.count('test double: copy statistics'), 6)
+        self.assertIn('Setup complete.', result.stdout)
         self.assert_clean()
 
     def test_push_and_pull_quoted_paths(self):

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -23,11 +23,12 @@ args=sys.argv[1:]
 if args == ['--version']:
     print('syq test double'); sys.exit(0)
 src=pathlib.Path(args[args.index('--srcs-in')+1])
-dst=pathlib.Path(args[args.index('--into')+1])
+dst=pathlib.Path(args[args.index('--into-existing')+1])
 if src.name == 'probe' and os.environ.get('BENCH_TEST_ASK'):
     print('Credentials:', flush=True)
     with open('/dev/tty') as terminal:
         if terminal.readline().strip() != 'test': sys.exit(4)
+if not dst.is_dir(): sys.exit(24)
 mode=os.environ.get('BENCH_TEST_FAILURE', '') if src.name != 'probe' else ''
 if mode == 'fail': sys.exit(23)
 if mode == 'hang':
@@ -43,6 +44,7 @@ FAKE_SSH = '''#!/usr/bin/env bash
 set -eu
 while [[ $1 == -o ]]; do shift 2; done
 shift
+if [[ ${BENCH_TEST_CLEANUP_FAIL:-} == 1 && $* == *cleanup_dir=* ]]; then exit 255; fi
 exec /bin/sh -c "$*"
 '''
 
@@ -66,7 +68,7 @@ class BenchmarkTests(unittest.TestCase):
         # missing-install test. All other commands use the host's real tools.
         for name in ['bash', 'rsync', 'openssl', 'dd', 'split', 'cksum', 'cmp',
                      'awk', 'mktemp', 'mkdir', 'rm', 'cat', 'ps', 'sleep', 'sed',
-                     'cp', 'python3', 'sh']:
+                     'cp', 'mv', 'python3', 'sh']:
             executable = shutil.which(name)
             if executable is None:
                 self.fail(f'Missing test prerequisite: {name}')
@@ -112,11 +114,18 @@ class BenchmarkTests(unittest.TestCase):
                 self.assertNotIn('Results (mean', result.stdout)
                 self.assert_clean()
 
-    def test_remote_failure_retains_only_owned_scratch(self):
+    def test_remote_failure_cleans_owned_scratch(self):
         result = self.invoke('--mode', 'push', '--host', 'test-host',
                              env=dict(self.env, BENCH_TEST_FAILURE='fail'))
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn('Remote scratch preserved', result.stderr)
+        self.assertIn('Cleaning up remote benchmark files', result.stdout)
+        self.assert_clean()
+
+    def test_unreachable_cleanup_reports_leftovers(self):
+        result = self.invoke('--mode', 'push', '--host', 'test-host',
+                             env=dict(self.env, BENCH_TEST_CLEANUP_FAIL='1'))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('Could not finish remote cleanup:', result.stderr)
         self.assertEqual(len(list(self.scratch.glob('syq-bench.*'))), 1)
         self.assertEqual(self.sentinel.read_text(), 'existing user data')
 
@@ -148,10 +157,18 @@ class BenchmarkTests(unittest.TestCase):
             self.assert_clean()
 
     def test_interruption_stops_child_and_cleans(self):
-        pidfile = self.root / 'child.pid'
+        self.check_interruption('local')
+
+    def test_remote_interruption_stops_child_and_cleans(self):
+        self.check_interruption('push')
+        self.check_interruption('pull')
+
+    def check_interruption(self, mode):
+        pidfile = self.root / f'child-{mode}.pid'
         proc = subprocess.Popen(
             ['/bin/bash', str(SCRIPT), '--yes', '--source-dir', str(self.scratch),
-             '--dest-dir', str(self.scratch), '--workload', 'large', '--rounds', '1'],
+             '--dest-dir', str(self.scratch), '--workload', 'large', '--rounds', '1',
+             '--mode', mode, '--host', 'test-host'],
             env=dict(self.env, BENCH_TEST_FAILURE='hang', BENCH_TEST_PID=str(pidfile)),
             stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True,
         )
@@ -174,6 +191,49 @@ class BenchmarkTests(unittest.TestCase):
             if proc.poll() is None:
                 proc.kill()
                 proc.wait()
+            if pidfile.exists():
+                try:
+                    os.kill(int(pidfile.read_text()), signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+    def test_keyboard_ctrl_c_cleans_remote_scratch(self):
+        pidfile = self.root / 'ctrl-c-child.pid'
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.execvpe('/bin/bash', ['/bin/bash', str(SCRIPT), '--yes', '--mode', 'push',
+                       '--host', 'test-host', '--workload', 'large', '--rounds', '1',
+                       '--source-dir', str(self.scratch), '--dest-dir', str(self.scratch)],
+                       dict(self.env, BENCH_TEST_FAILURE='hang', BENCH_TEST_PID=str(pidfile)))
+        output = b''
+        interrupted = False
+        deadline = time.monotonic() + 20
+        try:
+            while time.monotonic() < deadline:
+                if pidfile.exists() and not interrupted:
+                    os.write(fd, b'\x03')
+                    interrupted = True
+                if select.select([fd], [], [], 0.1)[0]:
+                    try:
+                        data = os.read(fd, 65536)
+                    except OSError:
+                        break
+                    if not data:
+                        break
+                    output += data
+            else:
+                self.fail(f'Ctrl-C timed out; last output: {output[-2000:]!r}')
+            _, status = os.waitpid(pid, 0)
+            self.assertTrue(interrupted)
+            self.assertEqual(os.waitstatus_to_exitcode(status), 130, output.decode())
+            self.assertIn(b'Cleaning up remote benchmark files', output)
+            self.assert_clean()
+        finally:
+            os.close(fd)
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
             if pidfile.exists():
                 try:
                     os.kill(int(pidfile.read_text()), signal.SIGKILL)

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# Standalone Linux/macOS benchmark. Bash 3.2 compatible; no syq-bench install.
+set -euo pipefail
+export LC_ALL=C
+# Quote remote paths ourselves for both old (including macOS) and new rsync.
+export RSYNC_OLD_ARGS=1
+export RSYNC_RSH="ssh -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=3"
+
+usage() {
+    cat <<'HELP'
+Compare syq with rsync, and cp for local copies, using disposable synthetic data.
+
+Usage: bash try-benchmark.sh [OPTIONS]
+Without --yes, unanswered choices are prompted through /dev/tty (also with curl | bash).
+
+  --mode local|push|pull    Copy locally, to an SSH host, or from an SSH host
+  --host USER@HOST          SSH host or config alias (configure ports in ~/.ssh/config)
+  --workload large|small|both
+  --size quick|medium|large Quick: 64 MiB + 1,024 files; medium: 1 GiB + 4,096;
+                           large: 8 GiB + 16,384. Small files are 8 KiB each.
+  --source-dir DIR         Local scratch parent (default: current directory)
+  --dest-dir DIR           Destination scratch parent (default: current directory)
+                           For push/pull this is the REMOTE scratch parent.
+                           For pull, --source-dir is the local destination parent.
+  --rounds N               Trials per tool/workload, rotating order (default: 3)
+  --install                Install syq locally if missing, using its official installer
+  --yes                    Use defaults for unspecified choices; do not prompt
+  --help                   Show this help
+
+Requires Bash, rsync, OpenSSL, and standard Unix utilities locally; remote tests
+also need SSH locally and rsync plus standard utilities on the remote host.
+Only newly created syq-bench.* directories are used. Existing data is not copied.
+HELP
+}
+fail() { printf 'Benchmark: %s\n' "$*" >&2; exit 1; }
+quote() { printf "'%s'" "${1//\'/\'\\\'\'}"; }
+ask() {
+    local answer
+    printf '%s [%s]: ' "$1" "$2" >&2
+    IFS= read -r answer <&3 || fail 'No answer received. Use --yes for noninteractive runs.'
+    REPLY=${answer:-$2}
+}
+need() { command -v "$1" >/dev/null || fail "Missing required command: $1"; }
+remote() { ssh -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 "$host" "$1"; }
+
+# Background jobs have their own process groups, so interruption stops the whole
+# local copy/generation group before cleanup. Remote scratch is retained on failure:
+# disconnecting SSH does not establish that every remote writer has stopped.
+active_pid=
+local_root=
+dest_root=
+remote_root=
+completed=false
+host=
+group_running() {
+    local states
+    states=$(ps -eo pgid=,stat=) || return 0
+    # A zombie cannot write or hold files open. It may await reaping by init.
+    awk -v group="$active_pid" '$1 == group && $2 !~ /^Z/ {live=1} END {exit !live}' <<< "$states"
+}
+cleanup() {
+    local status=$? attempt
+    trap - EXIT INT TERM HUP
+    if [[ -n $active_pid ]]; then
+        printf 'Stopping benchmark workers...\n' >&2
+        kill -TERM -- "-$active_pid" 2>/dev/null || :
+        for ((attempt=0; attempt<10; attempt++)); do
+            group_running || break
+            sleep 0.1
+        done
+        if group_running; then
+            kill -KILL -- "-$active_pid" 2>/dev/null || :
+            for ((attempt=0; attempt<20; attempt++)); do
+                group_running || break
+                sleep 0.1
+            done
+        fi
+        if group_running; then
+            printf 'Workers still exist; scratch preserved: %s %s\n' "$local_root" "$dest_root" >&2
+            exit 1
+        fi
+        wait "$active_pid" 2>/dev/null || :
+    fi
+    if [[ -n $remote_root ]]; then
+        if $completed; then
+            if ! remote "rm -rf $(quote "$remote_root")"; then
+                printf 'Remote cleanup failed; remove after checking: %s:%s\n' "$host" "$remote_root" >&2
+                status=1
+            fi
+        else
+            printf 'Remote scratch preserved after failure/interruption: %s:%s\n' "$host" "$remote_root" >&2
+        fi
+    fi
+    [[ -z $dest_root ]] || rm -rf -- "$dest_root" || status=1
+    [[ -z $local_root ]] || rm -rf -- "$local_root" || status=1
+    exit "$status"
+}
+run() {
+    "$@" &
+    active_pid=$!
+    local status=0
+    if [[ -t 3 ]]; then
+        # Permit SSH/passphrase prompts to read the controlling terminal.
+        fg %+ >/dev/null || status=$?
+    else
+        wait "$active_pid" || status=$?
+    fi
+    # Preserve the group ID on failure so EXIT can also stop surviving children.
+    [[ $status -eq 0 ]] || return "$status"
+    active_pid=
+}
+manifest() { (cd "$1"; for file in *; do cksum "$file"; done); }
+remote_manifest() { remote "cd $(quote "$1") && for file in *; do cksum \"\$file\" || exit; done"; }
+
+make_data() {
+    local workload=$1 amount=$2
+    mkdir "$local_root/$workload"
+    # Fixed AES-CTR stream: deterministic, dense and effectively incompressible.
+    # No keys or user data are involved. Generation is outside measured time.
+    if [[ $workload == large ]]; then
+        dd if=/dev/zero bs=1048576 count="$amount" 2>/dev/null |
+            openssl enc -aes-256-ctr -nosalt -K "$key" -iv "$iv" > "$local_root/$workload/data"
+    else
+        dd if=/dev/zero bs=8192 count="$amount" 2>/dev/null |
+            openssl enc -aes-256-ctr -nosalt -K "$key" -iv "$iv" |
+            (cd "$local_root/$workload"; split -b 8192 -a 6 - file-)
+    fi
+}
+copy_with() {
+    local tool=$1 source=$2 destination=$3
+    case $tool in
+        syq)
+            case $mode in
+                local) syq cp --preserve=permissions --srcs-in "$source" --into "$destination" --stats ;;
+                push) syq cp --preserve=permissions --srcs-in "$source" --to "$host" --into "$destination" --stats ;;
+                pull) syq cp --preserve=permissions --from "$host" --srcs-in "$source" --into "$destination" --stats ;;
+            esac ;;
+        rsync)
+            case $mode in
+                local) rsync -rpt -- "$source/" "$destination/" ;;
+                push) rsync -rpt -- "$source/" "$host:$(quote "$destination/")" ;;
+                pull) rsync -rpt -- "$host:$(quote "$source/")" "$destination/" ;;
+            esac ;;
+        cp) cp -pR "$source/." "$destination/" ;;
+    esac
+}
+timed_copy() {
+    # Separate Bash's timing output from the command's live stdout/stderr.
+    TIMEFORMAT='%R'
+    { time copy_with "$@" 1>&4 2>&5; } 2> "$local_root/time"
+}
+
+main() {
+    local mode='' workload='' size='' source_dir='' dest_dir='' rounds=3 yes=false install=false
+    local option tool round index offset source destination case_name bytes seconds local_parent remote_parent
+    local large_mib small_files
+    local key=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+    local iv=000102030405060708090a0b0c0d0e0f
+    while [[ $# -gt 0 ]]; do
+        option=$1
+        case $option in
+            --help|-h) usage; return ;;
+            --yes) yes=true; shift; continue ;;
+            --install) install=true; shift; continue ;;
+            --mode|--host|--workload|--size|--source-dir|--dest-dir|--rounds)
+                [[ $# -ge 2 && -n $2 ]] || fail "$option needs a value"
+                case $option in
+                    --mode) mode=$2 ;; --host) host=$2 ;; --workload) workload=$2 ;;
+                    --size) size=$2 ;; --source-dir) source_dir=$2 ;; --dest-dir) dest_dir=$2 ;;
+                    --rounds) rounds=$2 ;;
+                esac
+                shift 2 ;;
+            *) fail "Unknown option: $option (see --help)" ;;
+        esac
+    done
+    [[ -z $host || -n $mode ]] || mode=push
+    printf 'Compare copies on your machines — no speedup is guaranteed.\n'
+    if { exec 3</dev/tty; } 2>/dev/null; then
+        : # Also allow SSH credential prompts when --yes supplies benchmark choices.
+    elif ! $yes; then
+        fail 'No terminal. Pass --yes and your choices (see --help).'
+    fi
+    if ! $yes; then
+        if [[ -z $mode ]]; then ask 'Copy where? local / push / pull' local; mode=$REPLY; fi
+        if [[ $mode != local && -z $host ]]; then ask 'SSH host or config alias' ''; host=$REPLY; fi
+        if [[ -z $workload ]]; then ask 'Workloads? large / small / both' both; workload=$REPLY; fi
+        if [[ -z $size ]]; then ask 'Size? quick (64 MiB + 8 MiB) / medium (1 GiB + 32 MiB) / large (8 GiB + 128 MiB)' quick; size=$REPLY; fi
+        if [[ -z $source_dir ]]; then ask 'Local scratch parent' "$PWD"; source_dir=$REPLY; fi
+        if [[ -z $dest_dir ]]; then
+            if [[ $mode == local ]]; then ask 'Destination scratch parent (can be another disk or NFS mount)' "$source_dir"
+            else ask 'Remote scratch parent (existing writable directory)' .; fi
+            dest_dir=$REPLY
+        fi
+    fi
+    mode=${mode:-local}; workload=${workload:-both}; size=${size:-quick}
+    source_dir=${source_dir:-$PWD}; dest_dir=${dest_dir:-.}
+    case $mode in local|push|pull) ;; *) fail 'Mode must be local, push or pull.' ;; esac
+    case $workload in large|small|both) ;; *) fail 'Workload must be large, small or both.' ;; esac
+    case $size in quick) large_mib=64; small_files=1024 ;; medium) large_mib=1024; small_files=4096 ;; large) large_mib=8192; small_files=16384 ;; *) fail 'Size must be quick, medium or large.' ;; esac
+    [[ $rounds =~ ^[1-9]$ ]] || fail 'Rounds must be between 1 and 9.'
+    for tool in bash rsync openssl dd split cksum cmp awk mktemp mkdir rm cat ps sleep sed; do need "$tool"; done
+    [[ $mode != local ]] || need cp
+    if [[ $mode != local ]]; then
+        need ssh
+        [[ $host =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.@-]*$ ]] || fail 'Use an SSH config alias or USER@HOST; configure ports/IPv6 in ~/.ssh/config.'
+    fi
+    # Reject newlines in scratch paths so diagnostics remain unambiguous.
+    [[ $source_dir != *$'\n'* && $dest_dir != *$'\n'* ]] || fail 'Scratch paths cannot contain newlines.'
+    local_parent=$(cd -- "$source_dir" && pwd -P) || fail 'Local scratch parent must exist.'
+    trap cleanup EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    trap 'exit 129' HUP
+    set -m
+    local_root=$(mktemp -d "$local_parent/syq-bench.XXXXXXXX")
+    if ! command -v syq >/dev/null; then
+        if ! $install && ! $yes; then ask 'syq is missing. Install the official release into ~/.local/bin? yes / no' no; [[ $REPLY != yes ]] || install=true; fi
+        $install || fail 'Install syq first, or pass --install to use its official installer.'
+        need curl
+        run curl --proto '=https' --tlsv1.2 -fLsS https://github.com/greaber/syq/releases/latest/download/install.sh -o "$local_root/install.sh"
+        run sh "$local_root/install.sh"
+        export PATH="$HOME/.local/bin:$PATH"
+        need syq
+    fi
+    printf '\nVersions:\n'
+    syq --version
+    rsync --version | sed -n '1p'
+    if [[ $mode == local ]]; then
+        dest_dir=$(cd -- "$dest_dir" && pwd -P) || fail 'Destination scratch parent must exist.'
+        dest_root=$(mktemp -d "$dest_dir/syq-bench.XXXXXXXX")
+    else
+        printf '\nChecking SSH access and remote tools (normal SSH authentication applies)...\n'
+        remote 'command -v rsync >/dev/null && command -v cksum >/dev/null && command -v mktemp >/dev/null && rsync --version' | sed -n '1p' || fail 'Remote needs rsync, cksum and mktemp, and working SSH access.'
+        [[ $dest_dir == /* ]] || dest_dir=./$dest_dir
+        remote_parent=$(remote "cd $(quote "$dest_dir") && pwd -P")
+        [[ $remote_parent == /* && $remote_parent != *$'\n'* ]] || fail 'Remote shell must print only the requested output.'
+        remote_root=$(remote "mktemp -d $(quote "$remote_parent/syq-bench.XXXXXXXX")")
+        [[ $remote_root == "$remote_parent/"syq-bench.* && $remote_root != *$'\n'* ]] || fail 'Unexpected remote scratch path.'
+        dest_root=$(mktemp -d "$local_parent/syq-bench.XXXXXXXX")
+    fi
+    printf '\nMode: %s; workloads: %s; size: %s; rounds: %s\n' "$mode" "$workload" "$size" "$rounds"
+    printf 'Local scratch: %s\nDestination scratch: %s\n' "$local_root" "${remote_root:-$dest_root}"
+    printf 'Each trial uses an empty destination; order rotates. Setup and checksum verification are untimed.\n'
+    printf 'Caches are NOT flushed; times include startup and buffered writes, not durable disk flushes.\n'
+    printf 'Allow roughly twice the selected data size locally, plus one copy remotely for SSH tests.\n'
+    printf 'Using syq defaults with permissions preserved, rsync -rpt, and local cp -pR.\n\n'
+    exec 4>&1 5>&2
+    local tools=(syq rsync) workloads=(large small)
+    [[ $mode != local ]] || tools+=(cp)
+    [[ $workload == both ]] || workloads=("$workload")
+    : > "$local_root/results"
+    for case_name in "${workloads[@]}"; do
+        printf 'Generating %s workload...\n' "$case_name"
+        if [[ $case_name == large ]]; then run make_data large "$large_mib"; bytes=$((large_mib * 1048576))
+        else run make_data small "$small_files"; bytes=$((small_files * 8192)); fi
+        manifest "$local_root/$case_name" > "$local_root/expected"
+        source=$local_root/$case_name
+        if [[ $mode == pull ]]; then
+            printf 'Staging source on remote host (untimed)...\n'
+            run rsync -rpt -- "$source/" "$host:$(quote "$remote_root/$case_name/")"
+            source=$remote_root/$case_name
+            remote_manifest "$source" > "$local_root/actual"
+            cmp "$local_root/expected" "$local_root/actual" || fail 'Remote staging verification failed.'
+        fi
+        # Prime helpers/connections outside measurements with a tiny independent copy.
+        mkdir "$local_root/probe"
+        printf 'syq benchmark\n' > "$local_root/probe/data"
+        if [[ $mode == pull ]]; then
+            run rsync -rpt -- "$local_root/probe/" "$host:$(quote "$remote_root/probe/")"
+            run copy_with syq "$remote_root/probe" "$dest_root/probe"
+            rm -rf -- "$dest_root/probe"
+        elif [[ $mode == push ]]; then
+            run copy_with syq "$local_root/probe" "$remote_root/probe"
+            remote "rm -rf $(quote "$remote_root/probe")"
+        else
+            mkdir "$dest_root/probe"
+            run copy_with syq "$local_root/probe" "$dest_root/probe"
+            rm -rf -- "$dest_root/probe"
+        fi
+        rm -rf -- "$local_root/probe"
+        for ((round=1; round<=rounds; round++)); do
+            for ((offset=0; offset<${#tools[@]}; offset++)); do
+                index=$(((round - 1 + offset) % ${#tools[@]}))
+                tool=${tools[$index]}
+                destination=$dest_root/trial
+                if [[ $mode == push ]]; then destination=$remote_root/trial; remote "mkdir $(quote "$destination")"
+                else mkdir "$destination"; fi
+                printf '\n%s: %s, trial %s/%s (%s bytes)\n' "$case_name" "$tool" "$round" "$rounds" "$bytes"
+                run timed_copy "$tool" "$source" "$destination" || fail "$tool failed; no successful result recorded for this trial."
+                seconds=$(cat "$local_root/time")
+                if [[ $mode == push ]]; then remote_manifest "$destination" > "$local_root/actual"
+                else manifest "$destination" > "$local_root/actual"; fi
+                cmp "$local_root/expected" "$local_root/actual" || fail "$tool destination content check failed."
+                printf '%s %s %s %s\n' "$case_name" "$tool" "$seconds" "$bytes" >> "$local_root/results"
+                printf 'Verified contents; elapsed %s seconds.\n' "$seconds"
+                if [[ $mode == push ]]; then remote "rm -rf $(quote "$destination")"
+                else rm -rf -- "$destination"; fi
+            done
+        done
+        rm -rf -- "${local_root:?}/$case_name"
+        [[ $mode != pull ]] || remote "rm -rf $(quote "$source") $(quote "$remote_root/probe")"
+    done
+    printf '\nResults (mean elapsed seconds; all completed copies checked with POSIX cksum):\n'
+    awk '{key=$1 " " $2; if (!(key in n)) order[++count]=key; total[key]+=$3; n[key]++}
+         END {printf "%-18s %10s %8s\n", "Workload / tool", "Seconds", "Trials";
+              for (i=1; i<=count; i++) {key=order[i]; printf "%-18s %10.3f %8d\n", key, total[key]/n[key], n[key]}}' "$local_root/results"
+    printf '\nA quick synthetic comparison, not a prediction for every workload.\n'
+    printf 'Filesystem caching, cloning, network conditions and startup costs affect results.\n'
+    printf 'Try larger data and your real workloads too. Resume and direct server copies are other reasons to use syq.\n'
+    completed=true
+}
+# Keep execution last: a script downloaded through a pipe is parsed before prompts run.
+main "$@"

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -44,13 +44,12 @@ need() { command -v "$1" >/dev/null || fail "Missing required command: $1"; }
 remote() { ssh -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=3 "$host" "$1"; }
 
 # Background jobs have their own process groups, so interruption stops the whole
-# local copy/generation group before cleanup. Remote scratch is retained on failure:
-# disconnecting SSH does not establish that every remote writer has stopped.
+# local copy/generation group before cleanup. Remote cleanup first moves scratch
+# out of the transfer path; all copies require existing destination parents.
 active_pid=
 local_root=
 dest_root=
 remote_root=
-completed=false
 host=
 group_running() {
     local states
@@ -82,13 +81,23 @@ cleanup() {
         wait "$active_pid" 2>/dev/null || :
     fi
     if [[ -n $remote_root ]]; then
-        if $completed; then
-            if ! remote "rm -rf $(quote "$remote_root")"; then
-                printf 'Remote cleanup failed; remove after checking: %s:%s\n' "$host" "$remote_root" >&2
-                status=1
-            fi
-        else
-            printf 'Remote scratch preserved after failure/interruption: %s:%s\n' "$host" "$remote_root" >&2
+        printf 'Cleaning up remote benchmark files...\n'
+        # Fence the original path before removing files. syq requires an existing
+        # destination; rsync cannot create missing intermediate parents. Thus a
+        # late remote operation cannot recreate the tree under its old name.
+        if ! remote "set -eu
+root=$(quote "$remote_root")
+[ -d \"\$root\" ] || exit 0
+cleanup_dir=\$(mktemp -d \"\$root.cleanup.XXXXXXXX\")
+trap 'printf \"Remote cleanup incomplete: %s and %s\\n\" \"\$root\" \"\$cleanup_dir\" >&2' HUP INT TERM
+if mv \"\$root\" \"\$cleanup_dir/data\" && rm -rf \"\$cleanup_dir\"; then
+    trap - HUP INT TERM
+else
+    printf 'Remote cleanup incomplete: %s and %s\\n' \"\$root\" \"\$cleanup_dir\" >&2
+    exit 1
+fi"; then
+            printf 'Could not finish remote cleanup: %s:%s (also check sibling .cleanup.* directories).\n' "$host" "$remote_root" >&2
+            [[ $status -ne 0 ]] || status=1
         fi
     fi
     [[ -z $dest_root ]] || rm -rf -- "$dest_root" || status=1
@@ -105,6 +114,7 @@ run() {
     else
         wait "$active_pid" || status=$?
     fi
+    [[ $status -ne 130 && $status -ne 143 ]] || exit "$status"
     # Preserve the group ID on failure so EXIT can also stop surviving children.
     [[ $status -eq 0 ]] || return "$status"
     active_pid=
@@ -133,9 +143,9 @@ copy_with() {
     case $tool in
         syq)
             case $mode in
-                local) syq cp --preserve=permissions --srcs-in "$source" --into "$destination" "${syq_options[@]}" ;;
-                push) syq cp --preserve=permissions --srcs-in "$source" --to "$host" --into "$destination" "${syq_options[@]}" ;;
-                pull) syq cp --preserve=permissions --from "$host" --srcs-in "$source" --into "$destination" "${syq_options[@]}" ;;
+                local) syq cp --preserve=permissions --srcs-in "$source" --into-existing "$destination" "${syq_options[@]}" ;;
+                push) syq cp --preserve=permissions --srcs-in "$source" --to "$host" --into-existing "$destination" "${syq_options[@]}" ;;
+                pull) syq cp --preserve=permissions --from "$host" --srcs-in "$source" --into-existing "$destination" "${syq_options[@]}" ;;
             esac ;;
         rsync)
             case $mode in
@@ -271,10 +281,12 @@ main() {
             mkdir "$local_root/probe"
             printf 'syq benchmark\n' > "$local_root/probe/data"
             if [[ $mode == pull ]]; then
+                mkdir "$dest_root/probe"
                 run rsync -rpt -- "$local_root/probe/" "$host:$(quote "$remote_root/probe/")"
                 run copy_with syq "$remote_root/probe" "$dest_root/probe" setup
                 rm -rf -- "$dest_root/probe"
             elif [[ $mode == push ]]; then
+                remote "mkdir $(quote "$remote_root/probe")"
                 run copy_with syq "$local_root/probe" "$remote_root/probe" setup
                 remote "rm -rf $(quote "$remote_root/probe")"
             else
@@ -314,7 +326,6 @@ main() {
     printf '\nA quick synthetic comparison, not a prediction for every workload.\n'
     printf 'Filesystem caching, cloning, network conditions and startup costs affect results.\n'
     printf 'Try larger data and your real workloads too. Resume and direct server copies are other reasons to use syq.\n'
-    completed=true
 }
 # Keep execution last: a script downloaded through a pipe is parsed before prompts run.
 main "$@"

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -161,26 +161,34 @@ make_data() {
 }
 copy_with() {
     local tool=$1 source=$2 destination=$3
-    local syq_options=(--stats)
+    local command=() syq_options=(--stats)
     [[ ${4:-} != setup ]] || syq_options+=(--quiet)
     case $tool in
         syq)
             case $mode in
-                local) syq cp --preserve=permissions --srcs-in "$source" --into-existing "$destination" "${syq_options[@]}" ;;
-                push) syq cp --preserve=permissions --srcs-in "$source" --to "$host" --into-existing "$destination" "${syq_options[@]}" ;;
-                pull) syq cp --preserve=permissions --from "$host" --srcs-in "$source" --into-existing "$destination" "${syq_options[@]}" ;;
+                local) command=(syq cp --preserve=permissions --srcs-in "$source" --into-existing "$destination" "${syq_options[@]}") ;;
+                push) command=(syq cp --preserve=permissions --srcs-in "$source" --to "$host" --into-existing "$destination" "${syq_options[@]}") ;;
+                pull) command=(syq cp --preserve=permissions --from "$host" --srcs-in "$source" --into-existing "$destination" "${syq_options[@]}") ;;
             esac ;;
         rsync)
             case $mode in
-                local) rsync -rpt -- "$source/" "$destination/" ;;
-                push) rsync -rpt -- "$source/" "$host:$(quote "$destination/")" ;;
-                pull) rsync -rpt -- "$host:$(quote "$source/")" "$destination/" ;;
+                local) command=(rsync -rpt -- "$source/" "$destination/") ;;
+                push) command=(rsync -rpt -- "$source/" "$host:$(quote "$destination/")") ;;
+                pull) command=(rsync -rpt -- "$host:$(quote "$source/")" "$destination/") ;;
             esac ;;
-        cp) cp -pR "$source/." "$destination/" ;;
+        cp) command=(cp -pR "$source/." "$destination/") ;;
     esac
+    if [[ ${4:-} == show ]]; then
+        printf 'Command:'
+        printf ' %q' "${command[@]}"
+        printf '\n'
+    else
+        "${command[@]}"
+    fi
 }
 timed_copy() {
     # Separate Bash's timing output from the command's live stdout/stderr.
+    copy_with "$@" show
     TIMEFORMAT='%R'
     { time copy_with "$@" 1>&4 2>&5; } 2> "$local_root/time"
 }
@@ -262,7 +270,8 @@ main() {
         need syq
     fi
     printf '\nVersions:\n'
-    syq --version
+    printf 'syq: '
+    syq --build-identity
     rsync --version | sed -n '1p'
     if [[ $mode == local ]]; then
         dest_dir=$(cd -- "$dest_dir" && pwd -P) || fail 'Destination scratch parent must exist.'
@@ -278,6 +287,7 @@ main() {
         dest_root=$(mktemp -d "$local_parent/syq-bench.XXXXXXXX")
     fi
     printf '\nMode: %s; workloads: %s; size: %s; rounds: %s\n' "$mode" "$workload" "$size" "$rounds"
+    [[ $mode == local ]] || printf 'SSH host: %s\n' "$host"
     printf 'Local scratch: %s\nDestination scratch: %s\n' "$local_root" "${remote_root:-$dest_root}"
     printf 'Each trial uses an empty destination; order rotates. Setup and checksum verification are untimed.\n'
     printf 'Caches are NOT flushed; times include startup and buffered writes, not durable disk flushes.\n'
@@ -289,7 +299,8 @@ main() {
     [[ $workload == both ]] || workloads=("$workload")
     : > "$local_root/results"
     for case_name in "${workloads[@]}"; do
-        printf 'Generating %s workload...\n' "$case_name"
+        if [[ $case_name == large ]]; then printf 'Generating one %s MiB file...\n' "$large_mib"
+        else printf 'Generating %s files of 8 KiB each...\n' "$small_files"; fi
         if [[ $case_name == large ]]; then run make_data large "$large_mib"; bytes=$((large_mib * 1048576))
         else run make_data small "$small_files"; bytes=$((small_files * 8192)); fi
         manifest "$local_root/$case_name" > "$local_root/expected"
@@ -347,9 +358,12 @@ main() {
         [[ $mode != pull ]] || remote "rm -rf $(quote "$source") $(quote "$remote_root/probe")"
     done
     printf '\nResults (mean elapsed seconds; all completed copies checked with POSIX cksum):\n'
-    awk '{key=$1 " " $2; if (!(key in n)) order[++count]=key; total[key]+=$3; n[key]++}
-         END {printf "%-18s %10s %8s\n", "Workload / tool", "Seconds", "Trials";
-              for (i=1; i<=count; i++) {key=order[i]; printf "%-18s %10.3f %8d\n", key, total[key]/n[key], n[key]}}' "$local_root/results"
+    awk '{key=$1 " " $2;
+          if (!(key in n)) {order[++count]=key; low[key]=$3; high[key]=$3}
+          total[key]+=$3; n[key]++;
+          if ($3 < low[key]) low[key]=$3; if ($3 > high[key]) high[key]=$3}
+         END {printf "%-18s %10s %10s %10s %8s\n", "Workload / tool", "Mean", "Min", "Max", "Trials";
+              for (i=1; i<=count; i++) {key=order[i]; printf "%-18s %10.3f %10.3f %10.3f %8d\n", key, total[key]/n[key], low[key], high[key], n[key]}}' "$local_root/results"
     printf '\nA quick synthetic comparison, not a prediction for every workload.\n'
     printf 'Filesystem caching, cloning, network conditions and startup costs affect results.\n'
     printf 'Try larger data and your real workloads too. Resume and direct server copies are other reasons to use syq.\n'

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -27,7 +27,8 @@ Without --yes, unanswered choices are prompted through /dev/tty (also with curl 
   --yes                    Use defaults for unspecified choices; do not prompt
   --help                   Show this help
 
-Requires Bash, rsync, OpenSSL, and standard Unix utilities locally; remote tests
+Requires Bash, rsync, OpenSSL, and standard Unix utilities locally; terminal runs
+also need Perl (for terminal process-group control). Remote tests
 also need SSH locally and rsync plus standard utilities on the remote host.
 Only newly created syq-bench.* directories are used. Existing data is not copied.
 HELP
@@ -47,6 +48,7 @@ remote() { ssh -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCoun
 # local copy/generation group before cleanup. Remote cleanup first moves scratch
 # out of the transfer path; all copies require existing destination parents.
 active_pid=
+terminal_pgid=
 local_root=
 dest_root=
 remote_root=
@@ -57,12 +59,28 @@ group_running() {
     # A zombie cannot write or hold files open. It may await reaping by init.
     awk -v group="$active_pid" '$1 == group && $2 !~ /^Z/ {live=1} END {exit !live}' <<< "$states"
 }
+terminal_group() {
+    # Bash's fg builtin defers signal traps. Hand off only terminal ownership,
+    # leaving the shell free to use its interruptible wait builtin.
+    perl -MPOSIX -e '
+        $SIG{TTOU} = "IGNORE";
+        if (POSIX::tcsetpgrp(3, $ARGV[0]) != 0) {
+            my $error = "$!";
+            # A very short job can finish before the handoff.
+            exit 0 if !kill(0, -$ARGV[0]) && $! == POSIX::ESRCH();
+            die "terminal process group: $error\n";
+        }
+    ' "$1"
+}
 cleanup() {
     local status=$? attempt
     trap - EXIT INT TERM HUP
+    [[ -z $terminal_pgid ]] || terminal_group "$terminal_pgid" || :
     if [[ -n $active_pid ]]; then
         printf 'Stopping benchmark workers...\n' >&2
         kill -TERM -- "-$active_pid" 2>/dev/null || :
+        # A background terminal reader may have stopped on SIGTTIN.
+        kill -CONT -- "-$active_pid" 2>/dev/null || :
         for ((attempt=0; attempt<10; attempt++)); do
             group_running || break
             sleep 0.1
@@ -108,12 +126,17 @@ run() {
     "$@" &
     active_pid=$!
     local status=0
-    if [[ -t 3 ]]; then
-        # Permit SSH/passphrase prompts to read the controlling terminal.
-        fg %+ >/dev/null || status=$?
-    else
-        wait "$active_pid" || status=$?
+    # Disable job-status waits after assigning the job its own process group:
+    # wait must wait for exit, including if an early terminal read stopped it.
+    set +m
+    if [[ -n $terminal_pgid ]]; then
+        terminal_group "$active_pid" || status=$?
+        kill -CONT -- "-$active_pid" 2>/dev/null || :
     fi
+    [[ $status -eq 0 ]] || return "$status"
+    wait "$active_pid" || status=$?
+    [[ -z $terminal_pgid ]] || terminal_group "$terminal_pgid"
+    set -m
     [[ $status -ne 130 && $status -ne 143 ]] || exit "$status"
     # Preserve the group ID on failure so EXIT can also stop surviving children.
     [[ $status -eq 0 ]] || return "$status"
@@ -218,6 +241,10 @@ main() {
     fi
     # Reject newlines in scratch paths so diagnostics remain unambiguous.
     [[ $source_dir != *$'\n'* && $dest_dir != *$'\n'* ]] || fail 'Scratch paths cannot contain newlines.'
+    if [[ -t 3 ]]; then
+        need perl
+        terminal_pgid=$(ps -o pgid= -p "$$")
+    fi
     local_parent=$(cd -- "$source_dir" && pwd -P) || fail 'Local scratch parent must exist.'
     trap cleanup EXIT
     trap 'exit 130' INT

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -288,7 +288,9 @@ main() {
     fi
     printf '\nMode: %s; workloads: %s; size: %s; rounds: %s\n' "$mode" "$workload" "$size" "$rounds"
     [[ $mode == local ]] || printf 'SSH host: %s\n' "$host"
-    printf 'Local scratch: %s\nDestination scratch: %s\n' "$local_root" "${remote_root:-$dest_root}"
+    printf 'Local scratch: %s\n' "$local_root"
+    if [[ $mode == local ]]; then printf 'Destination scratch: %s\n' "$dest_root"
+    else printf 'Remote scratch: %s\n' "$remote_root"; fi
     printf 'Each trial uses an empty destination; order rotates. Setup and checksum verification are untimed.\n'
     printf 'Caches are NOT flushed; times include startup and buffered writes, not durable disk flushes.\n'
     printf 'Allow roughly twice the selected data size locally, plus one copy remotely for SSH tests.\n'

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -128,12 +128,14 @@ make_data() {
 }
 copy_with() {
     local tool=$1 source=$2 destination=$3
+    local syq_options=(--stats)
+    [[ ${4:-} != setup ]] || syq_options+=(--quiet)
     case $tool in
         syq)
             case $mode in
-                local) syq cp --preserve=permissions --srcs-in "$source" --into "$destination" --stats ;;
-                push) syq cp --preserve=permissions --srcs-in "$source" --to "$host" --into "$destination" --stats ;;
-                pull) syq cp --preserve=permissions --from "$host" --srcs-in "$source" --into "$destination" --stats ;;
+                local) syq cp --preserve=permissions --srcs-in "$source" --into "$destination" "${syq_options[@]}" ;;
+                push) syq cp --preserve=permissions --srcs-in "$source" --to "$host" --into "$destination" "${syq_options[@]}" ;;
+                pull) syq cp --preserve=permissions --from "$host" --srcs-in "$source" --into "$destination" "${syq_options[@]}" ;;
             esac ;;
         rsync)
             case $mode in
@@ -262,22 +264,27 @@ main() {
             remote_manifest "$source" > "$local_root/actual"
             cmp "$local_root/expected" "$local_root/actual" || fail 'Remote staging verification failed.'
         fi
-        # Prime helpers/connections outside measurements with a tiny independent copy.
-        mkdir "$local_root/probe"
-        printf 'syq benchmark\n' > "$local_root/probe/data"
-        if [[ $mode == pull ]]; then
-            run rsync -rpt -- "$local_root/probe/" "$host:$(quote "$remote_root/probe/")"
-            run copy_with syq "$remote_root/probe" "$dest_root/probe"
-            rm -rf -- "$dest_root/probe"
-        elif [[ $mode == push ]]; then
-            run copy_with syq "$local_root/probe" "$remote_root/probe"
-            remote "rm -rf $(quote "$remote_root/probe")"
-        else
-            mkdir "$dest_root/probe"
-            run copy_with syq "$local_root/probe" "$dest_root/probe"
-            rm -rf -- "$dest_root/probe"
+        if [[ $case_name == "${workloads[0]}" ]]; then
+            # Do this once, not once per workload. Keep the measured copy's full
+            # transport path, but suppress meaningless throughput for the 14-byte probe.
+            printf 'Preparing syq with a 14-byte setup copy (not timed as a benchmark)...\n'
+            mkdir "$local_root/probe"
+            printf 'syq benchmark\n' > "$local_root/probe/data"
+            if [[ $mode == pull ]]; then
+                run rsync -rpt -- "$local_root/probe/" "$host:$(quote "$remote_root/probe/")"
+                run copy_with syq "$remote_root/probe" "$dest_root/probe" setup
+                rm -rf -- "$dest_root/probe"
+            elif [[ $mode == push ]]; then
+                run copy_with syq "$local_root/probe" "$remote_root/probe" setup
+                remote "rm -rf $(quote "$remote_root/probe")"
+            else
+                mkdir "$dest_root/probe"
+                run copy_with syq "$local_root/probe" "$dest_root/probe" setup
+                rm -rf -- "$dest_root/probe"
+            fi
+            rm -rf -- "$local_root/probe"
+            printf 'Setup complete.\n'
         fi
-        rm -rf -- "$local_root/probe"
         for ((round=1; round<=rounds; round++)); do
             for ((offset=0; offset<${#tools[@]}; offset++)); do
                 index=$(((round - 1 + offset) % ${#tools[@]}))

--- a/tests/real-ssh/Dockerfile
+++ b/tests/real-ssh/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update \
         openssh-server \
         procps \
         python3 \
-
         zsh \
         rsync \
         openssl \

--- a/tests/real-ssh/Dockerfile
+++ b/tests/real-ssh/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update \
         python3 \
 
         zsh \
+        rsync \
+        openssl \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 1000 syq \
     && useradd --uid 1000 --gid syq --create-home --shell /bin/sh syq \
@@ -38,6 +40,7 @@ COPY --from=builder /tmp/syq /usr/local/bin/syq
 COPY --chmod=0755 tests/real-ssh/ssh-wrapper.sh /usr/local/bin/ssh
 COPY --chmod=0755 tests/real-ssh/entrypoint.sh /usr/local/libexec/syq-real-ssh-entrypoint
 COPY --chmod=0755 tests/real-ssh/scenarios.sh /usr/local/libexec/syq-real-ssh-scenarios
+COPY --chmod=0755 scripts/try-benchmark.sh /usr/local/libexec/syq-try-benchmark
 COPY tests/real-ssh/sshd_config /etc/ssh/sshd_config
 
 COPY tests/real-ssh/test-completion-display.py /usr/local/libexec/syq-test-completion-display.py

--- a/tests/real-ssh/Dockerfile.dockerignore
+++ b/tests/real-ssh/Dockerfile.dockerignore
@@ -12,3 +12,6 @@
 !tests/real-ssh/scenarios.sh
 !tests/real-ssh/ssh-wrapper.sh
 !tests/real-ssh/sshd_config
+
+!scripts/
+!scripts/try-benchmark.sh

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -105,3 +105,6 @@ The suite also runs the standalone interactive benchmark in noninteractive
 push and pull modes, with both synthetic workloads and scratch paths containing
 spaces and quotes. These are correctness and cleanup checks using the lab's
 debug binary, not performance measurements.
+
+A cancellation case waits for an active remote partial file, interrupts the
+benchmark, and checks that scratch is removed while an unrelated file remains.

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -100,3 +100,8 @@ python3 tests/real-ssh/test-completion-display.py --syq target/debug/syq
 ```
 
 The shell dependencies are installed only in the test image.
+
+The suite also runs the standalone interactive benchmark in noninteractive
+push and pull modes, with both synthetic workloads and scratch paths containing
+spaces and quotes. These are correctness and cleanup checks using the lab's
+debug binary, not performance measurements.

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -673,3 +673,19 @@ if ssh source 'pgrep -x syq >/dev/null' || ssh destination 'pgrep -x syq >/dev/n
 fi
 
 printf 'real-SSH smoke suite passed\n'
+
+# Exercise the user-facing script against real remote rsync and syq helpers.
+# Quoted scratch names must survive both SSH and rsync's remote argument parsing.
+benchmark_parent="$home/benchmark scratch's"
+mkdir "$benchmark_parent"
+ssh destination "mkdir -p \"/tmp/benchmark scratch's\""
+for benchmark_mode in push pull; do
+    bash /usr/local/libexec/syq-try-benchmark --yes \
+        --mode "$benchmark_mode" --host destination --workload both --size quick \
+        --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's"
+done
+test -z "$(find "$benchmark_parent" -mindepth 1 -print)"
+ssh destination 'test -z "$(find "/tmp/benchmark scratch'"'"'s" -mindepth 1 -print)"'
+rmdir "$benchmark_parent"
+ssh destination "rmdir \"/tmp/benchmark scratch's\""
+echo 'interactive benchmark push/pull passed'

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -689,3 +689,42 @@ ssh destination 'test -z "$(find "/tmp/benchmark scratch'"'"'s" -mindepth 1 -pri
 rmdir "$benchmark_parent"
 ssh destination "rmdir \"/tmp/benchmark scratch's\""
 echo 'interactive benchmark push/pull passed'
+
+# Interrupt a real copy after the remote partial file appears, then require all
+# temporary data to be gone. An unrelated file in the scratch parent must stay.
+cancel_parent=$home/benchmark-cancel
+mkdir "$cancel_parent"
+ssh destination 'mkdir /tmp/benchmark-cancel; printf keep > /tmp/benchmark-cancel/keep'
+bash /usr/local/libexec/syq-try-benchmark --yes --mode push --host destination \
+    --workload large --rounds 1 --source-dir "$cancel_parent" \
+    --dest-dir /tmp/benchmark-cancel &
+benchmark_pid=$!
+attempt=0
+copy_started=false
+while [ "$attempt" -lt 30 ]; do
+    if ssh destination 'for file in /tmp/benchmark-cancel/syq-bench.*/trial/.data.syq-part.*; do
+        if [ -f "$file" ]; then exit 0; fi
+    done; exit 1'; then
+        copy_started=true
+        break
+    fi
+    if [ $((attempt % 5)) -eq 0 ]; then
+        printf 'Waiting for remote benchmark partial file (%ss of 30s)...\n' "$attempt"
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+done
+kill -TERM "$benchmark_pid" 2>/dev/null || true
+benchmark_status=0
+wait "$benchmark_pid" || benchmark_status=$?
+if [ "$copy_started" != true ]; then
+    echo 'benchmark cancellation timed out after 30s: no remote partial file observed' >&2
+    exit 1
+fi
+test "$benchmark_status" -eq 143
+test -z "$(find "$cancel_parent" -mindepth 1 -print)"
+ssh destination 'test "$(cat /tmp/benchmark-cancel/keep)" = keep &&
+    test "$(find /tmp/benchmark-cancel -mindepth 1 -maxdepth 1 | wc -l)" -eq 1'
+rmdir "$cancel_parent"
+ssh destination 'rm /tmp/benchmark-cancel/keep; rmdir /tmp/benchmark-cancel'
+echo 'interactive benchmark remote interruption cleanup passed'


### PR DESCRIPTION
People can compare syq on their own disks or SSH connections without installing syq-bench. This standalone Bash script asks for local/push/pull, workloads, size and scratch locations. The install guide provides a curl-to-Bash entry point; flags support repeatable noninteractive runs, and installing syq is optional.

Each timed copy uses a fresh destination and rotating tool order. Local comparisons include cp and rsync; remote comparisons use rsync. Deterministic incompressible data and POSIX cksum checks make failed or incomplete copies visible. The transcript includes the exact syq build, shell-quoted commands printed outside timing, per-trial times, and mean/minimum/maximum results. Setup is one explicitly labeled, quiet 14-byte copy, excluded from timing. Caches remain warm and writes are buffered, as the output explains.

Cancellation stops the local worker process group, then remote cleanup moves scratch out of the transfer path before deleting it. Copies require existing destinations, so late operations cannot recreate the original tree. Interrupted trials are never resumed, and cleanup failures report leftovers. Terminal runs retain SSH credential prompts while using an interruptible wait; Perl/POSIX provides terminal ownership without Bash's signal-deferring fg builtin. Bash 3.2 syntax and prerequisites are documented.

Head `9693f1f`, rebased onto master `3c63d35`. This retains the newer completion and return-connection coverage alongside the benchmark scenarios.

Validation:
- All 12 script regressions passed: local comparisons/rotation, quoted remote push/pull, failure and corrupt-copy handling, optional installation, terminal/piped prompts, SIGTERM under a PTY, Ctrl-C, worker termination and remote cleanup. The summary regression verifies mean/min/max against recorded trial values; its final assertion passed separately at `9535e93`.
- Full default three-container real-SSH suite passed at `9535e93`, including actual syq/rsync push/pull, checked contents and cleanup after interrupting a live remote transfer with partial data. Its debug-binary timings are correctness evidence, not performance results.
- The final `9693f1f` commit only corrects the remote scratch label for pull mode; ShellCheck, whitespace and focused quoted push/pull tests passed afterward.
- Actual release-profile syq (`9e73649` binary), rsync and cp completed all 18 local quick-workload copies with checked contents and no leftover scratch. Repository-wide ShellCheck and documentation links (16 files) passed.
- No Rust source changed relative to master; Rust unit/clippy suites were not rerun. No local macOS execution. PR checks do not start automatically.

Ready for review, not merged. Branch `interactive-benchmark` is clean and pushed at `9693f1f`, matching GitHub. Final branch-status reports native CI and rsync-compat success on master `3c63d35`, but macOS failure on that same commit; it therefore exits 1. This script is not on master and no PR check success is claimed.
