### PR TITLE
Simplify benchmark onboarding and show remote setup progress

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -26,33 +26,40 @@ Compare syq with rsync on your own machines, or with rsync and cp locally:
 curl --proto '=https' --tlsv1.2 -fLsS https://raw.githubusercontent.com/greaber/syq/master/scripts/try-benchmark.sh | bash
 ```
 
-The script asks whether to copy locally, send to an SSH host, or fetch from
-one; which workloads to try; the test size; and where to put temporary files.
-You can choose another disk or an NFS mount for a local comparison. No
-syq-bench installation is needed. If syq is missing, it offers to run the
-normal installer locally.
+Choose a local or SSH copy, a workload, and a test size. The script uses
+throwaway data and cleans up afterward. No syq-bench install is needed;
+if syq is missing, it offers to install it.
 
-It needs Bash, rsync, OpenSSL, and standard Unix utilities on your machine.
-Terminal runs also need Perl to keep SSH prompts available while allowing
-immediate cancellation.
-SSH tests also need SSH access and rsync on the remote machine. Use an SSH
-config alias for custom ports or IPv6 addresses. No remote system packages are
-installed; syq performs its usual remote helper setup.
+<figure class="benchmark-example">
+<div class="benchmark-example-grid">
+<section aria-label="Example benchmark choices">
+<div class="visual-step">1 <span>Choose your test</span></div>
+<dl class="benchmark-choices">
+<dt>Copy where?</dt><dd>local</dd>
+<dt>Workloads?</dt><dd>both</dd>
+<dt>Size?</dt><dd>quick</dd>
+</dl>
+<p class="visual-note">One 64 MiB file<br>1,024 files of 8 KiB</p>
+</section>
+<section aria-label="Example benchmark results">
+<div class="visual-step">2 <span>Compare the results</span></div>
+<table>
+<caption>Mean seconds · 3 trials</caption>
+<thead><tr><th scope="col">Tool</th><th scope="col">Large file</th><th scope="col">Small files</th></tr></thead>
+<tbody>
+<tr><th scope="row">syq</th><td>0.095</td><td>0.167</td></tr>
+<tr><th scope="row">rsync</th><td>0.118</td><td>0.118</td></tr>
+<tr><th scope="row">cp</th><td>0.049</td><td>0.052</td></tr>
+</tbody>
+</table>
+<p class="visual-note">✓ Copied contents checked</p>
+</section>
+</div>
+<figcaption>Example from one local run, not a speed promise. Your results will differ.</figcaption>
+</figure>
 
-The quick test copies a 64 MiB file and 1,024 files of 8 KiB each. Each tool
-runs three times. Temporary test files are removed on success, failure, or Ctrl-C. If SSH is
-unreachable during cleanup, the script prints the remote scratch path for
-you to remove later. It never uses your existing files as test data.
-
-The transcript includes the exact syq build, the commands being timed, each
-verified trial, and the mean, minimum and maximum elapsed times. Keep that
-output when sharing a surprising result; differences smaller than the trial
-variation may not indicate a speed advantage.
-
-To inspect the script first, download it with curl's `-o try-benchmark.sh`,
-then run `bash try-benchmark.sh`. Use `--help` for repeatable command-line
-options, including `--yes` to use defaults without questions and `--install`
-to install syq if missing. See [how to interpret the comparison](speed.md#quick-comparison).
+For requirements, options and how to read the results, see
+[the benchmark guide](speed.md#quick-comparison).
 
 ## Updates
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -44,12 +44,12 @@ if syq is missing, it offers to install it.
 <section aria-label="Example benchmark results">
 <div class="visual-step">2 <span>Compare the results</span></div>
 <table>
-<caption>Mean seconds · 3 trials</caption>
+<caption>Mean MB/s · higher is faster · 3 trials</caption>
 <thead><tr><th scope="col">Tool</th><th scope="col">Large file</th><th scope="col">Small files</th></tr></thead>
 <tbody>
-<tr><th scope="row">syq</th><td>0.095</td><td>0.167</td></tr>
-<tr><th scope="row">rsync</th><td>0.118</td><td>0.118</td></tr>
-<tr><th scope="row">cp</th><td>0.049</td><td>0.052</td></tr>
+<tr><th scope="row">syq</th><td>710.0</td><td>50.1</td></tr>
+<tr><th scope="row">rsync</th><td>567.3</td><td>71.1</td></tr>
+<tr><th scope="row">cp</th><td>1379.1</td><td>160.4</td></tr>
 </tbody>
 </table>
 <p class="visual-note">✓ Copied contents checked</p>

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -9,11 +9,12 @@ authorizes the copy and shows the results; the file data bypasses it.
 syq cp --from hostA --srcs-in big --to hostB --into big
 ```
 
-```text
-Your machine ── authorizes the copy and displays results
-                       │
-                    hostA ───── file data ─────▶ hostB
-```
+<figure class="transfer-flow" aria-label="Your machine authorizes the copy and displays results. File data goes directly from hostA to hostB.">
+<div class="flow-machine"><strong>Your machine</strong><span>Authorize · see results</span></div>
+<div class="flow-control" aria-hidden="true">│</div>
+<div class="flow-data"><div class="flow-machine"><strong>hostA</strong><span>Source</span></div><div class="flow-arrow"><span>File data</span><b aria-hidden="true">⟶</b></div><div class="flow-machine"><strong>hostB</strong><span>Destination</span></div></div>
+<figcaption>The files travel directly between the servers.</figcaption>
+</figure>
 
 HostA gets permission for this transfer only. HostB checks that permission
 and reports what it changed. See [Security](security.md#a-compromised-source-server)

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -47,7 +47,9 @@ hard to compress. Every trial has an empty, pre-created destination; interrupted
 never resumed. On Ctrl-C the script stops its local workers, moves remote
 scratch out of the transfer path, and deletes its temporary data. If SSH
 is unavailable, it reports the remote path for later cleanup. The script rotates
-tool order and reports each elapsed time and the mean for each tool. It uses
+tool order and reports speeds in decimal MB/s (1 MB = 1,000,000 bytes):
+each trial’s copied bytes divided by its elapsed time, followed by the mean,
+minimum and maximum trial speeds. Higher is faster. It uses
 syq's defaults with permissions preserved, `rsync -rpt`, and local `cp -pR`.
 These copy the same regular files and request permissions and modification
 times; the tools still differ in compression, integrity checks, and filesystem

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -29,6 +29,13 @@ bash try-benchmark.sh --yes --mode push --host server --workload both --size med
 bash try-benchmark.sh --yes --mode local --source-dir /data --dest-dir /mnt/nfs --workload small
 ```
 
+The script needs Bash, rsync, OpenSSL and standard Unix utilities locally;
+terminal runs also use Perl to keep SSH prompts interruptible. Remote tests
+need SSH access and rsync on the other machine. Syq prepares a helper matching
+your local build and shows installation progress when one is needed.
+Use an SSH config alias for custom ports or IPv6. `--install` installs syq
+locally if missing; `--help` lists the choices.
+
 Scratch parents must already exist. For SSH tests, `--dest-dir` is the remote
 scratch parent, including when pulling; `--source-dir` is always the local
 scratch parent. Budget roughly twice the selected data size locally and one
@@ -48,7 +55,7 @@ optimizations. Syq prints its transfer statistics.
 
 Generation, a single 14-byte syq setup copy, and POSIX `cksum` comparisons are
 outside the timer. The setup copy prepares the helper and exercises transfer
-setup; it is labeled separately and does not print a throughput result. A failed command or content check stops the comparison.
+setup; it is labeled separately and shows helper installation messages without a throughput result. A failed command or content check stops the comparison.
 Caches are not flushed, so this is a cache-friendly test rather than a cold
 disk benchmark. Times include process startup and buffered writes, without
 waiting for durable storage. Small tests can mostly measure startup costs;

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -91,6 +91,21 @@ class BenchmarkTests(unittest.TestCase):
         self.assertEqual(self.sentinel.read_text(), 'existing user data')
         self.assertEqual(list(self.scratch.iterdir()), [self.sentinel])
 
+    def test_speed_summary_uses_decimal_bytes_and_mean_trial_speeds(self):
+        records = self.root / 'results'
+        records.write_text('large syq 1.000 1000000\nlarge syq 2.000 1000000\n'
+                           'small cp 0.000 1000000\nsmall cp 1.000 1000000\n')
+        # Load the real functions without starting the interactive main.
+        definitions = SCRIPT.read_text().removesuffix('main "$@"\n')
+        result = subprocess.run(['/bin/bash', '-c', definitions + '\nsummarize_results "$1"',
+                                 'summary-test', str(records)],
+                                env=self.env, capture_output=True, text=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        rows = [line.split() for line in result.stdout.splitlines()]
+        self.assertIn(['large', 'syq', '0.750', '0.500', '1.000', '2'], rows)
+        self.assertIn(['small', 'cp', 'n/a', 'n/a', 'n/a', '2'], rows)
+        self.assertIn('below timer resolution', result.stdout)
+
     def test_local_both_and_rotation(self):
         result = self.invoke('--workload', 'both', '--rounds', '3')
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
@@ -110,7 +125,7 @@ class BenchmarkTests(unittest.TestCase):
             match = re.match(r'(large|small): (syq|rsync|cp), trial', line)
             if match:
                 current = tuple(match.groups())
-            match = re.match(r'Verified contents; elapsed ([0-9.]+) seconds', line)
+            match = re.match(r'Verified contents; speed ([0-9.]+) MB/s', line)
             if match:
                 trials.setdefault(current, []).append(float(match[1]))
         summaries = 0
@@ -119,7 +134,7 @@ class BenchmarkTests(unittest.TestCase):
             if len(fields) == 6 and tuple(fields[:2]) in trials:
                 summaries += 1
                 values = trials[tuple(fields[:2])]
-                self.assertAlmostEqual(float(fields[2]), sum(values)/len(values), delta=0.00051)
+                self.assertAlmostEqual(float(fields[2]), sum(values)/len(values), delta=0.00101)
                 self.assertEqual(float(fields[3]), min(values))
                 self.assertEqual(float(fields[4]), max(values))
                 self.assertEqual(int(fields[5]), len(values))
@@ -158,7 +173,7 @@ class BenchmarkTests(unittest.TestCase):
             with self.subTest(failure=failure):
                 result = self.invoke(env=dict(self.env, BENCH_TEST_FAILURE=failure))
                 self.assertNotEqual(result.returncode, 0)
-                self.assertNotIn('Results (mean', result.stdout)
+                self.assertNotIn('Results (MB/s', result.stdout)
                 self.assert_clean()
 
     def test_remote_failure_cleans_owned_scratch(self):
@@ -326,7 +341,7 @@ class BenchmarkTests(unittest.TestCase):
                 self.fail(f'Interactive run timed out; last output: {output[-2000:]!r}')
             _, status = os.waitpid(pid, 0)
             self.assertEqual(os.waitstatus_to_exitcode(status), 0, output.decode())
-            self.assertIn(b'Results (mean', output)
+            self.assertIn(b'Results (MB/s', output)
             self.assert_clean()
         finally:
             os.close(fd)

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -29,6 +29,8 @@ if src.name == 'probe' and os.environ.get('BENCH_TEST_ASK'):
     with open('/dev/tty') as terminal:
         if terminal.readline().strip() != 'test': sys.exit(4)
 if not dst.is_dir(): sys.exit(24)
+if src.name == 'probe' and os.environ.get('BENCH_TEST_SETUP_FAIL'):
+    print('helper installation failed', file=sys.stderr); sys.exit(23)
 mode=os.environ.get('BENCH_TEST_FAILURE', '') if src.name != 'probe' else ''
 if mode == 'fail': sys.exit(23)
 if mode == 'hang':
@@ -36,7 +38,10 @@ if mode == 'hang':
     pathlib.Path(os.environ['BENCH_TEST_PID']).write_text(str(child.pid))
     child.wait(); sys.exit(1)
 shutil.copytree(src,dst,dirs_exist_ok=True)
-if '--quiet' not in args: print('test double: copy statistics')
+if '--quiet' not in args and src.name == 'probe':
+    print('test double: preparing matching remote helper', flush=True)
+if '--quiet' not in args and '--suppress-summary' not in args:
+    print('test double: copy statistics')
 if mode == 'corrupt':
     next(dst.iterdir()).write_bytes(b'bad')
 '''
@@ -120,9 +125,12 @@ class BenchmarkTests(unittest.TestCase):
                 self.assertEqual(int(fields[5]), len(values))
         self.assertEqual(summaries, 6)
 
-        self.assertEqual(result.stdout.count('Preparing syq with a 14-byte setup copy'), 1)
+        self.assertEqual(result.stdout.count('Preparing the benchmark'), 1)
         self.assertEqual(result.stdout.count('test double: copy statistics'), 6)
         self.assertIn('Setup complete.', result.stdout)
+        self.assertIn('test double: preparing matching remote helper', result.stdout)
+        for detail in ['14-byte', 'tiny setup copy', 'Caches are NOT flushed', 'twice the selected', 'permissions preserved']:
+            self.assertNotIn(detail, result.stdout)
         self.assert_clean()
 
     def test_push_and_pull_quoted_paths(self):
@@ -131,7 +139,19 @@ class BenchmarkTests(unittest.TestCase):
                 result = self.invoke('--mode', mode, '--host', 'test-host')
                 self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
                 self.assertNotIn('large cp', result.stdout)
+                self.assertIn('Preparing syq syq test double on test-host', result.stdout)
+                self.assertIn('test double: preparing matching remote helper', result.stdout)
+                self.assertIn('Setup complete: syq syq test double is ready on test-host', result.stdout)
                 self.assert_clean()
+
+    def test_setup_errors_stay_visible_and_stop_trials(self):
+        result = self.invoke('--mode', 'push', '--host', 'test-host',
+                             env=dict(self.env, BENCH_TEST_SETUP_FAIL='1'))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('helper installation failed', result.stderr)
+        self.assertNotIn('Setup complete', result.stdout)
+        self.assertNotIn('trial 1/', result.stdout)
+        self.assert_clean()
 
     def test_failures_do_not_report_success(self):
         for failure in ['fail', 'corrupt']:

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -196,9 +196,30 @@ timed_copy() {
     { time copy_with "$@" 1>&4 2>&5; } 2> "$local_root/time"
 }
 
+summarize_results() {
+    awk '{key=$1 " " $2;
+          if (!(key in n)) order[++count]=key;
+          n[key]++;
+          if ($3 <= 0) {unmeasurable[key]=1; next}
+          speed=$4 / $3 / 1000000;
+          if (!(key in total)) {low[key]=speed; high[key]=speed}
+          total[key]+=speed;
+          if (speed < low[key]) low[key]=speed; if (speed > high[key]) high[key]=speed}
+         END {printf "%-18s %10s %10s %10s %8s\n", "Workload / tool", "Mean", "Min", "Max", "Trials";
+              for (i=1; i<=count; i++) {
+                  key=order[i];
+                  if (unmeasurable[key]) {
+                      printf "%-18s %10s %10s %10s %8d\n", key, "n/a", "n/a", "n/a", n[key];
+                      note=1;
+                  } else printf "%-18s %10.3f %10.3f %10.3f %8d\n", key, total[key]/n[key], low[key], high[key], n[key];
+              }
+              if (note) print "n/a: a copy finished below timer resolution; try a larger test.";
+         }' "$1"
+}
+
 main() {
     local mode='' workload='' size='' source_dir='' dest_dir='' rounds=3 yes=false install=false
-    local option tool round index offset source destination case_name bytes seconds local_parent remote_parent
+    local option tool round index offset source destination case_name bytes seconds speed local_parent remote_parent
     local large_mib small_files syq_identity
     local key=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
     local iv=000102030405060708090a0b0c0d0e0f
@@ -360,7 +381,11 @@ main() {
                 else manifest "$destination" > "$local_root/actual"; fi
                 cmp "$local_root/expected" "$local_root/actual" || fail "$tool destination content check failed."
                 printf '%s %s %s %s\n' "$case_name" "$tool" "$seconds" "$bytes" >> "$local_root/results"
-                printf 'Verified contents; elapsed %s seconds.\n' "$seconds"
+                speed=$(awk -v bytes="$bytes" -v seconds="$seconds" 'BEGIN {
+                    if (seconds > 0) printf "%.3f", bytes / seconds / 1000000;
+                    else printf "n/a";
+                }')
+                printf 'Verified contents; speed %s MB/s.\n' "$speed"
                 if [[ $mode == push ]]; then remote "rm -rf $(quote "$destination")"
                 else rm -rf -- "$destination"; fi
             done
@@ -368,13 +393,8 @@ main() {
         rm -rf -- "${local_root:?}/$case_name"
         [[ $mode != pull ]] || remote "rm -rf $(quote "$source") $(quote "$remote_root/probe")"
     done
-    printf '\nResults (mean elapsed seconds; all completed copies checked with POSIX cksum):\n'
-    awk '{key=$1 " " $2;
-          if (!(key in n)) {order[++count]=key; low[key]=$3; high[key]=$3}
-          total[key]+=$3; n[key]++;
-          if ($3 < low[key]) low[key]=$3; if ($3 > high[key]) high[key]=$3}
-         END {printf "%-18s %10s %10s %10s %8s\n", "Workload / tool", "Mean", "Min", "Max", "Trials";
-              for (i=1; i<=count; i++) {key=order[i]; printf "%-18s %10.3f %10.3f %10.3f %8d\n", key, total[key]/n[key], low[key], high[key], n[key]}}' "$local_root/results"
+    printf '\nResults (MB/s; higher is faster; all copies checked):\n'
+    summarize_results "$local_root/results"
     printf '\nCompare the trial range as well as the mean; small differences may be noise.\n'
     printf 'Results depend on your machines and workload.\n'
 }

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -162,7 +162,10 @@ make_data() {
 copy_with() {
     local tool=$1 source=$2 destination=$3
     local command=() syq_options=(--stats)
-    [[ ${4:-} != setup ]] || syq_options+=(--quiet)
+    # This repository-owned caller suppresses only the tiny copy's summary,
+    # keeping bootstrap diagnostics and authentication prompts live. Supported
+    # by the released v0.3.2 CLI as well as current builds.
+    [[ ${4:-} != setup ]] || syq_options=(--suppress-summary --no-progress)
     case $tool in
         syq)
             case $mode in
@@ -196,7 +199,7 @@ timed_copy() {
 main() {
     local mode='' workload='' size='' source_dir='' dest_dir='' rounds=3 yes=false install=false
     local option tool round index offset source destination case_name bytes seconds local_parent remote_parent
-    local large_mib small_files
+    local large_mib small_files syq_identity
     local key=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
     local iv=000102030405060708090a0b0c0d0e0f
     while [[ $# -gt 0 ]]; do
@@ -270,8 +273,8 @@ main() {
         need syq
     fi
     printf '\nVersions:\n'
-    printf 'syq: '
-    syq --build-identity
+    syq_identity=$(syq --build-identity)
+    printf 'syq: %s\n' "$syq_identity"
     rsync --version | sed -n '1p'
     if [[ $mode == local ]]; then
         dest_dir=$(cd -- "$dest_dir" && pwd -P) || fail 'Destination scratch parent must exist.'
@@ -291,10 +294,7 @@ main() {
     printf 'Local scratch: %s\n' "$local_root"
     if [[ $mode == local ]]; then printf 'Destination scratch: %s\n' "$dest_root"
     else printf 'Remote scratch: %s\n' "$remote_root"; fi
-    printf 'Each trial uses an empty destination; order rotates. Setup and checksum verification are untimed.\n'
-    printf 'Caches are NOT flushed; times include startup and buffered writes, not durable disk flushes.\n'
-    printf 'Allow roughly twice the selected data size locally, plus one copy remotely for SSH tests.\n'
-    printf 'Using syq defaults with permissions preserved, rsync -rpt, and local cp -pR.\n\n'
+    printf 'Each trial copies fresh test data and checks the result. Setup and checks are not timed.\n'
     exec 4>&1 5>&2
     local tools=(syq rsync) workloads=(large small)
     [[ $mode != local ]] || tools+=(cp)
@@ -317,7 +317,12 @@ main() {
         if [[ $case_name == "${workloads[0]}" ]]; then
             # Do this once, not once per workload. Keep the measured copy's full
             # transport path, but suppress meaningless throughput for the 14-byte probe.
-            printf 'Preparing syq with a 14-byte setup copy (not timed as a benchmark)...\n'
+            if [[ $mode != local ]]; then
+                printf 'Preparing syq %s on %s to match this machine (untimed)...\n' "$syq_identity" "$host"
+                printf 'A matching remote helper is reused, or installed if needed.\n'
+            else
+                printf 'Preparing the benchmark (untimed)...\n'
+            fi
             mkdir "$local_root/probe"
             printf 'syq benchmark\n' > "$local_root/probe/data"
             if [[ $mode == pull ]]; then
@@ -335,7 +340,11 @@ main() {
                 rm -rf -- "$dest_root/probe"
             fi
             rm -rf -- "$local_root/probe"
-            printf 'Setup complete.\n'
+            if [[ $mode != local ]]; then
+                printf 'Setup complete: syq %s is ready on %s. Benchmark trials start next.\n' "$syq_identity" "$host"
+            else
+                printf 'Setup complete. Benchmark trials start next.\n'
+            fi
         fi
         for ((round=1; round<=rounds; round++)); do
             for ((offset=0; offset<${#tools[@]}; offset++)); do
@@ -366,9 +375,8 @@ main() {
           if ($3 < low[key]) low[key]=$3; if ($3 > high[key]) high[key]=$3}
          END {printf "%-18s %10s %10s %10s %8s\n", "Workload / tool", "Mean", "Min", "Max", "Trials";
               for (i=1; i<=count; i++) {key=order[i]; printf "%-18s %10.3f %10.3f %10.3f %8d\n", key, total[key]/n[key], low[key], high[key], n[key]}}' "$local_root/results"
-    printf '\nA quick synthetic comparison, not a prediction for every workload.\n'
-    printf 'Filesystem caching, cloning, network conditions and startup costs affect results.\n'
-    printf 'Try larger data and your real workloads too. Resume and direct server copies are other reasons to use syq.\n'
+    printf '\nCompare the trial range as well as the mean; small differences may be noise.\n'
+    printf 'Results depend on your machines and workload.\n'
 }
 # Keep execution last: a script downloaded through a pipe is parsed before prompts run.
 main "$@"

--- a/theme/README.md
+++ b/theme/README.md
@@ -59,6 +59,8 @@ screens. Prefer a compact example or flow diagram where it replaces a long
 explanation; keep detailed benchmark methodology on the speed page rather than
 the installation path. The benchmark figure is a condensed real local quick
 run (release-profile syq `9e73649`, three trials, 1 × 64 MiB and 1,024 × 8 KiB;
-means: syq 0.095/0.167 s, rsync 0.118/0.118 s, cp 0.049/0.052 s). It illustrates
+original mean times: syq 0.095/0.167 s, rsync 0.118/0.118 s, cp 0.049/0.052 s).
+The figure shows arithmetic mean trial speeds in decimal MB/s, calculated
+from the individual recorded durations rather than those rounded mean times. It illustrates
 the workflow, not comparative performance evidence: the run shared the machine
 with other work. Preserve the example caption if updating its presentation.

--- a/theme/README.md
+++ b/theme/README.md
@@ -52,3 +52,13 @@ forking the book template or replacing the control implementations.
 
 The oversized side-of-page chapter arrows are hidden; sidebar links and the
 end-of-page navigation provide the chapter routes.
+
+Documentation walkthroughs use semantic HTML styled in `docs.css`, keeping text
+selectable and readable without JavaScript, in both palettes and on narrow
+screens. Prefer a compact example or flow diagram where it replaces a long
+explanation; keep detailed benchmark methodology on the speed page rather than
+the installation path. The benchmark figure is a condensed real local quick
+run (release-profile syq `9e73649`, three trials, 1 × 64 MiB and 1,024 × 8 KiB;
+means: syq 0.095/0.167 s, rsync 0.118/0.118 s, cp 0.049/0.052 s). It illustrates
+the workflow, not comparative performance evidence: the run shared the machine
+with other work. Preserve the example caption if updating its presentation.

--- a/theme/docs.css
+++ b/theme/docs.css
@@ -128,3 +128,37 @@ a:focus-visible,button:focus-visible,label:focus-visible {outline:2px solid var(
   .docs-compact-header .site-nav {font-size:14px;gap:8px}
 }
 @media print {.docs-page-actions{display:none}}
+
+/* Readable, theme-aware walkthroughs; no JavaScript or text baked into images. */
+.benchmark-example,.transfer-flow{margin:28px 0;font:16px/1.5 var(--display)}
+.benchmark-example-grid{display:grid;grid-template-columns:1fr 1.45fr;border:1px solid var(--line);border-radius:8px;overflow:hidden;background:var(--panel)}
+.benchmark-example section{padding:22px;min-width:0}
+.benchmark-example section+section{background:var(--bg);border-left:1px solid var(--line)}
+.visual-step{display:flex;align-items:center;gap:12px;color:var(--syq);font:600 20px var(--mono)}
+.visual-step span{color:var(--ink);font:600 16px var(--display)}
+.benchmark-choices{display:grid;grid-template-columns:1fr auto;gap:12px;margin:24px 0}
+.benchmark-choices dt{color:var(--muted)}
+.benchmark-choices dd{margin:0;font-family:var(--mono);color:var(--syq)}
+.content .visual-note{font-size:14px;color:var(--muted);line-height:1.6;margin:18px 0 0}
+.content .benchmark-example table{display:table;width:100%;margin-top:18px;font-size:14px}
+.benchmark-example caption{text-align:left;color:var(--muted);padding-bottom:8px}
+.content .benchmark-example th,.content .benchmark-example td{padding:8px 6px;background:transparent;border:0;border-bottom:1px solid var(--line)}
+.benchmark-example td{text-align:right;font-family:var(--mono);font-variant-numeric:tabular-nums}
+.benchmark-example th{text-align:left;white-space:nowrap}
+.benchmark-example th:not(:first-child){text-align:right}
+.benchmark-example figcaption,.transfer-flow figcaption{margin-top:12px;color:var(--muted);font-size:14px}
+.transfer-flow{padding:24px;border:1px solid var(--line);border-radius:8px;background:var(--panel)}
+.flow-machine{display:flex;flex-direction:column;gap:4px;padding:12px 18px;background:var(--bg);border:1px solid var(--line);border-radius:6px;text-align:center}
+.flow-machine strong{font:600 16px var(--mono)}
+.flow-machine span{font-size:14px;color:var(--muted)}
+.transfer-flow>.flow-machine{width:max-content;margin:auto}
+.flow-control{text-align:center;color:var(--muted);height:36px;font-size:28px}
+.flow-data{display:grid;grid-template-columns:1fr 1fr 1fr;align-items:center;gap:12px}
+.flow-arrow{display:flex;flex-direction:column;align-items:center;color:var(--syq);font-size:14px}
+.flow-arrow b{font-size:44px;line-height:1;font-weight:400}
+@media(max-width:600px){
+  .benchmark-example-grid{grid-template-columns:1fr}
+  .benchmark-example section+section{border-left:0;border-top:1px solid var(--line)}
+  .benchmark-example section{padding:18px}
+  .transfer-flow{padding:16px 10px}.flow-data{gap:6px}.flow-machine{padding:12px 6px}
+}


### PR DESCRIPTION
The benchmark install section buried a simple action in implementation detail, and quiet setup hid remote helper installation along with the unhelpful tiny-copy throughput. Shorten the install section to the command and a visual choices/results example, and let setup show live installation diagnostics while naming the matching local syq build and remote host.

The script removes the cache, scratch-capacity, preservation-policy and 14-byte commentary from normal output. It still runs and checks the same disposable workloads, retains interruption cleanup, and leaves the timed copy operations unchanged. Results now show decimal MB/s rather than elapsed seconds: each trial speed and the mean/minimum/maximum trial speeds. Durations below timer resolution produce n/a rather than an invented speed. Setup uses the existing summary-only suppression and disables progress, so installation messages, credential prompts and errors stay visible without a tiny-copy speed report. It prepares the helper matching the local build; it does not independently update the server to the newest release.

The docs visual condenses an actual local result and labels it as an example, not performance evidence. Detailed prerequisites and methodology stay on the speed page. A second diagram replaces the ASCII server-to-server flow. Both use selectable semantic HTML, existing theme colors, responsive layout and no JavaScript. The shared branding assets are unchanged.

Compatibility: the script now consumes `--suppress-summary`, previously used by internal delegation. The unchanged official v0.3.2 binary accepted the exact setup option pair `--suppress-summary --no-progress`, copied the test contents correctly and emitted no summary. No CLI implementation, wire protocol, persistent state or SDK changed.

Validation: pinned mdBook 0.5.4 build, 16-page link check, ShellCheck, whitespace; Chromium checks at 320/390/820/1440 pixels in light/dark, no overflow and readable no-JavaScript content. Screenshots were visually inspected. The existing 12 script regressions passed with the setup change; focused remote push/pull and the new setup-error test passed after the final text changes. The full default real-SSH suite passed at the exact clean commit, including real benchmark push/pull, verified contents and interruption cleanup. No Rust implementation changed, so Rust unit/clippy suites were not rerun; no native macOS run.

Follow-up head `a121779` switches script and visual results to speeds. All 13 existing script cases passed; a new deterministic summary test checks decimal units, arithmetic mean of trial speeds, min/max and zero-duration handling. Local rotation and remote push/pull passed again after summary extraction. ShellCheck, docs build/links and Chromium layouts/themes passed on the speed changes. The full real-SSH suite at `6ad1af3` covers the unchanged transfer/setup/cleanup behavior; it was not repeated for presentation-only speed reporting.
