### PR TITLE
Prepare syq 0.4.0 and fix macOS benchmark quoting

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -1,0 +1,22 @@
+syq 0.4.0 adds approved copies initiated from remote machines, richer copy
+policies, and faster, steadier transfers.
+
+- `syq recv on` gives your laptop a name on connected SSH servers. A server can
+  send files back with `syq cp results --to @laptop`; each request requires
+  approval on the laptop unless you explicitly enable automatic approval.
+- A source server can ask your laptop to coordinate a copy to another server
+  with `--via @laptop`. The laptop keeps its destination credentials local and
+  approves the request before connecting onward.
+- `--verify-only`, `--ignore-existing`, `--existing`, and `--update` provide
+  explicit policies for checking or updating destination entries. The Python
+  API exposes the same options.
+- Network setup now overlaps more work, batches remote destination operations,
+  and can tune transfer internals through `--tuning-options`. Progress remains
+  stable during slow or sparse transfers and reports fatal errors clearly.
+- Shell completion can show file metadata in listing-style results, and the new
+  interactive benchmark records comparable local, SSH, and network-copy runs.
+
+Existing copy commands keep their behavior. Receiving settings are upgraded
+when this release starts the service; after returning to an older syq build,
+configure receiving again before using it. Remote helpers and return peers must
+use the same syq build as the command that starts the copy.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -34,7 +34,7 @@ Only newly created syq-bench.* directories are used. Existing data is not copied
 HELP
 }
 fail() { printf 'Benchmark: %s\n' "$*" >&2; exit 1; }
-quote() { printf "'%s'" "${1//\'/\'\\\'\'}"; }
+quote() { printf '%s\n' "$1" | sed "s/'/'\\\\''/g; s/^/'/; s/\$/'/"; }
 ask() {
     local answer
     printf '%s [%s]: ' "$1" "$2" >&2


### PR DESCRIPTION
`master` still identifies the package as 0.3.2 despite shipping approved return copies, `--via` routing, copy policies, transfer tuning, and richer completion. This prepares 0.4.0 with curated release notes.

The latest Apple Silicon workflow also showed that the standalone benchmark's Bash-only single-quote replacement breaks remote scratch paths under macOS Bash 3.2. The script now generates portable single-quoted shell words with `sed`; paths containing apostrophes work on both Linux and macOS shells.

Compatibility: existing copy commands retain their behavior. Remote helpers remain exact-build pinned. The receiver settings migration and unchanged v0.3.2 completion/receiver fixtures are covered by the existing native and real-SSH suites; the release notes describe the downgrade recovery step.

Validation at `c7efc33a9671`:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq` (475 passed; one opt-in v0.3.2 executable test ignored)
- `python3 scripts/check-python-api-sync.py`
- `python3 scripts/test-try-benchmark.py` (12 passed)
- `shellcheck scripts/try-benchmark.sh`
- `scripts/release-readiness.py v0.4.0 --check-ssh` (full default-profile real-SSH release evidence recorded for tree `f4e1fd11a4106776b4dadbcf9245d7aa1c65a4f0`)

Base `master` status before this PR: rsync compatibility passed at `336bdf3`; `ci.yml` failed only because the Intel macOS runner could not resolve `static.rust-lang.org`, and `macos.yml` failed in the benchmark quoting tests repaired here.
