### PR TITLE
Fix return-copy handshake timing, home paths, and helper recovery

### DIFF
--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -45,17 +45,20 @@ encrypted TCP. HostB must expose a [reachable data port](server-tuning.md#make-t
 to hostA. Failure to reach it fails the copy without switching to SSH data.
 
 The prompt shows the requested SSH endpoint and destination path. Relative
-destination paths start in that account's home directory on hostB. Receiving
-`--cwd` and `--root` govern copies onto the laptop; they do not describe hostB's
-filesystem. Receiving byte, entry, and deletion ceilings still apply. The
+destination paths start in that account's home directory on hostB. A quoted
+`~` or `~/archive` also uses hostB's home directory; use `./~/archive` to name a
+literal directory called `~`. Receiving `--cwd` and `--root` govern copies onto
+the laptop; they do not describe hostB's filesystem. Receiving byte, entry, and deletion ceilings still apply. The
 helper on hostB checks the approved copy permissions and protects its own
 control and SSH authority files. The source verifies its signed receipt before
 reporting success. No durable receiver enrollment or reusable grant is created.
 
 All three machines must use the same syq build. Keep the source command and
 the laptop's return connection alive until completion. Stopping receiving or
-losing that connection cancels the copy. Retry with a new approval to resume
-eligible partial files. This route accepts local sources and an ordinary SSH
+losing that connection cancels the copy. After hostB approves setup, the source
+has 60 seconds to start its handshake and then 10 seconds to complete it.
+Retry with a new approval to resume eligible partial files. This route accepts
+local sources and an ordinary SSH
 `--to` endpoint. It does not accept `--detach`, custom `--rsh`/`--syq-path`,
 `--no-bootstrap`, `--pscope`, alternative `--peer-auth`/`--coordinate-at`,
 `--no-tcp`, or `--tcp-plain`. Copy permissions and supported filesystem options

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -47,9 +47,10 @@ to hostA. Failure to reach it fails the copy without switching to SSH data.
 The prompt shows the requested SSH endpoint and destination path. Relative
 destination paths start in that account's home directory on hostB. A quoted
 `~` or `~/archive` also uses hostB's home directory; use `./~/archive` to name a
-literal directory called `~`. Receiving `--cwd` and `--root` govern copies onto
-the laptop; they do not describe hostB's filesystem. Receiving byte, entry, and deletion ceilings still apply. The
-helper on hostB checks the approved copy permissions and protects its own
+literal directory called `~`. On this route, `~//archive` also stays under that
+home directory. Receiving `--cwd` and `--root` govern copies onto the laptop;
+they do not describe hostB's filesystem. Receiving byte, entry, and deletion
+ceilings still apply. The helper on hostB checks the approved copy permissions and protects its own
 control and SSH authority files. The source verifies its signed receipt before
 reporting success. No durable receiver enrollment or reusable grant is created.
 
@@ -58,8 +59,7 @@ the laptop's return connection alive until completion. Stopping receiving or
 losing that connection cancels the copy. After hostB approves setup, the source
 has 60 seconds to start its handshake and then 10 seconds to complete it.
 Retry with a new approval to resume eligible partial files. This route accepts
-local sources and an ordinary SSH
-`--to` endpoint. It does not accept `--detach`, custom `--rsh`/`--syq-path`,
+local sources and an ordinary SSH `--to` endpoint. It does not accept `--detach`, custom `--rsh`/`--syq-path`,
 `--no-bootstrap`, `--pscope`, alternative `--peer-auth`/`--coordinate-at`,
 `--no-tcp`, or `--tcp-plain`. Copy permissions and supported filesystem options
 match [return copies](receive.md#copy-permissions-and-limits).

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1293,6 +1293,14 @@ fn option_takes_value(command: &clap::Command, option: &[u8]) -> bool {
     })
 }
 
+fn return_name_candidates(current: &[u8]) -> impl Iterator<Item = Candidate> + '_ {
+    crate::destination::registered_names()
+        .into_iter()
+        .flat_map(|name| [name.as_bytes().to_vec(), format!("@{name}").into_bytes()])
+        .filter(move |name| name.starts_with(current))
+        .map(Candidate::text)
+}
+
 fn complete_value(
     command: &str,
     args: &[Vec<u8>],
@@ -1300,25 +1308,14 @@ fn complete_value(
     kind: ValueCompletion,
 ) -> Result<Vec<Candidate>> {
     match kind {
-        ValueCompletion::ReturnName => Ok(crate::destination::registered_names()
-            .into_iter()
-            .flat_map(|name| [name.as_bytes().to_vec(), format!("@{name}").into_bytes()])
-            .filter(|name| name.starts_with(current))
-            .map(Candidate::text)
-            .collect()),
+        ValueCompletion::ReturnName => Ok(return_name_candidates(current).collect()),
         ValueCompletion::NamedOrSshDestination => {
             let mut candidates = endpoint_candidates(
                 current,
                 EndpointSyntax::Native,
                 pscope_from_args(command, args),
             );
-            candidates.extend(
-                crate::destination::registered_names()
-                    .into_iter()
-                    .flat_map(|name| [name.as_bytes().to_vec(), format!("@{name}").into_bytes()])
-                    .filter(|name| name.starts_with(current))
-                    .map(Candidate::text),
-            );
+            candidates.extend(return_name_candidates(current));
             Ok(candidates)
         }
         ValueCompletion::Endpoint(syntax) => Ok(endpoint_candidates(

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1302,7 +1302,7 @@ fn complete_value(
     match kind {
         ValueCompletion::ReturnName => Ok(crate::destination::registered_names()
             .into_iter()
-            .map(|name| format!("@{name}").into_bytes())
+            .flat_map(|name| [name.as_bytes().to_vec(), format!("@{name}").into_bytes()])
             .filter(|name| name.starts_with(current))
             .map(Candidate::text)
             .collect()),

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -296,8 +296,9 @@ fn exchange(
     message: Message,
     timeout: Duration,
 ) -> Result<(UnixStream, Reply)> {
-    let mut stream = UnixStream::connect(&registration.socket)
-        .context("receiving laptop is offline; it must reconnect before this transfer can start")?;
+    let mut stream = UnixStream::connect(&registration.socket).context(
+        "receiving machine is offline; it must reconnect before this transfer can start",
+    )?;
     stream.set_read_timeout(Some(timeout))?;
     stream.set_write_timeout(Some(timeout))?;
     write_message(
@@ -311,7 +312,7 @@ fn exchange(
     )?;
     let reply = read_message(&mut stream)?;
     if let Reply::Error(error) = &reply {
-        bail!("receiving laptop: {error}");
+        bail!("receiving machine: {error}");
     }
     Ok((stream, reply))
 }

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -617,7 +617,7 @@ pub(crate) fn finish_receipt(
         &expected.policy,
     )?;
     if receipt.terminal.status != crate::receipt::ReceiptStatus::Clean {
-        bail!("receiving laptop reports {:?}", receipt.terminal.status);
+        bail!("receiving machine reports {:?}", receipt.terminal.status);
     }
     Ok(())
 }

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -275,13 +275,9 @@ impl ForwardChild {
                         child.close().map_err(Into::into)
                     };
                     if !install
-                        && status.as_ref().is_ok_and(|s| {
-                            matches!(
-                                s.code(),
-                                Some(crate::remote_helper::HELPER_MISSING_EXIT)
-                                    | Some(crate::remote_helper::HELPER_NOT_EXECUTABLE_EXIT)
-                            )
-                        })
+                        && status
+                            .as_ref()
+                            .is_ok_and(|s| crate::remote_helper::needs_install(s.code()))
                     {
                         continue;
                     }

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -259,8 +259,8 @@ impl ForwardChild {
                 Ok(Reply::Error(error)) => bail!("destination refused the copy: {error}"),
                 Ok(Reply::Ready) => bail!("invalid destination setup response"),
                 Err(error) => {
-                    // The exact-build launcher returns this code before starting
-                    // a helper. Only that cache miss may replay the setup request.
+                    // Match ordinary bootstrap: a missing helper or an exec
+                    // failure may retry setup once, before a copy is approved.
                     let closed = error.downcast_ref::<std::io::Error>().is_some_and(|e| {
                         matches!(
                             e.kind(),
@@ -276,7 +276,11 @@ impl ForwardChild {
                     };
                     if !install
                         && status.as_ref().is_ok_and(|s| {
-                            s.code() == Some(crate::remote_helper::HELPER_MISSING_EXIT)
+                            matches!(
+                                s.code(),
+                                Some(crate::remote_helper::HELPER_MISSING_EXIT)
+                                    | Some(crate::remote_helper::HELPER_NOT_EXECUTABLE_EXIT)
+                            )
                         })
                     {
                         continue;
@@ -509,21 +513,66 @@ impl<T: Write + AsRawFd, F: Fn() -> bool> Write for DeadlineIo<'_, T, F> {
     }
 }
 
-pub(crate) struct HandshakeInput {
-    inner: File,
+struct HandshakeInput<R> {
+    inner: R,
     pending: Arc<AtomicBool>,
     deadline: Instant,
+    hello_timeout: Duration,
+    started: bool,
 }
-impl Read for HandshakeInput {
+impl<R> HandshakeInput<R> {
+    fn new(
+        inner: R,
+        pending: Arc<AtomicBool>,
+        start_timeout: Duration,
+        hello_timeout: Duration,
+    ) -> Self {
+        Self {
+            inner,
+            pending,
+            deadline: Instant::now() + start_timeout,
+            hello_timeout,
+            started: false,
+        }
+    }
+}
+impl<R: Read + AsRawFd> Read for HandshakeInput<R> {
     fn read(&mut self, bytes: &mut [u8]) -> std::io::Result<usize> {
+        if bytes.is_empty() {
+            return Ok(0);
+        }
         if self.pending.load(Ordering::Acquire) {
             wait_fd(self.inner.as_raw_fd(), libc::POLLIN, self.deadline, &|| {
                 false
             })?;
         }
-        self.inner.read(bytes)
+        let count = self.inner.read(bytes)?;
+        if count > 0 && !self.started {
+            // Preparing the source and reaching us through the return relay is
+            // separate from completing Hello. Neither phase can wait forever,
+            // and subsequent partial bytes never extend the Hello deadline.
+            self.started = true;
+            self.deadline = Instant::now() + self.hello_timeout;
+        }
+        Ok(count)
     }
 }
+
+fn resolve_ssh_destination(home: &Path, path: &[u8]) -> Result<(PathBuf, PathBuf)> {
+    let relative;
+    let path = if path == b"~" {
+        b"."
+    } else if let Some(rest) = path.strip_prefix(b"~/") {
+        // Keep even ~//path relative to the destination home. ./~/path still
+        // names a literal directory, and named receivers keep their cwd/root.
+        relative = [b"./".as_slice(), rest].concat();
+        &relative
+    } else {
+        path
+    };
+    resolve_destination(home, None, path)
+}
+
 fn receive() -> Result<i32> {
     let fd = unsafe { libc::dup(libc::STDIN_FILENO) };
     if fd < 0 {
@@ -540,8 +589,7 @@ fn receive() -> Result<i32> {
             bail!("return helper build mismatch");
         }
         let cwd = fs::canonicalize(std::env::var_os("HOME").context("HOME is unset")?)?;
-        let (destination, container) =
-            resolve_destination(&cwd, None, &request.request.destination)?;
+        let (destination, container) = resolve_ssh_destination(&cwd, &request.request.destination)?;
         let request = constrain(
             request.request,
             &destination,
@@ -562,11 +610,12 @@ fn receive() -> Result<i32> {
     let pending = Arc::new(AtomicBool::new(true));
     crate::server::run_forwarded(
         authority,
-        HandshakeInput {
-            inner: input,
-            pending: pending.clone(),
-            deadline: Instant::now() + Duration::from_secs(10),
-        },
+        HandshakeInput::new(
+            input,
+            pending.clone(),
+            START_TIMEOUT,
+            Duration::from_secs(10),
+        ),
         pending,
     )?;
     Ok(0)
@@ -630,6 +679,85 @@ pub(super) fn dispatch(argv: &[OsString]) -> Option<Result<i32>> {
 mod tests {
     use super::*;
     use crate::destination::tests::{args, broker, request};
+
+    #[test]
+    fn hello_has_a_separate_start_budget_and_partial_bytes_do_not_extend_it() {
+        let (reader, mut writer) = UnixStream::pair().unwrap();
+        let pending = Arc::new(AtomicBool::new(true));
+        let mut input = HandshakeInput::new(
+            reader,
+            pending,
+            Duration::from_secs(2),
+            Duration::from_millis(150),
+        );
+        // Source preparation may exceed the entire Hello budget.
+        std::thread::sleep(Duration::from_millis(200));
+        writer.write_all(b"a").unwrap();
+        let mut byte = [0];
+        input.read_exact(&mut byte).unwrap();
+        assert_eq!(byte, *b"a");
+        let sender = std::thread::spawn(move || {
+            for _ in 0..8 {
+                std::thread::sleep(Duration::from_millis(40));
+                if writer.write_all(b"b").is_err() {
+                    break;
+                }
+            }
+        });
+        let error = input.read_exact(&mut [0; 8]).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        drop(input);
+        sender.join().unwrap();
+    }
+
+    #[test]
+    fn an_idle_hello_expires_but_completed_transfers_have_no_hello_deadline() {
+        let (reader, mut writer) = UnixStream::pair().unwrap();
+        let pending = Arc::new(AtomicBool::new(true));
+        let mut input = HandshakeInput::new(
+            reader,
+            pending.clone(),
+            Duration::from_millis(20),
+            Duration::from_millis(20),
+        );
+        assert_eq!(input.read(&mut []).unwrap(), 0);
+        let error = input.read(&mut [0]).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        // Once the server has accepted Hello, the reader belongs to the copy.
+        pending.store(false, Ordering::Release);
+        writer.write_all(b"data").unwrap();
+        let mut bytes = [0; 4];
+        input.read_exact(&mut bytes).unwrap();
+        assert_eq!(&bytes, b"data");
+    }
+
+    #[test]
+    fn ssh_destinations_expand_only_a_leading_home_tilde() {
+        let root = tempfile::tempdir().unwrap();
+        let home = fs::canonicalize(root.path()).unwrap();
+        for path in [b"~/archive".as_slice(), b"~//archive", b"archive"] {
+            assert_eq!(
+                resolve_ssh_destination(&home, path).unwrap().0,
+                home.join("archive")
+            );
+        }
+        assert_eq!(resolve_ssh_destination(&home, b"~").unwrap().0, home);
+        assert_eq!(
+            resolve_ssh_destination(&home, b"./~/archive").unwrap().0,
+            home.join("~/archive")
+        );
+        assert_eq!(
+            resolve_ssh_destination(&home, b"~someone/archive")
+                .unwrap()
+                .0,
+            home.join("~someone/archive")
+        );
+        // The shared named resolver still interprets paths relative to cwd.
+        assert_eq!(
+            resolve_destination(&home, None, b"~/archive").unwrap().0,
+            home.join("~/archive")
+        );
+    }
 
     #[test]
     fn helper_exit_status_and_stderr_survive_group_cleanup() {

--- a/src/receive_approval.rs
+++ b/src/receive_approval.rs
@@ -156,7 +156,7 @@ impl Queue {
     ) -> Result<()> {
         let mut summary = Summary::new(from, request, TIMEOUT)?;
         summary.destination = format!(
-            "SSH {target:?}, path {:?} (relative paths start in the destination login home)",
+            "SSH {target:?}, path {:?} (relative paths and ~ refer to the destination login home)",
             std::ffi::OsStr::from_bytes(&request.destination)
         );
         summary.permission.push_str(". Connect using this machine's SSH access and install the matching syq helper if needed");

--- a/src/remote_helper.rs
+++ b/src/remote_helper.rs
@@ -17,6 +17,11 @@ pub const REMOTE_DOWNLOAD_INTEGRITY_EXIT: i32 = 76;
 pub const INSTALL_FAILED_EXIT: i32 = 77;
 const DOWNLOAD_CACHE_GENERATION: &str = "release";
 
+/// Launcher failures for which installing the matching helper can repair the cache.
+pub fn needs_install(code: Option<i32>) -> bool {
+    matches!(code, Some(HELPER_MISSING_EXIT | HELPER_NOT_EXECUTABLE_EXIT))
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Target {
     pub key: &'static str,

--- a/src/remote_to_remote.rs
+++ b/src/remote_to_remote.rs
@@ -1277,12 +1277,7 @@ fn run_remote(
 }
 
 fn helper_missing(code: Option<i32>, automatic: bool) -> bool {
-    automatic
-        && matches!(
-            code,
-            Some(crate::remote_helper::HELPER_MISSING_EXIT)
-                | Some(crate::remote_helper::HELPER_NOT_EXECUTABLE_EXIT)
-        )
+    automatic && crate::remote_helper::needs_install(code)
 }
 
 #[cfg(test)]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -17933,6 +17933,47 @@ fn receiving_v2_preferences_migrate_without_retaining_implicit_approval() {
 }
 
 #[test]
+fn return_via_completes_bare_and_explicit_names_without_contacting_hosts() {
+    let t = Tmp::new();
+    write(&t.path(".syq-destinations-v2/laptop.json"), b"{}");
+    write(
+        &t.path("bin/ssh"),
+        b"#!/bin/sh\ntouch \"$HOME/ssh-used\"\nexit 99\n",
+    );
+    fs::set_permissions(t.path("bin/ssh"), fs::Permissions::from_mode(0o755)).unwrap();
+    for (prefix, expected) in [
+        ("lap", b"laptop\0".as_slice()),
+        ("@lap", b"@laptop\0"),
+        ("absent", b""),
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args([
+                "completion",
+                "__complete",
+                "fish",
+                "6",
+                "--",
+                "syq",
+                "cp",
+                "source",
+                "--to",
+                "backup",
+                "--via",
+                prefix,
+            ])
+            .env("HOME", t.path(""))
+            .env("PATH", t.path("bin"))
+            .env("SYQ_NO_UPDATE_CHECK", "1")
+            .current_dir(t.path(""))
+            .output()
+            .unwrap();
+        assert_output_ok(&output);
+        assert_eq!(output.stdout, expected, "{prefix}");
+    }
+    assert!(!t.path("ssh-used").exists());
+}
+
+#[test]
 fn return_via_rejects_unsupported_routes_and_never_falls_back_to_ssh() {
     let t = Tmp::new();
     write(&t.path("source"), b"payload");

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -17936,9 +17936,14 @@ fn receiving_v2_preferences_migrate_without_retaining_implicit_approval() {
 fn return_via_completes_bare_and_explicit_names_without_contacting_hosts() {
     let t = Tmp::new();
     write(&t.path(".syq-destinations-v2/laptop.json"), b"{}");
+    fs::set_permissions(
+        t.path(".syq-destinations-v2"),
+        fs::Permissions::from_mode(0o700),
+    )
+    .unwrap();
     write(
         &t.path("bin/ssh"),
-        b"#!/bin/sh\ntouch \"$HOME/ssh-used\"\nexit 99\n",
+        b"#!/bin/sh\n: > \"$HOME/ssh-used\"\nexit 99\n",
     );
     fs::set_permissions(t.path("bin/ssh"), fs::Permissions::from_mode(0o755)).unwrap();
     for (prefix, expected) in [

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -68,6 +68,10 @@ Linux `notify-send` client with Allow, Deny, dismissal, unexpected actions, and
 service failure; only Allow starts a copy. This does not exercise a particular desktop's visual
 layout or the macOS dialog.
 
+Source-shell remote copies also cover cached helper reuse, bootstrap after a
+missing or unexecutable helper, a delayed approval relay before Hello, and
+remote-home tilde paths alongside literal `./~` paths.
+
 The smoke suite also checks that pooled helpers keep the spawning command’s
 `SendEnv` values, while direct sessions and restarted persistence use the new
 values. A remote wrapper records one test variable and executes the candidate

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -143,10 +143,10 @@ import json
 import os
 import subprocess
 import sys
-import threading
 import time
 
-child = subprocess.Popen(['/usr/local/bin/syq', *sys.argv[1:]], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+# The helper reads the SSH stream directly; this wrapper only delays its reply.
+child = subprocess.Popen(['/usr/local/bin/syq', *sys.argv[1:]], stdout=subprocess.PIPE)
 def pump(reader, writer):
     while True:
         # Preserve any preamble bytes buffered while reading Approved, while
@@ -157,14 +157,6 @@ def pump(reader, writer):
         while data:
             count = os.write(writer, data)
             data = data[count:]
-def send_input():
-    try:
-        pump(sys.stdin.buffer, child.stdin.fileno())
-    except BrokenPipeError:
-        pass
-    finally:
-        child.stdin.close()
-threading.Thread(target=send_input, daemon=True).start()
 header = child.stdout.read(4)
 assert len(header) == 4
 length = int.from_bytes(header, 'big')

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -149,7 +149,9 @@ import time
 child = subprocess.Popen(['/usr/local/bin/syq', *sys.argv[1:]], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 def pump(reader, writer):
     while True:
-        data = os.read(reader, 16384)
+        # Preserve any preamble bytes buffered while reading Approved, while
+        # returning available control bytes without waiting for a full chunk.
+        data = reader.read1(16384)
         if not data:
             break
         while data:
@@ -157,7 +159,7 @@ def pump(reader, writer):
             data = data[count:]
 def send_input():
     try:
-        pump(0, child.stdin.fileno())
+        pump(sys.stdin.buffer, child.stdin.fileno())
     except BrokenPipeError:
         pass
     finally:
@@ -172,7 +174,7 @@ assert 'Approved' in json.loads(reply)
 time.sleep(12)
 sys.stdout.buffer.write(header + reply)
 sys.stdout.buffer.flush()
-pump(child.stdout.fileno(), 1)
+pump(child.stdout, 1)
 sys.exit(child.wait())
 '''
 remote("printf %s " + shlex.quote(delayed_helper) + " > " + helper + ".fixture && chmod 700 " + helper + ".fixture && mv " + helper + ".fixture " + helper)

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -113,6 +113,74 @@ remote("rm " + helper)
 copy("/tmp/syq-real-ssh/forward/installed")
 assert remote("sha256sum /tmp/syq-real-ssh/forward/installed").split()[0] == expected
 
+print("case: an unexecutable cached helper gets one bootstrap retry", flush=True)
+# A malformed ELF passes the launcher's executable-bit check but exec fails
+# with 126. This is an actual exec failure, not a helper returning that code.
+remote("python3 -c " + shlex.quote(
+    "from pathlib import Path; p = Path(" + repr(helpers[0] + ".fixture") + "); "
+    "p.write_bytes(b'\\x7fELF' + b'\\x00' * 64); p.chmod(0o700); p.replace(" + repr(helpers[0]) + ")"))
+remote("sh -c " + shlex.quote("exec " + helper) + " 2>/dev/null; test \"$?\" -eq 126")
+try:
+    copy("/tmp/syq-real-ssh/forward/reinstalled")
+    assert remote("sha256sum /tmp/syq-real-ssh/forward/reinstalled").split()[0] == expected
+finally:
+    remote("cp /usr/local/bin/syq " + helper + ".fixture && mv " + helper + ".fixture " + helper)
+
+print("case: tilde paths use the destination home and ./~ stays literal", flush=True)
+copy("~/syq-real-ssh-forward-home/expanded")
+assert remote("sha256sum ~/syq-real-ssh-forward-home/expanded").split()[0] == expected
+remote("test ! -e './~/syq-real-ssh-forward-home/expanded'")
+copy("./~/syq-real-ssh-forward-home/literal")
+assert remote("sha256sum './~/syq-real-ssh-forward-home/literal'").split()[0] == expected
+remote("test ! -e ~/syq-real-ssh-forward-home/literal")
+
+print("case: a delayed approval relay leaves time for the source to begin Hello", flush=True)
+# Start the real helper, then hold its Approved reply for longer than the old
+# 10-second deadline. Stream every subsequent control chunk without buffering.
+delayed_helper = r'''#!/usr/bin/python3
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+child = subprocess.Popen(['/usr/local/bin/syq', *sys.argv[1:]], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+def pump(reader, writer):
+    while True:
+        data = os.read(reader, 16384)
+        if not data:
+            break
+        while data:
+            count = os.write(writer, data)
+            data = data[count:]
+def send_input():
+    try:
+        pump(0, child.stdin.fileno())
+    except BrokenPipeError:
+        pass
+    finally:
+        child.stdin.close()
+threading.Thread(target=send_input, daemon=True).start()
+header = child.stdout.read(4)
+assert len(header) == 4
+length = int.from_bytes(header, 'big')
+assert 0 < length <= 256 * 1024
+reply = child.stdout.read(length)
+assert 'Approved' in json.loads(reply)
+time.sleep(12)
+sys.stdout.buffer.write(header + reply)
+sys.stdout.buffer.flush()
+pump(child.stdout.fileno(), 1)
+sys.exit(child.wait())
+'''
+remote("printf %s " + shlex.quote(delayed_helper) + " > " + helper + ".fixture && chmod 700 " + helper + ".fixture && mv " + helper + ".fixture " + helper)
+try:
+    copy("/tmp/syq-real-ssh/forward/delayed-hello")
+    assert remote("sha256sum /tmp/syq-real-ssh/forward/delayed-hello").split()[0] == expected
+finally:
+    remote("cp /usr/local/bin/syq " + helper + ".fixture && mv " + helper + ".fixture " + helper)
+
 print("case: an approved copy's slow SSH setup does not block the next approval", flush=True)
 def deny_during_setup():
     command = "exec timeout 15 syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as during-forward-setup"

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -127,6 +127,7 @@ finally:
     remote("cp /usr/local/bin/syq " + helper + ".fixture && mv " + helper + ".fixture " + helper)
 
 print("case: tilde paths use the destination home and ./~ stays literal", flush=True)
+remote("mkdir -p ~/syq-real-ssh-forward-home './~/syq-real-ssh-forward-home'")
 copy("~/syq-real-ssh-forward-home/expanded")
 assert remote("sha256sum ~/syq-real-ssh-forward-home/expanded").split()[0] == expected
 remote("test ! -e './~/syq-real-ssh-forward-home/expanded'")


### PR DESCRIPTION
Source-shell copies through a return connection could time out before the source began Hello, treat `~/archive` as a literal directory on an SSH destination, or fail to repair an unexecutable cached helper. This fixes those paths, restores completion for bare `--via` names, and makes receipt and connection errors name the receiving machine consistently.

- Allow 60 seconds before the first Hello byte, then a fixed 10 seconds to complete the handshake. Partial bytes do not extend the deadline; completed copies have no Hello timeout.
- Resolve `~` and `~/` against the destination login home, including `~//archive`. Keep `./~/` literal and preserve named receivers' cwd/root behavior. The prompt and documentation describe the resolution. Ordinary path resolution is outside this change.
- Retry bootstrap once for launcher exit 125 or 126, before a copy is approved. Return copies and remote-to-remote copies use the same typed exit-code predicate. Both bootstrap attempts still share the existing 60-second setup deadline.
- Complete bare and `@` return names from local registrations through one shared iterator for `--via` and `--to`, without additional allocations or network requests.

Compatibility: checked against released v0.4.0 (`f4aee996`). No CLI/SDK names, wire schema, preference/enrollment/replay state, signing domains, receipt formats, resume identities, automation record shapes, or caches change. Human-readable failure wording changes. The tilde correction applies to new SSH-target requests; existing literal directories remain addressable with `./~/`. Live return/helper peers already require the same build and reject mixed builds before interpreting authority. Unchanged old receiving fixtures remain covered, including the exact f752ee8 preference output; no migration or compatibility alias is added.

Validation at `3dcdfc4`:

- Linux formatting, Clippy (`--all-targets --all-features -D warnings`), and `cargo test --all-targets -- --test-threads=1`: passed (477 unit, 418 local integration, 4 help, 5 output, 7 update; 911 total). One pre-existing opt-in v0.3.2 binary probe remains ignored.
- Documentation link checker: 16 files, no problems.
- Default `scripts/test-real-ssh.sh`: passed, including benchmark push/pull and interruption cleanup. Cases exercise a 12-second delay after hostB issues Approved with stdin inherited directly by the helper, an actual ELF exec failure returning 126, destination-home and literal-tilde paths, plus approval/denial, revocation, verification, and resumed-copy checks.
- Candidate macOS and separate SDK suites were not run. No SDK surface or platform-specific implementation changed.

Branch status at review handoff:

```text
Worktree: /home/grant/repos/syq/.worktrees/return-copy-review-followup
Branch:   return-copy-review-followup at 3dcdfc4 (clean)
Upstream: origin/return-copy-review-followup (ahead 0, behind 0)
Master:   336bdf3 from refs/heads/master (branch is ahead 18, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      7d5062d  https://github.com/greaber/syq/actions/runs/34034071321
  rsync-compat.yml success      7d5062d  https://github.com/greaber/syq/actions/runs/34034071282
  macos.yml        success      7d5062d  https://github.com/greaber/syq/actions/runs/34034071285

Pull request: #247 https://github.com/greaber/syq/pull/247
  base master, open, review none, merge state clean
  GitHub head 3dcdfc4: matches local 3dcdfc4
  checks: none registered yet
```
