### PR TITLE
Fix the tuning TCP test fixture on macOS

### DIFF
--- a/tests/local.rs
+++ b/tests/local.rs
@@ -6100,6 +6100,9 @@ fn tuning_options_are_in_full_help_and_validate_before_copying() {
 fn tuning_options_copy_remote_ranges_over_tcp_and_ssh() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);
+    // Exercise the SSH arrival address even where Linux interface discovery
+    // could otherwise mask a missing address in the fake SSH session.
+    executable(&t.path("remote-bin/ip"), b"#!/bin/sh\nexit 1\n");
     let data = prng(9 * 1024 * 1024 + 123, 904);
     write(&t.path("source"), &data);
     for tcp in [false, true] {
@@ -6139,6 +6142,7 @@ fn tuning_options_copy_remote_ranges_over_tcp_and_ssh() {
                     .env("FAKE_REMOTE_HOME", t.path("remote-home"))
                     .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
                     .env("FAKE_RSH_LOG", t.path("rsh.log"))
+                    .env("FAKE_SSH_CONNECTION", "127.0.0.1 40000 127.0.0.1 22")
                     .env("XDG_CONFIG_HOME", t.path("config"))
                     .env("XDG_CACHE_HOME", t.path("cache"));
                 let out = command.run().unwrap();


### PR DESCRIPTION
The tuning TCP/SSH matrix failed in the macOS post-merge suite for PR #235 at `588bc5f`: the fake SSH session had no arrival address, and macOS has no Linux `ip` interface listing to supply a reachable candidate. The TCP-required test consequently failed before copying with "no advertised data address is reachable".

Supply a loopback `FAKE_SSH_CONNECTION` through the existing fake-shell fixture. Stub interface listing as unavailable inside this test so Linux also exercises the same path and cannot hide the missing SSH address. Keep every upload/download and size/depth combination and the assertion that TCP is actually used. Production code and external interfaces are unchanged.

Validation:

- With interface listing disabled and the SSH address still missing, the exact integration test reproduced the macOS failure on Linux.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, all 442 binary unit tests, and the corrected exact integration test passed on the implementation committed as `573c09b`.
- The [full macOS workflow](https://github.com/greaber/syq/actions/runs/34002551871) passed on exact commit `573c09b`, including all native tests, Python/JavaScript/Go SDK tests, and release-tool suites.

Master `588bc5f` passed `ci` and Linux/macOS `rsync-compat`; its full macOS workflow failed solely on this new TCP fixture. Original real-SSH validation covered identical production code; this repair only changes the integration fixture.
