### PR TITLE
Add experimental transfer controls for benchmarking

### DIFF
--- a/docs/speed.md
+++ b/docs/speed.md
@@ -59,6 +59,49 @@ including mounted NFS paths, do not use the tuning cache.
 `--bwlimit` to cap bandwidth rather than trying to control it indirectly
 through worker count. Short copies may finish before tuning has enough data.
 
+## Benchmark tuning
+
+`syq cp` and `syq rsync` accept `--tuning-options` for controlled performance
+experiments. It appears in `--help-all`, outside the common options. Set one
+or both keys in a comma-separated value:
+
+```sh
+syq cp large-file --to server --as /scratch/benchmark-copy \
+  --connections 1 --tuning-options request-size=1M,pipeline-depth=8 --stats
+```
+
+| Key | Default | Accepted values |
+|---|---|---|
+| `request-size` | Hash block size, normally 4 MiB | 512 bytes through 64 MiB; `K`, `M`, and `G` use powers of 1024 |
+| `pipeline-depth` | 4 | 1 through 64 outstanding range requests per endpoint per worker |
+
+Request size controls the maximum payload of an individual range read or write.
+It does not change the blocks used to compare file contents, identify partial
+files, or resume a copy. `--bwlimit` can lower the effective request size to keep
+bursts small. With overrides, `--stats` or `-v` reports the effective request size,
+pipeline depth, and hash block size. A final request or a range selected for
+repair can be smaller than the effective request size.
+
+Larger requests reduce overhead per byte. Deeper pipelines allow more work to
+remain outstanding while replies travel back. Either can help a fast connection
+with high latency, but both increase potential buffering; neither guarantees
+higher throughput. In-process endpoints handle one request at a time. The
+background response queue on each worker connection follows its pipeline depth.
+
+These settings apply to range transfers. Small-file batches and same-machine
+whole-file copying can bypass them. Use a large remote file and a fresh,
+disposable destination for each comparison, and fix `--connections` (or
+`--syq-connections` with `syq rsync`) to isolate the two settings. Leave
+`--bwlimit` unset when measuring unrestricted throughput. Include capped runs
+when evaluating burst behavior.
+
+Overrides apply to this command, including any remote coordinator. They are
+not saved. Copies using overrides neither read nor update the remembered
+connection count; connection auto-tuning still runs unless you fix that count.
+These are experimental controls whose keys and bounds may change between
+releases. The default request size and pipeline depth are not automatically
+tuned.
+
 ## TCP data connections
 
 SSH authenticates and controls remote copies. When reachable, encrypted TCP

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -62,45 +62,116 @@ through worker count. Short copies may finish before tuning has enough data.
 ## Benchmark tuning
 
 `syq cp` and `syq rsync` accept `--tuning-options` for controlled performance
-experiments. It appears in `--help-all`, outside the common options. Set one
-or both keys in a comma-separated value:
+experiments. It appears in `--help-all`, outside the common options. Supply
+comma-separated `KEY=VALUE` pairs:
 
 ```sh
 syq cp large-file --to server --as /scratch/benchmark-copy \
-  --connections 1 --tuning-options request-size=1M,pipeline-depth=8 --stats
+  --connections 1 -v \
+  --tuning-options copy-path=ranges,request-size=1M,pipeline-depth=8
 ```
 
 | Key | Default | Accepted values |
 |---|---|---|
-| `request-size` | Hash block size, normally 4 MiB | 512 bytes through 64 MiB; `K`, `M`, and `G` use powers of 1024 |
+| `request-size` | Hash block size, normally 4 MiB | 512 bytes through 64 MiB |
 | `pipeline-depth` | 4 | 1 through 64 outstanding range requests per endpoint per worker |
+| `copy-path` | `auto` | `auto` or `ranges` |
+| `batch-files` | 128 or 512, depending on transport and latency | 1 through 4096 files per worker batch |
+| `batch-bytes` | 16 MiB | 512 bytes through 64 MiB per worker batch, including the first file |
+| `split-min-size` | 32 MiB, at least two hash blocks | 1 byte through 1 GiB, raised to at least two hash blocks |
+| `bw-pacing` | `125ms` when capped | `average`, or an integer interval from `1ms` through `10s`; requires a nonzero `--bwlimit` |
 
-Request size controls the maximum payload of an individual range read or write.
-It does not change the blocks used to compare file contents, identify partial
-files, or resume a copy. `--bwlimit` can lower the effective request size to keep
-bursts small. With overrides, `--stats` or `-v` reports the effective request size,
-pipeline depth, and hash block size. A final request or a range selected for
-repair can be smaller than the effective request size.
+Sizes accept `K`, `M`, and `G`, using powers of 1024. Unknown keys, repeated
+keys, and out-of-range values fail the command. Overrides apply to the remote
+coordinator too. They are not saved, and these runs neither read nor update
+the remembered connection count. Connection auto-tuning still runs unless you
+fix `--connections` (`--syq-connections` with `syq rsync`). These are experimental
+controls whose keys and bounds may change between releases.
 
-Larger requests reduce overhead per byte. Deeper pipelines allow more work to
-remain outstanding while replies travel back. Either can help a fast connection
-with high latency, but both increase potential buffering; neither guarantees
-higher throughput. In-process endpoints handle one request at a time. The
-background response queue on each worker connection follows its pipeline depth.
+Request size limits the payload of one range read or write. A final request or
+a range selected for repair can be smaller. Larger requests reduce overhead
+per byte; deeper pipelines allow more work to remain outstanding while replies
+travel back. Both increase potential buffering. In-process endpoints handle
+one request at a time; the response queue on worker connections follows the
+pipeline depth. These settings do not change hash blocks or partial identities.
 
-These settings apply to range transfers. Small-file batches and same-machine
-whole-file copying can bypass them. Use a large remote file and a fresh,
-disposable destination for each comparison, and fix `--connections` (or
-`--syq-connections` with `syq rsync`) to isolate the two settings. Leave
-`--bwlimit` unset when measuring unrestricted throughput. Include capped runs
-when evaluating burst behavior.
+`copy-path=ranges` makes file contents use range requests, bypassing both
+small-file batches and whole-file copying, including local kernel offload.
+Matching data can still be skipped or reused. With `auto`, syq chooses the copy
+method as usual. Explicit batch controls select worker batching instead of the
+native small-copy shortcut. Files larger than the batch byte limit use another
+copy path. File and byte limits are ceilings, and the scheduler can choose a
+smaller batch to share work among workers. With `--bwlimit`, worker batches
+contain at most one file. Batch controls cannot be combined with
+`copy-path=ranges`.
 
-Overrides apply to this command, including any remote coordinator. They are
-not saved. Copies using overrides neither read nor update the remembered
-connection count; connection auto-tuning still runs unless you fix that count.
-These are experimental controls whose keys and bounds may change between
-releases. The default request size and pipeline depth are not automatically
-tuned.
+For example, compare small-file batches with:
+
+```sh
+syq cp --srcs-in small-files --to server --into /scratch/benchmark-small \
+  --connections 1 -v --tuning-options batch-files=256,batch-bytes=8M
+```
+
+`split-min-size` controls when an idle worker can take part of another worker's
+remaining file region. Lower values permit smaller divisions; higher values
+avoid small assignments. A division remains aligned to hash blocks. The
+scheduler divides a region only when at least twice the effective minimum
+remains. This is a work-assignment threshold, separate from request size.
+
+### Average rate and burst patterns
+
+`--bwlimit` budgets logical file-data bytes across the copy's workers, before
+compression, encryption, and protocol overhead. It caps a rate, not a total
+byte count. The request pacing modes make different trade-offs:
+
+- **Timed pacing**, such as `bw-pacing=125ms`, limits request size to the smaller
+  of the configured request size and `max(rate * interval, 512 bytes)`. Workers
+  wait for the start of each reserved interval. The first request can start
+  immediately, so a short copy can exceed the configured average by that
+  initial request. The default `125ms` retains the existing sizing and pacing.
+- **Average pacing**, `bw-pacing=average`, leaves request size independent of
+  `--bwlimit`. Workers wait for the *end* of each reservation before issuing the
+  request, including the first one. A single 2 MiB request at 1 MiB/s therefore
+  waits about two seconds before it is issued. Large requests can then travel
+  in bursts, while their full byte budgets have already been paid.
+
+For example, to test larger requests under an average rate cap:
+
+```sh
+syq cp large-file --to server --as /scratch/benchmark-capped \
+  --connections 1 --bwlimit 1M -v \
+  --tuning-options copy-path=ranges,request-size=4M,bw-pacing=average
+```
+
+Neither mode promises a maximum network burst or uninterrupted service for
+other traffic. They pace source requests; helper processing, queues,
+compression, and transport buffering affect when bytes actually cross a link.
+A deeper pipeline can accumulate more data before forwarding it. A restricted
+receiver also enforces its signed rate ceiling independently, including its
+existing `max(rate * 125ms, 512 bytes)` request-size ceiling. Both tuning modes
+respect that additional ceiling; `-v` shows the effective size. Average pacing
+decouples size from rate where this signed receiver constraint does not apply.
+Measure both sustained throughput and short-interval traffic when evaluating
+capped runs.
+
+### Recording a comparison
+
+With overrides, `-v` reports effective settings, including any reduction in
+request size or increase in the split threshold. A final `syq: tuning observed:`
+line contains diagnostic JSON with copy-path counts, range request count,
+largest requested range, and largest worker batch by file count and content
+bytes. These are observations of attempted work, so retries can contribute
+more than once. They are experimental diagnostics, separate from completion
+records. `--stats` also enables them, but currently bypasses the native
+small-copy shortcut; use `-v` to compare that shortcut with other paths.
+
+Use the same reporting options for every comparison, a fresh disposable
+destination, and explicit defaults for the baseline, such as
+`--tuning-options copy-path=auto`. Record the source data, transport, connection
+count, effective settings, elapsed time, CPU use, and peak memory. Check the
+exit status and copied contents. Leave `--bwlimit` unset when measuring
+unrestricted throughput. Default request size and pipeline depth are not
+automatically tuned.
 
 ## TCP data connections
 

--- a/sdk/python/native-api.json
+++ b/sdk/python/native-api.json
@@ -71,6 +71,7 @@
         "no-progress",
         "progress-json",
         "stats",
+        "tuning-options",
         "detach"
       ],
       "follow_up": []

--- a/src/bwlimit.rs
+++ b/src/bwlimit.rs
@@ -97,7 +97,31 @@ impl BandwidthLimit {
     /// low limits. The floor permits the minimum 1 KiB/s rate without tiny
     /// protocol frames.
     pub fn burst_bytes(&self) -> u64 {
-        (self.bytes_per_sec / 8).max(512)
+        self.bytes_for_interval(125)
+    }
+
+    /// Request-sizing budget only, not a bound on bytes on the network.
+    pub fn bytes_for_interval(&self, milliseconds: u64) -> u64 {
+        ((self.bytes_per_sec as u128 * milliseconds as u128 / 1000).min(u64::MAX as u128) as u64)
+            .max(512)
+    }
+
+    /// Pay the entire reservation before admitting the request. With no
+    /// request-size cap, this avoids a free, arbitrarily large first chunk.
+    pub fn wait_prepaid(&self, bytes: u64) {
+        if bytes == 0 {
+            return;
+        }
+        let now = Instant::now();
+        let at = self.reserve_prepaid_at(now, bytes);
+        if at > now {
+            std::thread::sleep(at - now);
+        }
+    }
+
+    fn reserve_prepaid_at(&self, now: Instant, bytes: u64) -> Instant {
+        self.reserve_at(now, bytes)
+            + Duration::from_secs_f64(bytes as f64 / self.bytes_per_sec as f64)
     }
 
     pub fn wait(&self, bytes: u64) {
@@ -143,6 +167,35 @@ mod tests {
         for value in ["", "-1", "1XB", "511B", "nan", "1M/s", "1M+2", "0-1"] {
             assert!(parse_rate(value).is_err(), "accepted {value:?}");
         }
+    }
+
+    #[test]
+    fn prepaid_reservations_cover_the_first_request_and_share_one_budget() {
+        let limit = BandwidthLimit::new(1 << 20);
+        let now = Instant::now();
+        assert_eq!(
+            limit.reserve_prepaid_at(now, 4 << 20),
+            now + Duration::from_secs(4)
+        );
+        assert_eq!(
+            limit.reserve_prepaid_at(now, 1 << 19),
+            now + Duration::from_millis(4500)
+        );
+        let later = now + Duration::from_secs(10);
+        assert_eq!(
+            limit.reserve_prepaid_at(later, 1 << 20),
+            later + Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn interval_budget_handles_rounding_and_large_rates() {
+        assert_eq!(BandwidthLimit::new(1024).bytes_for_interval(1), 512);
+        assert_eq!(BandwidthLimit::new(2 << 20).bytes_for_interval(25), 52_428);
+        assert_eq!(
+            BandwidthLimit::new(u64::MAX).bytes_for_interval(10_000),
+            u64::MAX
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -220,6 +220,9 @@ pub struct Args {
     /// Transfer/hash block size (e.g. 4M)
     #[arg(short = 'B', long, default_value = "4M", value_name = "SIZE")]
     pub block_size: String,
+    /// Override transfer internals for benchmarking (see --help-all)
+    #[arg(long, value_name = "KEY=VALUE,...", long_help = crate::transfer_tuning::HELP)]
+    pub tuning_options: Option<crate::transfer_tuning::TransferTuning>,
     /// Limit the aggregate file-data rate across all workers (default unit: KiB/s; 0 disables)
     #[arg(long, value_name = "RATE")]
     pub bwlimit: Option<String>,
@@ -785,6 +788,9 @@ struct NativeCopyOperationalArgs {
     /// Limit aggregate file-data throughput (default unit: KiB/s; 0 disables)
     #[arg(long, value_name = "RATE")]
     bwlimit: Option<String>,
+    /// Override transfer internals for benchmarking (see --help-all)
+    #[arg(long, value_name = "KEY=VALUE,...", long_help = crate::transfer_tuning::HELP)]
+    tuning_options: Option<crate::transfer_tuning::TransferTuning>,
     /// Print transfer statistics at the end
     #[arg(long)]
     stats: bool,
@@ -1718,6 +1724,7 @@ fn apply_native_copy_operational(
         update,
         no_compress,
         bwlimit,
+        tuning_options,
         stats,
         ignore,
         ignore_from,
@@ -1745,6 +1752,7 @@ fn apply_native_copy_operational(
         .transpose()?
         .unwrap_or(0);
     args.bwlimit = bwlimit;
+    args.tuning_options = tuning_options;
     args.stats = stats;
     args.ignore_lines = ordered_ignore_lines(
         &ignore,
@@ -2037,6 +2045,7 @@ fn reject_unsupported_rsync_flags(argv: &[OsString]) -> Result<()> {
         "--syq-ignore-from",
         "--syq-connections",
         "--block-size",
+        "--tuning-options",
         "--bwlimit",
         "--max-size",
         "--min-size",

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1565,6 +1565,7 @@ fn connect_completion_endpoint(
         tcp: Default::default(),
         diagnostics: Default::default(),
         primed_control: Default::default(),
+        read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
     };
     spec.connect_completion()
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -605,16 +605,16 @@ pub struct RemoteConn {
     detached: bool,
 }
 
-const READ_AHEAD: usize = 4;
 const TRANSPORT_STATS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 fn spawn_reader(
     input: Box<dyn Read + Send>,
+    read_ahead: usize,
 ) -> (
     std::sync::mpsc::Receiver<std::io::Result<Response>>,
     std::thread::JoinHandle<()>,
 ) {
-    let (tx, rx) = std::sync::mpsc::sync_channel(READ_AHEAD);
+    let (tx, rx) = std::sync::mpsc::sync_channel(read_ahead);
     let reader = std::thread::spawn(move || {
         let mut r = FrameReader::new(input);
         loop {
@@ -686,7 +686,10 @@ impl RemoteConn {
         compress: bool,
         label: String,
     ) -> Self {
-        let (rx, reader) = spawn_reader(Box::new(session.stdout));
+        let (rx, reader) = spawn_reader(
+            Box::new(session.stdout),
+            crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
+        );
         let mut stderr = session.stderr;
         std::thread::spawn(move || {
             let _ = std::io::copy(&mut stderr, &mut std::io::stderr());
@@ -1220,6 +1223,10 @@ pub struct RemoteSpec {
     /// the control connection to consume. An empty result also prevents
     /// descriptor receipt during the later parallel connect.
     pub(crate) primed_control: std::sync::Arc<std::sync::Mutex<PrimedControl>>,
+    /// Must cover the worker request pipeline: otherwise a helper blocked
+    /// writing responses can stop reading requests while the coordinator is
+    /// still filling its pipeline. Control sessions do not need this depth.
+    pub(crate) read_ahead: usize,
 }
 
 #[derive(Debug, Default)]
@@ -1246,6 +1253,7 @@ impl RemoteSpec {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         }
     }
 
@@ -1651,7 +1659,7 @@ impl RemoteSpec {
         })?;
         let stdin = child.stdin.take().unwrap();
         let stdout = child.stdout.take().unwrap();
-        let (rx, reader) = spawn_reader(Box::new(stdout));
+        let (rx, reader) = spawn_reader(Box::new(stdout), self.read_ahead);
         let conn = RemoteConn {
             child: Some(child),
             w: FrameWriter::new(Box::new(stdin), compress),
@@ -1974,7 +1982,7 @@ impl RemoteSpec {
             let writer = RecordWriter::new(stream.try_clone()?, wc);
             let tcp_socket = stream.try_clone()?;
             let reader = RecordReader::new(stream, rc);
-            let (rx, reader) = spawn_reader(Box::new(reader));
+            let (rx, reader) = spawn_reader(Box::new(reader), self.read_ahead);
             let conn = RemoteConn {
                 child: None,
                 w: FrameWriter::new(Box::new(writer), compress),
@@ -3106,6 +3114,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let info = TcpInfo {
             addrs: vec!["127.0.0.1".into()],
@@ -3194,7 +3203,10 @@ mod tests {
         });
 
         let socket = TcpStream::connect(address).unwrap();
-        let (rx, reader) = spawn_reader(Box::new(socket.try_clone().unwrap()));
+        let (rx, reader) = spawn_reader(
+            Box::new(socket.try_clone().unwrap()),
+            crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
+        );
         let conn = RemoteConn {
             child: None,
             w: FrameWriter::new(Box::new(socket), false),
@@ -3240,7 +3252,10 @@ mod tests {
         });
 
         let socket = TcpStream::connect(address).unwrap();
-        let (rx, reader) = spawn_reader(Box::new(socket.try_clone().unwrap()));
+        let (rx, reader) = spawn_reader(
+            Box::new(socket.try_clone().unwrap()),
+            crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
+        );
         let conn = RemoteConn {
             child: None,
             w: FrameWriter::new(Box::new(socket), false),
@@ -3309,6 +3324,59 @@ mod tests {
     }
 
     #[test]
+    fn tuning_pipeline_drains_responses_while_sending_large_requests() {
+        use std::os::unix::net::UnixStream;
+        let (coordinator, helper) = UnixStream::pair().unwrap();
+        let timeout = std::time::Duration::from_secs(5);
+        for socket in [&coordinator, &helper] {
+            socket.set_read_timeout(Some(timeout)).unwrap();
+            socket.set_write_timeout(Some(timeout)).unwrap();
+        }
+        let depth = 64;
+        let server = std::thread::spawn(move || {
+            let mut requests = FrameReader::new(helper.try_clone().unwrap());
+            let mut responses = FrameWriter::new(helper, false);
+            for _ in 0..depth {
+                let Request::ReadRange { off, len, .. } = requests.read_msg().unwrap() else {
+                    panic!("expected a range request");
+                };
+                responses
+                    .write_msg(&Response::Block {
+                        off,
+                        hash: [0; 32],
+                        data: vec![7; len as usize],
+                    })
+                    .unwrap();
+            }
+        });
+        let (responses, reader) = spawn_reader(Box::new(coordinator.try_clone().unwrap()), depth);
+        let mut requests = FrameWriter::new(coordinator, false);
+        // Both directions exceed socket buffering. A reader queue stuck at
+        // four responses deadlocks against a sequential helper while the
+        // coordinator is still sending its 64 requests.
+        for i in 0..depth {
+            requests
+                .write_msg(&Request::ReadRange {
+                    path: vec![b'x'; 16 << 10],
+                    source: None,
+                    attempt: 0,
+                    off: i as u64 * (64 << 10),
+                    len: 64 << 10,
+                })
+                .unwrap();
+        }
+        for i in 0..depth {
+            let response = responses.recv_timeout(timeout).unwrap().unwrap();
+            assert!(matches!(response, Response::Block { off, data, .. }
+                if off == i as u64 * (64 << 10) && data == vec![7; 64 << 10]));
+        }
+        drop(responses);
+        drop(requests);
+        server.join().unwrap();
+        reader.join().unwrap();
+    }
+
+    #[test]
     fn transport_stats_response_wait_has_a_deadline() {
         let (_sender, receiver) = std::sync::mpsc::sync_channel(1);
         let timeout = std::time::Duration::from_millis(20);
@@ -3341,7 +3409,10 @@ mod tests {
                 inner: socket,
                 dropped: dropped.clone(),
             };
-            let (rx, reader) = spawn_reader(Box::new(input));
+            let (rx, reader) = spawn_reader(
+                Box::new(input),
+                crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
+            );
             let mut connection = RemoteConn {
                 child: None,
                 w: FrameWriter::new(Box::new(writer), false),
@@ -3483,6 +3554,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let command = spec.ssh_command(SshConnection::Independent, false);
         assert!(!command
@@ -3543,6 +3615,7 @@ mod tests {
             }))),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let endpoint = Endpoint::Remote(spec.clone());
         assert!(endpoint
@@ -3571,6 +3644,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let args = |connection| {
             spec.ssh_command(connection, false)
@@ -3663,6 +3737,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let args = |connection| {
             spec.ssh_command(connection, false)
@@ -3741,6 +3816,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
 
         let command = spec.ssh_command(SshConnection::Control, false);

--- a/src/help.rs
+++ b/src/help.rs
@@ -113,6 +113,7 @@ pub(crate) fn filesystem(command: Command) -> Command {
                 "Progress and results"
             }
             "connections" | "connections_opt" | "block_size" | "bwlimit" => "Performance",
+            "tuning_options" => "Benchmark tuning",
             "rsh" | "syq_path" | "no_bootstrap" | "no_tcp" | "tcp_plain" | "tcp_ports"
             | "tcp_congestion" | "pscope" | "compress" | "no_compress" => "SSH and transport",
             "coordinate_at"

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod tcp_records;
 #[cfg(test)]
 mod test_support;
 mod transfer;
+mod transfer_tuning;
 mod tune;
 mod update;
 

--- a/src/remote_to_remote.rs
+++ b/src/remote_to_remote.rs
@@ -886,6 +886,7 @@ fn run_remote(
         tcp: Default::default(),
         diagnostics: Default::default(),
         primed_control: Default::default(),
+        read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
     };
 
     // Rebuild the native command for the remote coordinator. Placement stays
@@ -969,6 +970,9 @@ fn run_remote(
     }
     if let Some(minimum) = &args.min_size {
         remote.push(format!("--min-size={minimum}"));
+    }
+    if let Some(tuning) = args.tuning_options {
+        remote.push(format!("--tuning-options={tuning}"));
     }
     if let Some(rate) = &args.bwlimit {
         remote.push(format!("--bwlimit={rate}"));

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -489,6 +489,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn tuning_split_threshold_controls_when_idle_workers_can_help() {
+        for (threshold, can_split) in [(8 << 20, true), (32 << 20, false)] {
+            let tuning: crate::transfer_tuning::TransferTuning =
+                format!("split-min-size={threshold}").parse().unwrap();
+            let sched = Sched::new(4 << 20, tuning.split_min_size(4 << 20));
+            let mut inner = sched.inner.lock().unwrap();
+            inner.inflight.push(Arc::new(Mutex::new(RangeState {
+                idx: 0,
+                pos: 0,
+                end: 48 << 20,
+            })));
+            let stolen = sched.steal(&mut inner);
+            assert_eq!(stolen.is_some(), can_split);
+            if let Some(stolen) = stolen {
+                let stolen = stolen.lock().unwrap();
+                assert_eq!((stolen.pos, stolen.end), (24 << 20, 48 << 20));
+            }
+        }
+    }
+
+    #[test]
     fn worker_exit_wakes_the_tuning_wait() {
         let sched = Arc::new(Sched::new(64, 128));
         {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -33,12 +33,7 @@ const FAST_BATCH_FILES: usize = 128;
 // does not, but needs the same amortization and remains bounded by bytes below.
 const HIGH_RTT_FAST_BATCH_FILES: usize = 512;
 const HIGH_RTT_US: u64 = 100_000;
-const FAST_BATCH_BYTES: u64 = 16 << 20;
 const CONNECTION_RECOVERY_ATTEMPTS: u32 = 3;
-// Range splitting is a scheduler implementation detail, not a public transfer
-// policy. Keep a conservative floor that avoids turning small tails into
-// separately scheduled work.
-const DEFAULT_MIN_SPLIT_BYTES: u64 = 32 << 20;
 
 fn fast_batch_file_limit(
     src_rtt_us: Option<u64>,
@@ -57,18 +52,25 @@ fn fast_batch_file_limit(
     }
 }
 
-fn initial_fast_workers(max_connections: usize, file_jobs: usize, file_bytes: u64) -> usize {
+fn initial_fast_workers(
+    max_connections: usize,
+    file_jobs: usize,
+    file_bytes: u64,
+    batch_files: usize,
+    batch_bytes: u64,
+) -> usize {
     // A batch is independently bounded by its entry count and its payload.
     // Provision enough fixed workers for whichever ceiling yields more work;
     // automatic runs may still tune from this bounded starting point.
-    let file_batches = file_jobs.div_ceil(FAST_BATCH_FILES);
-    let byte_batches = usize::try_from(file_bytes.div_ceil(FAST_BATCH_BYTES)).unwrap_or(usize::MAX);
+    let file_batches = file_jobs.div_ceil(batch_files);
+    let byte_batches = usize::try_from(file_bytes.div_ceil(batch_bytes)).unwrap_or(usize::MAX);
     max_connections.min(file_batches.max(byte_batches).max(1))
 }
 
 pub struct Opts {
     pub block: u64,
     pub tuning: crate::transfer_tuning::TransferTuning,
+    benchmark: Option<Mutex<crate::transfer_tuning::BenchmarkStats>>,
     pub flags: u8,
     pub recursive: bool,
     pub links: bool,
@@ -110,6 +112,16 @@ pub struct Opts {
     /// --max-size / --min-size: regular files outside the range are not transferred.
     pub max_size: Option<u64>,
     pub min_size: Option<u64>,
+}
+
+fn print_benchmark_observations(opts: &Opts) {
+    if let Some(benchmark) = &opts.benchmark {
+        crate::output::diagnostic!(
+            "syq: tuning observed: {}",
+            serde_json::to_string(&*benchmark.lock().unwrap())
+                .expect("benchmark counters serialize")
+        );
+    }
 }
 
 pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
@@ -840,6 +852,8 @@ fn small_copy_eligible(
         return false;
     }
     args.interface == Interface::NativeCp
+        && !args.tuning_options.unwrap_or_default().force_ranges()
+        && !args.tuning_options.unwrap_or_default().batch_override()
         && matches!(args.placement, Placement::Into | Placement::As)
         && args.target_existence == Existence::Any
         && dst.is_remote()
@@ -1510,6 +1524,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     let mut args = args;
     // A block becomes one WriteRange frame, so it must stay well under MAX_FRAME.
     let block = parse_size(&args.block_size)?.clamp(MIN_HASH_BLOCK_BYTES, MAX_HASH_BLOCK_BYTES);
+    args.tuning_options
+        .unwrap_or_default()
+        .validate(args.bwlimit_bytes)?;
     let max_size = args.max_size.as_deref().map(parse_size).transpose()?;
     let min_size = args.min_size.as_deref().map(parse_size).transpose()?;
     let bwlimit = (args.bwlimit_bytes > 0)
@@ -1702,6 +1719,10 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     let opts = Arc::new(Opts {
         block,
         tuning: args.tuning_options.unwrap_or_default(),
+        benchmark: (args.tuning_options.is_some()
+            && !args.quiet
+            && (args.stats || args.verbose > 0 || debug()))
+        .then(|| Mutex::new(crate::transfer_tuning::BenchmarkStats::default())),
         flags: args.meta_flags(),
         recursive: args.recursive,
         links: args.links,
@@ -1731,10 +1752,14 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         max_size,
         min_size,
     });
-    if args.tuning_options.is_some() && !args.quiet && (args.stats || args.verbose > 0 || debug()) {
+    if opts.benchmark.is_some() {
         crate::output::diagnostic!(
-            "syq: tuning: request-size={} bytes (after bandwidth limit), pipeline-depth={}, hash-block-size={} bytes",
-            opts.tuning.request_size(block, bwlimit.as_deref()), opts.tuning.pipeline_depth(), block
+            "syq: tuning: request-size={} bytes (after pacing and receiver limits), pipeline-depth={}, hash-block-size={} bytes, copy-path={}, batch-files={}, batch-bytes={}, split-min-size={}, bw-pacing={}",
+            opts.tuning.request_size(block, bwlimit.as_deref(), opts.restricted_receiver), opts.tuning.pipeline_depth(), block,
+            opts.tuning.copy_path.unwrap_or_default(),
+            opts.tuning.batch_files.map(|n| n.to_string()).unwrap_or_else(|| "adaptive(128/512)".into()),
+            opts.tuning.batch_bytes(), opts.tuning.split_min_size(block),
+            if bwlimit.is_some() { opts.tuning.bw_pacing.unwrap_or_default().to_string() } else { "disabled".into() }
         );
     }
     // Acquire the entire mapping through its retained selection before any
@@ -1756,7 +1781,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     } else {
         None
     };
-    let sched = Arc::new(Sched::new(block, DEFAULT_MIN_SPLIT_BYTES));
+    let sched = Arc::new(Sched::new(block, opts.tuning.split_min_size(block)));
 
     // Workers connect on their own threads once the control connections are
     // up: everything waits on those, so they must never compete with worker
@@ -1905,8 +1930,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         .into_iter()
                         .filter_map(real_remote_spec)
                         .any(|spec| spec.data_transport() == DataTransport::Ssh);
-                    let fast_batch_files =
-                        fast_batch_file_limit(src.tcp_rtt_us(), dst.tcp_rtt_us(), remote_ssh_data);
+                    let fast_batch_files = opts.tuning.batch_files.unwrap_or_else(|| {
+                        fast_batch_file_limit(src.tcp_rtt_us(), dst.tcp_rtt_us(), remote_ssh_data)
+                    });
                     let mut worker = Worker {
                         id,
                         src,
@@ -1918,6 +1944,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         gate: gate.clone(),
                         t: [0.0; 4],
                         fast: FastTiming::default(),
+                        benchmark: Default::default(),
                         fast_batch_files,
                     };
                     if debug() {
@@ -1927,6 +1954,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         );
                     }
                     let result = worker.run();
+                    if let Some(benchmark) = &opts.benchmark {
+                        benchmark.lock().unwrap().add(worker.benchmark);
+                    }
                     if collect_tcp_stats {
                         let stats = worker.collect_transport_stats();
                         transport_stats.lock().unwrap().extend(stats);
@@ -2077,7 +2107,13 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             &progress,
             t0,
         )? {
-            SmallCopy::Done(code) => return Ok(code),
+            SmallCopy::Done(code) => {
+                if let Some(benchmark) = &opts.benchmark {
+                    benchmark.lock().unwrap().native_small_copies += 1;
+                }
+                print_benchmark_observations(&opts);
+                return Ok(code);
+            }
             SmallCopy::Declined => {}
             SmallCopy::Reconnect => dst_ctl = connect_ctl(&dst_ep, &args)?,
         }
@@ -2909,9 +2945,17 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                     let jobs = sched.jobs.lock().unwrap();
                     (
                         !opts.verify_only
+                            && !opts.tuning.force_ranges()
                             && bwlimit.is_none()
                             && jobs.iter().all(|job| {
-                                job.entry.size <= opts.block
+                                job.entry.size
+                                    <= opts.block.min(opts.tuning.batch_bytes()).min(
+                                        opts.tuning.request_size(
+                                            opts.block,
+                                            None,
+                                            opts.restricted_receiver,
+                                        ),
+                                    )
                                     && job.dst_entry.is_none()
                                     && (!opts.inplace
                                         || (job.target_condition == TargetCondition::Any
@@ -2940,6 +2984,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                     // the first worker wakes the tuner to restore the ordinary
                     // local starting count immediately.
                     let single_direct_candidate = autotune
+                        && !opts.tuning.force_ranges()
                         && opts.same_host
                         && !opts.checksum
                         && !opts.verify_only
@@ -2949,7 +2994,13 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                             matches!(jobs.as_slice(), [job] if job.container_guard.is_none())
                         };
                     let mut initial = if multiplex_small_files {
-                        initial_fast_workers(args.connections, file_jobs, file_bytes)
+                        initial_fast_workers(
+                            args.connections,
+                            file_jobs,
+                            file_bytes,
+                            opts.tuning.batch_files.unwrap_or(FAST_BATCH_FILES),
+                            opts.tuning.batch_bytes(),
+                        )
                     } else {
                         args.connections
                     };
@@ -3259,6 +3310,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             );
         }
     }
+    print_benchmark_observations(&opts);
     // --stats is additional human output, not the summary line the local
     // attested settlement re-renders; a delegated coordinator keeps it.
     if !args.quiet && (!aborted || capacity_only_dry_run_abort) && args.stats {
@@ -7015,6 +7067,7 @@ struct Worker {
     /// Debug timing: seconds blocked in source recv, dest send, dest ack, idle in scheduler.
     t: [f64; 4],
     fast: FastTiming,
+    benchmark: crate::transfer_tuning::BenchmarkStats,
     fast_batch_files: usize,
 }
 
@@ -7113,11 +7166,17 @@ impl Worker {
                         // Keep rate-limited batches to one file so a push can't
                         // accumulate locally and then hit the network in a burst.
                         if self.bwlimit.is_none() {
-                            batch.extend(self.sched.take_small(
-                                self.opts.block,
-                                target - batch.len(),
-                                FAST_BATCH_BYTES,
-                            ));
+                            let first_bytes = self.job(idx).entry.size;
+                            batch.extend(
+                                self.sched.take_small(
+                                    self.opts
+                                        .block
+                                        .min(self.transfer_block())
+                                        .min(self.opts.tuning.batch_bytes()),
+                                    target - batch.len(),
+                                    self.opts.tuning.batch_bytes().saturating_sub(first_bytes),
+                                ),
+                            );
                         }
                         let (fast, slow): (Vec<usize>, Vec<usize>) =
                             batch.into_iter().partition(|&i| self.fast_eligible(i));
@@ -7212,7 +7271,13 @@ impl Worker {
         let jobs = self.sched.jobs.lock().unwrap();
         let j = &jobs[idx];
         !self.opts.verify_only
-            && j.entry.size <= self.opts.block.min(self.transfer_block())
+            && !self.opts.tuning.force_ranges()
+            && j.entry.size
+                <= self
+                    .opts
+                    .block
+                    .min(self.transfer_block())
+                    .min(self.opts.tuning.batch_bytes())
             && j.dst_entry.is_none()
             && (!self.opts.inplace
                 || (j.target_condition == TargetCondition::Any && j.container_guard.is_none()))
@@ -7225,6 +7290,12 @@ impl Worker {
             let all = self.sched.jobs.lock().unwrap();
             batch.iter().map(|&i| all[i].clone()).collect()
         };
+        self.benchmark.small_batches += 1;
+        self.benchmark.max_batch_files = self.benchmark.max_batch_files.max(jobs.len() as u64);
+        self.benchmark.max_batch_bytes = self
+            .benchmark
+            .max_batch_bytes
+            .max(jobs.iter().map(|j| j.entry.size).sum());
         // Reads.
         let phase = std::time::Instant::now();
         for j in &jobs {
@@ -7521,6 +7592,7 @@ impl Worker {
         // copy_file_range cannot be paced, so a limited same-machine transfer
         // uses the regular userspace path (also useful for mounted NFS paths).
         if self.opts.same_host
+            && !self.opts.tuning.force_ranges()
             && !self.opts.insecure_links
             && !self.opts.checksum
             && self.bwlimit.is_none()
@@ -7723,6 +7795,7 @@ impl Worker {
         })?;
         match resp {
             Response::Ok => {
+                self.benchmark.local_whole_files += 1;
                 self.progress.add_bytes(job.entry.size);
                 job.done.store(job.entry.size, Relaxed);
                 if let Err(e) = self.finish_file(idx) {
@@ -7930,6 +8003,8 @@ impl Worker {
                     off,
                     len: n as u32,
                 })?;
+                self.benchmark.range_requests += 1;
+                self.benchmark.max_request_bytes = self.benchmark.max_request_bytes.max(n);
                 reads_out += 1;
             }
             if reads_out == 0 {
@@ -7984,14 +8059,20 @@ impl Worker {
     }
 
     fn transfer_block(&self) -> u64 {
-        self.opts
-            .tuning
-            .request_size(self.opts.block, self.bwlimit.as_deref())
+        self.opts.tuning.request_size(
+            self.opts.block,
+            self.bwlimit.as_deref(),
+            self.opts.restricted_receiver,
+        )
     }
 
     fn limit(&self, bytes: u64) {
         if let Some(limit) = &self.bwlimit {
-            limit.wait(bytes);
+            if self.opts.tuning.bw_pacing == Some(crate::transfer_tuning::BwPacing::Average) {
+                limit.wait_prepaid(bytes);
+            } else {
+                limit.wait(bytes);
+            }
         }
     }
 
@@ -8356,9 +8437,36 @@ mod tests {
 
     #[test]
     fn initial_fast_workers_respect_file_and_byte_batch_limits() {
-        assert_eq!(initial_fast_workers(32, 100, 100 * (4 << 20)), 25);
-        assert_eq!(initial_fast_workers(8, 100, 100 * (4 << 20)), 8);
-        assert_eq!(initial_fast_workers(32, 300, 300), 3);
+        assert_eq!(
+            initial_fast_workers(
+                32,
+                100,
+                100 * (4 << 20),
+                FAST_BATCH_FILES,
+                crate::transfer_tuning::DEFAULT_BATCH_BYTES
+            ),
+            25
+        );
+        assert_eq!(
+            initial_fast_workers(
+                8,
+                100,
+                100 * (4 << 20),
+                FAST_BATCH_FILES,
+                crate::transfer_tuning::DEFAULT_BATCH_BYTES
+            ),
+            8
+        );
+        assert_eq!(
+            initial_fast_workers(
+                32,
+                300,
+                300,
+                FAST_BATCH_FILES,
+                crate::transfer_tuning::DEFAULT_BATCH_BYTES
+            ),
+            3
+        );
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -24,7 +24,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
 use std::sync::Arc;
 use std::sync::Mutex;
 
-const WINDOW: usize = 4;
 const MAX_ATTEMPTS: u32 = 3;
 pub const LOCAL_DEFAULT_CONNECTIONS: usize = 32;
 const FAST_BATCH_FILES: usize = 128;
@@ -69,6 +68,7 @@ fn initial_fast_workers(max_connections: usize, file_jobs: usize, file_bytes: u6
 
 pub struct Opts {
     pub block: u64,
+    pub tuning: crate::transfer_tuning::TransferTuning,
     pub flags: u8,
     pub recursive: bool,
     pub links: bool,
@@ -154,6 +154,7 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
                 tcp: Default::default(),
                 diagnostics: Default::default(),
                 primed_control: Default::default(),
+                read_ahead: args.tuning_options.unwrap_or_default().pipeline_depth(),
             })
         }
     })
@@ -1669,7 +1670,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         );
     }
     if matches!(dst_ep, Endpoint::Local { .. }) {
-        dst_ep = Endpoint::Remote(RemoteSpec::local_receiver(args.quiet));
+        let mut receiver = RemoteSpec::local_receiver(args.quiet);
+        receiver.read_ahead = args.tuning_options.unwrap_or_default().pipeline_depth();
+        dst_ep = Endpoint::Remote(receiver);
     }
     // TCP data connections are the default (auto-selecting the fastest reachable
     // NIC and falling back to ssh if unreachable); the interface's no-TCP
@@ -1698,6 +1701,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
 
     let opts = Arc::new(Opts {
         block,
+        tuning: args.tuning_options.unwrap_or_default(),
         flags: args.meta_flags(),
         recursive: args.recursive,
         links: args.links,
@@ -1727,6 +1731,12 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         max_size,
         min_size,
     });
+    if args.tuning_options.is_some() && !args.quiet && (args.stats || args.verbose > 0 || debug()) {
+        crate::output::diagnostic!(
+            "syq: tuning: request-size={} bytes (after bandwidth limit), pipeline-depth={}, hash-block-size={} bytes",
+            opts.tuning.request_size(block, bwlimit.as_deref()), opts.tuning.pipeline_depth(), block
+        );
+    }
     // Acquire the entire mapping through its retained selection before any
     // destination root can be created. The planner already consumes the whole
     // manifest; retaining these bytes also makes later namespace replacement
@@ -2642,7 +2652,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         args.connections = tune::START_TCP;
         gate.set_active(args.connections);
     }
-    let tuning_key = autotune.then(|| tune::path_key(&src_ep, &dst_ep)).flatten();
+    let tuning_key = (autotune && args.tuning_options.is_none())
+        .then(|| tune::path_key(&src_ep, &dst_ep))
+        .flatten();
     let remembered_start = tuning_key.as_deref().and_then(tune::cached);
     if let Some(remembered) = remembered_start {
         args.connections = remembered;
@@ -7200,7 +7212,7 @@ impl Worker {
         let jobs = self.sched.jobs.lock().unwrap();
         let j = &jobs[idx];
         !self.opts.verify_only
-            && j.entry.size <= self.transfer_block()
+            && j.entry.size <= self.opts.block.min(self.transfer_block())
             && j.dst_entry.is_none()
             && (!self.opts.inplace
                 || (j.target_condition == TargetCondition::Any && j.container_guard.is_none()))
@@ -7881,12 +7893,12 @@ impl Worker {
 
         let block = self.transfer_block();
         let read_window = if self.src.supports_request_pipelining() {
-            WINDOW
+            self.opts.tuning.pipeline_depth()
         } else {
             1
         };
         let write_window = if self.dst.supports_request_pipelining() {
-            WINDOW
+            self.opts.tuning.pipeline_depth()
         } else {
             1
         };
@@ -7972,9 +7984,9 @@ impl Worker {
     }
 
     fn transfer_block(&self) -> u64 {
-        self.bwlimit.as_ref().map_or(self.opts.block, |limit| {
-            self.opts.block.min(limit.burst_bytes())
-        })
+        self.opts
+            .tuning
+            .request_size(self.opts.block, self.bwlimit.as_deref())
     }
 
     fn limit(&self, bytes: u64) {

--- a/src/transfer_tuning.rs
+++ b/src/transfer_tuning.rs
@@ -1,0 +1,136 @@
+//! Explicit, per-command transfer experiments. These settings are never part
+//! of hash grids, resume identities, signed grants, or remembered tuning.
+
+use anyhow::{bail, Context, Result};
+use std::str::FromStr;
+
+pub(crate) const DEFAULT_PIPELINE_DEPTH: usize = 4;
+const MAX_PIPELINE_DEPTH: usize = 64;
+const MAX_REQUEST_BYTES: u64 = 64 << 20;
+
+pub(crate) const HELP: &str = "Override transfer internals for benchmarking: request-size=SIZE,pipeline-depth=N. Use one or both keys, separated by a comma. request-size accepts 512 bytes through 64M (K/M/G are binary units); its default is the hash block size, normally 4M. --bwlimit may reduce it further. pipeline-depth accepts 1 through 64 outstanding requests per endpoint per worker (default: 4); in-process endpoints remain synchronous. These options affect range transfers; whole-file optimizations can bypass them. Hash/resume blocks are unchanged. Overrides are not saved, and runs with overrides do not read or update the remembered connection count. Use a fixed connection count for comparisons.";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct TransferTuning {
+    pub request_size: Option<u64>,
+    pub pipeline_depth: Option<usize>,
+}
+
+impl TransferTuning {
+    pub fn pipeline_depth(self) -> usize {
+        self.pipeline_depth.unwrap_or(DEFAULT_PIPELINE_DEPTH)
+    }
+
+    pub fn request_size(
+        self,
+        hash_block: u64,
+        limit: Option<&crate::bwlimit::BandwidthLimit>,
+    ) -> u64 {
+        let size = self.request_size.unwrap_or(hash_block);
+        limit.map_or(size, |limit| size.min(limit.burst_bytes()))
+    }
+}
+
+impl FromStr for TransferTuning {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        let mut tuning = Self::default();
+        for pair in value.split(',') {
+            let Some((key, value)) = pair.split_once('=') else {
+                bail!("expected request-size=SIZE or pipeline-depth=N, got {pair:?}");
+            };
+            match key {
+                "request-size" => {
+                    if tuning.request_size.is_some() {
+                        bail!("duplicate tuning option request-size");
+                    }
+                    let size = crate::cli::parse_size(value).context("request-size")?;
+                    if !(512..=MAX_REQUEST_BYTES).contains(&size) {
+                        bail!("request-size must be between 512 bytes and 64M");
+                    }
+                    tuning.request_size = Some(size);
+                }
+                "pipeline-depth" => {
+                    if tuning.pipeline_depth.is_some() {
+                        bail!("duplicate tuning option pipeline-depth");
+                    }
+                    let depth: usize =
+                        value.parse().context("pipeline-depth must be an integer")?;
+                    if !(1..=MAX_PIPELINE_DEPTH).contains(&depth) {
+                        bail!("pipeline-depth must be between 1 and 64");
+                    }
+                    tuning.pipeline_depth = Some(depth);
+                }
+                _ => {
+                    bail!("unknown tuning option {key:?}; expected request-size or pipeline-depth")
+                }
+            }
+        }
+        Ok(tuning)
+    }
+}
+
+impl std::fmt::Display for TransferTuning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(size) = self.request_size {
+            write!(f, "request-size={size}")?;
+        }
+        if let Some(depth) = self.pipeline_depth {
+            if self.request_size.is_some() {
+                write!(f, ",")?;
+            }
+            write!(f, "pipeline-depth={depth}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tuning_preserves_defaults_and_bandwidth_burst_bound() {
+        let hash_block = 4 << 20;
+        let default = TransferTuning::default();
+        assert_eq!(default.request_size(hash_block, None), hash_block);
+        assert_eq!(default.pipeline_depth(), 4);
+        let override_: TransferTuning = "request-size=8M,pipeline-depth=16".parse().unwrap();
+        assert_eq!(override_.request_size(hash_block, None), 8 << 20);
+        let limit = crate::bwlimit::BandwidthLimit::new(1 << 20);
+        assert_eq!(override_.request_size(hash_block, Some(&limit)), 128 << 10);
+        let small: TransferTuning = "request-size=512".parse().unwrap();
+        assert_eq!(small.request_size(hash_block, Some(&limit)), 512);
+        assert_eq!(
+            override_.to_string().parse::<TransferTuning>().unwrap(),
+            override_
+        );
+    }
+
+    #[test]
+    fn tuning_rejects_mistyped_or_unbounded_experiments() {
+        for value in [
+            "",
+            "request-size",
+            "block-size=1M",
+            "request-size=0",
+            "request-size=511",
+            "request-size=65M",
+            "request-size=NaN",
+            "request-size=18446744073709551615G",
+            "pipeline-depth=0",
+            "pipeline-depth=65",
+            "pipeline-depth=-1",
+            "pipeline-depth=1.5",
+            "request-size=1M,",
+            "request-size=1M,request-size=2M",
+            "pipeline-depth=1,pipeline-depth=2",
+        ] {
+            assert!(
+                value.parse::<TransferTuning>().is_err(),
+                "accepted {value:?}"
+            );
+        }
+    }
+}

--- a/src/transfer_tuning.rs
+++ b/src/transfer_tuning.rs
@@ -1,5 +1,5 @@
-//! Explicit, per-command transfer experiments. These settings are never part
-//! of hash grids, resume identities, signed grants, or remembered tuning.
+//! Per-command transfer experiments. Settings never enter resume identities,
+//! signed grants, or the remembered connection-count cache.
 
 use anyhow::{bail, Context, Result};
 use std::str::FromStr;
@@ -7,64 +7,195 @@ use std::str::FromStr;
 pub(crate) const DEFAULT_PIPELINE_DEPTH: usize = 4;
 const MAX_PIPELINE_DEPTH: usize = 64;
 const MAX_REQUEST_BYTES: u64 = 64 << 20;
+pub(crate) const DEFAULT_BATCH_BYTES: u64 = 16 << 20;
+pub(crate) const DEFAULT_SPLIT_BYTES: u64 = 32 << 20;
 
-pub(crate) const HELP: &str = "Override transfer internals for benchmarking: request-size=SIZE,pipeline-depth=N. Use one or both keys, separated by a comma. request-size accepts 512 bytes through 64M (K/M/G are binary units); its default is the hash block size, normally 4M. --bwlimit may reduce it further. pipeline-depth accepts 1 through 64 outstanding requests per endpoint per worker (default: 4); in-process endpoints remain synchronous. These options affect range transfers; whole-file optimizations can bypass them. Hash/resume blocks are unchanged. Overrides are not saved, and runs with overrides do not read or update the remembered connection count. Use a fixed connection count for comparisons.";
+pub(crate) const HELP: &str = "Override copy internals for benchmarks with comma-separated KEY=VALUE pairs. Keys:\n\nrequest-size=SIZE: 512 bytes..64M; default is the hash block size, normally 4M.\npipeline-depth=N: 1..64 outstanding range requests per endpoint per worker; default 4. In-process endpoints remain synchronous.\ncopy-path=auto|ranges: default auto; ranges bypasses whole-file and small-file copy shortcuts.\nbatch-files=N: 1..4096 files per worker batch; default 128 or 512 depending on transport/latency.\nbatch-bytes=SIZE: 512 bytes..64M per worker batch; default 16M, including the first file. Explicit batch controls bypass the native small-copy shortcut.\nsplit-min-size=SIZE: 1..1G bytes; default 32M, raised to at least two hash blocks.\nbw-pacing=average|INTERVAL: requires --bwlimit. Default 125ms. Intervals accept integer ms or s, from 1ms through 10s. Timed pacing caps request size at max(rate * interval, 512 bytes). Average pacing preserves request size and waits for each request's full byte budget before issuing it. Neither mode guarantees a network burst ceiling. Restricted receivers retain their signed 125ms request-size ceiling in both modes.\n\nK/M/G sizes use powers of 1024. Hash/resume blocks stay unchanged. Overrides are not saved and bypass the remembered connection count. Use -v to report effective settings and observed paths; fix the connection count for comparisons. See the Speed guide for benchmark examples.";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum CopyPath {
+    #[default]
+    Auto,
+    Ranges,
+}
+
+impl std::fmt::Display for CopyPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Auto => "auto",
+            Self::Ranges => "ranges",
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BwPacing {
+    Average,
+    IntervalMs(u64),
+}
+
+impl Default for BwPacing {
+    fn default() -> Self {
+        Self::IntervalMs(125)
+    }
+}
+
+impl std::fmt::Display for BwPacing {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Average => f.write_str("average"),
+            Self::IntervalMs(ms) => write!(f, "{ms}ms"),
+        }
+    }
+}
+
+impl FromStr for BwPacing {
+    type Err = anyhow::Error;
+    fn from_str(value: &str) -> Result<Self> {
+        if value == "average" {
+            return Ok(Self::Average);
+        }
+        let (n, scale) = if let Some(n) = value.strip_suffix("ms") {
+            (n, 1)
+        } else if let Some(n) = value.strip_suffix('s') {
+            (n, 1000)
+        } else {
+            bail!("bw-pacing needs average or an integer interval with ms or s units");
+        };
+        let ms = n
+            .parse::<u64>()
+            .ok()
+            .and_then(|n| n.checked_mul(scale))
+            .filter(|ms| (1..=10_000).contains(ms))
+            .ok_or_else(|| anyhow::anyhow!("bw-pacing interval must be between 1ms and 10s"))?;
+        Ok(Self::IntervalMs(ms))
+    }
+}
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct TransferTuning {
     pub request_size: Option<u64>,
     pub pipeline_depth: Option<usize>,
+    pub copy_path: Option<CopyPath>,
+    pub batch_files: Option<usize>,
+    pub batch_bytes: Option<u64>,
+    pub split_min_size: Option<u64>,
+    pub bw_pacing: Option<BwPacing>,
 }
 
 impl TransferTuning {
     pub fn pipeline_depth(self) -> usize {
         self.pipeline_depth.unwrap_or(DEFAULT_PIPELINE_DEPTH)
     }
-
+    pub fn force_ranges(self) -> bool {
+        self.copy_path == Some(CopyPath::Ranges)
+    }
+    pub fn batch_bytes(self) -> u64 {
+        self.batch_bytes.unwrap_or(DEFAULT_BATCH_BYTES)
+    }
+    pub fn batch_override(self) -> bool {
+        self.batch_files.is_some() || self.batch_bytes.is_some()
+    }
+    pub fn split_min_size(self, hash_block: u64) -> u64 {
+        self.split_min_size
+            .unwrap_or(DEFAULT_SPLIT_BYTES)
+            .max(2 * hash_block)
+    }
+    pub fn validate(self, rate: u64) -> Result<()> {
+        if self.bw_pacing.is_some() && rate == 0 {
+            bail!("--tuning-options bw-pacing requires a nonzero --bwlimit");
+        }
+        if self.force_ranges() && self.batch_override() {
+            bail!("--tuning-options copy-path=ranges cannot be combined with batch controls");
+        }
+        Ok(())
+    }
     pub fn request_size(
         self,
         hash_block: u64,
         limit: Option<&crate::bwlimit::BandwidthLimit>,
+        restricted_receiver: bool,
     ) -> u64 {
         let size = self.request_size.unwrap_or(hash_block);
-        limit.map_or(size, |limit| size.min(limit.burst_bytes()))
+        let size = match (limit, self.bw_pacing.unwrap_or_default()) {
+            (Some(limit), BwPacing::IntervalMs(ms)) => size.min(limit.bytes_for_interval(ms)),
+            _ => size,
+        };
+        // The signed receiver independently refuses larger writes. Tuning
+        // cannot enlarge that authority; retain its released request ceiling.
+        match limit {
+            Some(limit) if restricted_receiver => size.min(limit.burst_bytes()),
+            _ => size,
+        }
     }
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T, key: &str) -> Result<()> {
+    if slot.replace(value).is_some() {
+        bail!("duplicate tuning option {key}");
+    }
+    Ok(())
+}
+
+fn size(value: &str, key: &str, min: u64, max: u64) -> Result<u64> {
+    let bytes = crate::cli::parse_size(value).with_context(|| key.to_string())?;
+    if !(min..=max).contains(&bytes) {
+        bail!("{key} must be between {min} and {max} bytes");
+    }
+    Ok(bytes)
+}
+
+fn count(value: &str, key: &str, max: usize) -> Result<usize> {
+    let n: usize = value
+        .parse()
+        .with_context(|| format!("{key} must be an integer"))?;
+    if !(1..=max).contains(&n) {
+        bail!("{key} must be between 1 and {max}");
+    }
+    Ok(n)
 }
 
 impl FromStr for TransferTuning {
     type Err = anyhow::Error;
-
     fn from_str(value: &str) -> Result<Self> {
         let mut tuning = Self::default();
         for pair in value.split(',') {
             let Some((key, value)) = pair.split_once('=') else {
-                bail!("expected request-size=SIZE or pipeline-depth=N, got {pair:?}");
+                bail!("expected a tuning KEY=VALUE pair, got {pair:?}; see --help-all");
             };
             match key {
-                "request-size" => {
-                    if tuning.request_size.is_some() {
-                        bail!("duplicate tuning option request-size");
-                    }
-                    let size = crate::cli::parse_size(value).context("request-size")?;
-                    if !(512..=MAX_REQUEST_BYTES).contains(&size) {
-                        bail!("request-size must be between 512 bytes and 64M");
-                    }
-                    tuning.request_size = Some(size);
-                }
-                "pipeline-depth" => {
-                    if tuning.pipeline_depth.is_some() {
-                        bail!("duplicate tuning option pipeline-depth");
-                    }
-                    let depth: usize =
-                        value.parse().context("pipeline-depth must be an integer")?;
-                    if !(1..=MAX_PIPELINE_DEPTH).contains(&depth) {
-                        bail!("pipeline-depth must be between 1 and 64");
-                    }
-                    tuning.pipeline_depth = Some(depth);
-                }
-                _ => {
-                    bail!("unknown tuning option {key:?}; expected request-size or pipeline-depth")
-                }
+                "request-size" => set_once(
+                    &mut tuning.request_size,
+                    size(value, key, 512, MAX_REQUEST_BYTES)?,
+                    key,
+                )?,
+                "pipeline-depth" => set_once(
+                    &mut tuning.pipeline_depth,
+                    count(value, key, MAX_PIPELINE_DEPTH)?,
+                    key,
+                )?,
+                "copy-path" => set_once(
+                    &mut tuning.copy_path,
+                    match value {
+                        "auto" => CopyPath::Auto,
+                        "ranges" => CopyPath::Ranges,
+                        _ => bail!("copy-path must be auto or ranges"),
+                    },
+                    key,
+                )?,
+                "batch-files" => set_once(&mut tuning.batch_files, count(value, key, 4096)?, key)?,
+                "batch-bytes" => set_once(
+                    &mut tuning.batch_bytes,
+                    size(value, key, 512, 64 << 20)?,
+                    key,
+                )?,
+                "split-min-size" => set_once(
+                    &mut tuning.split_min_size,
+                    size(value, key, 1, 1 << 30)?,
+                    key,
+                )?,
+                "bw-pacing" => set_once(&mut tuning.bw_pacing, value.parse()?, key)?,
+                _ => bail!("unknown tuning option {key:?}; see --help-all"),
             }
         }
         Ok(tuning)
@@ -73,16 +204,46 @@ impl FromStr for TransferTuning {
 
 impl std::fmt::Display for TransferTuning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(size) = self.request_size {
-            write!(f, "request-size={size}")?;
+        let mut pairs = Vec::new();
+        macro_rules! pair {
+            ($key:literal, $value:expr) => {
+                if let Some(value) = $value {
+                    pairs.push(format!("{}={value}", $key));
+                }
+            };
         }
-        if let Some(depth) = self.pipeline_depth {
-            if self.request_size.is_some() {
-                write!(f, ",")?;
-            }
-            write!(f, "pipeline-depth={depth}")?;
-        }
-        Ok(())
+        pair!("request-size", self.request_size);
+        pair!("pipeline-depth", self.pipeline_depth);
+        pair!("copy-path", self.copy_path);
+        pair!("batch-files", self.batch_files);
+        pair!("batch-bytes", self.batch_bytes);
+        pair!("split-min-size", self.split_min_size);
+        pair!("bw-pacing", self.bw_pacing);
+        f.write_str(&pairs.join(","))
+    }
+}
+
+/// Diagnostic counters for attempted work, independent of completion records.
+#[derive(Clone, Copy, Debug, Default, serde::Serialize)]
+pub(crate) struct BenchmarkStats {
+    pub native_small_copies: u64,
+    pub local_whole_files: u64,
+    pub range_requests: u64,
+    pub max_request_bytes: u64,
+    pub small_batches: u64,
+    pub max_batch_files: u64,
+    pub max_batch_bytes: u64,
+}
+
+impl BenchmarkStats {
+    pub fn add(&mut self, other: Self) {
+        self.native_small_copies += other.native_small_copies;
+        self.local_whole_files += other.local_whole_files;
+        self.range_requests += other.range_requests;
+        self.small_batches += other.small_batches;
+        self.max_request_bytes = self.max_request_bytes.max(other.max_request_bytes);
+        self.max_batch_files = self.max_batch_files.max(other.max_batch_files);
+        self.max_batch_bytes = self.max_batch_bytes.max(other.max_batch_bytes);
     }
 }
 
@@ -94,18 +255,65 @@ mod tests {
     fn tuning_preserves_defaults_and_bandwidth_burst_bound() {
         let hash_block = 4 << 20;
         let default = TransferTuning::default();
-        assert_eq!(default.request_size(hash_block, None), hash_block);
+        assert_eq!(default.request_size(hash_block, None, false), hash_block);
         assert_eq!(default.pipeline_depth(), 4);
         let override_: TransferTuning = "request-size=8M,pipeline-depth=16".parse().unwrap();
-        assert_eq!(override_.request_size(hash_block, None), 8 << 20);
+        assert_eq!(override_.request_size(hash_block, None, false), 8 << 20);
         let limit = crate::bwlimit::BandwidthLimit::new(1 << 20);
-        assert_eq!(override_.request_size(hash_block, Some(&limit)), 128 << 10);
+        assert_eq!(
+            override_.request_size(hash_block, Some(&limit), false),
+            128 << 10
+        );
         let small: TransferTuning = "request-size=512".parse().unwrap();
-        assert_eq!(small.request_size(hash_block, Some(&limit)), 512);
+        assert_eq!(small.request_size(hash_block, Some(&limit), false), 512);
         assert_eq!(
             override_.to_string().parse::<TransferTuning>().unwrap(),
             override_
         );
+    }
+
+    #[test]
+    fn tuning_round_trips_every_key_for_remote_coordinators() {
+        for value in [
+            "request-size=8M,pipeline-depth=16,copy-path=ranges,split-min-size=1M,bw-pacing=average",
+            "copy-path=auto,batch-files=4096,batch-bytes=64M,split-min-size=1G,bw-pacing=2s",
+        ] {
+            let tuning: TransferTuning = value.parse().unwrap();
+            tuning.validate(1 << 20).unwrap();
+            assert_eq!(tuning.to_string().parse::<TransferTuning>().unwrap(), tuning);
+        }
+        let limit = crate::bwlimit::BandwidthLimit::new(1 << 20);
+        let average: TransferTuning = "request-size=8M,bw-pacing=average,split-min-size=1M"
+            .parse()
+            .unwrap();
+        assert_eq!(average.request_size(4 << 20, Some(&limit), false), 8 << 20);
+        assert_eq!(average.split_min_size(4 << 20), 8 << 20);
+        let interval: TransferTuning = "bw-pacing=250ms".parse().unwrap();
+        assert_eq!(
+            interval.request_size(4 << 20, Some(&limit), false),
+            256 << 10
+        );
+        assert!(average.validate(0).is_err());
+        assert!("copy-path=ranges,batch-files=1"
+            .parse::<TransferTuning>()
+            .unwrap()
+            .validate(0)
+            .is_err());
+    }
+
+    #[test]
+    fn tuning_preserves_the_signed_receiver_request_ceiling() {
+        let limit = crate::bwlimit::BandwidthLimit::new(1 << 20);
+        for pacing in ["average", "1s"] {
+            let tuning: TransferTuning = format!("request-size=8M,bw-pacing={pacing}")
+                .parse()
+                .unwrap();
+            assert_eq!(tuning.request_size(4 << 20, Some(&limit), true), 128 << 10);
+        }
+        let tighter: TransferTuning = "bw-pacing=25ms".parse().unwrap();
+        assert_eq!(tighter.request_size(4 << 20, Some(&limit), true), 26_214);
+        let uncapped: TransferTuning = "request-size=8M".parse().unwrap();
+        assert_eq!(uncapped.request_size(4 << 20, None, true), 8 << 20);
     }
 
     #[test]
@@ -126,6 +334,19 @@ mod tests {
             "request-size=1M,",
             "request-size=1M,request-size=2M",
             "pipeline-depth=1,pipeline-depth=2",
+            "copy-path=magic",
+            "copy-path=auto,copy-path=ranges",
+            "batch-files=0",
+            "batch-files=4097",
+            "batch-bytes=511",
+            "batch-bytes=65M",
+            "split-min-size=0",
+            "split-min-size=2G",
+            "bw-pacing=0ms",
+            "bw-pacing=11s",
+            "bw-pacing=125",
+            "bw-pacing=0.1s",
+            "bw-pacing=18446744073709551615s",
         ] {
             assert!(
                 value.parse::<TransferTuning>().is_err(),

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1130,6 +1130,7 @@ mod tests {
             }))),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         })
     }
 

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -5893,6 +5893,164 @@ fn progress_bar_is_opt_in_for_pipes_and_disabled_by_no_progress() {
 }
 
 #[test]
+fn tuning_options_are_in_full_help_and_validate_before_copying() {
+    let t = Tmp::new();
+    write(&t.path("source"), b"source");
+    for interface in ["cp", "rsync"] {
+        let help = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([interface, "--help"])
+            .run()
+            .unwrap();
+        assert_output_ok(&help);
+        assert!(!String::from_utf8_lossy(&help.stdout).contains("--tuning-options"));
+        let help = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([interface, "--help-all"])
+            .run()
+            .unwrap();
+        assert_output_ok(&help);
+        let text = String::from_utf8_lossy(&help.stdout);
+        assert!(
+            text.contains("--tuning-options") && text.contains("pipeline-depth"),
+            "{text}"
+        );
+        for options in [
+            "typo=4",
+            "pipeline-depth=0",
+            "request-size=65M",
+            "pipeline-depth=4,pipeline-depth=8",
+        ] {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+            command.args([interface, "--tuning-options", options, &t.s("source")]);
+            if interface == "cp" {
+                command.arg("--as");
+            }
+            let out = command.arg(t.s("destination")).run().unwrap();
+            assert!(!out.status.success(), "{out:?}");
+            assert!(stderr_of(&out).contains("--tuning-options"), "{out:?}");
+            assert!(!t.path("destination").exists());
+        }
+    }
+}
+
+#[test]
+fn tuning_options_copy_remote_ranges_over_tcp_and_ssh() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    let data = prng(9 * 1024 * 1024 + 123, 904);
+    write(&t.path("source"), &data);
+    for tcp in [false, true] {
+        for pull in [false, true] {
+            for (size, depth) in [(64 << 10, 1), (1 << 20, 8), (64 << 10, 64), (8 << 20, 8)] {
+                let destination = t.s(&format!("dst-{tcp}-{pull}-{size}-{depth}"));
+                let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+                command.args([
+                    "cp",
+                    "--rsh",
+                    rsh.to_str().unwrap(),
+                    "--syq-path",
+                    env!("CARGO_BIN_EXE_syq"),
+                    "--connections",
+                    "1",
+                    "--no-progress",
+                    "--stats",
+                    "--tcp-ports",
+                    EPHEMERAL_TCP_PORTS,
+                    "--tuning-options",
+                    &format!("request-size={size},pipeline-depth={depth}"),
+                ]);
+                if !tcp {
+                    command.arg("--no-tcp");
+                } else {
+                    command.env("SYQ_TEST_REQUIRE_TCP", "1");
+                }
+                if pull {
+                    command.args(["--from", "host"]);
+                }
+                command.arg(t.s("source"));
+                if !pull {
+                    command.args(["--to", "host"]);
+                }
+                command
+                    .args(["--as", &destination])
+                    .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+                    .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+                    .env("FAKE_RSH_LOG", t.path("rsh.log"))
+                    .env("XDG_CONFIG_HOME", t.path("config"))
+                    .env("XDG_CACHE_HOME", t.path("cache"));
+                let out = command.run().unwrap();
+                assert_output_ok(&out);
+                let diagnostic = stderr_of(&out);
+                assert!(
+                    diagnostic.contains(&format!("request-size={size} bytes")),
+                    "{diagnostic}"
+                );
+                assert!(
+                    diagnostic.contains(&format!("pipeline-depth={depth}")),
+                    "{diagnostic}"
+                );
+                assert!(
+                    diagnostic.contains("hash-block-size=4194304 bytes"),
+                    "{diagnostic}"
+                );
+                assert_eq!(read(Path::new(&destination)), data);
+            }
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn tuning_options_preserve_partial_identity_and_reused_hash_blocks() {
+    let t = Tmp::new();
+    let data = prng(6 * 1024 * 1024, 905);
+    write(&t.path("source"), &data);
+    set_mtime(&t.path("source"), 1_600_000_000);
+    let src = t.s("source");
+    let dst = t.s("destination");
+    let initial = ["-a", "--block-size=1M", "--bwlimit=1G", &src, &dst];
+    let partial = interrupted_partial(&initial, &t.0);
+    let f = File::create(&partial).unwrap();
+    (&f).write_all(&data[..3 * 1024 * 1024]).unwrap();
+    f.set_len(data.len() as u64).unwrap();
+    drop(f);
+    let out = run_ok(&[
+        "-a",
+        "--block-size=1M",
+        "--bwlimit=1G",
+        "--tuning-options=request-size=128K,pipeline-depth=8",
+        &src,
+        &dst,
+    ]);
+    assert_eq!(read(&t.path("destination")), data);
+    assert!(!partial.exists(), "override stranded the existing partial");
+    assert!(
+        out.contains("1 files (3.00 MiB), 3.00 MiB unchanged"),
+        "{out}"
+    );
+}
+
+#[test]
+fn tuning_options_keep_the_aggregate_bandwidth_limit() {
+    let t = Tmp::new();
+    let data = prng(2 * 1024 * 1024, 906);
+    write(&t.path("source"), &data);
+    let start = std::time::Instant::now();
+    let out = run_ok(&[
+        "-a",
+        "--bwlimit=1M",
+        "--syq-connections=4",
+        "--tuning-options=request-size=64M,pipeline-depth=64",
+        &t.s("source"),
+        &t.s("destination"),
+    ]);
+    assert!(
+        start.elapsed() >= std::time::Duration::from_millis(1600),
+        "{out}"
+    );
+    assert_eq!(read(&t.path("destination")), data);
+}
+
+#[test]
 fn bwlimit_is_aggregate_across_workers() {
     let t = Tmp::new();
     for i in 0..4 {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -5893,6 +5893,168 @@ fn progress_bar_is_opt_in_for_pipes_and_disabled_by_no_progress() {
 }
 
 #[test]
+fn tuning_options_force_ranges_for_small_and_whole_local_files() {
+    let t = Tmp::new();
+    for (file, size) in [("small", 1024), ("large", 6 << 20), ("empty", 0)] {
+        write(&t.path(&format!("source/{file}")), &prng(size, 909));
+    }
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--srcs-in",
+            &t.s("source"),
+            "--into",
+            &t.s("destination"),
+            "--tuning-options=copy-path=ranges,request-size=1M,split-min-size=1M",
+            "-j",
+            "2",
+            "-v",
+            "--no-progress",
+            "--preserve=permissions",
+        ])
+        .run()
+        .unwrap();
+    assert_output_ok(&out);
+    let observed = tuning_observed(&out);
+    assert!(observed["range_requests"].as_u64().unwrap() >= 7);
+    assert_eq!(observed["max_request_bytes"], 1 << 20);
+    assert_eq!(observed["local_whole_files"], 0);
+    assert_eq!(observed["small_batches"], 0);
+    assert!(stderr_of(&out).contains("split-min-size=8388608"));
+    assert_same_tree(&t.path("source"), &t.path("destination"));
+}
+
+fn tuning_observed(out: &Output) -> serde_json::Value {
+    let diagnostic = stderr_of(out);
+    let line = diagnostic
+        .lines()
+        .find_map(|line| line.strip_prefix("syq: tuning observed: "))
+        .unwrap_or_else(|| panic!("missing benchmark observations: {diagnostic}"));
+    serde_json::from_str(line).unwrap()
+}
+
+#[test]
+fn tuning_options_batch_limits_include_the_first_file() {
+    let t = Tmp::new();
+    for i in 0..7 {
+        write(&t.path(&format!("source/{i}")), &prng(600 << 10, i));
+    }
+    for (files, bytes, expected_files) in [(3, 2 << 20, 3), (10, 1 << 20, 1)] {
+        let destination = t.s(&format!("destination-{files}"));
+        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "cp",
+                "--srcs-in",
+                &t.s("source"),
+                "--into",
+                &destination,
+                "--tuning-options",
+                &format!("batch-files={files},batch-bytes={bytes}"),
+                "-j",
+                "1",
+                "-v",
+                "--no-progress",
+                "--preserve=permissions",
+            ])
+            .run()
+            .unwrap();
+        assert_output_ok(&out);
+        let observed = tuning_observed(&out);
+        assert_eq!(observed["max_batch_files"], expected_files, "{observed}");
+        assert!(observed["max_batch_bytes"].as_u64().unwrap() <= bytes);
+        assert_eq!(observed["range_requests"], 0);
+        assert_same_tree(&t.path("source"), Path::new(&destination));
+    }
+}
+
+#[test]
+fn tuning_options_control_the_native_small_copy_shortcut() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    write(&t.path("source"), b"native small copy");
+    for options in [
+        "copy-path=auto",
+        "copy-path=ranges",
+        "batch-files=2,batch-bytes=512",
+    ] {
+        let destination = t.s(&format!("destination-{}", options.len()));
+        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "cp",
+                &t.s("source"),
+                "--to",
+                "host",
+                "--as",
+                &destination,
+                "--rsh",
+                rsh.to_str().unwrap(),
+                "--syq-path",
+                env!("CARGO_BIN_EXE_syq"),
+                "--no-tcp",
+                "-j",
+                "1",
+                "-v",
+                "--no-progress",
+                "--tuning-options",
+                options,
+            ])
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env("XDG_CONFIG_HOME", t.path("config"))
+            .env("XDG_CACHE_HOME", t.path("cache"))
+            .run()
+            .unwrap();
+        assert_output_ok(&out);
+        let observed = tuning_observed(&out);
+        let counter = match options {
+            "copy-path=auto" => "native_small_copies",
+            "copy-path=ranges" => "range_requests",
+            _ => "small_batches",
+        };
+        assert_eq!(observed[counter], 1, "{observed}");
+        assert_eq!(read(Path::new(&destination)), b"native small copy");
+    }
+}
+
+#[test]
+fn tuning_options_average_pacing_pays_for_one_large_request() {
+    let t = Tmp::new();
+    let data = prng(2 << 20, 910);
+    write(&t.path("source"), &data);
+    for (pacing, expected_max) in [("average", 2 << 20), ("25ms", 52_428)] {
+        let start = std::time::Instant::now();
+        let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "cp",
+                &t.s("source"),
+                "--as",
+                &t.s(pacing),
+                "-j",
+                "1",
+                "-v",
+                "--no-progress",
+                "--bwlimit=2M",
+                "--tuning-options",
+                &format!("copy-path=ranges,request-size=2M,bw-pacing={pacing}"),
+            ])
+            .run()
+            .unwrap();
+        assert_output_ok(&out);
+        assert!(
+            start.elapsed() >= std::time::Duration::from_millis(900),
+            "{out:?}"
+        );
+        let observed = tuning_observed(&out);
+        assert_eq!(observed["max_request_bytes"], expected_max, "{observed}");
+        if pacing == "average" {
+            assert_eq!(observed["range_requests"], 1);
+        }
+        assert_eq!(read(&t.path(pacing)), data);
+    }
+}
+
+#[test]
 fn tuning_options_are_in_full_help_and_validate_before_copying() {
     let t = Tmp::new();
     write(&t.path("source"), b"source");
@@ -5918,6 +6080,8 @@ fn tuning_options_are_in_full_help_and_validate_before_copying() {
             "pipeline-depth=0",
             "request-size=65M",
             "pipeline-depth=4,pipeline-depth=8",
+            "copy-path=ranges,batch-files=1",
+            "bw-pacing=average",
         ] {
             let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
             command.args([interface, "--tuning-options", options, &t.s("source")]);
@@ -6017,7 +6181,7 @@ fn tuning_options_preserve_partial_identity_and_reused_hash_blocks() {
         "-a",
         "--block-size=1M",
         "--bwlimit=1G",
-        "--tuning-options=request-size=128K,pipeline-depth=8",
+        "--tuning-options=request-size=128K,pipeline-depth=8,copy-path=ranges,split-min-size=2M,bw-pacing=average",
         &src,
         &dst,
     ]);

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -69,6 +69,10 @@ the reversed constrained-agent edge, and an explicit local relay. Every path
 uses real SSH for control and bootstrap, and the suite compares the complete
 source and destination manifests afterward.
 
+Range-transfer checks also copy a large file with a 64-request pipeline and
+64 KiB requests over TCP and SSH, then through source, destination, and local
+coordinators. Each result is compared byte for byte with the original.
+
 This suite is intentionally outside `cargo test` and CI. Run it after changing
 SSH, remote-helper, enrollment, restricted-receiver, transport, or remote
 topology behavior, and before cutting a release. For release preparation, use

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -70,8 +70,9 @@ uses real SSH for control and bootstrap, and the suite compares the complete
 source and destination manifests afterward.
 
 Range-transfer checks also copy a large file with a 64-request pipeline and
-64 KiB requests over TCP and SSH, then through source, destination, and local
-coordinators. Each result is compared byte for byte with the original.
+2 MiB requests with average bandwidth pacing over TCP and SSH, then through
+source, destination, and local coordinators. Batch overrides also run through
+a restricted receiver. Each result is compared byte for byte with the original.
 
 This suite is intentionally outside `cargo test` and CI. Run it after changing
 SSH, remote-helper, enrollment, restricted-receiver, transport, or remote

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -457,6 +457,38 @@ assert_same_tree \
     destination /tmp/syq-real-ssh/relay-destination \
     relay
 
+printf 'case: tuning overrides for range uploads, downloads, direct copies, and relay\n'
+tuning=request-size=64K,pipeline-depth=64
+dd if=/dev/urandom of=/tmp/syq-real-ssh-tuning.bin bs=1M count=9 status=none
+for transport in tcp ssh; do
+    if [ "$transport" = ssh ]; then
+        set -- --no-tcp
+    else
+        set --
+    fi
+    syq cp /tmp/syq-real-ssh-tuning.bin --to source \
+        --as "/tmp/syq-real-ssh/tuning-$transport" -j 1 --no-progress \
+        --tuning-options "$tuning" "$@"
+    syq cp --from source "/tmp/syq-real-ssh/tuning-$transport" \
+        --as "/tmp/syq-real-ssh-tuning-$transport-download" -j 1 --no-progress \
+        --tuning-options "$tuning" "$@"
+    cmp /tmp/syq-real-ssh-tuning.bin "/tmp/syq-real-ssh-tuning-$transport-download"
+done
+for coordinator in src dst local; do
+    case "$coordinator" in
+        src) set -- ;;
+        dst) set -- --peer-auth broker --no-tcp ;;
+        local) set -- --no-tcp ;;
+    esac
+    syq cp --from source /tmp/syq-real-ssh/tuning-tcp --to destination \
+        --as "/tmp/syq-real-ssh/tuning-$coordinator" --coordinate-at "$coordinator" \
+        -j 1 --no-progress --tuning-options "$tuning" "$@"
+    ssh destination sh -s -- "$coordinator" > /tmp/syq-real-ssh-tuning-check <<'EOF'
+cat "/tmp/syq-real-ssh/tuning-$1"
+EOF
+    cmp /tmp/syq-real-ssh-tuning.bin /tmp/syq-real-ssh-tuning-check
+done
+
 if ssh source 'pgrep -x syq >/dev/null' || ssh destination 'pgrep -x syq >/dev/null'; then
     echo 'a remote syq process survived the attached test suite' >&2
     exit 1

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -458,7 +458,7 @@ assert_same_tree \
     relay
 
 printf 'case: tuning overrides for range uploads, downloads, direct copies, and relay\n'
-tuning=request-size=64K,pipeline-depth=64
+tuning=copy-path=ranges,request-size=2M,pipeline-depth=64,split-min-size=8M,bw-pacing=average
 dd if=/dev/urandom of=/tmp/syq-real-ssh-tuning.bin bs=1M count=9 status=none
 for transport in tcp ssh; do
     if [ "$transport" = ssh ]; then
@@ -468,10 +468,10 @@ for transport in tcp ssh; do
     fi
     syq cp /tmp/syq-real-ssh-tuning.bin --to source \
         --as "/tmp/syq-real-ssh/tuning-$transport" -j 1 --no-progress \
-        --tuning-options "$tuning" "$@"
+        --bwlimit 8M --tuning-options "$tuning" "$@"
     syq cp --from source "/tmp/syq-real-ssh/tuning-$transport" \
         --as "/tmp/syq-real-ssh-tuning-$transport-download" -j 1 --no-progress \
-        --tuning-options "$tuning" "$@"
+        --bwlimit 8M --tuning-options "$tuning" "$@"
     cmp /tmp/syq-real-ssh-tuning.bin "/tmp/syq-real-ssh-tuning-$transport-download"
 done
 for coordinator in src dst local; do
@@ -482,12 +482,20 @@ for coordinator in src dst local; do
     esac
     syq cp --from source /tmp/syq-real-ssh/tuning-tcp --to destination \
         --as "/tmp/syq-real-ssh/tuning-$coordinator" --coordinate-at "$coordinator" \
-        -j 1 --no-progress --tuning-options "$tuning" "$@"
+        -j 1 --no-progress --bwlimit 8M --tuning-options "$tuning" "$@"
     ssh destination sh -s -- "$coordinator" > /tmp/syq-real-ssh-tuning-check <<'EOF'
 cat "/tmp/syq-real-ssh/tuning-$1"
 EOF
     cmp /tmp/syq-real-ssh-tuning.bin /tmp/syq-real-ssh-tuning-check
 done
+
+printf 'case: batch overrides through a command-restricted receiver\n'
+ssh source 'mkdir /tmp/syq-real-ssh/tuning-batches; for n in 1 2 3 4 5 6 7; do dd if=/dev/urandom of=/tmp/syq-real-ssh/tuning-batches/$n bs=1024 count=600 status=none; done'
+syq cp --from source --srcs-in /tmp/syq-real-ssh/tuning-batches \
+    --to destination --into /tmp/syq-real-ssh/tuning-batches -j 1 --no-progress \
+    --tuning-options batch-files=3,batch-bytes=1M
+assert_same_tree source /tmp/syq-real-ssh/tuning-batches \
+    destination /tmp/syq-real-ssh/tuning-batches tuning-batches
 
 if ssh source 'pgrep -x syq >/dev/null' || ssh destination 'pgrep -x syq >/dev/null'; then
     echo 'a remote syq process survived the attached test suite' >&2


### PR DESCRIPTION
Transfer request sizes, pipeline depth, copy shortcuts, small-file batching, and file-region splitting were fixed internals or shared other settings. Add experimental `--tuning-options` to `syq cp` and `syq rsync` so benchmarks can vary them without changing the hash/resume grid. The namespace is in `--help-all` under Benchmark tuning; `docs/speed.md` explains effective limits, trade-offs, and reproducible comparisons.

Supported keys: `request-size`, `pipeline-depth`, `copy-path`, `batch-files`, `batch-bytes`, `split-min-size`, and `bw-pacing`. Reject unknown, duplicate, out-of-range, and incompatible settings. `copy-path=ranges` bypasses whole-file and small-copy shortcuts; explicit batch settings bypass the fused native small-copy shortcut. Batch byte limits include the first file. Split thresholds retain the minimum of two hash blocks and hash alignment. Background response queues follow pipeline depth to avoid mutual blocking when requests and responses exceed transport buffers.

`bw-pacing=average` pays each request's full shared byte budget before issuing it, including the first request. For example, a 2 MiB request at 1 MiB/s waits about two seconds, then may travel in a burst. Timed pacing (`1ms` through `10s`) caps request size using rate times interval and the existing 512-byte floor. The existing `125ms` sizing/pacing remains the default. These pace logical source requests, not continuous wire traffic. Restricted receivers retain their independent signed rate and 125ms request-size ceiling in both modes; tuning cannot enlarge that authority.

Forward settings to remote coordinators. With overrides, `-v` reports effective settings and diagnostic counts/maxima for observed copy paths, requests, and batches. Diagnostic counters describe attempted work, including retries; automation records are unchanged. Experimental runs neither read nor update the remembered connection count. Connection auto-tuning still runs unless the user fixes the connection count. Python classifies the namespace as a raw CLI option. No throughput improvement or automatic request-size tuning is claimed.

Compatibility baseline: v0.3.2. `src/proto.rs`, `src/resume.rs`, and `src/restricted.rs` are unchanged from the tag, including the fixed resume identity fixture and signed receiver refusal tests. New settings do not enter hash grids, partial identities, grants, receipts, completion records, or saved tuning state. An existing partial resumes with different tuning settings and reuses the original hash blocks. Remote coordinators receive the CLI argument through existing helper selection; an old CLI rejects the new argument. There is no new wire message or on-disk migration, and old/new clients sharing a host use existing state formats.

Validation on `020fe90` (rebased onto master `9599c96`):

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --bin syq` passed (442 unit tests). `cargo test --all-targets` passed, including 409 local integration tests.
- Local integration coverage for forced range paths, native shortcut selection, batch count/byte ceilings including the first file, average/timed pacing including a one-request copy, aggregate rate limiting, changed-setting resume reuse, and TCP/SSH request-size/depth matrices.
- The socket regression test drains 64 responses while large outgoing requests exceed transport buffering.
- `scripts/test-real-ssh.sh` passed with forced ranges, average pacing, 64-request pipelines, TCP/SSH uploads/downloads, source/destination/local coordinators, and restricted receiver batches; copied contents are compared. An initial run exposed the signed request ceiling; after preserving it explicitly, the full suite passed. The suite was repeated from the clean rebased commit.
- Documentation link checks and ShellCheck passed. No local macOS run or optimization benchmark was performed.
