### PR TITLE
Overlap TCP route probing with buffered source planning

### DIFF
--- a/design/remote-setup-performance.md
+++ b/design/remote-setup-performance.md
@@ -107,3 +107,35 @@ probing delayed transport readiness until 6.12 seconds, matching the baseline.
 Workers connected during subsequent candidate planning; the baseline waited
 until planning completed to start them. The probing wait limits how much of
 the reduced setup latency reaches the TCP elapsed result.
+
+## Probe-overlap measurement, 2026-09-06
+
+A follow-up compares clean `e6dc071` (the setup and early-worker changes above)
+with clean `9e73649` (buffered planning overlaps route probes). Both use the
+same static release build flags, 1,024-file source, copy command, stats/debug
+output and verification method above. Each binary receives an untimed full-copy
+warmup to install its exact helper; three measured rounds reverse case order
+in the middle round. This task's builds and test suites finished before timing.
+The source and OS caches remain warm, the machines and public route are shared,
+and copies do not request durable disk writes. Every destination passed the
+checksum comparison, and the disposable remote root was removed afterward.
+
+| Transport | Baseline seconds | Candidate seconds | Mean baseline → candidate |
+|---|---|---|---|
+| Encrypted TCP | 10.251, 10.263, 10.303 | 10.019, 10.204, 10.437 | 10.272 → 10.220 |
+| SSH control comparison | 10.522, 11.112, 10.965 | 11.111, 10.639, 10.903 | 10.866 → 10.884 |
+
+The total TCP difference is only 0.052 seconds (0.5%), well within the observed
+variation; these trials do not establish an end-to-end speedup. The internal
+stages do show the intended overlap consistently. Time from control connection
+readiness to completed payload planning was 2.36/2.39/2.33 seconds before and
+2.09/2.10/2.12 seconds afterward: roughly one 260 ms round trip is covered by
+the probe window. Remaining planning after transport readiness shrinks from
+1.09/1.11/1.06 to 0.81/0.82/0.84 seconds. TCP worker authentication still overlaps
+the later destination checks, and each trial starts eight workers.
+
+This workload's scan covers only part of the roughly half-second probe wait
+remaining after destination preflight. The bounded probe window still finishes
+about one second after it starts. SSH connection setup and payload processing
+remain larger costs; a wider performance claim needs controlled latency and
+more repetitions rather than extrapolating from the stage improvement.

--- a/design/remote-setup-performance.md
+++ b/design/remote-setup-performance.md
@@ -23,6 +23,31 @@ preflights pass; planning failure aborts the idle workers. This overlap excludes
 same-machine copies, dry runs, verification, in-place copying, checksumming,
 update/ignore-existing, forced ranges, and bandwidth-limited copies.
 
+## Overlapping route probes with buffered planning
+
+For buffered planning into an existing destination, the coordinator settles
+pending TCP address probes after the source scan and sidecar namespace checks.
+Those checks use the control connection and do not mutate the destination.
+The complete probe window and bandwidth-based address selection are unchanged;
+only the point at which the coordinator joins the probe thread moves.
+Transport selection, the tuning cache lookup, and initial connection counts
+still settle before any worker starts or the buffered plan is replayed.
+Unreachable ordinary TCP routes still fall back to SSH.
+
+Initially missing destination trees retain their earlier worker startup during
+scanning. Unbuffered planning retains its previous setup order, since it can
+release work while scanning. Signed receivers settle TCP before destination
+creation because their one-time grants cannot be replayed for SSH fallback.
+Detached copies also retain their earlier setup order so readiness notification
+does not wait for a potentially long source scan. No extra scan or buffering
+is introduced to obtain the overlap.
+
+The regression test records coordinator setup events separately from helper
+stderr. It checks scan-before-transport ordering for an empty existing remote
+directory, the previous ordering for missing destinations, forced SSH and
+detached copies, successful fallback when advertised TCP is unreachable, and
+an empty destination when a required TCP probe fails after scanning.
+
 ## Compatibility
 
 No messages, state formats, resume identities, CLI options, or output fields

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -80,6 +80,19 @@ fn record_worker_event_for_test(event: &str, worker: usize, files: usize) -> Res
     Ok(())
 }
 
+#[cfg(debug_assertions)]
+fn record_setup_event_for_test(event: &str) -> Result<()> {
+    use std::io::Write;
+    if let Some(path) = std::env::var_os("SYQ_TEST_SETUP_EVENTS") {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        writeln!(file, "{event}")?;
+    }
+    Ok(())
+}
+
 fn fast_file_size_limit(opts: &Opts) -> u64 {
     opts.block
         .min(opts.tuning.batch_bytes())
@@ -2685,91 +2698,110 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         );
     }
 
-    for (spec, pending) in pending_tcp_setups {
-        if let Err(error) = spec.finish_tcp_setup(pending) {
-            handle_tcp_setup_error(
-                &args,
-                &spec,
-                tcp_ports.expect("pending TCP setup has a port range"),
-                error,
-                &sched,
-                &progress,
-            )?;
-        }
-        if debug() {
-            crate::output::diagnostic!(
-                "syq: {}: tcp data port {:?}",
-                spec.label(),
-                spec.tcp
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .map(|info| (info.addrs.clone(), info.port))
-            );
-        }
-    }
-    #[cfg(debug_assertions)]
-    if std::env::var_os("SYQ_TEST_REQUIRE_TCP").is_some() {
-        let remote_specs: Vec<_> = [&src_ep, &dst_ep]
-            .into_iter()
-            .filter_map(real_remote_spec)
-            .collect();
-        if remote_specs.is_empty()
-            || remote_specs
-                .iter()
-                .any(|spec| spec.data_transport() == DataTransport::Ssh)
-        {
-            sched.abort();
-            progress.stop();
-            bail!("TCP data transport required by test");
-        }
-    }
-    if debug() {
-        crate::output::diagnostic!(
-            "syq: data transport setup complete at {:.2}s",
-            t0.elapsed().as_secs_f64()
-        );
-    }
-    announce_detached_ready()?;
-    let all_remote_endpoints_use_tcp = use_tcp
-        && [&src_ep, &dst_ep]
-            .into_iter()
-            .all(|endpoint| match endpoint {
-                Endpoint::Local { .. } => true,
-                Endpoint::Remote(spec) => spec
-                    .tcp
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .is_some_and(|info| !info.failed),
-            });
-    if autotune && all_remote_endpoints_use_tcp && (src_ep.is_remote() || dst_ep.is_remote()) {
-        args.connections = tune::START_TCP;
-        gate.set_active(args.connections);
-    }
-    let tuning_key = (autotune && args.tuning_options.is_none())
-        .then(|| tune::path_key(&src_ep, &dst_ep))
-        .flatten();
-    let remembered_start = tuning_key.as_deref().and_then(tune::cached);
-    if let Some(remembered) = remembered_start {
-        args.connections = remembered;
-        gate.set_active(remembered);
-    }
-    print_transport_diagnostics(&args, &src_ep, &dst_ep);
-    if args.verbose >= 2 {
-        if let Some(remembered) = remembered_start {
-            crate::output::diagnostic!(
-                "syq: auto-tuning: starting with {remembered} connections remembered for this path"
-            );
-        }
-    }
     let destination_tree_known_missing = dst.is_remote()
         && dst_initially_missing
         && !opts.ignore_existing
         && !opts.update
         && !opts.checksum;
+    // Buffered planning performs no destination mutations and starts no
+    // workers. Let route probes overlap that scan, while preserving the early
+    // worker startup used for initially missing destination trees. Restricted
+    // receivers already settled their probes before destination creation.
+    // Detached copies keep their readiness notification ahead of the scan.
+    let defer_transport_setup = defer_destination_mutations
+        && !destination_tree_known_missing
+        && std::env::var_os("SYQ_INTERNAL_DETACH_READY").is_none()
+        && !pending_tcp_setups.is_empty();
+    let mut finish_transport_setup = |args: &mut Args| -> Result<(bool, Option<String>)> {
+        for (spec, pending) in std::mem::take(&mut pending_tcp_setups) {
+            if let Err(error) = spec.finish_tcp_setup(pending) {
+                handle_tcp_setup_error(
+                    args,
+                    &spec,
+                    tcp_ports.expect("pending TCP setup has a port range"),
+                    error,
+                    &sched,
+                    &progress,
+                )?;
+            }
+            if debug() {
+                crate::output::diagnostic!(
+                    "syq: {}: tcp data port {:?}",
+                    spec.label(),
+                    spec.tcp
+                        .lock()
+                        .unwrap()
+                        .as_ref()
+                        .map(|info| (info.addrs.clone(), info.port))
+                );
+            }
+        }
+        #[cfg(debug_assertions)]
+        if std::env::var_os("SYQ_TEST_REQUIRE_TCP").is_some() {
+            let remote_specs: Vec<_> = [&src_ep, &dst_ep]
+                .into_iter()
+                .filter_map(real_remote_spec)
+                .collect();
+            if remote_specs.is_empty()
+                || remote_specs
+                    .iter()
+                    .any(|spec| spec.data_transport() == DataTransport::Ssh)
+            {
+                sched.abort();
+                progress.stop();
+                bail!("TCP data transport required by test");
+            }
+        }
+        if debug() {
+            crate::output::diagnostic!(
+                "syq: data transport setup complete at {:.2}s",
+                t0.elapsed().as_secs_f64()
+            );
+        }
+        #[cfg(debug_assertions)]
+        record_setup_event_for_test("transport_ready")?;
+        announce_detached_ready()?;
+        let all_remote_endpoints_use_tcp = use_tcp
+            && [&src_ep, &dst_ep]
+                .into_iter()
+                .all(|endpoint| match endpoint {
+                    Endpoint::Local { .. } => true,
+                    Endpoint::Remote(spec) => spec
+                        .tcp
+                        .lock()
+                        .unwrap()
+                        .as_ref()
+                        .is_some_and(|info| !info.failed),
+                });
+        if autotune && all_remote_endpoints_use_tcp && (src_ep.is_remote() || dst_ep.is_remote()) {
+            args.connections = tune::START_TCP;
+            gate.set_active(args.connections);
+        }
+        let tuning_key = (autotune && args.tuning_options.is_none())
+            .then(|| tune::path_key(&src_ep, &dst_ep))
+            .flatten();
+        let remembered_start = tuning_key.as_deref().and_then(tune::cached);
+        if let Some(remembered) = remembered_start {
+            args.connections = remembered;
+            gate.set_active(remembered);
+        }
+        print_transport_diagnostics(args, &src_ep, &dst_ep);
+        if args.verbose >= 2 {
+            if let Some(remembered) = remembered_start {
+                crate::output::diagnostic!(
+                    "syq: auto-tuning: starting with {remembered} connections remembered for this path"
+                );
+            }
+        }
+        Ok((all_remote_endpoints_use_tcp, tuning_key))
+    };
+    let mut transport_setup = if defer_transport_setup {
+        None
+    } else {
+        Some(finish_transport_setup(&mut args)?)
+    };
     let mut workers_started = false;
-    if all_remote_endpoints_use_tcp
+    if transport_setup.as_ref().is_some_and(|(tcp, _)| *tcp)
         && destination_tree_known_missing
         && !opts.dry_run
         && !opts.inplace
@@ -2942,6 +2974,13 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             scan_err = Some(e);
         }
     }
+    #[cfg(debug_assertions)]
+    record_setup_event_for_test("scan_complete")?;
+    if transport_setup.is_none() {
+        transport_setup = Some(finish_transport_setup(&mut args)?);
+    }
+    let (all_remote_endpoints_use_tcp, tuning_key) =
+        transport_setup.expect("transport setup completed before releasing planned work");
     // The complete buffered scan lets small trees keep the same bounded
     // starting count as normal scheduling. Open TCP workers while the control
     // connection rechecks capacity and inspects the destination; no jobs are

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7249,6 +7249,97 @@ fn small_files_atomic_no_partials() {
 
 #[cfg(debug_assertions)]
 #[test]
+fn buffered_remote_scan_overlaps_tcp_setup() {
+    for (case, existing, tcp, detached, reachable, require_tcp) in [
+        ("empty", true, true, false, true, true),
+        ("missing", false, true, false, true, true),
+        ("ssh", true, false, false, true, false),
+        ("detached", true, true, true, true, true),
+        ("fallback", true, true, false, false, false),
+        ("required-failure", true, true, false, false, true),
+    ] {
+        let t = Tmp::new();
+        let rsh = fake_rsh(&t);
+        executable(&t.path("remote-bin/ip"), b"#!/bin/sh\nexit 1\n");
+        for i in 0..3 {
+            write(
+                &t.path(&format!("src/f{i}")),
+                format!("contents-{i}").as_bytes(),
+            );
+        }
+        if existing {
+            fs::create_dir_all(t.path("dst")).unwrap();
+        }
+        let events = t.path("setup-events");
+        let mut command = compat_command();
+        command
+            .arg("-e")
+            .arg(&rsh)
+            .arg("--rsync-path")
+            .arg(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "--syq-tcp-ports",
+                EPHEMERAL_TCP_PORTS,
+                "-a",
+                "--no-progress",
+            ])
+            .arg(t.s("src/"))
+            .arg(format!("setup.invalid:{}", t.s("dst/")))
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env(
+                "FAKE_SSH_CONNECTION",
+                if reachable {
+                    "127.0.0.1 40000 127.0.0.1 22"
+                } else {
+                    "192.0.2.1 40000 192.0.2.1 22"
+                },
+            )
+            .env("XDG_CONFIG_HOME", t.path("config"))
+            .env("SYQ_TEST_SETUP_EVENTS", &events);
+        if require_tcp {
+            command.env("SYQ_TEST_REQUIRE_TCP", "1");
+        }
+        if !tcp {
+            command.arg("--syq-no-tcp");
+        }
+        if detached {
+            command.env("SYQ_INTERNAL_DETACH_READY", t.path("ready"));
+        }
+        let output = command.run().unwrap();
+        if require_tcp && !reachable {
+            assert!(!output.status.success(), "{case}");
+            assert!(stderr_of(&output).contains("TCP data transport required by test"));
+            assert_eq!(fs::read_to_string(events).unwrap(), "scan_complete\n");
+            assert_eq!(fs::read_dir(t.path("dst")).unwrap().count(), 0);
+            continue;
+        }
+        assert!(output.status.success(), "{case}: {}", stderr_of(&output));
+        assert_eq!(
+            fs::read_to_string(events).unwrap(),
+            if existing && tcp && !detached {
+                "scan_complete\ntransport_ready\n"
+            } else {
+                "transport_ready\nscan_complete\n"
+            },
+            "{case}"
+        );
+        for i in 0..3 {
+            assert_eq!(
+                read(&t.path(&format!("dst/f{i}"))),
+                format!("contents-{i}").as_bytes()
+            );
+        }
+        assert!(partial_files(&t.path("dst")).is_empty(), "{case}");
+        if detached {
+            assert_eq!(read(&t.path("ready")), b"ready\n");
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+#[test]
 fn small_inplace_files_use_one_batched_worker() {
     let t = Tmp::new();
     for i in 0..3 {


### PR DESCRIPTION
Buffered remote copies waited for TCP address probes before scanning sources, even though the scan and sidecar namespace checks use only the control connection. This moves the probe join after buffered planning, so those checks cover part of the existing bounded probe window. Route selection and tuning still settle before workers start or the plan is replayed.

Stacked on #238 (`e6dc071`), with base `small-tree-ssh-performance` to isolate this change during its review. Head `76a0292`; production implementation is `9e73649`, followed only by measurement documentation. Neither PR should be merged into its task-branch base as a substitute for integration into master.

Missing-destination early workers, unbuffered planning, signed-receiver checks before destination creation, and detached readiness retain their previous ordering. TCP fallback and full bandwidth-based address selection are preserved. No wire messages, durable state, resume identities, CLI/SDK options, or structured output fields change. The unchanged official v0.3.2 receiver passes the existing setup replay test; production helpers still enforce exact identities.

Three alternating j5 trials, 1,024 × 8 KiB files, fresh empty destinations, static release builds, untimed helper warmups, and checksum verification of every copy:

| Mean elapsed | e6dc071 | 9e73649 |
|---|---:|---:|
| Encrypted TCP | 10.272 s | 10.220 s |
| Forced SSH control comparison | 10.866 s | 10.884 s |

This does **not** establish an end-to-end speedup. Stage timing consistently reduces control-ready → planning-complete from 2.33–2.39 s to 2.09–2.12 s, covering approximately one 260 ms RTT. Full samples and limitations are in `design/remote-setup-performance.md`. This task's builds/tests finished before timed copies; remote scratch was removed after verification.

Validation passed at implementation commit `9e73649`: fmt, clippy all targets/features with warnings denied, all-targets (448 unit, 411 local, 4 CLI, 5 output, 7 update), explicit v0.3.2 setup replay, and the default three-container real-SSH suite. The new integration test covers setup ordering, missing destinations, forced SSH, detached readiness, automatic fallback, and no destination writes after a required-TCP failure. Docs links and whitespace checks passed after the documentation-only commit. No local macOS run.

`branch-status.sh` reports the head clean and pushed, and exits 1 because master macOS is red at `caa1d61`: the tuning fixture plus two return-connection unit tests fail. The final status check confirms native CI and rsync-compat passed at `caa1d61`. PR workflows do not start automatically; no PR check success is claimed.
