### PR TITLE
Simplify introductory docs and remove Discussions links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ It is built for large files, large trees, and fast networks.
 - **Gitignore-style filters**, programmable file placement, and JSON results.
 
 [Documentation](https://greaber.github.io/syq/) ·
-[Benchmarks](https://greaber.github.io/syq-bench/) ·
-[Discussions](https://github.com/greaber/syq/discussions)
+[Benchmarks](https://greaber.github.io/syq-bench/)
 
 ## Developing syq
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,6 @@ Syq (pronounced "sick") copies and removes files in parallel, on one machine
 or over SSH. It can resume interrupted copies and transfer directly between
 servers without forwarding your SSH agent.
 
-[Discussions](https://github.com/greaber/syq/discussions)
-
 In published tests, syq copied a folder from Amsterdam to Tokyo
 [5.2× faster than rsync](https://greaber.github.io/syq-bench/#fly-cross-region-memory),
 and 20,000 small files to NFS
@@ -25,19 +23,6 @@ of `project` directly into `/backup`, use `--srcs-in`:
 ```sh
 syq cp --srcs-in project --to server --into /backup
 ```
-
-Directories are copied recursively; no recursion flag is needed. Native
-copies preserve modification times. To preserve permissions too, including
-executable permissions on scripts, add `--preserve=permissions`:
-
-```sh
-syq cp --preserve=permissions project --to server --into /backup
-```
-
-The final summary shows transferred and unchanged files and bytes, directories
-created, elapsed time, rate, and errors. Add `-v` for copied paths, `-vv` for
-helper and transport details, or `--stats` for more totals and connection
-statistics. See [understanding a copy result](reference.md).
 
 Use `--dry-run` to preview a summary without copying, or `--dry-run -v`
 to list the planned changes by path.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -252,7 +252,7 @@ with its exact name. Keep partials belonging to copies still running.
 ## Check file contents
 
 Syq normally skips files whose size and modification time match.
-`-H` / `--hash` checks contents even when those two attributes match:
+`--hash` checks contents even when those two attributes match:
 
 ```sh
 syq cp --hash --srcs-in project --into backup

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,9 +9,6 @@ needed; unrelated files stay.
 
 The default final summary reports transferred files and bytes, unchanged
 files and bytes, directories created, elapsed time, rate, and any errors.
-An unchanged file needed no content transfer; by default, matching size and
-modification time are enough to skip it. Progress appears while copying when
-stderr is a terminal.
 
 Add `-v` to list copied paths. `-vv` also explains helper selection and
 transport; `--stats` adds scan totals, excluded-file counts, connection count,
@@ -255,7 +252,7 @@ with its exact name. Keep partials belonging to copies still running.
 ## Check file contents
 
 Syq normally skips files whose size and modification time match.
-`--hash` checks contents even when those two attributes match:
+`-H` / `--hash` checks contents even when those two attributes match:
 
 ```sh
 syq cp --hash --srcs-in project --into backup

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -5,18 +5,7 @@ syq cp project --into backup
 ```
 
 This copies `project` to `backup/project`. Existing files are updated when
-needed; unrelated files stay. Directories are copied recursively without a
-special option. Modification times are preserved; permissions are not
-preserved unless requested. For a project with executable scripts, use:
-
-```sh
-syq cp --preserve=permissions project --into backup
-```
-
-Without that option, new files use the source permissions limited by the
-destination umask, and existing files keep their destination permissions.
-`--preserve=permissions` copies the source permission bits in both cases. See
-[metadata preservation](#preserve-metadata) for ownership and special files.
+needed; unrelated files stay.
 
 The default final summary reports transferred files and bytes, unchanged
 files and bytes, directories created, elapsed time, rate, and any errors.
@@ -29,7 +18,7 @@ transport; `--stats` adds scan totals, excluded-file counts, connection count,
 and available TCP statistics. For example:
 
 ```sh
-syq cp -vv --stats --preserve=permissions project --into backup
+syq cp -vv --stats project --into backup
 ```
 
 See [diagnosing a slow copy](speed.md#diagnose-a-slow-copy) for interpreting
@@ -307,8 +296,14 @@ through your machine, including when you need comparison results in JSON.
 
 ## Preserve metadata
 
-Copy keeps modification times and copies symlinks as symlinks. Add other
-metadata when needed:
+Copy keeps modification times and copies symlinks as symlinks. New files use
+the source read, write, and execute permissions limited by the destination
+umask; existing files keep their destination permissions. For example, a new
+script with mode `755` stays executable with umask `022`. Source setuid,
+setgid, and sticky bits are not copied by default.
+
+To copy source permissions exactly, including onto existing files, or request
+ownership too:
 
 ```sh
 syq cp --preserve=permissions,ownership project --into backup


### PR DESCRIPTION
Remove Discussions links from the README and documentation intro, cut the intro result-summary paragraph, and remove the opening permissions examples. Keep the accurate default-mode explanation in Preserve metadata, including that new executable files normally remain executable. No runtime behavior changes.

Validation: documentation link checker (16 files, zero problems), pinned mdBook 0.5.4 build with verified archive checksum, and git diff --check passed. Rust and SSH suites were not run for this documentation-only change.