### PR TITLE
Keep progress stable during slow transfers

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -103,6 +103,26 @@ A colon in a native path is simply part of the path.
 
 For two remote endpoints, see [Copy between servers](remote-to-remote.md).
 
+## Progress
+
+When stderr is a terminal, syq shows one progress bar for the whole copy.
+The bar stays in place as files and workers change. It shows bytes processed
+out of the discovered total; while syq is still scanning, the percentage is
+unknown. Wider terminals also show elapsed time, speed, ETA, and file counts.
+Use `--progress` to force the display or `--no-progress` to hide it. `--quiet`
+hides it too. `--progress-json` selects JSON progress instead of the bar.
+
+The bar advances when syq processes a block or completes a file. On a slow
+link, or during a local server-side copy, it can stay at the same position
+for a while. After five seconds without a byte update, `no update` shows how
+long it has been; this does not mean the connection has failed. Syq does not
+guess extra completed bytes between updates. A final `done` or `incomplete`
+bar stays visible when the copy settles. Reaching the end of the byte bar
+alone does not mean all files have finished or that the copy succeeded.
+
+The bar also covers `syq rm`, counting entries instead of bytes. For scripts,
+use [results records](automation.md) rather than parsing the terminal bar.
+
 ## Choose a destination
 
 | Option | Meaning |

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,11 +2,72 @@
 //! These writes can still block; they deliberately do not buffer or drop slow output.
 
 use std::fmt::Arguments;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use std::sync::Mutex;
+
+/// One lock owns both the live row and writes that can disturb it. Diagnostic
+/// writers never take a Progress lock, so worker warnings cannot invert the
+/// ticker's lock order. Redirected stdout stays outside this lock.
+static TERMINAL: Mutex<Terminal> = Mutex::new(Terminal { line: None });
+
+#[derive(Default)]
+pub(crate) struct Terminal {
+    line: Option<String>,
+}
+
+impl Terminal {
+    pub(crate) fn draw(&mut self, out: &mut impl Write, line: String) -> io::Result<()> {
+        if self.line.as_ref() != Some(&line) {
+            out.write_all(format!("\r{line}\x1b[K").as_bytes())?;
+            out.flush()?;
+            self.line = Some(line);
+        }
+        Ok(())
+    }
+
+    fn clear(&mut self, out: &mut impl Write) -> io::Result<()> {
+        if self.line.take().is_some() {
+            out.write_all(b"\r\x1b[2K")?;
+            out.flush()?;
+        }
+        Ok(())
+    }
+
+    fn diagnostic(&mut self, out: &mut impl Write, args: Arguments<'_>) -> io::Result<()> {
+        let line = self.line.clone();
+        self.clear(out)?;
+        writeln!(out, "{args}")?;
+        if let Some(line) = line {
+            self.draw(out, line)?;
+        }
+        out.flush()
+    }
+}
+
+pub(crate) fn draw_progress(line: String) {
+    let _ = TERMINAL
+        .lock()
+        .unwrap()
+        .draw(&mut io::stderr().lock(), line);
+}
+
+pub(crate) fn clear_progress() {
+    let _ = TERMINAL.lock().unwrap().clear(&mut io::stderr().lock());
+}
+
+pub(crate) fn finish_progress() {
+    let mut terminal = TERMINAL.lock().unwrap();
+    if terminal.line.take().is_some() {
+        let _ = writeln!(io::stderr().lock());
+    }
+}
 
 pub(crate) fn emit_diagnostic(args: Arguments<'_>) {
-    let _ = writeln!(io::stderr().lock(), "{args}");
+    let _ = TERMINAL
+        .lock()
+        .unwrap()
+        .diagnostic(&mut io::stderr().lock(), args);
 }
 
 pub(crate) fn emit_human_stdout(args: Arguments<'_>) {
@@ -18,6 +79,13 @@ pub(crate) fn emit_human_stdout(args: Arguments<'_>) {
 /// Essential output (such as a receipt frame or detach handoff) must let
 /// its caller handle failure. The stdout lock is released before returning.
 pub(crate) fn write_stdout(args: Arguments<'_>) -> io::Result<()> {
+    // A full pipe must not freeze stderr progress or diagnostics.
+    if !io::stdout().is_terminal() {
+        let mut out = io::stdout().lock();
+        return writeln!(out, "{args}").and_then(|()| out.flush());
+    }
+    let mut terminal = TERMINAL.lock().unwrap();
+    let _ = terminal.clear(&mut io::stderr().lock());
     let mut out = io::stdout().lock();
     writeln!(out, "{args}").and_then(|()| out.flush())
 }
@@ -40,3 +108,25 @@ macro_rules! human_stdout {
     ($($arg:tt)*) => { $crate::output::emit_human_stdout(format_args!($($arg)*)) };
 }
 pub(crate) use human_stdout;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostics_get_a_clean_row_and_restore_the_bar() {
+        let mut terminal = Terminal::default();
+        let mut output = Vec::new();
+        let bar = "[========= ]  93%";
+        terminal.draw(&mut output, bar.into()).unwrap();
+        terminal
+            .diagnostic(&mut output, format_args!("syq: warning: broken pipe"))
+            .unwrap();
+        terminal
+            .diagnostic(&mut output, format_args!("syq: worker connection lost"))
+            .unwrap();
+        assert_eq!(String::from_utf8(output).unwrap(), format!(
+            "\r{bar}\x1b[K\r\x1b[2Ksyq: warning: broken pipe\n\r{bar}\x1b[K\r\x1b[2Ksyq: worker connection lost\n\r{bar}\x1b[K"));
+        assert_eq!(terminal.line.as_deref(), Some(bar));
+    }
+}

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,7 +1,7 @@
 //! A fixed-height aggregate progress bar. Byte accounting belongs to the engine.
 
 use std::collections::VecDeque;
-use std::io::{IsTerminal, Write};
+use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -53,20 +53,32 @@ pub struct Progress {
 }
 
 struct TermState {
-    line: Option<String>,
     samples: VecDeque<(Instant, u64)>,
     last_json: Option<Instant>,
     last_results: Option<Instant>,
 }
 
-impl TermState {
-    fn draw(&mut self, out: &mut impl Write, line: String) -> std::io::Result<()> {
-        if self.line.as_ref() != Some(&line) {
-            out.write_all(format!("\r{line}\x1b[K").as_bytes())?;
-            out.flush()?;
-            self.line = Some(line);
-        }
-        Ok(())
+/// Own the ticker until it has stopped. In particular, `?` must not detach a
+/// thread that can clear or redraw the final bar after a fatal copy error.
+pub struct ProgressTicker {
+    progress: Arc<Progress>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl ProgressTicker {
+    fn stop_and_join(&mut self) -> std::thread::Result<()> {
+        self.progress.stop();
+        self.thread.take().map_or(Ok(()), |thread| thread.join())
+    }
+
+    pub fn join(mut self) -> std::thread::Result<()> {
+        self.stop_and_join()
+    }
+}
+
+impl Drop for ProgressTicker {
+    fn drop(&mut self) {
+        let _ = self.stop_and_join();
     }
 }
 
@@ -98,7 +110,6 @@ impl Progress {
             active_workers: AtomicU64::new(0),
             start: Instant::now(),
             term: Mutex::new(TermState {
-                line: None,
                 samples: VecDeque::from([(Instant::now(), 0)]),
                 last_json: None,
                 last_results: None,
@@ -123,29 +134,11 @@ impl Progress {
 
     /// Print a line to stdout, keeping the progress area intact.
     pub fn println(&self, line: &str) {
-        let mut term = Some(self.term.lock().unwrap());
-        if std::io::stdout().is_terminal() {
-            self.erase(term.as_mut().unwrap());
-        }
-        // A redirected stdout cannot disturb the terminal display. Let the
-        // ticker keep running while a slow pipe blocks this printing worker.
-        if !std::io::stdout().is_terminal() {
-            drop(term.take());
-        }
-        let result = {
-            let mut out = std::io::stdout().lock();
-            writeln!(out, "{line}").and_then(|()| out.flush())
-        };
-        drop(term);
-        if let Err(error) = result {
-            crate::output::warn_stdout(&error);
-        }
+        crate::output::emit_human_stdout(format_args!("{line}"));
     }
 
-    /// Print a line to stderr (errors and warnings), keeping the progress area intact.
+    /// Print diagnostics through the same output lock as the live bar.
     pub fn eprintln(&self, line: &str) {
-        let mut t = self.term.lock().unwrap();
-        self.erase(&mut t);
         crate::output::diagnostic!("{line}");
     }
 
@@ -167,8 +160,6 @@ impl Progress {
     }
 
     pub fn warning(&self, code: &str, count: u64, message: &str) {
-        let mut term = self.term.lock().unwrap();
-        self.erase(&mut term);
         if self.json {
             crate::output::diagnostic!(
                 "{}",
@@ -181,12 +172,6 @@ impl Progress {
             );
         } else {
             crate::output::diagnostic!("syq: warning: {message}");
-        }
-    }
-
-    fn erase(&self, t: &mut TermState) {
-        if t.line.take().is_some() {
-            let _ = write!(std::io::stderr().lock(), "\r\x1b[2K");
         }
     }
 
@@ -336,38 +321,42 @@ impl Progress {
         );
         // Never blank the display between frames or move through worker rows.
         // One buffered write replaces this line and clears only its old tail.
-        let _ = t.draw(&mut std::io::stderr().lock(), line);
+        crate::output::draw_progress(line);
     }
 
     /// Leave the final bar visible. Call after joining the ticker, with the
     /// actual operation outcome; a full byte counter alone is not success.
     pub fn finish(&self, success: bool) {
         self.render_status(Some(if success { "done" } else { "incomplete" }));
-        let mut t = self.term.lock().unwrap();
-        if t.line.take().is_some() {
-            let _ = writeln!(std::io::stderr().lock());
+        if self.enabled {
+            crate::output::finish_progress();
         }
     }
 
     pub fn clear(&self) {
-        let mut t = self.term.lock().unwrap();
-        self.erase(&mut t);
+        if self.enabled {
+            crate::output::clear_progress();
+        }
     }
 
-    pub fn spawn_ticker(self: &Arc<Self>) -> Option<std::thread::JoinHandle<()>> {
+    pub fn spawn_ticker(self: &Arc<Self>) -> Option<ProgressTicker> {
         // A results stream needs the ticker too: sampled progress records
         // are emitted from render() even when stderr is not a terminal.
         if !self.enabled && !self.json && self.results.get().is_none() {
             return None;
         }
         let p = self.clone();
-        Some(std::thread::spawn(move || {
+        let thread = std::thread::spawn(move || {
             while !p.stop.load(Relaxed) {
                 p.render();
                 std::thread::sleep(Duration::from_millis(100));
             }
             p.clear();
-        }))
+        });
+        Some(ProgressTicker {
+            progress: self.clone(),
+            thread: Some(thread),
+        })
     }
 
     pub fn stop(&self) {
@@ -537,8 +526,7 @@ mod tests {
 
     #[test]
     fn bar_stays_visible_across_sparse_updates_without_scrolling_or_clearing() {
-        let progress = Progress::new(false, false, None, false);
-        let mut term = progress.term.lock().unwrap();
+        let mut term = crate::output::Terminal::default();
         let mut output = Vec::new();
         let first = bar_line(
             79,
@@ -600,5 +588,34 @@ mod tests {
         assert!(scanning.contains("---") && !scanning.contains("100%"));
         let empty = bar_line(79, 0, 0, true, true, "0 B/0 B", &["done".into()]);
         assert!(empty.contains("100%") && empty.contains("done"));
+    }
+
+    #[test]
+    fn ticker_is_joined_when_an_error_leaves_its_scope() {
+        let progress = Progress::new(false, false, None, false);
+        let stopped = Arc::new(AtomicBool::new(false));
+        let p = progress.clone();
+        let done = stopped.clone();
+        let result: Result<(), ()> = (|| {
+            let _ticker = ProgressTicker {
+                progress: progress.clone(),
+                thread: Some(std::thread::spawn(move || {
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.stop.load(Relaxed) && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    assert!(p.stop.load(Relaxed), "ticker was detached on error");
+                    done.store(true, Relaxed);
+                })),
+            };
+            Err(())?;
+            Ok(())
+        })();
+        assert!(result.is_err());
+        assert!(
+            stopped.load(Relaxed),
+            "finalization must wait for the ticker to exit"
+        );
+        assert_eq!(Arc::strong_count(&progress), 1);
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,17 +1,10 @@
-//! Progress display: one status line plus one line per active worker.
+//! A fixed-height aggregate progress bar. Byte accounting belongs to the engine.
 
 use std::collections::VecDeque;
 use std::io::{IsTerminal, Write};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-
-#[derive(Clone)]
-pub struct WorkerStatus {
-    pub path: String,
-    pub done: Arc<AtomicU64>,
-    pub total: u64,
-}
 
 pub struct Progress {
     pub enabled: bool,
@@ -52,7 +45,6 @@ pub struct Progress {
     /// Workers currently allowed to take work (0 = fixed -j, not shown).
     pub active_workers: AtomicU64,
     pub start: Instant,
-    workers: Mutex<Vec<Option<WorkerStatus>>>,
     term: Mutex<TermState>,
     stop: AtomicBool,
     /// `--results`: machine-readable NDJSON outcome stream, set once after
@@ -61,22 +53,27 @@ pub struct Progress {
 }
 
 struct TermState {
-    lines_drawn: usize,
+    line: Option<String>,
     samples: VecDeque<(Instant, u64)>,
     last_json: Option<Instant>,
     last_results: Option<Instant>,
 }
 
+impl TermState {
+    fn draw(&mut self, out: &mut impl Write, line: String) -> std::io::Result<()> {
+        if self.line.as_ref() != Some(&line) {
+            out.write_all(format!("\r{line}\x1b[K").as_bytes())?;
+            out.flush()?;
+            self.line = Some(line);
+        }
+        Ok(())
+    }
+}
+
 impl Progress {
-    pub fn new(
-        n_workers: usize,
-        enabled: bool,
-        force: bool,
-        width: Option<usize>,
-        json: bool,
-    ) -> Arc<Self> {
+    pub fn new(enabled: bool, force: bool, width: Option<usize>, json: bool) -> Arc<Self> {
         Arc::new(Progress {
-            enabled: enabled && (force || std::io::stderr().is_terminal()),
+            enabled: enabled && !json && (force || std::io::stderr().is_terminal()),
             json,
             width,
             rm: false,
@@ -100,10 +97,9 @@ impl Progress {
             specials_created: AtomicU64::new(0),
             active_workers: AtomicU64::new(0),
             start: Instant::now(),
-            workers: Mutex::new(vec![None; n_workers]),
             term: Mutex::new(TermState {
-                lines_drawn: 0,
-                samples: VecDeque::new(),
+                line: None,
+                samples: VecDeque::from([(Instant::now(), 0)]),
                 last_json: None,
                 last_results: None,
             }),
@@ -120,14 +116,6 @@ impl Progress {
         self.results.get()
     }
 
-    pub fn set_worker(&self, id: usize, s: Option<WorkerStatus>) {
-        let mut w = self.workers.lock().unwrap();
-        if id >= w.len() {
-            w.resize(id + 1, None);
-        }
-        w[id] = s;
-    }
-
     pub fn add_bytes(&self, n: u64) {
         let done = self.bytes_done.fetch_add(n, Relaxed).saturating_add(n);
         self.tuning_high_water.fetch_max(done, Relaxed);
@@ -136,7 +124,9 @@ impl Progress {
     /// Print a line to stdout, keeping the progress area intact.
     pub fn println(&self, line: &str) {
         let mut term = Some(self.term.lock().unwrap());
-        self.erase(term.as_mut().unwrap());
+        if std::io::stdout().is_terminal() {
+            self.erase(term.as_mut().unwrap());
+        }
         // A redirected stdout cannot disturb the terminal display. Let the
         // ticker keep running while a slow pipe blocks this printing worker.
         if !std::io::stdout().is_terminal() {
@@ -195,25 +185,28 @@ impl Progress {
     }
 
     fn erase(&self, t: &mut TermState) {
-        if t.lines_drawn > 0 {
-            let _ = write!(std::io::stderr().lock(), "\r\x1b[{}A\x1b[J", t.lines_drawn);
-            t.lines_drawn = 0;
+        if t.line.take().is_some() {
+            let _ = write!(std::io::stderr().lock(), "\r\x1b[2K");
         }
     }
 
-    fn rate(&self, t: &mut TermState) -> f64 {
-        let now = Instant::now();
-        let done = self.bytes_done.load(Relaxed);
+    fn rate(&self, t: &mut TermState, now: Instant, done: u64) -> f64 {
         if t.samples
             .back()
             .is_some_and(|&(_, previous)| done < previous)
         {
             // Recovery can retract bytes whose acknowledgement is uncertain.
-            // A window spanning that rollback is not a meaningful rate.
             t.samples.clear();
         }
-        t.samples.push_back((now, done));
-        while t.samples.len() > 2 && now - t.samples[0].0 > Duration::from_secs(5) {
+        // Sample byte changes, not redraws. Keep the sample before the window:
+        // a block taking 30 seconds must not look like it arrived in 5 seconds.
+        if t.samples
+            .back()
+            .is_none_or(|&(_, previous)| done != previous)
+        {
+            t.samples.push_back((now, done));
+        }
+        while t.samples.len() > 2 && now - t.samples[1].0 > Duration::from_secs(5) {
             t.samples.pop_front();
         }
         let (t0, b0) = t.samples[0];
@@ -225,9 +218,14 @@ impl Progress {
     }
 
     pub fn render(&self) {
+        self.render_status(None);
+    }
+
+    fn render_status(&self, status: Option<&str>) {
         let mut t = self.term.lock().unwrap();
-        let rate = self.rate(&mut t);
+        let now = Instant::now();
         let done = self.bytes_done.load(Relaxed);
+        let rate = self.rate(&mut t, now, done);
         let total = self.bytes_total.load(Relaxed);
         let fdone = self.files_done.load(Relaxed);
         let ftotal = self.files_total.load(Relaxed);
@@ -240,7 +238,7 @@ impl Progress {
             None
         };
 
-        if let Some(results) = self.results.get() {
+        if let Some(results) = self.results.get().filter(|_| status.is_none()) {
             let now = Instant::now();
             if t.last_results
                 .is_none_or(|last| now - last >= Duration::from_secs(1))
@@ -260,7 +258,7 @@ impl Progress {
                 });
             }
         }
-        if self.json {
+        if self.json && status.is_none() {
             let now = Instant::now();
             if t.last_json
                 .is_none_or(|l| now - l >= Duration::from_secs(1))
@@ -280,63 +278,75 @@ impl Progress {
         if !self.enabled {
             return;
         }
-        self.erase(&mut t);
-        let width = self.width.unwrap_or_else(term_width);
-        let mut lines = Vec::new();
-        let pct = if total > 0 { done * 100 / total } else { 0 };
-        let mut head = if self.rm {
-            format!("removed {} / {} entries", commas(fdone), commas(ftotal))
+        let age = now - t.samples.back().unwrap().0;
+        let elapsed = now - self.start;
+        let state = if let Some(status) = status {
+            status.to_string()
+        } else if !scan_done {
+            format!("scanning {}", commas(self.scanned.load(Relaxed)))
+        } else if self.errors.load(Relaxed) > 0 {
+            format!("{} errors", self.errors.load(Relaxed))
+        } else if !self.rm && done >= total && fdone < ftotal {
+            "finishing".to_string()
+        } else if age >= Duration::from_secs(5) && !self.rm {
+            format!("no update {}", hms(age.as_secs_f64()))
+        } else if self.rm {
+            "removing".to_string()
         } else {
-            format!(
-                "{} / {}  {pct:>3}%  {}/s  files {fdone}/{ftotal}",
-                human(done),
-                human(total),
-                human(rate as u64)
-            )
+            format!("{}/s", human(rate as u64))
         };
-        if let Some(e) = eta {
-            head.push_str(&format!("  ETA {}", hms(e)));
+        let (count, total, units) = if self.rm {
+            (
+                fdone,
+                ftotal,
+                format!("{}/{} entries", commas(fdone), commas(ftotal)),
+            )
+        } else {
+            (done, total, format!("{}/{}", human(done), human(total)))
+        };
+        let mut details = vec![state, format!("elapsed {}", hms(elapsed.as_secs_f64()))];
+        if status.is_none() && age < Duration::from_secs(5) && !self.rm {
+            if let Some(eta) = eta {
+                details.push(format!("ETA {}", hms(eta)));
+            }
+        }
+        if !self.rm {
+            details.push(format!("files {fdone}/{ftotal}"));
+        }
+        if skipped > 0 {
+            details.push(format!("unchanged {}", human(skipped)));
         }
         let active = self.active_workers.load(Relaxed);
         if active > 0 {
-            head.push_str(&format!("  {active} conn"));
+            details.push(format!("{active} conn"));
         }
-        if skipped > 0 {
-            head.push_str(&format!("  (unchanged {})", human(skipped)));
+        let line = bar_line(
+            self.width.unwrap_or_else(term_width).saturating_sub(1),
+            count,
+            total,
+            scan_done || status.is_some(),
+            status == Some("done")
+                || (status.is_none()
+                    && scan_done
+                    && ftotal > 0
+                    && fdone == ftotal
+                    && self.errors.load(Relaxed) == 0),
+            &units,
+            &details,
+        );
+        // Never blank the display between frames or move through worker rows.
+        // One buffered write replaces this line and clears only its old tail.
+        let _ = t.draw(&mut std::io::stderr().lock(), line);
+    }
+
+    /// Leave the final bar visible. Call after joining the ticker, with the
+    /// actual operation outcome; a full byte counter alone is not success.
+    pub fn finish(&self, success: bool) {
+        self.render_status(Some(if success { "done" } else { "incomplete" }));
+        let mut t = self.term.lock().unwrap();
+        if t.line.take().is_some() {
+            let _ = writeln!(std::io::stderr().lock());
         }
-        if !scan_done {
-            head.push_str(&format!(
-                "  scanning: {} entries",
-                self.scanned.load(Relaxed)
-            ));
-        }
-        lines.push(head);
-        // One line per file in flight; several workers may share a file.
-        let mut seen: Vec<(String, u64, u64, usize)> = Vec::new();
-        for w in self.workers.lock().unwrap().iter().flatten() {
-            match seen.iter_mut().find(|s| s.0 == w.path) {
-                Some(s) => s.3 += 1,
-                None => seen.push((w.path.clone(), w.done.load(Relaxed), w.total, 1)),
-            }
-        }
-        for (path, done, total, n) in seen {
-            let done = done.min(total);
-            let pct = if total > 0 { done * 100 / total } else { 100 };
-            let prefix = format!("  {pct:>3}% ");
-            let suffix = if n > 1 {
-                format!("  ×{n}")
-            } else {
-                String::new()
-            };
-            let room = width.saturating_sub(prefix.len() + suffix.len() + 1);
-            lines.push(format!("{prefix}{}{suffix}", truncate(&path, room)));
-        }
-        let mut err = std::io::stderr().lock();
-        for l in &lines {
-            let _ = writeln!(err, "{}", truncate(l, width.saturating_sub(1)));
-        }
-        let _ = err.flush();
-        t.lines_drawn = lines.len();
     }
 
     pub fn clear(&self) {
@@ -375,24 +385,52 @@ pub fn term_width() -> usize {
     }
 }
 
-fn truncate(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        return s.to_string();
+/// All fields are ASCII and the line reserves the terminal's final column,
+/// avoiding autowrap. Drop optional fields whole; never truncate away progress.
+fn bar_line(
+    width: usize,
+    done: u64,
+    total: u64,
+    known: bool,
+    success: bool,
+    units: &str,
+    details: &[String],
+) -> String {
+    let pct = if total > 0 {
+        (u128::from(done.min(total)) * 100 / u128::from(total)) as usize
+    } else if success {
+        100
+    } else {
+        0
+    };
+    let percent = if known {
+        format!("{pct:>3}%")
+    } else {
+        " ---".to_string()
+    };
+    let cells = (width / 5).clamp(3, 24);
+    let filled = if known { pct * cells / 100 } else { 0 };
+    let mut line = format!(
+        "[{}{}] {percent}",
+        "=".repeat(filled),
+        " ".repeat(cells - filled)
+    );
+    if line.len() > width {
+        return percent.trim().chars().take(width).collect();
     }
-    if max < 4 {
-        return s.chars().take(max).collect();
+    for field in details
+        .iter()
+        .take(1)
+        .map(String::as_str)
+        .chain(std::iter::once(units))
+        .chain(details.iter().skip(1).map(String::as_str))
+    {
+        if line.len() + 2 + field.len() <= width {
+            line.push_str("  ");
+            line.push_str(field);
+        }
     }
-    let keep = max - 1;
-    // keep the tail (file names matter more than leading dirs)
-    let tail: String = s
-        .chars()
-        .rev()
-        .take(keep)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .collect();
-    format!("…{tail}")
+    line
 }
 
 pub fn human(n: u64) -> String {
@@ -454,14 +492,14 @@ mod tests {
 
     #[test]
     fn rollback_resets_display_rate_and_retries_do_not_inflate_tuning_progress() {
-        let progress = Progress::new(1, false, false, None, false);
+        let progress = Progress::new(false, false, None, false);
         progress.add_bytes(1_000);
         let mut term = progress.term.lock().unwrap();
         term.samples
             .push_back((Instant::now() - Duration::from_secs(1), 1_000));
 
         progress.bytes_done.fetch_sub(600, Relaxed);
-        assert_eq!(progress.rate(&mut term), 0.0);
+        assert_eq!(progress.rate(&mut term, Instant::now(), 400), 0.0);
         assert_eq!(term.samples.len(), 1);
         assert_eq!(Meter::bytes(&*progress), 1_000);
 
@@ -469,5 +507,98 @@ mod tests {
         assert_eq!(Meter::bytes(&*progress), 1_000);
         progress.add_bytes(100);
         assert_eq!(Meter::bytes(&*progress), 1_100);
+    }
+
+    #[test]
+    fn slow_blocks_keep_their_full_measurement_interval() {
+        let progress = Progress::new(false, false, None, false);
+        let mut term = progress.term.lock().unwrap();
+        let start = Instant::now();
+        term.samples = VecDeque::from([(start, 0)]);
+        for second in 1..30 {
+            assert_eq!(
+                progress.rate(&mut term, start + Duration::from_secs(second), 0),
+                0.0
+            );
+        }
+        let block = 4 * 1024 * 1024;
+        let rate = progress.rate(&mut term, start + Duration::from_secs(30), block);
+        assert_eq!(rate, block as f64 / 30.0);
+        // No invented bytes, and no jump to zero after the old five-second window.
+        assert_eq!(
+            progress.rate(&mut term, start + Duration::from_secs(40), block),
+            block as f64 / 40.0
+        );
+        assert_eq!(
+            progress.rate(&mut term, start + Duration::from_secs(60), block * 2),
+            block as f64 / 30.0
+        );
+    }
+
+    #[test]
+    fn bar_stays_visible_across_sparse_updates_without_scrolling_or_clearing() {
+        let progress = Progress::new(false, false, None, false);
+        let mut term = progress.term.lock().unwrap();
+        let mut output = Vec::new();
+        let first = bar_line(
+            79,
+            25,
+            100,
+            true,
+            false,
+            "25 B/100 B",
+            &["elapsed 0:01".into()],
+        );
+        term.draw(&mut output, first.clone()).unwrap();
+        let before = output.clone();
+        term.draw(&mut output, first.clone()).unwrap();
+        assert_eq!(output, before, "identical frames need no terminal writes");
+        let waiting = bar_line(
+            79,
+            25,
+            100,
+            true,
+            false,
+            "25 B/100 B",
+            &["no update 0:30".into()],
+        );
+        assert_eq!(first.split(']').next(), waiting.split(']').next());
+        term.draw(&mut output, waiting.clone()).unwrap();
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            format!("\r{first}\x1b[K\r{waiting}\x1b[K")
+        );
+    }
+
+    #[test]
+    fn bar_fits_narrow_terminals_and_keeps_counts_and_outcomes() {
+        for width in 0..200 {
+            let line = bar_line(
+                width,
+                u64::MAX,
+                u64::MAX,
+                true,
+                false,
+                "16.0 EiB/16.0 EiB",
+                &["incomplete".into(), "elapsed 0:30".into()],
+            );
+            assert!(line.len() <= width, "width {width}: {line}");
+            assert!(!line.contains('\n'));
+            if width >= 30 {
+                assert!(line.contains("incomplete"), "{line}");
+            }
+        }
+        let scanning = bar_line(
+            79,
+            10,
+            10,
+            false,
+            false,
+            "10 B/10 B",
+            &["scanning 10".into()],
+        );
+        assert!(scanning.contains("---") && !scanning.contains("100%"));
+        let empty = bar_line(79, 0, 0, true, true, "0 B/0 B", &["done".into()]);
+        assert!(empty.contains("100%") && empty.contains("done"));
     }
 }

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -38,7 +38,6 @@ pub fn run(mut args: Args) -> Result<i32> {
         .is_some_and(|location| location.is_remote());
     let show_progress = !args.no_progress && !args.quiet && !args.dry_run;
     let progress = Progress::new(
-        args.connections,
         show_progress,
         args.progress,
         args.width,
@@ -68,6 +67,7 @@ pub fn run(mut args: Args) -> Result<i32> {
         Ok(()) => {
             let exit_code = if summary.entries_failed > 0 { 23 } else { 0 };
             let status = if exit_code == 0 { "success" } else { "partial" };
+            progress.finish(exit_code == 0);
             emit_terminal(
                 results.as_deref(),
                 &progress,
@@ -83,6 +83,7 @@ pub fn run(mut args: Args) -> Result<i32> {
             Ok(exit_code)
         }
         Err(error) => {
+            progress.finish(false);
             summary.errors += 1;
             if let Some(writer) = results.as_deref().filter(|writer| !writer.is_dead()) {
                 let (class, os_kind) = fatal_classification(&error, remote);

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1400,10 +1400,10 @@ pub fn run(args: Args) -> Result<i32> {
     let prune = args.delete;
     let outcome = run_transfer(args, Arc::clone(&progress));
     if outcome.is_err() {
-        // An error can unwind past run_transfer's own ticker shutdown; stop
-        // it here so no progress render races the terminal record below
-        // (the writer additionally seals itself after emit_result).
+        // run_transfer's ticker guard has stopped and joined on every return,
+        // including failures in deferred metadata and deletion finalization.
         progress.stop();
+        progress.finish(false);
         // The error text reaches stderr via main; the stream still gets its
         // terminal record so a consumer never mistakes a handled fatal for a
         // crash (only a real crash leaves the terminal record missing).

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -10,7 +10,7 @@ use crate::conn::{
     SshMultiplexer, TcpCandidate, TcpPairStats,
 };
 use crate::fsops::{content_digest, is_partial_name, join};
-use crate::progress::{commas, human, Progress, WorkerStatus};
+use crate::progress::{commas, human, Progress};
 use crate::proto::DestinationRoot as RegisteredDestinationRoot;
 use crate::proto::*;
 use crate::sched::{FileJob, Item, RangeHandle, Sched};
@@ -1230,6 +1230,7 @@ fn attempt_small_copy(
         deletions_completed: None,
         deletions_blocked: None,
     };
+    progress.finish(exit_code == 0);
     if !args.quiet && !args.suppress_summary {
         print_transfer_summary(&terminal, progress.start.elapsed().as_secs_f64(), "");
     }
@@ -1377,7 +1378,6 @@ pub fn run(args: Args) -> Result<i32> {
     // record — fatal setup failures included (spec: automation results).
     let show_progress = !args.no_progress && !args.quiet && !args.dry_run;
     let progress = Progress::new(
-        args.connections,
         show_progress,
         args.progress,
         args.width,
@@ -1929,7 +1929,6 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         }
                         Err(error) if dropped => {
                             failures += 1;
-                            progress.set_worker(id, None);
                             if failures >= CONNECTION_RECOVERY_ATTEMPTS {
                                 gate.mark_failed(id);
                                 return Err(error);
@@ -3126,6 +3125,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     } else {
         ("success", 0)
     };
+    progress.finish(exit_code == 0);
     let (deletions_planned, deletions_completed, deletions_blocked) = if opts.delete {
         let planned = match delete_plan {
             DeletePlan::Planned(n) => n,
@@ -7190,7 +7190,6 @@ impl Worker {
                     }
                 }
             }
-            self.progress.set_worker(self.id, None);
         }
     }
 
@@ -7214,16 +7213,6 @@ impl Worker {
             let all = self.sched.jobs.lock().unwrap();
             batch.iter().map(|&i| all[i].clone()).collect()
         };
-        if let Some(j) = jobs.last() {
-            self.progress.set_worker(
-                self.id,
-                Some(WorkerStatus {
-                    path: format!("{} (+{} small files)", j.rel, jobs.len() - 1),
-                    done: j.done.clone(),
-                    total: j.entry.size,
-                }),
-            );
-        }
         // Reads.
         let phase = std::time::Instant::now();
         for j in &jobs {
@@ -7507,14 +7496,6 @@ impl Worker {
         let size = job.entry.size;
         let opts = self.opts.clone();
         let _ = &opts;
-        self.progress.set_worker(
-            self.id,
-            Some(WorkerStatus {
-                path: job.rel.clone(),
-                done: job.done.clone(),
-                total: size,
-            }),
-        );
 
         // Placement guards must be enforced by the final mutation. Stage even
         // an explicit --inplace transfer until that checked update; an
@@ -7730,14 +7711,6 @@ impl Worker {
         })?;
         match resp {
             Response::Ok => {
-                self.progress.set_worker(
-                    self.id,
-                    Some(WorkerStatus {
-                        path: job.rel.clone(),
-                        done: job.done.clone(),
-                        total: job.entry.size,
-                    }),
-                );
                 self.progress.add_bytes(job.entry.size);
                 job.done.store(job.entry.size, Relaxed);
                 if let Err(e) = self.finish_file(idx) {
@@ -7905,14 +7878,7 @@ impl Worker {
         if self.sched.is_failed(idx) {
             return Ok(());
         }
-        self.progress.set_worker(
-            self.id,
-            Some(WorkerStatus {
-                path: job.rel.clone(),
-                done: job.done.clone(),
-                total: job.entry.size,
-            }),
-        );
+
         let block = self.transfer_block();
         let read_window = if self.src.supports_request_pipelining() {
             WINDOW
@@ -8183,14 +8149,7 @@ impl Worker {
 
     fn verify_file(&mut self, idx: usize) -> Result<()> {
         let job = self.job(idx);
-        self.progress.set_worker(
-            self.id,
-            Some(WorkerStatus {
-                path: job.rel.clone(),
-                done: job.done.clone(),
-                total: job.entry.size,
-            }),
-        );
+
         let r = (|| -> Result<bool> {
             self.src.send(Request::FileHash {
                 path: job.src.clone(),

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -5773,6 +5773,124 @@ fn large_file_parallel_chunks() {
 }
 
 #[test]
+fn progress_bar_slow_copy_stays_on_one_line_and_leaves_final_counts() {
+    let t = Tmp::new();
+    let data = prng(2 * 1024 * 1024, 451);
+    write(&t.path("src"), &data);
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            &t.s("src"),
+            "--as",
+            &t.s("dst"),
+            "--progress",
+            "--connections",
+            "4",
+            "--bwlimit",
+            "1M",
+        ])
+        .run()
+        .unwrap();
+    assert!(out.status.success(), "{out:?}");
+    assert_eq!(read(&t.path("dst")), data);
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("100%  done  2.00 MiB/2.00 MiB"),
+        "{stderr:?}"
+    );
+    assert_eq!(
+        stderr.matches('\n').count(),
+        1,
+        "only final frame ends a line: {stderr:?}"
+    );
+    assert!(
+        !stderr
+            .replace("\x1b[K", "")
+            .replace("\x1b[2K", "")
+            .contains("\x1b"),
+        "no screen clearing or cursor-up: {stderr:?}"
+    );
+    assert!(
+        stderr
+            .split('\r')
+            .filter(|frame| frame.starts_with('['))
+            .count()
+            > 2,
+        "{stderr:?}"
+    );
+}
+
+#[test]
+fn progress_bar_reports_incomplete_verification_and_entry_removal() {
+    let t = Tmp::new();
+    write(&t.path("src"), b"source");
+    write(&t.path("dst"), b"different");
+    let out = compat_command()
+        .args(["--syq-verify-only", "--progress", &t.s("src"), &t.s("dst")])
+        .run()
+        .unwrap();
+    assert!(!out.status.success(), "{out:?}");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(stderr.contains("incomplete"), "{stderr:?}");
+    assert!(!stderr.contains("%  done"), "{stderr:?}");
+    assert_eq!(read(&t.path("dst")), b"different");
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["rm", "--progress", &t.s("dst")])
+        .run()
+        .unwrap();
+    assert!(out.status.success(), "{out:?}");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(stderr.contains("100%  done  1/1 entries"), "{stderr:?}");
+    assert!(!t.path("dst").exists());
+}
+
+#[test]
+fn progress_bar_does_not_mix_with_json_progress() {
+    let t = Tmp::new();
+    write(&t.path("src"), &prng(1024 * 1024, 452));
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            &t.s("src"),
+            "--as",
+            &t.s("dst"),
+            "--progress",
+            "--progress-json",
+            "--bwlimit",
+            "1M",
+        ])
+        .run()
+        .unwrap();
+    assert!(out.status.success(), "{out:?}");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(!stderr.is_empty());
+    for line in stderr.lines() {
+        let value: serde_json::Value =
+            serde_json::from_str(line).expect("JSON without a terminal bar");
+        assert!(value["bytes_done"].is_u64(), "{line}");
+    }
+}
+
+#[test]
+fn progress_bar_is_opt_in_for_pipes_and_disabled_by_no_progress() {
+    let t = Tmp::new();
+    write(&t.path("src"), b"payload");
+    for (dst, flags) in [
+        ("default", vec![]),
+        ("disabled", vec!["--progress", "--no-progress"]),
+        ("quiet", vec!["--progress", "--quiet"]),
+    ] {
+        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(["cp", &t.s("src"), "--as", &t.s(dst)])
+            .args(flags)
+            .run()
+            .unwrap();
+        assert!(out.status.success(), "{out:?}");
+        assert!(out.stderr.is_empty(), "{dst}: {out:?}");
+    }
+}
+
+#[test]
 fn bwlimit_is_aggregate_across_workers() {
     let t = Tmp::new();
     for i in 0..4 {

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -186,3 +186,101 @@ fn full_stdout_keeps_results_progress_running() {
     );
     assert_eq!(terminal(&root.join("result.json"))["exit_code"], 0);
 }
+
+#[test]
+fn broken_stdout_warning_does_not_append_to_live_progress() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().canonicalize().unwrap();
+    let data = vec![42; 2 * 1024 * 1024];
+    fs::write(root.join("src"), &data).unwrap();
+    let output = command(&root)
+        .args([
+            "cp",
+            "src",
+            "--as",
+            "dst",
+            "--progress",
+            "-v",
+            "--bwlimit",
+            "1M",
+            "--connections",
+            "1",
+        ])
+        .stdout(broken_output())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(fs::read(root.join("dst")).unwrap(), data);
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let warning = "syq: warning: could not write human output to stdout";
+    let before = stderr.split_once(warning).expect("broken-pipe warning").0;
+    assert!(
+        before.contains("%"),
+        "warning must interrupt a live bar: {stderr:?}"
+    );
+    assert!(
+        before.ends_with("\r\x1b[2K"),
+        "warning needs a cleared row: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("100%  done  2.00 MiB/2.00 MiB"),
+        "{stderr:?}"
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn fatal_deferred_metadata_error_leaves_final_incomplete_counts() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path().canonicalize().unwrap();
+    fs::create_dir(root.join("src")).unwrap();
+    fs::create_dir(root.join("dst")).unwrap();
+    let data = vec![42; 2 * 1024 * 1024];
+    fs::write(root.join("src/file"), &data).unwrap();
+    let output = command(&root)
+        .args([
+            "cp",
+            "src",
+            "--as",
+            "dst",
+            "--preserve",
+            "permissions",
+            "--progress",
+            "--bwlimit",
+            "1M",
+            "--connections",
+            "1",
+            "--results",
+            "result.json",
+        ])
+        .env("SYQ_TEST_FAIL_APPLY_ENOSPC", "/dst")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "{output:?}");
+    assert_eq!(
+        fs::read(root.join("dst/file")).unwrap(),
+        data,
+        "failure must happen after copying"
+    );
+    let record = terminal(&root.join("result.json"));
+    assert_eq!(record["status"], "failed");
+    assert_eq!(record["bytes_transferred"], data.len());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("apply destination changes"),
+        "must fail in deferred metadata: {stderr:?}"
+    );
+    let (before, after) = stderr
+        .split_once("100%  incomplete  2.00 MiB/2.00 MiB")
+        .expect("final incomplete byte counts");
+    assert!(
+        before.contains("%"),
+        "must have live progress before failure: {stderr:?}"
+    );
+    assert!(
+        !after.contains("\r"),
+        "ticker must not erase or redraw final counts: {stderr:?}"
+    );
+    assert!(!stderr.contains("%  done"), "{stderr:?}");
+}


### PR DESCRIPTION
Slow transfers can leave the byte counter unchanged for many seconds while the old display repeatedly erases and redraws a changing set of worker rows. Replace it with one stationary aggregate bar that preserves the last measured progress, shows the time since the last byte update, and leaves a final `done` or `incomplete` line. Copy and removal use the same bounded-width display; JSON progress selects JSON alone.

Measure speed across actual byte changes, including the interval before a slow block arrives. A block taking 30 seconds no longer looks like a five-second burst. Keep completion and tuning counters authoritative, and do not interpolate completed bytes. Document the display, scanning state, and the distinction between byte progress and operation success.

Ticker ownership guarantees it is stopped and joined on every return, including fatal errors in deferred metadata or deletion finalization, before final incomplete counts are rendered. Diagnostics share the live row's output lock, clear it before printing a warning, and restore it afterward. Redirected stdout can still block without holding up stderr progress. Regression tests exercise a late ENOSPC failure, broken stdout with verbose progress, diagnostic row restoration, and ticker cleanup on error.

Validation at `c716c75` (rebased on master `5f0b341`):

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets` (including bin tests, sparse-update/rollback/width tests, real copies, failure/removal/JSON tests, and existing automation schema and output-failure coverage)
- `scripts/test-real-ssh.sh` (default three-container suite)
- `python3 scripts/check-doc-links.py`
- Manual 80-column pseudo-terminal probe before rebase: a six-second injected local-copy pause kept one row, displayed no-update age, left final counts, and produced matching SHA-256 contents.

Compatibility: inspected released v0.3.2 as the output baseline. This deliberately changes the human terminal layout and gives JSON mode precedence over the bar. JSON field names/formats and results records are preserved; the progress JSON rate uses the corrected sampling interval. No helper messages, stored state, resume identities, or SDK interfaces change. Existing live automation/schema tests pass.

Bandwidth sizing assessment: this PR does not change `--bwlimit`. Its current request-size bound prevents large bursts because pacing occurs before whole source requests. Removing that bound alone weakens burst control, particularly with remote read-ahead. The recommended follow-up separates incremental byte pacing on the actual sender from request size/pipeline tuning based on measured throughput and latency; hash/resume blocks stay independent. The local assessment is recorded in `current-plans/progress-bandwidth-sizing.md`.

Local checks pass; latest post-merge ci, rsync-compat and macOS runs succeeded at master `5f0b341`. Pull requests do not trigger test workflows in this repository. Ready for review; not merged.
