### PR TITLE
Make syq cat print in bursts and add pronunciation to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # syq
 
-Syq copies and removes files in parallel, on one machine or over SSH.
+Syq (pronounced "sick") copies and removes files in parallel, on one machine
+or over SSH.
 It is built for large files, large trees, and fast networks.
 
 - **Parallel copies and removal**, with automatic connection tuning.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Copy files with syq
 
-Syq copies and removes files in parallel, on one machine or over SSH. It can
-resume interrupted copies and transfer directly between servers without
-forwarding your SSH agent.
+Syq (pronounced "sick") copies and removes files in parallel, on one machine
+or over SSH. It can resume interrupted copies and transfer directly between
+servers without forwarding your SSH agent.
 
 [Discussions](https://github.com/greaber/syq/discussions)
 

--- a/src/janky_cat.rs
+++ b/src/janky_cat.rs
@@ -6,8 +6,9 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::time::Duration;
 
-const CHUNK_SIZES: [usize; 8] = [1, 3, 1, 2, 5, 1, 8, 2];
-const PAUSE_MILLIS: [u64; 8] = [80, 25, 140, 45, 10, 110, 30, 175];
+// Emit a few lines at once, then visibly stall before the next burst.
+const CHUNK_SIZES: [usize; 8] = [128, 384, 192, 512, 256, 128, 768, 256];
+const PAUSE_MILLIS: [u64; 8] = [600, 250, 900, 350, 200, 800, 300, 1100];
 
 enum CopyError {
     Read(io::Error),
@@ -40,7 +41,7 @@ fn copy_slowly(
     output: &mut dyn Write,
     pace: &mut Pace,
 ) -> std::result::Result<(), CopyError> {
-    let mut buffer = [0_u8; 8];
+    let mut buffer = [0_u8; 1024];
     loop {
         let count = input
             .read(&mut buffer[..pace.chunk_size()])

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -1179,7 +1179,9 @@ fn partial_files(dir: &Path) -> Vec<PathBuf> {
 #[test]
 fn janky_cat_concatenates_files_and_stdin() {
     let t = Tmp::new();
-    write(&t.path("first"), b"first\0");
+    // Cross several bursts, including a short final one, without changing bytes.
+    let first: Vec<u8> = (0..=255).cycle().take(1300).collect();
+    write(&t.path("first"), &first);
     write(&t.path("last"), b"\nlast");
 
     let mut child = Command::new(env!("CARGO_BIN_EXE_syq"))
@@ -1192,7 +1194,7 @@ fn janky_cat_concatenates_files_and_stdin() {
     let output = child.wait_with_output().unwrap();
 
     assert_output_ok(&output);
-    assert_eq!(output.stdout, b"first\0middle\nlast");
+    assert_eq!(output.stdout, [first.as_slice(), b"middle\nlast"].concat());
 }
 
 #[test]


### PR DESCRIPTION
`syq cat` currently emits 1–8 bytes at a time, making it look like slow typing. It now prints 128–768-byte bursts separated by uneven 0.2–1.1-second pauses. The first burst appears immediately. Add “pronounced "sick"” to the opening sentence of the README and documentation home page.

The hidden command keeps its existing arguments, raw output bytes, error handling, and absence from help. Compared against the released `v0.3.2` implementation: only burst sizes, pauses, and buffer capacity change. No persistent state, helper protocol, SDK interface, or documentation URL changes.

Validation at `6f483a4`:

- Passed `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and all 429 tests in `cargo test --bin syq`.
- Passed all three `cargo test --test local janky_cat_` tests; the concatenation fixture now crosses several bursts with binary input and a short final chunk.
- Measured pipe and terminal output: 128 bytes immediately, 384 bytes at 0.6 s, 192 bytes at 0.85 s; a full pacing cycle preserved all 2,817 input bytes. `/dev/full` produced exit 1 and the expected diagnostic.
- Passed the documentation link checker (15 files), pinned mdBook 0.5.4 build, and whitespace checks.
- Full all-target tests, real-SSH, and native macOS tests were not run locally; this change is confined to the hidden local cat command and introductory prose.

<details>
<summary>Branch status at review handoff</summary>

```text
Worktree: /home/grant/repos/syq/.worktrees/cat-chunks-pronunciation
Branch:   cat-chunks-pronunciation at 6f483a4 (clean)
Upstream: origin/cat-chunks-pronunciation (ahead 0, behind 0)
Master:   4c02593 from refs/heads/master (branch is ahead 8, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      5f0b341  https://github.com/greaber/syq/actions/runs/33989933695
  rsync-compat.yml success      5f0b341  https://github.com/greaber/syq/actions/runs/33989933701
  macos.yml        success      5f0b341  https://github.com/greaber/syq/actions/runs/33989933707

Pull request: #234 https://github.com/greaber/syq/pull/234
  base master, open, review none, merge state clean
  GitHub head 6f483a4: matches local 6f483a4
  checks: none registered yet
```

The coordination checkout remains at `4c02593`; this task started from remote master `5f0b341`.
</details>
