### PR TITLE
Allow slower macOS benchmark validation

### DIFF
--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -288,7 +288,7 @@ class BenchmarkTests(unittest.TestCase):
         prompts_answered = 0
         # All five default answers are read from /dev/tty, not the script pipe.
         os.write(fd, b'\n' * 5)
-        deadline = time.monotonic() + 45
+        deadline = time.monotonic() + 90
         try:
             while time.monotonic() < deadline:
                 if select.select([fd], [], [], 0.2)[0]:


### PR DESCRIPTION
The automated Python SDK 0.4.0 follow-up merged successfully, but its Apple Silicon post-merge validation twice timed out in the final rsync trial of the piped interactive benchmark. Both failures reached that last trial at the existing 45-second deadline; the release-certified tree had already passed the same test.

This gives the end-to-end interactive test a 90-second deadline so slower hosted macOS filesystems can finish while retaining a hard timeout.

Validation:
- python3 scripts/test-try-benchmark.py (12 passed in 39.7s)
- git diff --check
