### PR TITLE
Add approved server-to-server copies with --via

### DIFF
--- a/docs/receive.md
+++ b/docs/receive.md
@@ -81,6 +81,10 @@ needed for copying, write unwanted content, or consume disk space within its
 limits. The server receives neither your SSH agent nor an interface for running
 arbitrary laptop commands.
 
+To send files from that server to another SSH host using this machine's
+permission, use `syq cp results --to hostB --via @laptop`. These requests always
+need a local decision. See [Start a copy from the source server](remote-to-remote.md#start-a-copy-from-the-source-server).
+
 ## Names and paths
 
 A bare name uses a live return connection before trying an SSH host of the same

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -107,6 +107,8 @@ Enclose IPv6 addresses in brackets: `alice@[2001:db8::1]:2222`.
 A colon in a native path is simply part of the path.
 
 For two remote endpoints, see [Copy between servers](remote-to-remote.md).
+From a server shell, `syq cp results --to hostB --via @laptop` can ask a live
+receiving machine to authorize the copy while data flows directly to hostB.
 
 ## Progress
 

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -19,6 +19,48 @@ HostA gets permission for this transfer only. HostB checks that permission
 and reports what it changed. See [Security](security.md#a-compromised-source-server)
 for what this protects against.
 
+## Start a copy from the source server
+
+If your laptop has a [return connection](receive.md) to the source server,
+you can inspect files in any server shell and send them to another SSH host:
+
+```sh
+# Run on hostA, including in an existing tmux shell.
+ls -lh results
+syq cp results --to hostB --via @laptop --into /archive
+```
+
+The laptop asks for approval before contacting hostB. Approve with the desktop
+prompt or `syq recv pending` and `syq recv approve REQUEST_ID` on the laptop.
+These requests require a decision even when `recv --approve always` permits
+automatic copies onto the laptop itself. `--via laptop` also works; both forms
+require a live return connection and never fall back to an SSH host named laptop.
+
+The laptop uses its own SSH configuration, credentials, and trusted host keys
+to connect to hostB and install the matching syq helper. Connect to hostB with
+ordinary SSH from the laptop first if its host key is not yet trusted. The
+source server receives no SSH credentials or agent access. The control stream
+passes through the laptop; file data goes directly from hostA to hostB over
+encrypted TCP. HostB must expose a [reachable data port](server-tuning.md#make-tcp-reachable)
+to hostA. Failure to reach it fails the copy without switching to SSH data.
+
+The prompt shows the requested SSH endpoint and destination path. Relative
+destination paths start in that account's home directory on hostB. Receiving
+`--cwd` and `--root` govern copies onto the laptop; they do not describe hostB's
+filesystem. Receiving byte, entry, and deletion ceilings still apply. The
+helper on hostB checks the approved copy permissions and protects its own
+control and SSH authority files. The source verifies its signed receipt before
+reporting success. No durable receiver enrollment or reusable grant is created.
+
+All three machines must use the same syq build. Keep the source command and
+the laptop's return connection alive until completion. Stopping receiving or
+losing that connection cancels the copy. Retry with a new approval to resume
+eligible partial files. This route accepts local sources and an ordinary SSH
+`--to` endpoint. It does not accept `--detach`, custom `--rsh`/`--syq-path`,
+`--no-bootstrap`, `--pscope`, alternative `--peer-auth`/`--coordinate-at`,
+`--no-tcp`, or `--tcp-plain`. Copy permissions and supported filesystem options
+match [return copies](receive.md#copy-permissions-and-limits).
+
 ## What you need
 
 - SSH access from your machine to both servers, with their host keys already

--- a/docs/security.md
+++ b/docs/security.md
@@ -128,3 +128,14 @@ that protection. Downloaded code for remote operations and explicit
 self-updates is verified against a signed release manifest before use.
 That verification cannot protect a machine whose trusted account or programs
 have already been compromised.
+
+A server can also request a copy to another SSH host with `--via @name`.
+This always needs a local decision, even if automatic receiving is enabled.
+Approval authorizes a connection using the receiving machine's SSH access and
+installation of a matching helper. The destination helper enforces one copy's
+paths, permissions and limits. The server gets a restricted control stream
+and encrypted TCP worker access for that copy; it gets no SSH agent, private
+key, or command-running interface. Host trust and SSH configuration are those
+of the approving machine. The destination account remains trusted, including
+its interpretation of relative paths. A compromised source can substitute
+content within the approved scope, just as with other return copies.

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -57,6 +57,7 @@ learn a second set of names for concepts that syq already names.
 | `--into-existing` | `into_existing=` |
 | `--no-compress` | `no_compress=` |
 | `--max-delete` | `max_delete=` |
+| `--via @laptop` | `via="@laptop"` |
 | `--from` | `from_=` |
 | `--as` | `as_=` |
 | `class` event field | `class_` attribute |

--- a/sdk/python/native-api.json
+++ b/sdk/python/native-api.json
@@ -27,6 +27,7 @@
         "max-delete",
         "dry-run",
         "connections",
+        "via",
         "coordinate-at",
         "rsh",
         "pscope",

--- a/sdk/python/src/syq/async_client.py
+++ b/sdk/python/src/syq/async_client.py
@@ -626,6 +626,7 @@ class AsyncClient:
         no_compress: bool = False,
         bwlimit: str | int | None = None,
         connections: int | None = None,
+        via: str | None = None,
         coordinate_at: str | None = None,
         rsh: str | None = None,
         pscope: PathArgument | None = None,
@@ -706,6 +707,8 @@ class AsyncClient:
             min_size=min_size,
             max_delete=max_delete,
         )
+        if via is not None:
+            argv.extend(("--via", _text_arg(via, label="via")))
         _append_remote_arguments(
             argv,
             coordinate_at=coordinate_at,

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -1047,6 +1047,7 @@ class Client:
         no_compress: bool = False,
         bwlimit: str | int | None = None,
         connections: int | None = None,
+        via: str | None = None,
         coordinate_at: str | None = None,
         rsh: str | None = None,
         pscope: PathArgument | None = None,
@@ -1125,6 +1126,8 @@ class Client:
             min_size=min_size,
             max_delete=max_delete,
         )
+        if via is not None:
+            argv.extend(("--via", _text_arg(via, label="via")))
         _append_remote_arguments(
             argv,
             coordinate_at=coordinate_at,

--- a/sdk/python/tests/test_async.py
+++ b/sdk/python/tests/test_async.py
@@ -238,6 +238,11 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(entries), 1)
         self.assertEqual(stream.cwd, home / "selected")
 
+    async def test_cp_can_request_permission_via_a_return_connection(self) -> None:
+        await self.client.cp("source", to="backup", via="@laptop", into="out")
+        argv = self.argv()
+        self.assertEqual(argv[argv.index("--via") + 1], "@laptop")
+
     async def test_cp_forwards_native_remote_controls(self) -> None:
         await self.client.cp(
             "source",

--- a/sdk/python/tests/test_native.py
+++ b/sdk/python/tests/test_native.py
@@ -518,6 +518,11 @@ class NativeClientTests(unittest.TestCase):
         self.assertEqual(operation.disposition, syq.Disposition.SUCCEEDED)
         self.assertEqual(operation.kind, syq.EntryKind.FILE)
 
+    def test_cp_can_request_permission_via_a_return_connection(self) -> None:
+        self.client.cp("source", to="backup", via="@laptop", into="out")
+        argv = self.argv()
+        self.assertEqual(argv[argv.index("--via") + 1], "@laptop")
+
     def test_cp_forwards_native_remote_controls(self) -> None:
         self.client.cp(
             "source",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,8 @@ pub enum CoordinateAt {
 pub struct Args {
     #[arg(skip)]
     pub(crate) named_receipt: Option<std::sync::Arc<crate::destination::NamedReceipt>>,
+    #[arg(skip)]
+    pub(crate) via: Option<String>,
     /// Which public command produced this execution request.
     #[arg(skip)]
     pub interface: Interface,
@@ -857,6 +859,9 @@ struct NativeRemoteHelperArgs {
 
 #[derive(clap::Args, Debug, Default)]
 struct NativeRemoteArgs {
+    /// Ask a receiving machine to authorize a copy to another SSH host; file data goes directly to that host
+    #[arg(long, value_name = "@NAME")]
+    via: Option<String>,
     /// Choose the endpoint that runs the coordinator
     #[arg(long, value_enum, default_value_t = CoordinateAt::Auto, help_heading = REMOTE_TO_REMOTE_HEADING)]
     coordinate_at: CoordinateAt,
@@ -1793,6 +1798,7 @@ fn apply_native_remote(args: &mut Args, remote: NativeRemoteArgs) -> Result<()> 
             "--detach cannot be combined with --peer-auth broker or full-agent; a brokered or forwarded agent exists only while syq stays attached"
         );
     }
+    args.via = remote.via;
     args.coordinate_at = remote.coordinate_at;
     args.rsh = remote.rsh;
     args.syq_path = remote.helper.syq_path;

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -856,6 +856,7 @@ enum EndpointSyntax {
 }
 
 enum ValueCompletion {
+    ReturnName,
     NamedOrSshDestination,
     Endpoint(EndpointSyntax),
     SourcePath { apply_base: bool },
@@ -1212,6 +1213,7 @@ fn value_completion(
         "cp" => match option {
             b"--from" => Some(ValueCompletion::Endpoint(EndpointSyntax::Native)),
             b"--to" => Some(ValueCompletion::NamedOrSshDestination),
+            b"--via" => Some(ValueCompletion::ReturnName),
             b"-C" | b"--cwd" | b"--root" => Some(ValueCompletion::SourcePath { apply_base: false }),
             b"--src" | b"--srcs-in" | b"--src-file" | b"--src-dir" | b"--srcs" | b"--src-files"
             | b"--src-dirs" => Some(ValueCompletion::SourcePath { apply_base: true }),
@@ -1298,6 +1300,12 @@ fn complete_value(
     kind: ValueCompletion,
 ) -> Result<Vec<Candidate>> {
     match kind {
+        ValueCompletion::ReturnName => Ok(crate::destination::registered_names()
+            .into_iter()
+            .map(|name| format!("@{name}").into_bytes())
+            .filter(|name| name.starts_with(current))
+            .map(Candidate::text)
+            .collect()),
         ValueCompletion::NamedOrSshDestination => {
             let mut candidates = endpoint_candidates(
                 current,
@@ -1379,6 +1387,9 @@ fn complete_path_for(
 ) -> Result<Vec<Candidate>> {
     if source {
         return complete_source_path(command, args, current, true);
+    }
+    if find_option_value(args, b"--via").is_some() {
+        return Ok(Vec::new());
     }
     let Some(endpoint_text) = find_option_value(args, b"--to") else {
         return Ok(local_path_candidates_at(
@@ -1655,6 +1666,7 @@ fn connect_completion_endpoint(
         tcp: Default::default(),
         diagnostics: Default::default(),
         primed_control: Default::default(),
+        forwarded: None,
         read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
     };
     spec.connect_completion()

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2821,10 +2821,12 @@ impl Endpoint {
                         Err(e) => {
                             if spec.restricted_grant.is_some() {
                                 return Err(e).with_context(|| {
-                                    format!(
-                                        "{}: signed receiver TCP data connection failed; its one-time SSH grant cannot be replayed as a fallback",
-                                        spec.label()
-                                    )
+                                    let reason = if spec.forwarded.is_some() {
+                                        "TCP data connection failed; --via requires direct encrypted TCP and cannot fall back to SSH data"
+                                    } else {
+                                        "signed receiver TCP data connection failed; its one-time SSH grant cannot be replayed as a fallback"
+                                    };
+                                    format!("{}: {reason}", spec.label())
                                 });
                             }
                             #[cfg(debug_assertions)]
@@ -2855,10 +2857,12 @@ impl Endpoint {
                 if spec.restricted_grant.is_some()
                     && !crate::destination::is_named(&spec.restricted_grant)
                 {
-                    bail!(
-                        "{}: signed receiver has no authorized TCP data connection",
-                        spec.label()
-                    );
+                    let reason = if spec.forwarded.is_some() {
+                        "--via has no authorized encrypted TCP data connection"
+                    } else {
+                        "signed receiver has no authorized TCP data connection"
+                    };
+                    bail!("{}: {reason}", spec.label());
                 }
                 Ok(Box::new(spec.connect_with_role(compress, true, role)?))
             }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1233,6 +1233,7 @@ pub struct RemoteSpec {
     /// writing responses can stop reading requests while the coordinator is
     /// still filling its pipeline. Control sessions do not need this depth.
     pub(crate) read_ahead: usize,
+    pub(crate) forwarded: Option<std::sync::Arc<crate::destination::NamedReceipt>>,
 }
 
 #[derive(Debug, Default)]
@@ -1259,6 +1260,7 @@ impl RemoteSpec {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            forwarded: None,
             read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         }
     }
@@ -1473,6 +1475,12 @@ impl RemoteSpec {
         *self.primed_control.lock().unwrap() = PrimedControl::Checked(conn.map(Box::new));
     }
 
+    pub(crate) fn helper_command(&self, args: &[String]) -> Command {
+        let mut command = self.ssh_command(SshConnection::Independent, false);
+        command.arg(self.program_command(args));
+        command
+    }
+
     /// A shell command that runs syq with `args` on this host.  Automatic mode
     /// addresses the exact release/build-identified helper; explicit mode preserves the
     /// administrator-provided path; disabling bootstrap uses normal PATH lookup.
@@ -1627,11 +1635,20 @@ impl RemoteSpec {
         ssh_connection: SshConnection,
         role: ConnectionRole,
     ) -> Result<RemoteConn> {
-        if crate::destination::is_named(&self.restricted_grant) {
-            let stream = crate::destination::connect(
+        let return_stream = if let Some(approved) = &self.forwarded {
+            if !matches!(role, ConnectionRole::Control) {
+                bail!("copies via a return connection require encrypted TCP workers");
+            }
+            Some(approved.take_control()?)
+        } else if crate::destination::is_named(&self.restricted_grant) {
+            Some(crate::destination::connect(
                 self.restricted_grant.as_deref().unwrap(),
                 matches!(role, ConnectionRole::Control),
-            )?;
+            )?)
+        } else {
+            None
+        };
+        if let Some(stream) = return_stream {
             let (rx, reader) = spawn_reader(Box::new(stream.try_clone()?), self.read_ahead);
             let conn = RemoteConn {
                 child: None,
@@ -3149,6 +3166,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            forwarded: None,
             read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let info = TcpInfo {
@@ -3593,6 +3611,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            forwarded: None,
             read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let command = spec.ssh_command(SshConnection::Independent, false);
@@ -3654,6 +3673,7 @@ mod tests {
             }))),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            forwarded: None,
             read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let endpoint = Endpoint::Remote(spec.clone());
@@ -3683,6 +3703,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            forwarded: None,
             read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let args = |connection| {
@@ -3776,6 +3797,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            forwarded: None,
             read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
         let args = |connection| {
@@ -3855,6 +3877,7 @@ mod tests {
             tcp: Default::default(),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            forwarded: None,
             read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         };
 

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -333,6 +333,16 @@ pub(crate) struct FilterPolicy {
 }
 
 impl FilterPolicy {
+    fn normalize(&mut self) {
+        // With no filters, --delete-excluded has no observable effect.
+        if self.ignore.is_empty() {
+            self.delete_excluded = false;
+            self.destination_roots.clear();
+        } else {
+            self.destination_roots.sort();
+            self.destination_roots.dedup();
+        }
+    }
     fn validate(&self, grant: &Grant) -> Result<()> {
         if self.ignore.len() > MAX_FILTER_RULES {
             bail!("signed filter-rule count exceeds the supported range");
@@ -549,13 +559,7 @@ pub(crate) fn validate_return_request(request: &crate::destination::CopyRequest)
         operation: GrantOperation::Copy(request.copy.clone()),
     };
     let mut policy = request.constraints.clone();
-    if policy.filters.ignore.is_empty() {
-        policy.filters.destination_roots.clear();
-        policy.filters.delete_excluded = false;
-    } else {
-        policy.filters.destination_roots.sort();
-        policy.filters.destination_roots.dedup();
-    }
+    policy.filters.normalize();
     signing_payload(
         &grant,
         policy.max_file_data_bytes_per_second,
@@ -580,14 +584,7 @@ pub(crate) fn sign_grant(
     if private_key.is_encrypted() {
         bail!("cannot sign a grant with an encrypted enrollment key");
     }
-    // With no filters, --delete-excluded has no observable effect.
-    if filters.ignore.is_empty() {
-        filters.delete_excluded = false;
-        filters.destination_roots.clear();
-    } else {
-        filters.destination_roots.sort();
-        filters.destination_roots.dedup();
-    }
+    filters.normalize();
     filters.validate(&grant)?;
     let payload = signing_payload(
         &grant,

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -534,6 +534,38 @@ impl SignedGrantEnvelope {
     }
 }
 
+/// Validate an ephemeral request before an approval can authorize outbound SSH.
+/// This does not sign, redeem, or touch any durable authority state.
+pub(crate) fn validate_return_request(request: &crate::destination::CopyRequest) -> Result<()> {
+    let grant = Grant {
+        enrollment_id: EnrollmentId::random(),
+        target_login: "return".into(),
+        signer: "return".into(),
+        request_id: RequestId::fresh(0)?,
+        issued_at: 0,
+        not_before: 0,
+        start_by: 60,
+        finish_by: 3600,
+        operation: GrantOperation::Copy(request.copy.clone()),
+    };
+    let mut policy = request.constraints.clone();
+    if policy.filters.ignore.is_empty() {
+        policy.filters.destination_roots.clear();
+        policy.filters.delete_excluded = false;
+    } else {
+        policy.filters.destination_roots.sort();
+        policy.filters.destination_roots.dedup();
+    }
+    signing_payload(
+        &grant,
+        policy.max_file_data_bytes_per_second,
+        &policy.filters,
+        policy.root_existence,
+        &policy.receipt_policy,
+    )?;
+    Ok(())
+}
+
 pub(crate) fn sign_grant(
     grant: Grant,
     constraints: GrantConstraints,

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -27,6 +27,8 @@ use std::time::{Duration, Instant};
 use crate::delegation::{CopyOperation, DestinationPlacement, GrantConstraints};
 use crate::private_broker::{PrivateBroker, PrivateBrokerConfig, TrackedStream};
 
+mod forward;
+
 const VERSION: u16 = 2;
 const MAX_MESSAGE: usize = 256 * 1024;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
@@ -90,9 +92,20 @@ pub(crate) struct Approved {
 
 #[derive(Debug)]
 pub(crate) struct NamedReceipt {
+    control: Mutex<Option<UnixStream>>,
     secret: crate::receipt::RecipientSecret,
     approved: Approved,
     policy: crate::receipt::ReceiptPolicy,
+}
+
+impl NamedReceipt {
+    pub(crate) fn take_control(&self) -> Result<UnixStream> {
+        self.control
+            .lock()
+            .unwrap()
+            .take()
+            .context("approved return control connection was already consumed")
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -107,7 +120,14 @@ struct Envelope {
 enum Message {
     Ping,
     Request(Box<CopyRequest>),
-    Open { token: String, control: bool },
+    Forward {
+        target: String,
+        request: Box<CopyRequest>,
+    },
+    Open {
+        token: String,
+        control: bool,
+    },
 }
 #[derive(Serialize, Deserialize)]
 enum Reply {
@@ -440,6 +460,9 @@ pub(crate) fn is_named(grant: &Option<String>) -> bool {
 }
 
 pub(crate) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
+    if args.via.is_some() {
+        return forward::prepare(args);
+    }
     let Some(destination) = args.locations.last() else {
         return Ok(());
     };
@@ -520,6 +543,7 @@ pub(crate) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
         })?)
     ));
     args.named_receipt = Some(Arc::new(NamedReceipt {
+        control: Mutex::new(None),
         secret,
         approved,
         policy,
@@ -626,6 +650,8 @@ struct Receiver {
     #[cfg(test)]
     prompts: mpsc::SyncSender<Prompt>,
     sessions: Mutex<HashMap<String, Session>>,
+    forwarded: Arc<crate::private_broker::ConnectionRegistry>,
+    forward_count: std::sync::atomic::AtomicUsize,
     request_lock: Mutex<()>,
     stop: Arc<AtomicBool>,
 }
@@ -666,6 +692,7 @@ impl Receiver {
     fn revoke_all(&self) {
         let mut sessions = self.sessions.lock().unwrap();
         self.generation.fetch_add(1, Ordering::AcqRel);
+        self.forwarded.shutdown_all();
         for (_, session) in sessions.drain() {
             session.authority.close_control();
             session.channels.shutdown_all();
@@ -683,6 +710,7 @@ impl Receiver {
         }
         match envelope.message {
             Message::Ping => write_message(&mut stream, &Reply::Ready),
+            Message::Forward { target, request } => self.forward(target, *request, stream),
             Message::Request(request) => {
                 let _request = self.request_lock.try_lock().map_err(|_| {
                     anyhow::anyhow!(
@@ -885,6 +913,10 @@ pub(crate) fn serve_background(
         #[cfg(test)]
         prompts,
         sessions: Mutex::new(HashMap::new()),
+        forwarded: Arc::new(crate::private_broker::ConnectionRegistry::new(
+            Duration::from_secs(10),
+        )),
+        forward_count: std::sync::atomic::AtomicUsize::new(0),
         request_lock: Mutex::new(()),
         stop: stop.clone(),
     });
@@ -1204,7 +1236,7 @@ pub(crate) fn dispatch(argv: &[OsString]) -> Option<Result<i32>> {
                 argv[4].to_str().context("invalid credential")?,
             )
         })()),
-        _ => None,
+        _ => forward::dispatch(argv),
     }
 }
 
@@ -1215,7 +1247,7 @@ mod tests {
     use crate::conn::Conn;
     use crate::proto::{Request, Response};
 
-    fn args(source: &Path, destination: &str) -> Args {
+    pub(super) fn args(source: &Path, destination: &str) -> Args {
         let mut args =
             Args::try_parse_from(["syq", "-rlt", "--no-progress", "src", "dst"]).unwrap();
         args.interface = Interface::NativeCp;
@@ -1229,7 +1261,7 @@ mod tests {
         args.normalize();
         args
     }
-    fn request(args: &Args) -> (CopyRequest, crate::receipt::RecipientSecret) {
+    pub(super) fn request(args: &Args) -> (CopyRequest, crate::receipt::RecipientSecret) {
         let (secret, public) = crate::receipt::generate_recipient().unwrap();
         let policy = crate::receipt::ReceiptPolicy {
             required: true,
@@ -1246,7 +1278,7 @@ mod tests {
             secret,
         )
     }
-    fn broker(
+    pub(super) fn broker(
         root: &Path,
         approval: Approval,
     ) -> (
@@ -1271,6 +1303,10 @@ mod tests {
             approval,
             prompts,
             sessions: Mutex::new(HashMap::new()),
+            forwarded: Arc::new(crate::private_broker::ConnectionRegistry::new(
+                Duration::from_secs(10),
+            )),
+            forward_count: std::sync::atomic::AtomicUsize::new(0),
             request_lock: Mutex::new(()),
             stop: Arc::new(AtomicBool::new(false)),
         });
@@ -1677,6 +1713,7 @@ mod tests {
         args.locations.last_mut().unwrap().path = approved.destination.clone();
         args.restricted_grant = Some(route(registration, approved.token.clone()));
         args.named_receipt = Some(Arc::new(NamedReceipt {
+            control: Mutex::new(None),
             secret,
             approved,
             policy,

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -854,31 +854,31 @@ impl Drop for OwnedSsh {
         let _ = self.0.wait();
     }
 }
+const RETURN_SSH_OPTIONS: &[&str] = &[
+    "-a",
+    "-x",
+    "-T",
+    "-o",
+    "ForwardAgent=no",
+    "-o",
+    "ForwardX11=no",
+    "-o",
+    "PermitLocalCommand=no",
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    "ConnectTimeout=10",
+    "-o",
+    "ServerAliveInterval=15",
+    "-o",
+    "ServerAliveCountMax=3",
+];
 fn ssh_command(endpoint: &crate::persistence::EndpointRecord) -> Command {
     let mut cmd = Command::new("ssh");
-    cmd.args([
-        "-a",
-        "-x",
-        "-T",
-        "-o",
-        "ForwardAgent=no",
-        "-o",
-        "ForwardX11=no",
-        "-o",
-        "PermitLocalCommand=no",
-        "-o",
-        "ControlMaster=no",
-        "-o",
-        "ControlPath=none",
-        "-o",
-        "BatchMode=yes",
-        "-o",
-        "ConnectTimeout=10",
-        "-o",
-        "ServerAliveInterval=15",
-        "-o",
-        "ServerAliveCountMax=3",
-    ]);
+    // This connection installs a remote forward and follows the user's host-key
+    // policy. The outbound --via connection adds stricter options of its own.
+    cmd.args(RETURN_SSH_OPTIONS)
+        .args(["-o", "ControlMaster=no", "-o", "ControlPath=none"]);
     if let Some(user) = &endpoint.user {
         cmd.arg("-l").arg(user);
     }

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -72,25 +72,7 @@ pub(super) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
     if args.connections_opt.is_some() && args.connections > 32 {
         bail!("--via supports at most 32 workers per copy");
     }
-    let host = destination.host.as_deref().unwrap();
-    let host = if host.contains(':') {
-        format!("[{host}]")
-    } else {
-        host.into()
-    };
-    let target = format!(
-        "{}{}{}",
-        destination
-            .user
-            .as_ref()
-            .map(|u| format!("{u}@"))
-            .unwrap_or_default(),
-        host,
-        destination
-            .port
-            .map(|p| format!(":{p}"))
-            .unwrap_or_default()
-    );
+    let target = crate::remote_to_remote::endpoint_arg(destination, None, None);
     target_endpoint(&target)?;
     let registration = load_registration(&name)?;
     let (secret, public) = crate::receipt::generate_recipient()?;
@@ -206,37 +188,23 @@ impl Receiver {
         if setup_cancelled() {
             bail!("remote copy disconnected before setup");
         }
+        // This lock only serializes decisions, not SSH setup or active copies.
+        drop(request_lock);
         let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(target.as_bytes());
-        let mut child = ForwardChild::spawn(&encoded)?;
+        let (mut child, approved) = ForwardChild::connect(
+            &encoded,
+            &HelperRequest {
+                version: HELPER_VERSION,
+                identity: crate::identity::build().into(),
+                request,
+            },
+            Instant::now() + SETUP_TIMEOUT,
+            &setup_cancelled,
+        )?;
         let result = (|| {
-            let deadline = Instant::now() + SETUP_TIMEOUT;
-            let mut input = child.child.stdin.take().unwrap();
-            let mut output = child.child.stdout.take().unwrap();
-            write_message(
-                &mut DeadlineIo {
-                    inner: &mut input,
-                    deadline,
-                    cancelled: &setup_cancelled,
-                },
-                &HelperRequest {
-                    version: HELPER_VERSION,
-                    identity: crate::identity::build().into(),
-                    request,
-                },
-            )?;
-            let reply: Reply = read_message(&mut DeadlineIo {
-                inner: &mut output,
-                deadline,
-                cancelled: &setup_cancelled,
-            })?;
-            match reply {
-                Reply::Approved(approved) => {
-                    write_message(&mut stream, &Reply::Approved(approved))?
-                }
-                Reply::Error(error) => bail!("destination refused the copy: {error}"),
-                Reply::Ready => bail!("invalid destination setup response"),
-            }
-            drop(request_lock);
+            let input = child.child.stdin.take().unwrap();
+            let output = child.child.stdout.take().unwrap();
+            write_message(&mut stream, &Reply::Approved(approved))?;
             socket.set_read_timeout(None)?;
             socket.set_write_timeout(None)?;
             relay(socket.try_clone()?, input, output, cancelled, &mut child)
@@ -254,10 +222,109 @@ struct ForwardChild {
     closed: bool,
 }
 impl ForwardChild {
-    fn spawn(target: &str) -> Result<Self> {
-        let mut command = Command::new(std::env::current_exe()?);
-        command.args(["--return-connect", target]);
-        Self::spawn_command(command)
+    fn connect(
+        target: &str,
+        request: &HelperRequest,
+        deadline: Instant,
+        cancelled: &impl Fn() -> bool,
+    ) -> Result<(Self, Approved)> {
+        for install in [false, true] {
+            let mut command = Command::new(std::env::current_exe()?);
+            command.args([
+                if install {
+                    "--return-connect-install"
+                } else {
+                    "--return-connect"
+                },
+                target,
+            ]);
+            let mut child = Self::spawn_command(command)?;
+            let reply = (|| {
+                write_message(
+                    &mut DeadlineIo {
+                        inner: child.child.stdin.as_mut().unwrap(),
+                        deadline,
+                        cancelled,
+                    },
+                    request,
+                )?;
+                read_message::<Reply>(&mut DeadlineIo {
+                    inner: child.child.stdout.as_mut().unwrap(),
+                    deadline,
+                    cancelled,
+                })
+            })();
+            match reply {
+                Ok(Reply::Approved(approved)) => return Ok((child, approved)),
+                Ok(Reply::Error(error)) => bail!("destination refused the copy: {error}"),
+                Ok(Reply::Ready) => bail!("invalid destination setup response"),
+                Err(error) => {
+                    // The exact-build launcher returns this code before starting
+                    // a helper. Only that cache miss may replay the setup request.
+                    let closed = error.downcast_ref::<std::io::Error>().is_some_and(|e| {
+                        matches!(
+                            e.kind(),
+                            std::io::ErrorKind::UnexpectedEof
+                                | std::io::ErrorKind::BrokenPipe
+                                | std::io::ErrorKind::ConnectionReset
+                        )
+                    });
+                    let status = if closed {
+                        child.wait_for_exit(deadline, cancelled)
+                    } else {
+                        child.close().map_err(Into::into)
+                    };
+                    if !install
+                        && status.as_ref().is_ok_and(|s| {
+                            s.code() == Some(crate::remote_helper::HELPER_MISSING_EXIT)
+                        })
+                    {
+                        continue;
+                    }
+                    return Err(error).with_context(|| {
+                        format!(
+                            "return helper setup failed ({status:?}): {}",
+                            child.errors()
+                        )
+                    });
+                }
+            }
+        }
+        unreachable!("the second helper attempt returns its result")
+    }
+    fn wait_for_exit(
+        &mut self,
+        deadline: Instant,
+        cancelled: &impl Fn() -> bool,
+    ) -> Result<std::process::ExitStatus> {
+        loop {
+            // Observe without reaping, so cleanup can still kill descendants
+            // without allowing the leader's PID to be reused for another group.
+            let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+            let result = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    self.child.id(),
+                    &mut info,
+                    libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+                )
+            };
+            if result < 0 {
+                let error = std::io::Error::last_os_error();
+                if error.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(error.into());
+            }
+            if info.si_signo != 0 {
+                return Ok(self.close()?);
+            }
+            if cancelled() || Instant::now() >= deadline {
+                let _ = self.close();
+                bail!("return helper stopped while waiting for its exit status");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
     fn spawn_command(mut command: Command) -> Result<Self> {
         let mut child = command
@@ -290,17 +357,18 @@ impl ForwardChild {
             closed: false,
         })
     }
-    fn close(&mut self) {
+    fn close(&mut self) -> std::io::Result<std::process::ExitStatus> {
         if !self.closed {
             self.closed = true;
             unsafe {
                 libc::kill(-(self.child.id() as i32), libc::SIGKILL);
             }
-            let _ = self.child.wait();
         }
+        let status = self.child.wait();
         if let Some(capture) = self.capture.take() {
             let _ = capture.join();
         }
+        status
     }
     fn errors(&self) -> String {
         format!(
@@ -311,7 +379,7 @@ impl ForwardChild {
 }
 impl Drop for ForwardChild {
     fn drop(&mut self) {
-        self.close();
+        let _ = self.close();
     }
 }
 
@@ -367,7 +435,7 @@ fn relay(
         }
     };
     let _ = shutdown.shutdown(std::net::Shutdown::Both);
-    child.close();
+    let _ = child.close();
     let _ = upload.join();
     let _ = download.join();
     result
@@ -503,7 +571,7 @@ fn receive() -> Result<i32> {
     )?;
     Ok(0)
 }
-fn connect(target: &str) -> Result<i32> {
+fn connect(target: &str, install: bool) -> Result<i32> {
     let target =
         String::from_utf8(base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(target)?)?;
     let endpoint = target_endpoint(&target)?;
@@ -512,33 +580,19 @@ fn connect(target: &str) -> Result<i32> {
         user: endpoint.user,
         host: endpoint.host,
         port: endpoint.port,
-        rsh: [
-            "ssh",
-            "-a",
-            "-x",
-            "-T",
-            "-o",
-            "ForwardAgent=no",
-            "-o",
-            "ForwardX11=no",
-            "-o",
-            "ClearAllForwardings=yes",
-            "-o",
-            "PermitLocalCommand=no",
-            "-o",
-            "BatchMode=yes",
-            "-o",
-            "StrictHostKeyChecking=yes",
-            "-o",
-            "ConnectTimeout=10",
-            "-o",
-            "ServerAliveInterval=15",
-            "-o",
-            "ServerAliveCountMax=3",
-        ]
-        .into_iter()
-        .map(str::to_owned)
-        .collect(),
+        // A return connection needs its explicit remote forwarding. This
+        // outbound copy needs no forwarding and must not ask about host keys
+        // from the background service. RemoteSpec disables multiplexing.
+        rsh: std::iter::once("ssh")
+            .chain(RETURN_SSH_OPTIONS.iter().copied())
+            .chain([
+                "-o",
+                "ClearAllForwardings=yes",
+                "-o",
+                "StrictHostKeyChecking=yes",
+            ])
+            .map(str::to_owned)
+            .collect(),
         syq_path: None,
         bootstrap_helper: true,
         restricted_grant: None,
@@ -551,7 +605,9 @@ fn connect(target: &str) -> Result<i32> {
         forwarded: None,
         read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
     };
-    spec.install_helper()?;
+    if install {
+        spec.install_helper()?;
+    }
     Err(spec
         .helper_command(&["--return-receiver".into()])
         .exec()
@@ -560,11 +616,11 @@ fn connect(target: &str) -> Result<i32> {
 pub(super) fn dispatch(argv: &[OsString]) -> Option<Result<i32>> {
     match argv.get(1).and_then(|v| v.to_str())? {
         "--return-receiver" if argv.len() == 2 => Some(receive()),
-        "--return-connect" if argv.len() == 3 => Some(
+        "--return-connect" | "--return-connect-install" if argv.len() == 3 => Some(
             argv[2]
                 .to_str()
                 .context("invalid return target")
-                .and_then(connect),
+                .and_then(|target| connect(target, argv[1] == "--return-connect-install")),
         ),
         _ => None,
     }
@@ -574,6 +630,38 @@ pub(super) fn dispatch(argv: &[OsString]) -> Option<Result<i32>> {
 mod tests {
     use super::*;
     use crate::destination::tests::{args, broker, request};
+
+    #[test]
+    fn helper_exit_status_and_stderr_survive_group_cleanup() {
+        let mut command = Command::new("sh");
+        // A descendant keeps stderr open after the launcher has exited.
+        command.args(["-c", "sleep 30 & printf missing >&2; exit 125"]);
+        let mut child = ForwardChild::spawn_command(command).unwrap();
+        let status = child
+            .wait_for_exit(Instant::now() + Duration::from_secs(2), &|| false)
+            .unwrap();
+        assert_eq!(
+            status.code(),
+            Some(crate::remote_helper::HELPER_MISSING_EXIT)
+        );
+        assert_eq!(child.errors(), "\"missing\"");
+        assert_eq!(child.close().unwrap(), status);
+    }
+
+    #[test]
+    fn helper_exit_wait_remains_bounded_and_cancellable() {
+        for cancel in [false, true] {
+            let mut command = Command::new("sh");
+            command.args(["-c", "sleep 30"]);
+            let mut child = ForwardChild::spawn_command(command).unwrap();
+            let started = Instant::now();
+            assert!(child
+                .wait_for_exit(started + Duration::from_millis(20), &|| cancel)
+                .is_err());
+            assert!(started.elapsed() < Duration::from_secs(2));
+            assert!(child.child.try_wait().unwrap().is_some());
+        }
+    }
 
     #[test]
     fn duplex_control_relay_delivers_small_messages_without_waiting_for_eof() {

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -114,6 +114,9 @@ pub(super) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
         },
         REQUEST_TIMEOUT + SETUP_TIMEOUT + Duration::from_secs(10),
     )?;
+    if args.verbose > 0 {
+        crate::output::diagnostic!("syq: remote copy approved; opening its control connection");
+    }
     let Reply::Approved(approved) = reply else {
         bail!("unexpected remote copy approval response");
     };
@@ -252,8 +255,12 @@ struct ForwardChild {
 }
 impl ForwardChild {
     fn spawn(target: &str) -> Result<Self> {
-        let mut child = Command::new(std::env::current_exe()?)
-            .args(["--return-connect", target])
+        let mut command = Command::new(std::env::current_exe()?);
+        command.args(["--return-connect", target]);
+        Self::spawn_command(command)
+    }
+    fn spawn_command(mut command: Command) -> Result<Self> {
+        let mut child = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -308,6 +315,24 @@ impl Drop for ForwardChild {
     }
 }
 
+// Control frames must reach the other side immediately. Avoid kernel copy
+// offload, which can wait for more pipe data across this request/reply boundary.
+fn pump(reader: &mut impl Read, writer: &mut impl Write) -> std::io::Result<u64> {
+    let mut buffer = [0; 16 * 1024];
+    let mut total = 0;
+    loop {
+        let count = match reader.read(&mut buffer) {
+            Ok(0) => return Ok(total),
+            Ok(count) => count,
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        };
+        writer.write_all(&buffer[..count])?;
+        writer.flush()?;
+        total += count as u64;
+    }
+}
+
 fn relay(
     mut socket: UnixStream,
     mut input: std::process::ChildStdin,
@@ -320,10 +345,10 @@ fn relay(
     let (done, completions) = mpsc::channel();
     let sent = done.clone();
     let upload = std::thread::spawn(move || {
-        let _ = sent.send(std::io::copy(&mut socket, &mut input));
+        let _ = sent.send(pump(&mut socket, &mut input));
     });
     let download = std::thread::spawn(move || {
-        let _ = done.send(std::io::copy(&mut output, &mut writer));
+        let _ = done.send(pump(&mut output, &mut writer));
     });
     let deadline = Instant::now() + FINISH_TIMEOUT;
     let result = loop {
@@ -409,7 +434,7 @@ impl<T: Write + AsRawFd, F: Fn() -> bool> Write for DeadlineIo<'_, T, F> {
             self.deadline,
             self.cancelled,
         )?;
-        self.inner.write(&bytes[..bytes.len().min(4096)])
+        self.inner.write(&bytes[..bytes.len().min(512)])
     }
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()
@@ -550,6 +575,26 @@ mod tests {
     use super::*;
     use crate::destination::tests::{args, broker, request};
 
+    #[test]
+    fn duplex_control_relay_delivers_small_messages_without_waiting_for_eof() {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut command = Command::new("cat");
+        command.arg("-");
+        let mut child = ForwardChild::spawn_command(command).unwrap();
+        let input = child.child.stdin.take().unwrap();
+        let output = child.child.stdout.take().unwrap();
+        let thread = std::thread::spawn(move || relay(server, input, output, || false, &mut child));
+        client.write_all(b"hello").unwrap();
+        let mut response = [0; 5];
+        let result = client.read_exact(&mut response);
+        client.shutdown(std::net::Shutdown::Both).unwrap();
+        let _ = thread.join().unwrap();
+        result.unwrap();
+        assert_eq!(&response, b"hello");
+    }
     #[test]
     fn remote_targets_are_endpoints_not_shell_or_ssh_options() {
         for target in ["backup", "alice@backup:2222", "alice@[2001:db8::1]:22"] {

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -1,0 +1,676 @@
+//! One approved control stream through the receiving machine; data goes to the
+//! destination's restricted TCP workers. There is no remote signing interface.
+use super::*;
+use std::fs::File;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::sync::atomic::AtomicUsize;
+
+const HELPER_VERSION: u16 = 1;
+const SETUP_TIMEOUT: Duration = Duration::from_secs(60);
+const FINISH_TIMEOUT: Duration = Duration::from_secs(7 * 24 * 3600);
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HelperRequest {
+    version: u16,
+    identity: String,
+    request: CopyRequest,
+}
+
+fn target_endpoint(target: &str) -> Result<crate::cli::NativeEndpoint> {
+    if target.len() > 512 {
+        bail!("destination SSH endpoint is too long");
+    }
+    let endpoint = crate::cli::parse_native_endpoint(Some(target))?.unwrap();
+    // These values also enter the user's OpenSSH configuration substitutions.
+    // Only endpoint text is accepted, never shell or SSH option syntax.
+    if endpoint.host.starts_with('-')
+        || !endpoint
+            .host
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"._-:".contains(&b))
+        || endpoint.user.as_ref().is_some_and(|user| {
+            user.starts_with('-')
+                || !user
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"._-".contains(&b))
+        })
+    {
+        bail!("--via requires an ordinary SSH destination with a plain host and login name");
+    }
+    Ok(endpoint)
+}
+
+pub(super) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
+    use crate::cli::{CoordinateAt, Interface, PeerAuth};
+    let name = args.via.as_deref().unwrap();
+    let name = name.strip_prefix('@').unwrap_or(name).to_owned();
+    validate_name(&name)?;
+    let (destination, sources) = args
+        .locations
+        .split_last()
+        .context("copy endpoints missing")?;
+    if args.interface != Interface::NativeCp
+        || sources.iter().any(|s| s.is_remote())
+        || !destination.is_remote()
+    {
+        bail!("--via requires syq cp with local sources and an SSH --to destination");
+    }
+    if args.rsh.is_some()
+        || args.syq_path.is_some()
+        || args.no_bootstrap
+        || args.pscope_explicit
+        || args.detach
+        || args.restricted_grant.is_some()
+        || args.no_tcp
+        || args.tcp_plain
+        || args.peer_auth != PeerAuth::Restricted
+        || args.coordinate_at != CoordinateAt::Auto
+    {
+        bail!("--via owns its SSH connection and requires encrypted direct TCP; it cannot be combined with --rsh, --syq-path, --no-bootstrap, --pscope, --detach, --no-tcp, --tcp-plain, --peer-auth, or --coordinate-at");
+    }
+    if args.connections_opt.is_some() && args.connections > 32 {
+        bail!("--via supports at most 32 workers per copy");
+    }
+    let host = destination.host.as_deref().unwrap();
+    let host = if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host.into()
+    };
+    let target = format!(
+        "{}{}{}",
+        destination
+            .user
+            .as_ref()
+            .map(|u| format!("{u}@"))
+            .unwrap_or_default(),
+        host,
+        destination
+            .port
+            .map(|p| format!(":{p}"))
+            .unwrap_or_default()
+    );
+    target_endpoint(&target)?;
+    let registration = load_registration(&name)?;
+    let (secret, public) = crate::receipt::generate_recipient()?;
+    let policy = crate::receipt::ReceiptPolicy {
+        required: true,
+        hashed: args.receiver_receipt == Some(crate::cli::ReceiptDetail::Digests),
+        max_records: crate::receipt::DEFAULT_MAX_RECORDS,
+        max_plaintext_bytes: crate::receipt::DEFAULT_MAX_PLAINTEXT_BYTES,
+        delivery: crate::receipt::ReceiptDelivery::AttachedEncrypted {
+            suite: crate::receipt::HpkeSuite::X25519HkdfSha256HkdfSha256ChaCha20Poly1305,
+            recipient_public_key: public,
+        },
+    };
+    let request = crate::restricted::named_request(args, policy.clone())?;
+    crate::output::diagnostic!("syq: requesting permission from @{name} to copy to {target:?}; approve on that machine with its desktop prompt or syq recv pending");
+    let (stream, reply) = exchange(
+        &registration,
+        Message::Forward {
+            target,
+            request: Box::new(request),
+        },
+        REQUEST_TIMEOUT + SETUP_TIMEOUT + Duration::from_secs(10),
+    )?;
+    let Reply::Approved(approved) = reply else {
+        bail!("unexpected remote copy approval response");
+    };
+    stream.set_read_timeout(None)?;
+    stream.set_write_timeout(None)?;
+    args.locations.last_mut().unwrap().path = approved.destination.clone();
+    // The actual authority never leaves the destination helper. This internal
+    // marker makes the engine require TCP and suppress ordinary SSH fallback.
+    args.restricted_grant = Some("return-control-v1".into());
+    args.named_receipt = Some(Arc::new(NamedReceipt {
+        control: Mutex::new(Some(stream)),
+        secret,
+        approved,
+        policy,
+    }));
+    Ok(())
+}
+
+struct Slot<'a>(&'a AtomicUsize);
+impl Drop for Slot<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+impl Receiver {
+    pub(super) fn forward(
+        &self,
+        target: String,
+        request: CopyRequest,
+        mut stream: TrackedStream,
+    ) -> Result<()> {
+        let request_lock = self.request_lock.try_lock().map_err(|_| {
+            anyhow::anyhow!("another transfer is awaiting approval; retry after it is decided")
+        })?;
+        target_endpoint(&target)?;
+        if request.copy.destination != REQUEST_ROOT
+            || request.destination.len() > 4096
+            || request.destination.contains(&0)
+        {
+            bail!("invalid remote copy destination");
+        }
+        let request = constrain(
+            request,
+            Path::new(std::ffi::OsStr::from_bytes(REQUEST_ROOT)),
+            self.max_bytes,
+            self.max_entries,
+            self.max_delete,
+        )?;
+        crate::delegation::validate_return_request(&request)?;
+        if !request.constraints.receipt_policy.required
+            || !matches!(
+                request.constraints.receipt_policy.delivery,
+                crate::receipt::ReceiptDelivery::AttachedEncrypted { .. }
+            )
+        {
+            bail!("remote copies require an attached encrypted receipt");
+        }
+        let count = self.forward_count.fetch_add(1, Ordering::AcqRel);
+        let _slot = Slot(&self.forward_count);
+        if count >= 8 {
+            bail!("too many active remote copies; wait for one to finish");
+        }
+        let (generation, _channel) = {
+            // Serialize registration with revocation, including reconnects.
+            let _sessions = self.sessions.lock().unwrap();
+            (
+                self.generation.load(Ordering::Acquire),
+                self.forwarded.track(stream.try_clone()?)?,
+            )
+        };
+        let socket = stream.try_clone()?;
+        let cancelled = || {
+            self.stop.load(Ordering::Acquire)
+                || self.generation.load(Ordering::Acquire) != generation
+        };
+        let setup_cancelled = || cancelled() || requester_closed(&socket);
+        // Automatic approval of writes to this machine does not authorize use
+        // of its SSH credentials on another host.
+        self.approvals.request_remote(
+            &self.requester,
+            &target,
+            &request,
+            self.notifications,
+            setup_cancelled,
+        )?;
+        if setup_cancelled() {
+            bail!("remote copy disconnected before setup");
+        }
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(target.as_bytes());
+        let mut child = ForwardChild::spawn(&encoded)?;
+        let result = (|| {
+            let deadline = Instant::now() + SETUP_TIMEOUT;
+            let mut input = child.child.stdin.take().unwrap();
+            let mut output = child.child.stdout.take().unwrap();
+            write_message(
+                &mut DeadlineIo {
+                    inner: &mut input,
+                    deadline,
+                    cancelled: &setup_cancelled,
+                },
+                &HelperRequest {
+                    version: HELPER_VERSION,
+                    identity: crate::identity::build().into(),
+                    request,
+                },
+            )?;
+            let reply: Reply = read_message(&mut DeadlineIo {
+                inner: &mut output,
+                deadline,
+                cancelled: &setup_cancelled,
+            })?;
+            match reply {
+                Reply::Approved(approved) => {
+                    write_message(&mut stream, &Reply::Approved(approved))?
+                }
+                Reply::Error(error) => bail!("destination refused the copy: {error}"),
+                Reply::Ready => bail!("invalid destination setup response"),
+            }
+            drop(request_lock);
+            socket.set_read_timeout(None)?;
+            socket.set_write_timeout(None)?;
+            relay(socket.try_clone()?, input, output, cancelled, &mut child)
+        })();
+        result.with_context(|| format!("copy via this machine to {target:?}: {}", child.errors()))
+    }
+}
+
+/// Kill before reaping, including bootstrap/ProxyCommand descendants. Capture
+/// is bounded while the complete pipe is drained; diagnostics never block SSH.
+struct ForwardChild {
+    child: Child,
+    errors: Arc<Mutex<Vec<u8>>>,
+    capture: Option<std::thread::JoinHandle<()>>,
+    closed: bool,
+}
+impl ForwardChild {
+    fn spawn(target: &str) -> Result<Self> {
+        let mut child = Command::new(std::env::current_exe()?)
+            .args(["--return-connect", target])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .process_group(0)
+            .spawn()?;
+        let mut stderr = child.stderr.take().unwrap();
+        let errors = Arc::new(Mutex::new(Vec::new()));
+        let captured = errors.clone();
+        let capture = std::thread::spawn(move || {
+            let mut bytes = [0; 1024];
+            while let Ok(count) = stderr.read(&mut bytes) {
+                if count == 0 {
+                    break;
+                }
+                let mut output = captured.lock().unwrap();
+                output.extend_from_slice(&bytes[..count]);
+                if output.len() > 4096 {
+                    let excess = output.len() - 4096;
+                    output.drain(..excess);
+                }
+            }
+        });
+        Ok(Self {
+            child,
+            errors,
+            capture: Some(capture),
+            closed: false,
+        })
+    }
+    fn close(&mut self) {
+        if !self.closed {
+            self.closed = true;
+            unsafe {
+                libc::kill(-(self.child.id() as i32), libc::SIGKILL);
+            }
+            let _ = self.child.wait();
+        }
+        if let Some(capture) = self.capture.take() {
+            let _ = capture.join();
+        }
+    }
+    fn errors(&self) -> String {
+        format!(
+            "{:?}",
+            String::from_utf8_lossy(&self.errors.lock().unwrap())
+        )
+    }
+}
+impl Drop for ForwardChild {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+fn relay(
+    mut socket: UnixStream,
+    mut input: std::process::ChildStdin,
+    mut output: std::process::ChildStdout,
+    cancelled: impl Fn() -> bool,
+    child: &mut ForwardChild,
+) -> Result<()> {
+    let mut writer = socket.try_clone()?;
+    let shutdown = socket.try_clone()?;
+    let (done, completions) = mpsc::channel();
+    let sent = done.clone();
+    let upload = std::thread::spawn(move || {
+        let _ = sent.send(std::io::copy(&mut socket, &mut input));
+    });
+    let download = std::thread::spawn(move || {
+        let _ = done.send(std::io::copy(&mut output, &mut writer));
+    });
+    let deadline = Instant::now() + FINISH_TIMEOUT;
+    let result = loop {
+        if cancelled() {
+            break Err(anyhow::anyhow!("return connection stopped during copy"));
+        }
+        if Instant::now() >= deadline {
+            break Err(anyhow::anyhow!(
+                "remote copy exceeded its seven-day lifetime"
+            ));
+        }
+        match completions.recv_timeout(Duration::from_millis(100)) {
+            Ok(result) => break result.map(|_| ()).map_err(Into::into),
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(error) => break Err(error.into()),
+        }
+    };
+    let _ = shutdown.shutdown(std::net::Shutdown::Both);
+    child.close();
+    let _ = upload.join();
+    let _ = download.join();
+    result
+}
+
+fn wait_fd(
+    fd: std::os::fd::RawFd,
+    events: i16,
+    deadline: Instant,
+    cancelled: &impl Fn() -> bool,
+) -> std::io::Result<()> {
+    loop {
+        if cancelled() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionAborted,
+                "return request cancelled",
+            ));
+        }
+        let left = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|d| !d.is_zero())
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "return helper deadline expired",
+                )
+            })?;
+        let mut descriptor = libc::pollfd {
+            fd,
+            events,
+            revents: 0,
+        };
+        let result =
+            unsafe { libc::poll(&mut descriptor, 1, left.as_millis().clamp(1, 100) as i32) };
+        if result > 0 {
+            return Ok(());
+        }
+        if result < 0 && std::io::Error::last_os_error().kind() != std::io::ErrorKind::Interrupted {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+}
+struct DeadlineIo<'a, T, F> {
+    inner: &'a mut T,
+    deadline: Instant,
+    cancelled: &'a F,
+}
+impl<T: Read + AsRawFd, F: Fn() -> bool> Read for DeadlineIo<'_, T, F> {
+    fn read(&mut self, bytes: &mut [u8]) -> std::io::Result<usize> {
+        wait_fd(
+            self.inner.as_raw_fd(),
+            libc::POLLIN,
+            self.deadline,
+            self.cancelled,
+        )?;
+        self.inner.read(bytes)
+    }
+}
+impl<T: Write + AsRawFd, F: Fn() -> bool> Write for DeadlineIo<'_, T, F> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        wait_fd(
+            self.inner.as_raw_fd(),
+            libc::POLLOUT,
+            self.deadline,
+            self.cancelled,
+        )?;
+        self.inner.write(&bytes[..bytes.len().min(4096)])
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+pub(crate) struct HandshakeInput {
+    inner: File,
+    pending: Arc<AtomicBool>,
+    deadline: Instant,
+}
+impl Read for HandshakeInput {
+    fn read(&mut self, bytes: &mut [u8]) -> std::io::Result<usize> {
+        if self.pending.load(Ordering::Acquire) {
+            wait_fd(self.inner.as_raw_fd(), libc::POLLIN, self.deadline, &|| {
+                false
+            })?;
+        }
+        self.inner.read(bytes)
+    }
+}
+fn receive() -> Result<i32> {
+    let fd = unsafe { libc::dup(libc::STDIN_FILENO) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let mut input = unsafe { File::from_raw_fd(fd) };
+    let setup = (|| {
+        let request: HelperRequest = read_message(&mut DeadlineIo {
+            inner: &mut input,
+            deadline: Instant::now() + Duration::from_secs(10),
+            cancelled: &|| false,
+        })?;
+        if request.version != HELPER_VERSION || request.identity != crate::identity::build() {
+            bail!("return helper build mismatch");
+        }
+        let cwd = fs::canonicalize(std::env::var_os("HOME").context("HOME is unset")?)?;
+        let (destination, container) =
+            resolve_destination(&cwd, None, &request.request.destination)?;
+        let request = constrain(
+            request.request,
+            &destination,
+            crate::delegation::MAX_COPY_BYTES,
+            crate::delegation::MAX_ENTRIES,
+            u64::MAX,
+        )?;
+        crate::restricted::named_authority(&container, request)
+    })();
+    let (authority, approved) = match setup {
+        Ok(value) => value,
+        Err(error) => {
+            write_message(&mut std::io::stdout(), &Reply::Error(format!("{error:#}")))?;
+            return Err(error);
+        }
+    };
+    write_message(&mut std::io::stdout(), &Reply::Approved(approved))?;
+    let pending = Arc::new(AtomicBool::new(true));
+    crate::server::run_forwarded(
+        authority,
+        HandshakeInput {
+            inner: input,
+            pending: pending.clone(),
+            deadline: Instant::now() + Duration::from_secs(10),
+        },
+        pending,
+    )?;
+    Ok(0)
+}
+fn connect(target: &str) -> Result<i32> {
+    let target =
+        String::from_utf8(base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(target)?)?;
+    let endpoint = target_endpoint(&target)?;
+    let spec = crate::conn::RemoteSpec {
+        local_process: false,
+        user: endpoint.user,
+        host: endpoint.host,
+        port: endpoint.port,
+        rsh: [
+            "ssh",
+            "-a",
+            "-x",
+            "-T",
+            "-o",
+            "ForwardAgent=no",
+            "-o",
+            "ForwardX11=no",
+            "-o",
+            "ClearAllForwardings=yes",
+            "-o",
+            "PermitLocalCommand=no",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "ServerAliveInterval=15",
+            "-o",
+            "ServerAliveCountMax=3",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+        syq_path: None,
+        bootstrap_helper: true,
+        restricted_grant: None,
+        helper_install: Default::default(),
+        ssh_multiplexer: None,
+        quiet: true,
+        tcp: Default::default(),
+        diagnostics: Default::default(),
+        primed_control: Default::default(),
+        forwarded: None,
+        read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
+    };
+    spec.install_helper()?;
+    Err(spec
+        .helper_command(&["--return-receiver".into()])
+        .exec()
+        .into())
+}
+pub(super) fn dispatch(argv: &[OsString]) -> Option<Result<i32>> {
+    match argv.get(1).and_then(|v| v.to_str())? {
+        "--return-receiver" if argv.len() == 2 => Some(receive()),
+        "--return-connect" if argv.len() == 3 => Some(
+            argv[2]
+                .to_str()
+                .context("invalid return target")
+                .and_then(connect),
+        ),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::destination::tests::{args, broker, request};
+
+    #[test]
+    fn remote_targets_are_endpoints_not_shell_or_ssh_options() {
+        for target in ["backup", "alice@backup:2222", "alice@[2001:db8::1]:22"] {
+            assert!(target_endpoint(target).is_ok(), "{target}");
+        }
+        for target in [
+            "@laptop",
+            "-oProxyCommand=evil",
+            "a$(id)",
+            "user`id`@host",
+            "user;id@host",
+            "a\nHost *",
+            "a/b",
+            "x@host:0",
+        ] {
+            assert!(target_endpoint(target).is_err(), "{target}");
+        }
+    }
+
+    #[test]
+    fn forward_validation_precedes_approval_and_outbound_ssh() {
+        let root = tempfile::tempdir().unwrap();
+        let (_broker, receiver, registration, _) = broker(root.path(), Approval::Always);
+        let (valid, _) = request(&args(root.path(), "output"));
+        for case in 0..5 {
+            let mut copy = valid.clone();
+            let mut target = "backup".to_owned();
+            match case {
+                0 => target = "bad$(command)".into(),
+                1 => copy.copy.mutation_scopes[0].path = b"/outside".to_vec(),
+                2 => copy.copy.limits.max_entries = 0,
+                3 => copy.destination = b"bad\0path".to_vec(),
+                _ => copy.constraints.receipt_policy.required = false,
+            }
+            assert!(exchange(
+                &registration,
+                Message::Forward {
+                    target,
+                    request: Box::new(copy)
+                },
+                Duration::from_secs(2)
+            )
+            .is_err());
+            assert!(receiver.approvals.snapshots().is_empty());
+        }
+        assert_eq!(receiver.forward_count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn forward_always_requires_a_local_decision_and_revocation_cancels_it() {
+        for revoke in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let (_broker, receiver, registration, _) = broker(root.path(), Approval::Always);
+            let (copy, _) = request(&args(root.path(), "output"));
+            let task = std::thread::spawn(move || {
+                exchange(
+                    &registration,
+                    Message::Forward {
+                        target: "backup".into(),
+                        request: Box::new(copy),
+                    },
+                    Duration::from_secs(3),
+                )
+            });
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let pending = loop {
+                if let Some(summary) = receiver.approvals.snapshots().first() {
+                    break summary.clone();
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "forward request did not become pending"
+                );
+                std::thread::sleep(Duration::from_millis(5));
+            };
+            assert!(pending.destination.contains("backup"));
+            assert!(pending.destination.contains("output"));
+            assert!(pending.permission.contains("SSH access"));
+            if revoke {
+                receiver.revoke_all();
+            } else {
+                receiver.approvals.decide(&pending.id, false).unwrap();
+            }
+            assert!(task.join().unwrap().is_err());
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while receiver.forward_count.load(Ordering::Acquire) != 0 {
+                assert!(
+                    Instant::now() < deadline,
+                    "forward request did not release its slot"
+                );
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            assert!(receiver.approvals.snapshots().is_empty());
+        }
+    }
+
+    #[test]
+    fn setup_deadlines_cover_partial_frames_and_cancellation_is_not_retried() {
+        let (mut reader, mut writer) = UnixStream::pair().unwrap();
+        writer.write_all(&[0, 0]).unwrap();
+        let error = read_message::<Reply>(&mut DeadlineIo {
+            inner: &mut reader,
+            deadline: Instant::now() + Duration::from_millis(20),
+            cancelled: &|| false,
+        })
+        .err()
+        .unwrap();
+        assert_eq!(
+            error.downcast_ref::<std::io::Error>().unwrap().kind(),
+            std::io::ErrorKind::TimedOut
+        );
+        let error = read_message::<Reply>(&mut DeadlineIo {
+            inner: &mut reader,
+            deadline: Instant::now() + Duration::from_secs(60),
+            cancelled: &|| true,
+        })
+        .err()
+        .unwrap();
+        assert_eq!(
+            error.downcast_ref::<std::io::Error>().unwrap().kind(),
+            std::io::ErrorKind::ConnectionAborted
+        );
+    }
+}

--- a/src/receive_approval.rs
+++ b/src/receive_approval.rs
@@ -146,6 +146,22 @@ impl Queue {
             cancelled,
         )
     }
+    pub(crate) fn request_remote(
+        &self,
+        from: &str,
+        target: &str,
+        request: &crate::destination::CopyRequest,
+        notifications: Notifications,
+        cancelled: impl Fn() -> bool,
+    ) -> Result<()> {
+        let mut summary = Summary::new(from, request, TIMEOUT)?;
+        summary.destination = format!(
+            "SSH {target:?}, path {:?} (relative paths start in the destination login home)",
+            std::ffi::OsStr::from_bytes(&request.destination)
+        );
+        summary.permission.push_str(". Connect using this machine's SSH access and install the matching syq helper if needed");
+        self.wait(summary, notifications, TIMEOUT, cancelled)
+    }
     fn wait(
         &self,
         summary: Summary,

--- a/src/remote_to_remote.rs
+++ b/src/remote_to_remote.rs
@@ -886,6 +886,7 @@ fn run_remote(
         tcp: Default::default(),
         diagnostics: Default::default(),
         primed_control: Default::default(),
+        forwarded: None,
         read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
     };
 

--- a/src/remote_to_remote.rs
+++ b/src/remote_to_remote.rs
@@ -676,7 +676,7 @@ fn delegated_operand(path: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD_NO_PAD.encode(path)
 }
 
-fn endpoint_arg(
+pub(crate) fn endpoint_arg(
     location: &Location,
     login_user: Option<&str>,
     connection_host: Option<&str>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -75,6 +75,7 @@ impl Drop for RequestReader {
 }
 
 struct ServeSession {
+    handshake_pending: Option<Arc<std::sync::atomic::AtomicBool>>,
     allow_tcp: bool,
     named_socket: Option<std::os::unix::net::UnixStream>,
     authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
@@ -137,6 +138,7 @@ pub fn run() -> Result<()> {
         None,
         None,
         ServeSession {
+            handshake_pending: None,
             allow_tcp: true,
             named_socket: None,
             authority: None,
@@ -157,9 +159,37 @@ pub(crate) fn run_restricted(authority: Arc<crate::restricted::RestrictedAuthori
         None,
         None,
         ServeSession {
+            handshake_pending: None,
             allow_tcp: true,
             named_socket: None,
             authority: Some(Arc::clone(&authority)),
+            descriptor_session: descriptor_session.clone(),
+        },
+    );
+    descriptor_session.close();
+    authority.close_control();
+    result
+}
+
+/// A laptop-authenticated, one-copy helper with direct encrypted TCP workers.
+pub(crate) fn run_forwarded<R: Read + Send + 'static>(
+    authority: Arc<crate::restricted::RestrictedAuthority>,
+    input: R,
+    pending: Arc<std::sync::atomic::AtomicBool>,
+) -> Result<()> {
+    let descriptor_session = DescriptorSessionSlot::default();
+    let result = serve(
+        input,
+        io::stdout().lock(),
+        true,
+        None,
+        None,
+        None,
+        ServeSession {
+            handshake_pending: Some(pending),
+            allow_tcp: true,
+            named_socket: None,
+            authority: Some(authority.clone()),
             descriptor_session: descriptor_session.clone(),
         },
     );
@@ -194,6 +224,7 @@ pub(crate) fn run_named(
         None,
         None,
         ServeSession {
+            handshake_pending: None,
             allow_tcp: false,
             named_socket: Some(socket),
             authority: Some(Arc::clone(&authority)),
@@ -219,6 +250,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
     session: ServeSession,
 ) -> Result<()> {
     let ServeSession {
+        handshake_pending,
         allow_tcp,
         named_socket,
         authority,
@@ -363,6 +395,10 @@ fn serve<R: Read + Send + 'static, W: Write>(
     if let Some(socket) = &named_socket {
         socket.set_read_timeout(None)?;
         socket.set_write_timeout(None)?;
+    }
+
+    if let Some(pending) = handshake_pending {
+        pending.store(false, std::sync::atomic::Ordering::Release);
     }
 
     // Requests are parsed on a reader thread so incoming data keeps flowing
@@ -1101,6 +1137,7 @@ fn serve_tcp(
         Some(&authed),
         Some(stream.try_clone()?),
         ServeSession {
+            handshake_pending: None,
             allow_tcp: true,
             named_socket: None,
             authority,
@@ -1317,6 +1354,7 @@ mod tests {
                 None,
                 Some(socket),
                 ServeSession {
+                    handshake_pending: None,
                     allow_tcp: true,
                     named_socket: None,
                     authority: None,
@@ -1466,6 +1504,7 @@ mod tests {
                 None,
                 None,
                 ServeSession {
+                    handshake_pending: None,
                     allow_tcp: true,
                     named_socket: None,
                     authority: None,
@@ -1528,6 +1567,7 @@ mod tests {
                 None,
                 None,
                 ServeSession {
+                    handshake_pending: None,
                     allow_tcp: true,
                     named_socket: None,
                     authority: None,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -166,6 +166,7 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
                 tcp: Default::default(),
                 diagnostics: Default::default(),
                 primed_control: Default::default(),
+                forwarded: args.via.as_ref().and(args.named_receipt.clone()),
                 read_ahead: args.tuning_options.unwrap_or_default().pipeline_depth(),
             })
         }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -330,7 +330,9 @@ fn interface_option<'a>(args: &Args, native: &'a str, rsync: &'a str) -> &'a str
 }
 
 fn remote_helper_mode(spec: &RemoteSpec, interface: Interface) -> &'static str {
-    if spec.bootstrap_helper {
+    if spec.forwarded.is_some() {
+        "approved return connection"
+    } else if spec.bootstrap_helper {
         if *spec.helper_install.lock().unwrap() {
             "managed; installed now"
         } else {
@@ -1384,10 +1386,12 @@ fn handle_tcp_setup_error(
         sched.abort();
         progress.stop();
         return Err(error).with_context(|| {
-            format!(
-                "{}: a signed receiver uses its one SSH authorization for the control connection, so encrypted TCP data connections are required",
-                spec.label()
-            )
+            let reason = if spec.forwarded.is_some() {
+                "--via requires direct encrypted TCP data connections"
+            } else {
+                "a signed receiver uses its one SSH authorization for the control connection, so encrypted TCP data connections are required"
+            };
+            format!("{}: {reason}", spec.label())
         });
     }
     if !args.quiet || debug() {

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -1130,6 +1130,7 @@ mod tests {
             }))),
             diagnostics: Default::default(),
             primed_control: Default::default(),
+            forwarded: None,
             read_ahead: crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH,
         })
     }

--- a/tests/fixtures/receive-v3-f752ee8.json
+++ b/tests/fixtures/receive-v3-f752ee8.json
@@ -1,0 +1,1 @@
+{"version":3,"enabled":true,"name":"compat","cwd":"/","root":null,"max_bytes":12345,"max_entries":321,"max_delete":0,"approval":"always","notifications":"off"}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -17931,3 +17931,67 @@ fn receiving_v2_preferences_migrate_without_retaining_implicit_approval() {
     assert!(!t.path("config/syq/persistence.json").exists());
     assert_output_ok(&run(&["recv", "off"]));
 }
+
+#[test]
+fn return_via_rejects_unsupported_routes_and_never_falls_back_to_ssh() {
+    let t = Tmp::new();
+    write(&t.path("source"), b"payload");
+    write(
+        &t.path("bin/ssh"),
+        b"#!/bin/sh\ntouch \"$HOME/ssh-used\"\nexit 99\n",
+    );
+    fs::set_permissions(t.path("bin/ssh"), fs::Permissions::from_mode(0o755)).unwrap();
+    for extra in [
+        vec![],
+        vec!["--no-tcp"],
+        vec!["--tcp-plain"],
+        vec!["--detach"],
+        vec!["--rsh", "ssh"],
+        vec!["--syq-path", "/opt/syq"],
+        vec!["--no-bootstrap"],
+        vec!["--coordinate-at", "dst"],
+        vec!["--peer-auth", "full-agent"],
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(["cp", "source", "--to", "backup", "--via", "@laptop"])
+            .args(extra)
+            .current_dir(t.path(""))
+            .env("HOME", t.path(""))
+            .env("XDG_CONFIG_HOME", t.path("config"))
+            .env("XDG_RUNTIME_DIR", t.path("runtime"))
+            .env("PATH", t.path("bin"))
+            .env("SYQ_NO_UPDATE_CHECK", "1")
+            .output()
+            .unwrap();
+        assert!(!output.status.success(), "{:?}", output);
+        assert!(
+            !t.path("ssh-used").exists(),
+            "--via attempted ordinary SSH: {:?}",
+            output
+        );
+    }
+    assert_eq!(fs::read(t.path("source")).unwrap(), b"payload");
+}
+
+#[test]
+fn remote_copy_addition_preserves_approval_preferences_from_f752ee8() {
+    let t = Tmp::new();
+    let path = t.path("config/syq/receive.json");
+    // Produced by the unchanged PR #240 f752ee8 executable, not this writer.
+    let old = include_bytes!("fixtures/receive-v3-f752ee8.json");
+    write(&path, old);
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["recv", "status", "--json"])
+        .env("HOME", t.path(""))
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_RUNTIME_DIR", t.path("runtime"))
+        .env("SYQ_NO_UPDATE_CHECK", "1")
+        .output()
+        .unwrap();
+    assert_output_ok(&output);
+    let status: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let previous: serde_json::Value = serde_json::from_slice(old).unwrap();
+    assert_eq!(status["settings"], previous);
+    assert_eq!(fs::read(path).unwrap(), old);
+}

--- a/tests/real-ssh/Dockerfile
+++ b/tests/real-ssh/Dockerfile
@@ -47,4 +47,6 @@ COPY tests/real-ssh/test-completion-display.py /usr/local/libexec/syq-test-compl
 
 COPY tests/real-ssh/test-receive-notifications.py /usr/local/libexec/syq-test-receive-notifications.py
 
+COPY tests/real-ssh/test-forward-copy.py /usr/local/libexec/syq-test-forward-copy.py
+
 ENTRYPOINT ["/usr/local/libexec/syq-real-ssh-entrypoint"]

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -106,3 +106,8 @@ python3 tests/real-ssh/test-completion-display.py --syq target/debug/syq
 ```
 
 The shell dependencies are installed only in the test image.
+
+The source-shell remote-copy checks use `--via @laptop` without a source key or
+agent. They cover local approval despite automatic local receiving, denial,
+direct TCP, preview/verification, protected destination authority files,
+unreachable data ports, and revocation followed by an approved retry.

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -108,7 +108,8 @@ The shell dependencies are installed only in the test image.
 
 The source-shell remote-copy checks use `--via @laptop` without a source key or
 agent. They cover local approval despite automatic local receiving, denial,
-direct TCP, preview/verification, protected destination authority files,
+direct TCP, cached and missing helper startup, a second approval during slow
+SSH setup, preview/verification, protected destination authority files,
 unreachable data ports, and revocation followed by an approved retry.
 
 The suite also runs the standalone interactive benchmark in noninteractive

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -195,6 +195,8 @@ test ! -e "$receive_root/cancelled-policy"
 printf 'case: native Linux notification actions control return copies\n'
 dbus-run-session -- python3 /usr/local/libexec/syq-test-receive-notifications.py
 
+python3 /usr/local/libexec/syq-test-forward-copy.py
+
 printf 'case: explicit automatic approval supports unattended copies\n'
 syq recv on --approve always
 syq recv wait source --timeout 30

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -20,7 +20,7 @@ def remote(command, *, success=True):
 
 
 def copy(path, *, allow=True, success=True, extra=(), cancel=False,
-         source="/tmp/syq-real-ssh/return-source/subdir/chunks.bin", prefix=None):
+         source="/tmp/syq-real-ssh/return-source/subdir/chunks.bin", prefix=None, after_approval=None):
     argv = ["syq", "cp", "-vv", source, "--to", "destination",
             "--via", "@laptop", "--as", path, "--connections", "2", *extra]
     command = "test -z \"${SSH_AUTH_SOCK:-}\" && test ! -e ~/.ssh/id_ed25519 && exec timeout 75 " + shlex.join(argv)
@@ -34,6 +34,8 @@ def copy(path, *, allow=True, success=True, extra=(), cancel=False,
             assert "SSH access" in request["permission"], request
             run("syq", "recv", "approve" if allow else "deny", request["id"])
             run("syq", "recv", "approve", request["id"], success=False)
+            if after_approval is not None:
+                after_approval()
             if cancel:
                 deadline = time.monotonic() + 25
                 progress = time.monotonic() + 5
@@ -67,6 +69,8 @@ def copy(path, *, allow=True, success=True, extra=(), cancel=False,
             output.seek(0)
             text = output.read().decode(errors="replace")
             print(text, end="", flush=True)
+            assert "one-time SSH grant" not in text and "signed receiver" not in text, text
+            assert "(restricted grant)" not in text, text
             assert status != 124, ("copy timed out", text)
             assert (status == 0) == success, (status, text)
             if success:
@@ -89,9 +93,49 @@ copy("/tmp/syq-real-ssh/forward/denied", allow=False, success=False)
 remote("test ! -e /tmp/syq-real-ssh/forward/denied")
 
 print("case: approved copy uses direct encrypted TCP without source SSH credentials", flush=True)
+trace = Path("/tmp/syq-real-ssh-ssh.trace")
+def destination_connections():
+    events = [dict(field.split("=", 1) for field in line.split("\t"))
+              for line in trace.read_text().splitlines()]
+    return sum(event["phase"] == "start" and event["host"] == "destination" for event in events)
+
+before = destination_connections()
 copy("/tmp/syq-real-ssh/forward/approved", extra=("--stats",))
+assert destination_connections() - before == 1, "a cached helper must need only the copy's SSH connection"
 expected = run("ssh", "source", "sha256sum /tmp/syq-real-ssh/return-source/subdir/chunks.bin").split()[0]
 assert remote("sha256sum /tmp/syq-real-ssh/forward/approved").split()[0] == expected
+
+print("case: a missing helper is installed once after its launcher reports the cache miss", flush=True)
+helpers = remote('find "$HOME/.cache/syq/helpers" -type f -name syq').splitlines()
+assert len(helpers) == 1, helpers
+helper = shlex.quote(helpers[0])
+remote("rm " + helper)
+copy("/tmp/syq-real-ssh/forward/installed")
+assert remote("sha256sum /tmp/syq-real-ssh/forward/installed").split()[0] == expected
+
+print("case: an approved copy's slow SSH setup does not block the next approval", flush=True)
+def deny_during_setup():
+    command = "exec timeout 15 syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as during-forward-setup"
+    process = subprocess.Popen(["ssh", "source", command], start_new_session=True)
+    try:
+        pending = json.loads(run("syq", "recv", "pending", "--json", "--wait", "--timeout", "3"))
+        assert len(pending) == 1 and "during-forward-setup" in pending[0]["destination"], pending
+        run("syq", "recv", "deny", pending[0]["id"])
+        assert process.wait(timeout=5) not in (0, 124)
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGKILL)
+            process.wait(timeout=3)
+
+# The approval happens before the destination helper starts; keep that window
+# open long enough to exercise another request on the same return connection.
+remote("printf '%s\\n' '#!/bin/sh' 'sleep 10' 'exec /usr/local/bin/syq \"$@\"' > " + helper + ".fixture && chmod 700 " + helper + ".fixture && mv " + helper + ".fixture " + helper)
+try:
+    run("syq", "recv", "on", "--approve", "ask", "--notify", "off")
+    run("syq", "recv", "wait", "source", "--timeout", "30")
+    copy("/tmp/syq-real-ssh/forward/slow-setup", after_approval=deny_during_setup)
+finally:
+    remote("cp /usr/local/bin/syq " + helper + ".fixture && mv " + helper + ".fixture " + helper)
 
 print("case: preview, verification, and protected paths remain restricted", flush=True)
 copy("/tmp/syq-real-ssh/forward/preview", extra=("--dry-run",))

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -1,0 +1,99 @@
+"""Source-shell copies authorized by the runner; all paths are disposable."""
+import json
+import os
+from pathlib import Path
+import shlex
+import signal
+import subprocess
+import tempfile
+import time
+
+
+def run(*args, success=True):
+    result = subprocess.run(args, capture_output=True, text=True, timeout=40)
+    assert (result.returncode == 0) == success, (args, result)
+    return result.stdout
+
+
+def remote(command, *, success=True):
+    return run("ssh", "destination", command, success=success)
+
+
+def copy(path, *, allow=True, success=True, extra=(), cancel=False):
+    argv = ["syq", "cp", "/tmp/syq-real-ssh/return-source/subdir/chunks.bin", "--to", "destination",
+            "--via", "@laptop", "--as", path, "--connections", "2", *extra]
+    command = "test -z \"${SSH_AUTH_SOCK:-}\" && test ! -e ~/.ssh/id_ed25519 && exec timeout 75 " + shlex.join(argv)
+    with tempfile.TemporaryFile() as output:
+        process = subprocess.Popen(["ssh", "source", command], stdout=output, stderr=output, start_new_session=True)
+        try:
+            pending = json.loads(run("syq", "recv", "pending", "--json", "--wait", "--timeout", "15"))
+            assert len(pending) == 1, pending
+            request = pending[0]
+            assert 'SSH "destination"' in request["destination"], request
+            assert "SSH access" in request["permission"], request
+            run("syq", "recv", "approve" if allow else "deny", request["id"])
+            run("syq", "recv", "approve", request["id"], success=False)
+            if cancel:
+                deadline = time.monotonic() + 25
+                progress = time.monotonic() + 5
+                state = ""
+                while time.monotonic() < deadline:
+                    state = remote("find /tmp/syq-real-ssh/forward -type f -name '*.part'")
+                    if state:
+                        break
+                    assert process.poll() is None, "copy exited before cancellation"
+                    if time.monotonic() >= progress:
+                        print("Waiting for remote copy partial:", repr(state), flush=True)
+                        progress += 5
+                    time.sleep(.1)
+                assert state, ("no copy partial before deadline", state)
+                run("syq", "recv", "on", "--notify", "off")
+            status = process.wait(timeout=65)
+            output.seek(0)
+            text = output.read().decode(errors="replace")
+            print(text, end="", flush=True)
+            assert status != 124, ("copy timed out", text)
+            assert (status == 0) == success, (status, text)
+            if success:
+                assert "receipt:" not in text.lower(), text
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGTERM)
+                try:
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    os.killpg(process.pid, signal.SIGKILL)
+                    process.wait(timeout=3)
+
+
+print("case: source-shell remote copy requires approval even with automatic local receiving", flush=True)
+run("syq", "recv", "on", "--approve", "always", "--notify", "off")
+run("syq", "recv", "wait", "source", "--timeout", "30")
+remote("mkdir -p /tmp/syq-real-ssh/forward")
+copy("/tmp/syq-real-ssh/forward/denied", allow=False, success=False)
+remote("test ! -e /tmp/syq-real-ssh/forward/denied")
+
+print("case: approved copy uses direct encrypted TCP without source SSH credentials", flush=True)
+copy("/tmp/syq-real-ssh/forward/approved", extra=("--stats",))
+expected = run("ssh", "source", "sha256sum /tmp/syq-real-ssh/return-source/subdir/chunks.bin").split()[0]
+assert remote("sha256sum /tmp/syq-real-ssh/forward/approved").split()[0] == expected
+
+print("case: preview, verification, and protected paths remain restricted", flush=True)
+copy("/tmp/syq-real-ssh/forward/preview", extra=("--dry-run",))
+remote("test ! -e /tmp/syq-real-ssh/forward/preview")
+copy("/tmp/syq-real-ssh/forward/approved", extra=("--verify-only",))
+authorized = remote("sha256sum ~/.ssh/authorized_keys")
+copy(".ssh/authorized_keys", success=False)
+assert remote("sha256sum ~/.ssh/authorized_keys") == authorized
+
+print("case: unreachable TCP fails without an SSH data fallback", flush=True)
+port = os.environ["SYQ_REAL_SSH_BLOCKED_TCP_PORT"]
+copy("/tmp/syq-real-ssh/forward/blocked", extra=("--tcp-ports", f"{port}-{port}"), success=False)
+remote("test ! -e /tmp/syq-real-ssh/forward/blocked")
+
+print("case: receiver restart revokes an active remote copy; a new approval can resume", flush=True)
+copy("/tmp/syq-real-ssh/forward/cancelled", extra=("--bwlimit", "128"), cancel=True, success=False)
+run("syq", "recv", "wait", "source", "--timeout", "30")
+copy("/tmp/syq-real-ssh/forward/cancelled")
+assert remote("sha256sum /tmp/syq-real-ssh/forward/cancelled").split()[0] == expected
+print("source-shell remote copy checks passed", flush=True)

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -19,8 +19,9 @@ def remote(command, *, success=True):
     return run("ssh", "destination", command, success=success)
 
 
-def copy(path, *, allow=True, success=True, extra=(), cancel=False):
-    argv = ["syq", "cp", "-vv", "/tmp/syq-real-ssh/return-source/subdir/chunks.bin", "--to", "destination",
+def copy(path, *, allow=True, success=True, extra=(), cancel=False,
+         source="/tmp/syq-real-ssh/return-source/subdir/chunks.bin", prefix=None):
+    argv = ["syq", "cp", "-vv", source, "--to", "destination",
             "--via", "@laptop", "--as", path, "--connections", "2", *extra]
     command = "test -z \"${SSH_AUTH_SOCK:-}\" && test ! -e ~/.ssh/id_ed25519 && exec timeout 75 " + shlex.join(argv)
     with tempfile.TemporaryFile() as output:
@@ -38,15 +39,18 @@ def copy(path, *, allow=True, success=True, extra=(), cancel=False):
                 progress = time.monotonic() + 5
                 state = ""
                 while time.monotonic() < deadline:
-                    state = remote("find /tmp/syq-real-ssh/forward -type f -name '.cancelled.syq-part.*'")
-                    if state:
-                        break
+                    partials = remote("find /tmp/syq-real-ssh/forward -type f -name '.cancelled.syq-part.*'").splitlines()
+                    state = repr(partials)
+                    if len(partials) == 1:
+                        state = remote("dd if=" + shlex.quote(partials[0]) + " bs=1M count=4 status=none | sha256sum")
+                        if state == prefix:
+                            break
                     assert process.poll() is None, "copy exited before cancellation"
                     if time.monotonic() >= progress:
                         print("Waiting for remote copy partial:", repr(state), flush=True)
                         progress += 5
                     time.sleep(.1)
-                assert state, ("no copy partial before deadline", state)
+                assert state == prefix, ("no complete resumable prefix before deadline", state)
                 run("syq", "recv", "on", "--notify", "off")
             deadline = time.monotonic() + 65
             last_output = 0
@@ -104,8 +108,20 @@ copy("/tmp/syq-real-ssh/forward/blocked", extra=("--tcp-ports", f"{port}-{port}"
 remote("test ! -e /tmp/syq-real-ssh/forward/blocked")
 
 print("case: receiver restart revokes an active remote copy; a new approval can resume", flush=True)
-copy("/tmp/syq-real-ssh/forward/cancelled", extra=("--bwlimit", "128"), cancel=True, success=False)
+source = "/tmp/syq-real-ssh/return-source/forward-resume.bin"
+run("ssh", "source", f"dd if=/dev/urandom of={source} bs=1M count=16 status=none")
+prefix = run("ssh", "source", f"dd if={source} bs=1M count=4 status=none | sha256sum")
+expected = run("ssh", "source", f"sha256sum {source}").split()[0]
+# Wait for a complete hash block, so the retry must actually reuse copied data.
+copy("/tmp/syq-real-ssh/forward/cancelled", source=source, prefix=prefix,
+     extra=("--bwlimit", "512"), cancel=True, success=False)
+remote("test ! -e /tmp/syq-real-ssh/forward/cancelled")
 run("syq", "recv", "wait", "source", "--timeout", "30")
-copy("/tmp/syq-real-ssh/forward/cancelled")
+results = "/tmp/syq-real-ssh/forward-resume.ndjson"
+copy("/tmp/syq-real-ssh/forward/cancelled", source=source, extra=("--results", results))
+records = [json.loads(line) for line in run("ssh", "source", f"cat {results}").splitlines()]
+assert records[-1]["type"] == "result", records
+assert records[-1]["bytes_unchanged"] >= 4 * 1024 * 1024, records[-1]
 assert remote("sha256sum /tmp/syq-real-ssh/forward/cancelled").split()[0] == expected
+assert not remote("find /tmp/syq-real-ssh/forward -type f -name '.cancelled.syq-part.*'")
 print("source-shell remote copy checks passed", flush=True)

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -93,6 +93,7 @@ print("case: preview, verification, and protected paths remain restricted", flus
 copy("/tmp/syq-real-ssh/forward/preview", extra=("--dry-run",))
 remote("test ! -e /tmp/syq-real-ssh/forward/preview")
 copy("/tmp/syq-real-ssh/forward/approved", extra=("--verify-only",))
+remote("printf '%s\\n' '# protected syq test fixture' > ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys")
 authorized = remote("sha256sum ~/.ssh/authorized_keys")
 copy(".ssh/authorized_keys", success=False)
 assert remote("sha256sum ~/.ssh/authorized_keys") == authorized

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -38,7 +38,7 @@ def copy(path, *, allow=True, success=True, extra=(), cancel=False):
                 progress = time.monotonic() + 5
                 state = ""
                 while time.monotonic() < deadline:
-                    state = remote("find /tmp/syq-real-ssh/forward -type f -name '*.part'")
+                    state = remote("find /tmp/syq-real-ssh/forward -type f -name '.cancelled.syq-part.*'")
                     if state:
                         break
                     assert process.poll() is None, "copy exited before cancellation"

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -20,7 +20,7 @@ def remote(command, *, success=True):
 
 
 def copy(path, *, allow=True, success=True, extra=(), cancel=False):
-    argv = ["syq", "cp", "/tmp/syq-real-ssh/return-source/subdir/chunks.bin", "--to", "destination",
+    argv = ["syq", "cp", "-vv", "/tmp/syq-real-ssh/return-source/subdir/chunks.bin", "--to", "destination",
             "--via", "@laptop", "--as", path, "--connections", "2", *extra]
     command = "test -z \"${SSH_AUTH_SOCK:-}\" && test ! -e ~/.ssh/id_ed25519 && exec timeout 75 " + shlex.join(argv)
     with tempfile.TemporaryFile() as output:
@@ -48,7 +48,18 @@ def copy(path, *, allow=True, success=True, extra=(), cancel=False):
                     time.sleep(.1)
                 assert state, ("no copy partial before deadline", state)
                 run("syq", "recv", "on", "--notify", "off")
-            status = process.wait(timeout=65)
+            deadline = time.monotonic() + 65
+            last_output = 0
+            while True:
+                try:
+                    status = process.wait(timeout=5)
+                    break
+                except subprocess.TimeoutExpired:
+                    data = os.pread(output.fileno(), 1024 * 1024, last_output)
+                    last_output += len(data)
+                    print(data.decode(errors="replace"), end="", flush=True)
+                    print("Waiting for remote copy:", path, flush=True)
+                    assert time.monotonic() < deadline, "remote copy exceeded its deadline"
             output.seek(0)
             text = output.read().decode(errors="replace")
             print(text, end="", flush=True)


### PR DESCRIPTION
A user already working in a source server's shell can now run:

```sh
syq cp results --to hostB --via @laptop --into /archive
```

The live return connection asks for a local decision, then the approving machine uses its own SSH access to start a matching, restricted helper on hostB. The source receives one approved control stream; file data travels directly from source to destination over encrypted TCP. This works inside existing tmux shells without source-side SSH keys or agent forwarding.

Remote requests always require approval, including when `recv --approve always` permits unattended copies onto the receiving machine itself. The prompt identifies the requested destination account/path and permission to connect and install the helper. Receiving byte, entry, and deletion ceilings apply. `--cwd`/`--root` continue to describe the local receiving filesystem. The destination enforces the approved copy and protects its control files; the source verifies the signed receipt.

The route requires local sources, an ordinary SSH destination, trusted host keys on the approving machine, and reachable destination TCP ports. It refuses SSH data fallback, plaintext, custom remote commands, detach, and alternative coordinator/authentication settings. Stopping or losing the return connection revokes the copy; retry requires a fresh approval. The cached helper is tried first; only launcher exit 125 permits one installation and retry, within the same setup deadline. The approval lock is released before SSH setup. Setup and unfinished handshakes have deadlines, active copies have bounded slots/lifetimes, and owned SSH process groups are killed before reaping. A small-message relay regression covers the pipe buffering failure found during real-SSH validation.

CLI help, completion, Python sync/async `cp(via=...)`, and user documentation are updated. Completion never contacts the destination through an unapproved route.

Compatibility: latest published baseline is `v0.3.2`, which predates receiving. For the existing return/approval implementation, an unchanged `f752ee8` binary produced the committed v3 preference fixture; the new reader preserves its exact settings and bytes. That old binary also rejects `cp --via`. Existing v2 fixtures, receiving preferences, registrations, enrollment/replay/signing state, receipts, resume identities, and ordinary persistence formats are unchanged. The new message is additive to the build-pinned return connection; a different build is rejected and must reconnect with matching binaries. The destination helper is launched by exact build identity before consuming the new request. No persistent remote authorization or reusable grant is introduced.

Review follow-up at `b23726d`:

| Finding | Disposition |
| --- | --- |
| 1. Unconditional bootstrap | Fixed: cached helper first; install only on the launcher's missing-helper exit. Real SSH verifies one connection on a cache hit and a successful copy after removing the helper. |
| 2. Approval lock through setup | Fixed: release immediately after approval and cancellation check. A second local-return request reaches approval while the first destination helper waits 10 seconds before startup. |
| 3. Lost mid-copy helper diagnosis on the laptop | Still open for discussion. The source already reports copy failure; receiving runs with stderr discarded, so merely emitting a diagnostic would not help. Useful laptop-side reporting needs a status/log destination. Setup failures now preserve exit status and stderr as needed for cache-miss handling. |
| 4. Synthetic restricted-grant marker | Misleading helper/TCP diagnostics fixed and covered in SSH tests. Replacing the representation across shared transfer-engine predicates remains a separate proposed refactor. |
| 5. Hello deadline | Unchanged. Starting it only with the first byte needs an outer bound; no timing policy change made. |
| 6. Validation duplication | Filter normalization shared. The synthetic validation Grant and existing canonical validator remain intact; no signed bytes or validation bounds changed. |
| 7. SSH options | Common options shared; deliberate host-key and forwarding differences documented beside the callers. |
| 8. Endpoint formatter | Reuses the existing endpoint_arg formatter. |

The user requested straightforward fixes and discussion before broader changes. Items 3, 5, and the remainder of 4/6 are recommendations for separate consideration, not silently claimed resolved. This follow-up adds no persistent state or protocol/schema change; `--return-connect-install` is an internal local argument between identical executable processes.

Validation at `b23726d`:

- Linux `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets -- --test-threads=1` passed: 475 unit, 417 local, 4 help, 5 output, and 7 update tests.
- Default three-container `scripts/test-real-ssh.sh` passed, including helper cache hit/miss, approval during slow setup, direct TCP, error wording, denial, protected paths, revocation, and a fresh approval reusing 4 MiB from an interrupted copy. Existing SSH and benchmark cleanup cases also passed.
- [macOS workflow at `b23726d`](https://github.com/greaber/syq/actions/runs/34011751976): Clippy, native tests, and Python/JavaScript/Go SDK checks passed. The later benchmark step failed seven quoted-path/interruption tests, matching [master `4a8ee24`](https://github.com/greaber/syq/actions/runs/34008785259); release-shell steps were skipped. Benchmark code is unchanged here. No manual desktop tests were added.
- Earlier Python candidate SDK run: 88 tests passed; SDK sources are unchanged in this follow-up. Documentation links: 16 files checked, no problems; Python API inventory check passed. The unchanged `f752ee8` preferences fixture remains in the integration suite.

Head `b23726d`, branch `remote-copy-via-laptop`, clean and pushed. Not merged.

Branch status at handoff (exit 1 for the existing master macOS failure):

```text
Worktree: /home/grant/repos/syq/.worktrees/remote-copy-via-laptop
Branch:   remote-copy-via-laptop at b23726d (clean)
Upstream: origin/remote-copy-via-laptop (ahead 0, behind 0)
Master:   3c63d35 from refs/heads/master (branch is ahead 26, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      4a8ee24  https://github.com/greaber/syq/actions/runs/34008785308
  rsync-compat.yml success      4a8ee24  https://github.com/greaber/syq/actions/runs/34008785257
  macos.yml        failure      4a8ee24  https://github.com/greaber/syq/actions/runs/34008785259

Pull request: #241 https://github.com/greaber/syq/pull/241
  base master, open, review none, merge state clean
  GitHub head b23726d: matches local b23726d
  checks: none registered yet

WARNING: master is red: macos.yml failure at 4a8ee24 https://github.com/greaber/syq/actions/runs/34008785259
```
