### PR TITLE
Include Python in the syq release flow

### DIFF
--- a/.agents/skills/syq-release/SKILL.md
+++ b/.agents/skills/syq-release/SKILL.md
@@ -21,11 +21,11 @@ SHA, then act without repeated permission questions. Do not merge unrelated
 features. Authorization persists through retries and continuations of this
 release and ends on completion or cancellation.
 
-Default destinations are the syq GitHub release, crates.io, and Homebrew.
-SDK publication is separate unless requested; the automated Python SDK
-preparation PR is a normal follow-up. Preserve protections and secret
-boundaries. Report concrete credential, required-review, or product-decision
-blockers; do not bypass them.
+Default destinations are the syq GitHub release, crates.io, Homebrew, and the
+matching Python SDK on PyPI. Python preparation and publication are required
+phases of the same release; JavaScript and Go SDK releases remain separate.
+Preserve protections and secret boundaries. Report concrete credential,
+required-review, or product-decision blockers; do not bypass them.
 
 ## Choose the next action from readiness
 
@@ -69,9 +69,23 @@ signing is unavailable. Sign and push the matching annotated tag after preflight
 
 Use `scripts/release-status.sh v<version>` to follow the exact release run,
 approve its eligible deployment, and verify every configured destination.
+After the immutable syq release triggers Python preparation, wait for its
+generated pull request, merge, and exact-commit post-merge checks. Repair a
+failed preparation or certification under this release authorization. Then use
+the maintainer's forwarded SSH signing agent to create and push the annotated
+`sdk-python-v<version>` tag at that verified master commit, approve the `pypi`
+environment, and wait for `publish-sdks.yml`. A PyPI outage leaves the release
+incomplete: rerun the idempotent workflow from the same permanent SDK tag and
+verify the registry rather than moving the tag or requiring a new release.
 Exercise the documented installation paths in disposable locations. A partial
-publication is incomplete. Apply the provisional/permanent tag rules in
-`AGENTS.md`; never move a permanent tag, including any pushed Go module tag.
+publication is incomplete, including a missing matching PyPI version. Apply the
+provisional/permanent tag rules in `AGENTS.md`; never move a permanent tag,
+including any pushed Go module tag.
+
+Run `scripts/release-timings.py v<version>` at completion and include its
+observable GitHub window and slowest phases in the release report. The phases
+can overlap, so use the window as wall time and job durations as optimization
+evidence rather than adding job durations together.
 
 Finish with the version, exact commit, release URL, verified destinations,
 checks, remaining failures, and branch-status/cleanliness. Keep interrupted

--- a/.github/workflows/prepare-python-sdk.yml
+++ b/.github/workflows/prepare-python-sdk.yml
@@ -115,7 +115,7 @@ jobs:
             "- sets the Python SDK version to match syq $SYQ_VERSION" \
             "- embeds the exact signed v$SYQ_VERSION release manifest" \
             "- updates the managed executable cache documentation" \
-            "The preparation workflow ran the pinned SDK release-tool and unit-test suites before opening this pull request. It will explicitly run and await the post-merge workflows on the exact merge commit. Publication still requires the maintainer-signed tag sdk-python-v$PYTHON_VERSION and approval of the protected pypi environment.")
+            "The preparation workflow ran the pinned SDK release-tool and unit-test suites before opening this pull request. It will explicitly run and await the post-merge workflows on the exact merge commit. The release orchestrator will then sign sdk-python-v$PYTHON_VERSION, approve the protected pypi environment, and verify publication.")
           pr_url=$(gh pr create \
             --base master \
             --head "$branch" \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -258,19 +258,26 @@ release request does not require another preparation PR or another test run.
    every uploaded byte, publishes it, publishes the matching source package to
    crates.io with a short-lived OIDC credential, and finally updates the tap.
    Once the entire release workflow succeeds, the Python SDK preparation
-   workflow opens a pull request for the matching SDK release using this
-   immutable syq manifest. PyPI publication remains a separate signed-tag and
-   protected-environment action, so a registry outage cannot block syq.
+   workflow opens and merges a pull request for the matching SDK release using
+   this immutable syq manifest. The `$syq-release` flow waits for the exact
+   merge-commit checks, signs the Python tag, approves its protected environment,
+   and verifies PyPI as required phases of the same release. A PyPI outage does
+   not roll back already-published syq artifacts; it leaves the release
+   incomplete and the idempotent Python workflow is retried from the same tag.
    Track the complete state at any time with:
 
    ```sh
    scripts/release-status.sh v0.1.9
    scripts/release-status.sh --json v0.1.9
+   scripts/release-timings.py v0.1.9
    ```
 
    The report correlates the exact tag commit, release runs and pending
    environments, GitHub release state, crates.io, the matching PyPI SDK version,
-   and the Homebrew formula without modifying any of them.
+   and the Homebrew formula without modifying any of them. The timing report
+   reconstructs the observable GitHub wall-clock window and the duration of
+   each workflow, job, and (in JSON) step. Workflow and job times can overlap
+   and should not be added together.
 4. Verify one or more downloaded artifacts and exercise all install paths:
 
    ```sh

--- a/scripts/release-status.sh
+++ b/scripts/release-status.sh
@@ -137,7 +137,14 @@ result=$(jq -n \
    release_runs:$runs,
    publications:{crates_io:{version:($tag | ltrimstr("v")), state:$crates},
      pypi:{version:($pypi_version | if length > 0 then . else null end), state:$pypi},
-     homebrew:{tag:$tag, state:$homebrew}}}
+     homebrew:{tag:$tag, state:$homebrew}}} |
+   . + {complete:(
+     .tag_state == "verified" and
+     .github_release.state == "published" and .github_release.immutable and
+     (.release_runs | length > 0 and all(.[]; .status == "completed" and .conclusion == "success")) and
+     .publications.crates_io.state == "published" and
+     .publications.pypi.state == "published" and
+     .publications.homebrew.state == "published")}
   ')
 
 if [ "$json" = true ]; then
@@ -151,6 +158,7 @@ jq -r '
   "  crates.io: \(.publications.crates_io.state)",
   "  PyPI SDK:  \(.publications.pypi.state)\(if .publications.pypi.version then " (" + .publications.pypi.version + ")" else "" end)",
   "  Homebrew:  \(.publications.homebrew.state)",
+  "  complete:  \(if .complete then "yes" else "no" end)",
   (if (.release_runs | length) == 0 then "  runs:       none"
    else .release_runs[] | "  run \(.databaseId): \(.status)\(if .conclusion then "/" + .conclusion else "" end), pending environments: \(if .pending_environments == null then "unknown" else (.pending_environments | join(", ") | if length == 0 then "none" else . end) end)\n    \(.url)" end)
 ' <<<"$result"

--- a/scripts/release-timings.py
+++ b/scripts/release-timings.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Report the observable GitHub Actions phases of a syq release."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPOSITORY = "greaber/syq"
+WORKFLOWS = (
+    ("syq certification", "ci.yml"),
+    ("syq certification", "rsync-compat.yml"),
+    ("syq certification", "macos.yml"),
+    ("syq publication", "release.yml"),
+    ("Python preparation", "prepare-python-sdk.yml"),
+)
+
+
+def gh_api(endpoint: str, *fields: str) -> Any:
+    command = ["gh", "api", "-X", "GET", endpoint]
+    for field in fields:
+        command.extend(("-f", field))
+    return json.loads(subprocess.check_output(command, text=True))
+
+
+def parse_time(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def duration(start: str | None, end: str | None) -> int | None:
+    parsed_start, parsed_end = parse_time(start), parse_time(end)
+    if parsed_start is None or parsed_end is None:
+        return None
+    return max(0, round((parsed_end - parsed_start).total_seconds()))
+
+
+def resolve_tag(tag: str) -> str | None:
+    refs = gh_api(f"repos/{REPOSITORY}/git/matching-refs/tags/{tag}")
+    exact = next((item for item in refs if item.get("ref") == f"refs/tags/{tag}"), None)
+    if exact is None:
+        return None
+    target = exact["object"]
+    while target["type"] == "tag":
+        target = gh_api(f"repos/{REPOSITORY}/git/tags/{target['sha']}")["object"]
+    return target["sha"] if target["type"] == "commit" else None
+
+
+def matching_runs(workflow: str, commit: str, branch: str | None = None) -> list[dict[str, Any]]:
+    response = gh_api(
+        f"repos/{REPOSITORY}/actions/workflows/{workflow}/runs",
+        f"head_sha={commit}",
+        "per_page=100",
+    )
+    runs = [run for run in response.get("workflow_runs", []) if run.get("head_sha") == commit]
+    if branch is not None:
+        runs = [run for run in runs if run.get("head_branch") == branch]
+    return sorted(runs, key=lambda run: run.get("created_at", ""))
+
+
+def selected_run(workflow: str, runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not runs:
+        return None
+    successful = [run for run in runs if run.get("conclusion") == "success"]
+    if workflow in {"ci.yml", "rsync-compat.yml", "macos.yml"} and successful:
+        return successful[-1]
+    return runs[-1]
+
+
+def describe_run(phase: str, workflow: str, run: dict[str, Any]) -> dict[str, Any]:
+    attempt = run.get("run_attempt", 1)
+    response = gh_api(
+        f"repos/{REPOSITORY}/actions/runs/{run['id']}/attempts/{attempt}/jobs",
+        "per_page=100",
+    )
+    jobs = []
+    for job in response.get("jobs", []):
+        steps = [
+            {
+                "name": step["name"],
+                "status": step.get("status"),
+                "conclusion": step.get("conclusion"),
+                "started_at": step.get("started_at"),
+                "completed_at": step.get("completed_at"),
+                "duration_seconds": duration(step.get("started_at"), step.get("completed_at")),
+            }
+            for step in job.get("steps", [])
+        ]
+        jobs.append(
+            {
+                "name": job["name"],
+                "status": job.get("status"),
+                "conclusion": job.get("conclusion"),
+                "started_at": job.get("started_at"),
+                "completed_at": job.get("completed_at"),
+                "duration_seconds": duration(job.get("started_at"), job.get("completed_at")),
+                "steps": steps,
+            }
+        )
+    return {
+        "phase": phase,
+        "workflow": workflow,
+        "run_id": run["id"],
+        "attempt": attempt,
+        "status": run.get("status"),
+        "conclusion": run.get("conclusion"),
+        "created_at": run.get("created_at"),
+        "updated_at": run.get("updated_at"),
+        "duration_seconds": duration(run.get("created_at"), run.get("updated_at")),
+        "url": run.get("html_url"),
+        "jobs": jobs,
+    }
+
+
+def format_duration(seconds: int | None) -> str:
+    if seconds is None:
+        return "in progress"
+    minutes, remainder = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m {remainder}s"
+    if minutes:
+        return f"{minutes}m {remainder}s"
+    return f"{remainder}s"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="syq release tag, for example v0.4.0")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable details")
+    args = parser.parse_args()
+    if not __import__("re").fullmatch(r"v\d+\.\d+\.\d+", args.tag):
+        parser.error("tag must have the form vMAJOR.MINOR.PATCH")
+
+    commit = resolve_tag(args.tag)
+    if commit is None:
+        print(f"release tag does not exist: {args.tag}", file=sys.stderr)
+        return 1
+
+    entries = []
+    for phase, workflow in WORKFLOWS:
+        branch = args.tag if workflow == "release.yml" else None
+        run = selected_run(workflow, matching_runs(workflow, commit, branch))
+        if run is not None:
+            entries.append(describe_run(phase, workflow, run))
+
+    sdk_tag = f"sdk-python-{args.tag}"
+    sdk_commit = resolve_tag(sdk_tag)
+    if sdk_commit is not None:
+        for workflow in ("ci.yml", "rsync-compat.yml", "macos.yml"):
+            run = selected_run(workflow, matching_runs(workflow, sdk_commit))
+            if run is not None:
+                entries.append(describe_run("Python certification", workflow, run))
+        runs = matching_runs("publish-sdks.yml", sdk_commit, sdk_tag)
+        run = selected_run("publish-sdks.yml", runs)
+        if run is not None:
+            entries.append(describe_run("Python publication", "publish-sdks.yml", run))
+
+    starts = [parse_time(entry["created_at"]) for entry in entries]
+    ends = [parse_time(entry["updated_at"]) for entry in entries]
+    starts = [value for value in starts if value is not None]
+    ends = [value for value in ends if value is not None]
+    observed = round((max(ends) - min(starts)).total_seconds()) if starts and ends else None
+    result = {
+        "repository": REPOSITORY,
+        "tag": args.tag,
+        "tag_commit": commit,
+        "python_tag": sdk_tag if sdk_commit else None,
+        "python_tag_commit": sdk_commit,
+        "observable_window_seconds": observed,
+        "runs": entries,
+    }
+    if args.json:
+        json.dump(result, sys.stdout, indent=2)
+        print()
+        return 0
+
+    print(f"Release timing for {args.tag} at {commit}")
+    print(f"  observable GitHub window: {format_duration(observed)}")
+    for entry in entries:
+        state = entry["conclusion"] or entry["status"]
+        print(f"  {entry['phase']}: {entry['workflow']} run {entry['run_id']} — "
+              f"{format_duration(entry['duration_seconds'])} ({state})")
+        for job in sorted(entry["jobs"], key=lambda item: item["duration_seconds"] or -1, reverse=True):
+            print(f"    {format_duration(job['duration_seconds']):>10}  {job['name']}")
+    print("  Runs and jobs can overlap; their durations are not additive.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -483,8 +483,12 @@ cat >"$status_bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$1:$2" in
-  run:list) jq -cn --arg sha "$SYQ_TEST_STATUS_COMMIT" '[
-    {conclusion:null,databaseId:303,event:"push",headSha:$sha,status:"in_progress",url:"https://example.test/303",workflowName:"release"}]' ;;
+  run:list) jq -cn --arg sha "$SYQ_TEST_STATUS_COMMIT" \
+    --arg status "${SYQ_TEST_STATUS_RUN_STATUS:-in_progress}" \
+    --arg conclusion "${SYQ_TEST_STATUS_RUN_CONCLUSION:-}" '[
+    {conclusion:($conclusion | if length == 0 then null else . end),
+     databaseId:303,event:"push",headSha:$sha,status:$status,
+     url:"https://example.test/303",workflowName:"release"}]' ;;
   api:*)
     case " $* " in
       *"/git/matching-refs/tags/$SYQ_TEST_STATUS_TAG "*) jq -cn \
@@ -526,7 +530,7 @@ jq -e --arg commit "$status_commit" '
   .tag_state == "verified" and .tag_commit == $commit and
   .github_release.state == "published" and .github_release.immutable == true and
   .release_runs[0].databaseId == 303 and
-  .release_runs[0].pending_environments == ["release"] and
+  .release_runs[0].pending_environments == ["release"] and .complete == false and
   .publications.crates_io.state == "published" and
   .publications.pypi.state == "published" and
   .publications.homebrew.state == "published"
@@ -535,6 +539,17 @@ jq -e --arg commit "$status_commit" '
   jq . "$work/status.json" >&2
   exit 1
 }
+
+PATH="$status_bin:$PATH" \
+SYQ_TEST_STATUS_COMMIT="$status_commit" \
+SYQ_TEST_STATUS_TAG_OBJECT="$status_tag_object" \
+SYQ_TEST_STATUS_TAG="$status_tag" \
+SYQ_TEST_STATUS_VERSION="$status_version" \
+SYQ_TEST_STATUS_FORMULA_B64="$status_formula_b64" \
+SYQ_TEST_STATUS_RUN_STATUS=completed \
+SYQ_TEST_STATUS_RUN_CONCLUSION=success \
+  "$script_dir/release-status.sh" --json "$status_tag" >"$work/status-complete.json"
+jq -e '.complete == true' "$work/status-complete.json" >/dev/null
 
 PATH="$status_bin:$PATH" \
 SYQ_TEST_STATUS_COMMIT="$status_commit" \
@@ -559,5 +574,6 @@ jq -e '.tag_state == "invalid-target" and .tag_commit == null' \
   "$work/status-nested-tag.json" >/dev/null
 
 python3 "$script_dir/test-release-readiness.py"
+python3 "$script_dir/test-release-timings.py"
 
 echo 'release orchestration tests passed'

--- a/scripts/test-release-timings.py
+++ b/scripts/test-release-timings.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Unit checks for release timing selection and calculations."""
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+SCRIPT = Path(__file__).resolve().with_name("release-timings.py")
+SPEC = importlib.util.spec_from_file_location("release_timings", SCRIPT)
+assert SPEC and SPEC.loader
+release_timings = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(release_timings)
+
+
+class ReleaseTimingTests(unittest.TestCase):
+    def test_duration_and_display(self):
+        self.assertEqual(
+            release_timings.duration("2026-09-06T11:49:29Z", "2026-09-06T11:56:12Z"),
+            403,
+        )
+        self.assertEqual(release_timings.format_duration(403), "6m 43s")
+        self.assertIsNone(release_timings.duration("2026-09-06T11:49:29Z", None))
+
+    def test_certification_prefers_latest_success(self):
+        runs = [
+            {"conclusion": "success", "created_at": "2026-09-06T01:00:00Z"},
+            {"conclusion": "failure", "created_at": "2026-09-06T02:00:00Z"},
+        ]
+        self.assertIs(release_timings.selected_run("ci.yml", runs), runs[0])
+        self.assertIs(release_timings.selected_run("release.yml", runs), runs[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -73,7 +73,8 @@ class BenchmarkTests(unittest.TestCase):
             if executable is None:
                 self.fail(f'Missing test prerequisite: {name}')
             (self.bin / name).symlink_to(executable)
-        self.env = dict(os.environ, PATH=str(self.bin))
+        self.env = dict(os.environ, PATH=str(self.bin),
+                        SYQ_BENCHMARK_TEST_SMALL_FIXTURES='1')
 
     def invoke(self, *args, env=None):
         return subprocess.run(

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -240,6 +240,13 @@ main() {
     case $mode in local|push|pull) ;; *) fail 'Mode must be local, push or pull.' ;; esac
     case $workload in large|small|both) ;; *) fail 'Workload must be large, small or both.' ;; esac
     case $size in quick) large_mib=64; small_files=1024 ;; medium) large_mib=1024; small_files=4096 ;; large) large_mib=8192; small_files=16384 ;; *) fail 'Size must be quick, medium or large.' ;; esac
+    # The script tests exercise real generation, copies, checksums, ordering,
+    # and cleanup. Smaller private fixtures keep that coverage without making
+    # prompt-routing tests copy the full user-facing benchmark workload.
+    if [[ ${SYQ_BENCHMARK_TEST_SMALL_FIXTURES:-} == 1 ]]; then
+        large_mib=1
+        small_files=8
+    fi
     [[ $rounds =~ ^[1-9]$ ]] || fail 'Rounds must be between 1 and 9.'
     for tool in bash rsync openssl dd split cksum cmp awk mktemp mkdir rm cat ps sleep sed; do need "$tool"; done
     [[ $mode != local ]] || need cp

--- a/sdk/RELEASING.md
+++ b/sdk/RELEASING.md
@@ -148,14 +148,18 @@ Actions, contents, and pull-request write scopes only inside this preparation
 workflow.
 
 The generated pull request does not have a pending review or cancellation
-window. The final publication remains a deliberate release-authority action:
-create the signed annotated `sdk-python-v<version>` tag and approve the
-protected `pypi` environment. The tag then publishes through OIDC without a
-local upload or long-lived PyPI credential. Keeping the tag signature manual
-avoids placing maintainer signing authority in CI. The additional PyPI
-environment approval is intentionally retained as defense in depth for a
-separate package registry; PyPI availability cannot block publication of syq
-itself.
+window. The `$syq-release` flow waits for its exact-commit checks, creates the
+signed annotated `sdk-python-v<version>` tag with the maintainer's forwarded
+signing agent, approves the protected `pypi` environment, and verifies PyPI.
+These are normal phases of the same release rather than a separately requested
+SDK release. The tag publishes through OIDC without a local upload or long-lived
+PyPI credential, while keeping maintainer signing authority out of CI.
+
+Publication across GitHub, crates.io, Homebrew, and PyPI is sequential rather
+than atomic. If PyPI is unavailable, the already-published syq artifacts remain
+valid and the release remains incomplete. Rerun `publish-sdks.yml` from the
+same permanent SDK tag until PyPI contains the exact reproducible distributions;
+never move the tag or substitute a new package version merely to retry.
 
 Python distributions use a pinned interpreter and the tagged commit timestamp
 as `SOURCE_DATE_EPOCH`, and the source archive is repacked with normalized


### PR DESCRIPTION
The v0.4.0 follow-up exposed two release problems: the interactive benchmark prompt test copied production-sized fixtures 18 times, and the normal syq release stopped before publishing its matching Python SDK.

This change gives benchmark tests private 1 MiB/8-file fixtures while retaining real copies, checksums, rotation, failure, and cleanup coverage. It also makes the matching PyPI package a required `$syq-release` destination, records a machine-readable `complete` result in release status, and documents retrying the same immutable SDK tag when PyPI is unavailable. A new `release-timings.py` report reconstructs the observable GitHub window and workflow, job, and step durations across syq certification/publication and Python preparation/certification/publication.

Validation:
- `scripts/branch-status.sh --check`
- `python3 scripts/test-try-benchmark.py` (12 tests, 5.6s locally)
- `scripts/test-release-orchestration.sh`
- `scripts/test-release-tools.sh`
- `scripts/test-python-sdk-release-tools.sh`
- Python SDK unit suite (88 tests, 6 skipped)
- shellcheck and documentation link checks
