### PR TITLE
Harmonize docs UI and highlight features and Python SDK

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -15,5 +15,5 @@ git-repository-url = "https://github.com/greaber/syq"
 edit-url-template = "https://github.com/greaber/syq/edit/master/{path}"
 
 # Shared branding and mdBook layout, plus the interactive copy examples.
-additional-css = ["theme/copy-demo.css", "theme/brand.css", "theme/docs.css"]
-additional-js = ["theme/docs.js", "theme/copy-demo.js"]
+additional-css = ["theme/copy-demo.css", "theme/brand.css", "theme/docs.css", "theme/sidebar.css", "theme/controls.css"]
+additional-js = ["theme/docs.js", "theme/copy-demo.js", "theme/sidebar.js", "theme/controls.js"]

--- a/book.toml
+++ b/book.toml
@@ -7,7 +7,7 @@ src = "docs"
 [build]
 build-dir = "target/book"
 create-missing = false
-extra-watch-dirs = ["theme"]
+extra-watch-dirs = ["theme", "sdk"]
 
 [output.html]
 site-url = "/syq/"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,8 @@
 - [Send files home from a server](receive.md)
 - [Copy between servers](remote-to-remote.md)
 - [Rename and reorganize](mappings.md)
+# SDKs
+
 - [Python SDK](python.md)
 
 # Performance

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Send files home from a server](receive.md)
 - [Copy between servers](remote-to-remote.md)
 - [Rename and reorganize](mappings.md)
+- [Python SDK](python.md)
 
 # Performance
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -32,3 +32,6 @@
 # SDKs
 
 - [Python SDK](python.md)
+  - [Guide and examples](python-guide.md)
+  - [API reference](python-reference.md)
+  - [Compatibility](sdk-compatibility.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,10 +10,6 @@
 - [Send files home from a server](receive.md)
 - [Copy between servers](remote-to-remote.md)
 - [Rename and reorganize](mappings.md)
-# SDKs
-
-- [Python SDK](python.md)
-
 # Performance
 
 - [Speed](speed.md)
@@ -32,3 +28,7 @@
 # Development
 
 - [Developing syq](development.md)
+
+# SDKs
+
+- [Python SDK](python.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ transfers, send files home from a remote shell, and automate with JSON.
 <a href="receive.html">Send files home</a>
 <a href="remote-to-remote.html">Copy between servers</a>
 <a href="mappings.html">Script file placement</a>
+<a href="python.html">Python SDK</a>
 </nav>
 
 ## Try a copy
@@ -57,5 +58,6 @@ substituting it in an existing script.
 | Remove files in parallel | [Removal](remove.md) |
 | Copy between two servers | [Remote-to-remote transfers](remote-to-remote.md) |
 | Rename or reorganize files during a copy | [Mappings](mappings.md) |
+| Use syq from Python | [Python SDK](python.md) |
 | Read results from a script | [Automation results](automation.md) |
 | Make copies faster | [Speed](speed.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,7 @@
-# Copy files with syq
+<h1 class="landing-title" id="copy-files-with-syq" aria-label="Copy files with syq">
+<span class="landing-wordmark">syq</span>
+<span class="landing-subtitle">Copy files</span>
+</h1>
 
 Syq (pronounced "sick") copies and removes files in parallel, on one machine
 or over SSH. It can resume interrupted copies and transfer directly between

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,20 @@
-<h1 class="landing-title" id="copy-files-with-syq" aria-label="Copy files with syq">
+<h1 class="landing-title" id="copy-files-with-syq" aria-label="syq: Fast, programmable file operations">
 <span class="landing-wordmark">syq</span>
-<span class="landing-subtitle">Copy files</span>
+<span class="landing-subtitle">Fast, programmable file operations.</span>
 </h1>
 
-Syq (pronounced "sick") copies and removes files in parallel, on one machine
-or over SSH. It can resume interrupted copies and transfer directly between
-servers without forwarding your SSH agent.
+Copy, reorganize and remove files—locally or across machines. Resume interrupted
+transfers, send files home from a remote shell, and automate with JSON.
 
-In published tests, syq copied a folder from Amsterdam to Tokyo
-[5.2× faster than rsync](https://greaber.github.io/syq-bench/#fly-cross-region-memory),
-and 20,000 small files to NFS
-[4.6× faster than cp](https://greaber.github.io/syq-bench/#nfs-directory-trees).
-These are workload-specific results; the benchmarks include cases where other
-tools win.
+<nav class="landing-actions" aria-label="Explore syq">
+<a class="landing-primary" href="install.html">Install syq</a>
+<a href="https://greaber.github.io/syq-bench/">Benchmarks ↗</a>
+<a href="receive.html">Send files home</a>
+<a href="remote-to-remote.html">Copy between servers</a>
+<a href="mappings.html">Script file placement</a>
+</nav>
 
-[Install syq](install.md), then try a copy:
+## Try a copy
 
 ```sh
 syq cp project --to server --into /backup

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -4,6 +4,9 @@
 Transform that list with a script, then give it to `syq cp --mapping`.
 The copy checks for destination collisions and supports normal resume.
 
+For Python scripts, see the [Python SDK](python.md) and its
+[mapping examples](https://github.com/greaber/syq/blob/master/sdk/python/README.md).
+
 ## Lowercase destination names
 
 ```bash

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -5,7 +5,7 @@ Transform that list with a script, then give it to `syq cp --mapping`.
 The copy checks for destination collisions and supports normal resume.
 
 For Python scripts, see the [Python SDK](python.md) and its
-[mapping examples](https://github.com/greaber/syq/blob/master/sdk/python/README.md).
+[mapping examples](python-guide.md).
 
 ## Lowercase destination names
 

--- a/docs/python-guide.md
+++ b/docs/python-guide.md
@@ -1,0 +1,1 @@
+{{#include ../sdk/python/README.md}}

--- a/docs/python-reference.md
+++ b/docs/python-reference.md
@@ -1,0 +1,1 @@
+{{#include ../sdk/python/NATIVE_API.md}}

--- a/docs/python.md
+++ b/docs/python.md
@@ -30,11 +30,11 @@ rather than treating a truncated stream as success.
 
 ## Guide and reference
 
-- [Python guide and examples](https://github.com/greaber/syq/blob/master/sdk/python/README.md):
+- [Python guide and examples](python-guide.md):
   event callbacks, asyncio, mapping transformations, errors and custom binaries.
-- [Native API reference](https://github.com/greaber/syq/blob/master/sdk/python/NATIVE_API.md):
+- [Native API reference](python-reference.md):
   signatures, option mappings and result types.
-- [SDK compatibility](https://github.com/greaber/syq/blob/master/sdk/README.md):
+- [SDK compatibility](sdk-compatibility.md):
   package versions and their pinned executables.
 - [Rename and reorganize](mappings.md) and [Automation results](automation.md):
   the underlying CLI interfaces.

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,0 +1,40 @@
+# Python SDK
+
+Use syq from Python to copy, remove or reorganize files, with typed results
+and streaming events. Synchronous and asyncio clients are available.
+
+## Install
+
+The [syq package on PyPI](https://pypi.org/project/syq/) supports Python 3.10+
+on Linux and macOS:
+
+    python -m pip install syq
+
+On first use, the default client downloads and verifies the matching syq
+executable, then caches it. It does not use an unrelated syq from your PATH.
+
+## Preview a copy
+
+    import syq
+
+    plan = syq.cp("data", into="backup", dry_run=True)
+    print(plan.files_transferred, plan.bytes_transferred)
+
+Remove `dry_run=True` to perform the copy. Use `to="server"` for an SSH destination;
+the same placement options are described in [Copy files](reference.md).
+
+The typed API includes `syq.cp()`, `syq.rm()` and `syq.map()`. Call `syq.run([...])`
+for other commands. Asyncio programs use `await syq.AsyncClient().cp(...)`.
+Failures raise exceptions; typed calls also check the complete results stream
+rather than treating a truncated stream as success.
+
+## Guide and reference
+
+- [Python guide and examples](https://github.com/greaber/syq/blob/master/sdk/python/README.md):
+  event callbacks, asyncio, mapping transformations, errors and custom binaries.
+- [Native API reference](https://github.com/greaber/syq/blob/master/sdk/python/NATIVE_API.md):
+  signatures, option mappings and result types.
+- [SDK compatibility](https://github.com/greaber/syq/blob/master/sdk/README.md):
+  package versions and their pinned executables.
+- [Rename and reorganize](mappings.md) and [Automation results](automation.md):
+  the underlying CLI interfaces.

--- a/docs/python.md
+++ b/docs/python.md
@@ -27,14 +27,3 @@ The typed API includes `syq.cp()`, `syq.rm()` and `syq.map()`. Call `syq.run([..
 for other commands. Asyncio programs use `await syq.AsyncClient().cp(...)`.
 Failures raise exceptions; typed calls also check the complete results stream
 rather than treating a truncated stream as success.
-
-## Guide and reference
-
-- [Python guide and examples](python-guide.md):
-  event callbacks, asyncio, mapping transformations, errors and custom binaries.
-- [Native API reference](python-reference.md):
-  signatures, option mappings and result types.
-- [SDK compatibility](sdk-compatibility.md):
-  package versions and their pinned executables.
-- [Rename and reorganize](mappings.md) and [Automation results](automation.md):
-  the underlying CLI interfaces.

--- a/docs/sdk-compatibility.md
+++ b/docs/sdk-compatibility.md
@@ -1,0 +1,1 @@
+{{#include ../sdk/README.md}}

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -9,11 +9,11 @@ copy, remain available through raw `run`. The executable remains authoritative
 for argument semantics, filesystem behavior, exit status, and safety checks.
 
 The Python-native surface is documented in
-[`python/NATIVE_API.md`](python/NATIVE_API.md).
+[`python/NATIVE_API.md`](https://greaber.github.io/syq/python-reference.html).
 
 | Ecosystem | Package/module | Source |
 |---|---|---|
-| Python | `syq` | [`python/`](python/) |
+| Python | `syq` | [`python/`](https://github.com/greaber/syq/tree/master/sdk/python) |
 
 Every SDK release pins one exact, tested syq release. The default client does
 not search `PATH` or adopt a separately installed syq. On first use it downloads
@@ -40,5 +40,5 @@ to untested executable drift.
 
 The Python package implements this model.
 
-See [`RELEASING.md`](RELEASING.md) for the one-time registry setup and exact
+See [`RELEASING.md`](https://github.com/greaber/syq/blob/master/sdk/RELEASING.md) for the one-time registry setup and exact
 tag conventions.

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -1,7 +1,7 @@
 # Python native API
 
 The Python package pins a matching syq executable. To use a custom development
-build, pass executable= explicitly; see the [Python guide](README.md).
+build, pass executable= explicitly; see the [Python guide](https://greaber.github.io/syq/python-guide.html).
 
 This document describes the Python interface to syq's native filesystem
 commands.
@@ -573,8 +573,8 @@ receiver-attested `FinalStateEvent`, and the terminal `CpResult` or `RmResult`.
 Additive unknown record types are validated for a well-formed envelope and
 sequence position, then ignored.
 
-The product's [automation results contract](../../docs/automation.md) and
-[JSON Schema](../../schemas/automation.schema.json), not this document, own
+The product's [automation results contract](https://greaber.github.io/syq/automation.html) and
+[JSON Schema](https://github.com/greaber/syq/blob/master/schemas/automation.schema.json), not this document, own
 their exact fields and enum members. The Python types expose every stable
 schema field without parsing display text.
 

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -1,9 +1,7 @@
 # Python native API
 
-Status: implemented for the upcoming syq release that ships the automation
-results stream. Until such a release exists, source-tree users must select the candidate
-binary explicitly; the next Python SDK release updates its managed pin after
-conformance tests pass.
+The Python package pins a matching syq executable. To use a custom development
+build, pass executable= explicitly; see the [Python guide](README.md).
 
 This document describes the Python interface to syq's native filesystem
 commands.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -184,10 +184,10 @@ for local development, controlled offline provisioning, or when deliberately
 testing a different syq release.
 
 The package targets Python 3.10 or newer on Linux and macOS and has no runtime
-Python dependencies. See the [SDK compatibility policy](../README.md) for the
+Python dependencies. See the [SDK compatibility policy](https://greaber.github.io/syq/sdk-compatibility.html) for the
 release mapping.
 
 ## Native API reference
 
-See [Python native API](NATIVE_API.md) for command signatures, mappings,
+See [Python native API](https://greaber.github.io/syq/python-reference.html) for command signatures, mappings,
 failure behavior, resource ownership, and the CLI/SDK synchronization policy.

--- a/theme/README.md
+++ b/theme/README.md
@@ -57,3 +57,8 @@ Anchor navigation scrolls smoothly, matching benchmarks. The reduced-motion
 preference disables this animation. Both sites use 20px Open Sans main prose
 and compact 14px Open Sans navigation with a 300px default sidebar width;
 their content layouts remain independent.
+
+The docs and benchmark homepages use the shared landing-title styles: a large
+blue Manrope wordmark above an Open Sans title. This adds character to the
+homepages while retaining the compact navigation and normal article headings.
+The docs homepage preserves its copy-files-with-syq fragment for existing links.

--- a/theme/README.md
+++ b/theme/README.md
@@ -54,3 +54,11 @@ description of copying, reorganizing, removing, resuming and automation.
 Shared landing-actions buttons offer installation, benchmarks, sending files
 home, server-to-server copies and programmable file placement. Quickstart
 examples follow under Try a copy.
+
+## SDK documentation
+
+The SDK guide, API reference and compatibility pages in docs/ use mdBook
+includes to render the sources in sdk/. Edit those source files so the web
+pages and packaged SDK documentation stay in sync. Links in included sources
+use full documentation URLs so they also work on GitHub and PyPI. book.toml
+watches sdk/ when serving the book locally.

--- a/theme/README.md
+++ b/theme/README.md
@@ -52,3 +52,8 @@ forking the book template or replacing the control implementations.
 
 The oversized side-of-page chapter arrows are hidden; sidebar links and the
 end-of-page navigation provide the chapter routes.
+
+Anchor navigation scrolls smoothly, matching benchmarks. The reduced-motion
+preference disables this animation. Both sites use 20px Open Sans main prose
+and compact 14px Open Sans navigation with a 300px default sidebar width;
+their content layouts remain independent.

--- a/theme/README.md
+++ b/theme/README.md
@@ -5,57 +5,43 @@ a blue Manrope syq wordmark, IBM Plex Mono commands and numbers, and white/dark
 palettes. Main text is 20px. The same top navigation links both sites, while
 the docs retain mdBook's compact sidebar and benchmarks keep their own layout.
 
-The shared source lives in syq-bench. Keep these copies byte-for-byte identical:
+The shared UI toolkit is inventoried in site-ui.json. Every mapped file must
+remain byte-for-byte identical to the syq-bench copy, including fonts/licenses.
+It owns branding, homepage buttons, sidebars, and Contents/Theme/Search controls.
+Both sidebars use 15px links, 16px headings, 24px left and 12px right padding.
 
-| syq-bench | syq |
-| --- | --- |
-| `src/syq_bench/brand.css` | `theme/brand.css` |
-| `src/syq_bench/site-nav.html` | `theme/header.hbs` |
-| `src/syq_bench/fonts/` including licenses | `theme/fonts/` |
+Compare from either repo before review (arguments are toolkit directories):
 
-See `site/BRANDING.md` in syq-bench for the copy and comparison commands.
-Prepare paired task worktrees and pull requests for shared edits. Each repo
-keeps its own committed assets and builds independently; neither site fetches
-styles or fonts from the other at build time or in the browser.
+    python3 theme/check-site-ui.py /path/to/syq-bench-task/src/syq_bench theme
 
-`docs.css` is the mdBook adapter: prose, code, tables, sidebar, toolbar and
-anchor offsets. `docs.js` adds the current-site marker and moves the existing search, theme and
-sidebar controls into the shared header, preserving mdBook listeners and shortcuts.
-Print and edit links appear below the article; the duplicate title and GitHub
-shortcut no longer need a separate toolbar row. Search opens only when requested.
-The header is a supported partial; the full mdBook template and scripts remain
-upstream so search, chapter navigation, keyboard shortcuts and code copying
-continue to receive mdBook fixes. The built-in light/rust preferences use the
-white palette; navy/coal/ayu use the matching dark palette. Auto follows the OS.
+See site/BRANDING.md in syq-bench for the inventory and copy workflow.
+Each site builds independently from its committed toolkit.
 
-Use the mdBook version pinned in `.github/workflows/pages.yml`, run
-`mdbook build` and `python3 scripts/check-doc-links.py`, and check rendered
-fonts, desktop/phone layouts, both color schemes, search, mobile chapter menus,
-code copying, anchor offsets and JavaScript-disabled navigation. Theme assets
-are included in the Pages trigger and mdBook's preview watch list.
+docs.css and docs.js adapt mdBook. Native search and theme handlers remain
+behind the shared controls. Print/edit actions stay below the article. The
+toolkit replaces the toggle and resize handle and reconciles native touch
+gestures; mdBook still generates chapters, in-page links and search results.
+Widths and desktop visibility persist when storage is available. Drag or use
+arrow keys to resize; Home/double-click resets width. Mobile drawer behavior
+and animations match benchmarks, including reduced-motion support.
+System/Light/Dark replace the redundant mdBook palette names in the visible UI.
+The native toolbar remains available when JavaScript is disabled.
+
+Build with pinned mdBook and run the source link checker. Check both sites at
+320/390/620/760/820/1440px: resizing, persistence, navigation, keyboard controls,
+search hits/misses, themes, code copying, reduced motion and no-JS fallback.
+Resize arrow keys must not trigger mdBook chapter navigation.
 
 The font stylesheet uses mdBook's resource helper to resolve hashed font
 filenames. syq-bench embeds the same resources as data URIs. Do not replace the
 resource placeholders with literal paths: those break mdBook's asset hashing.
-
-With JavaScript enabled, the original toolbar and hover placeholder are hidden,
-and the page margin no longer compensates for that placeholder. Header controls
-remain fixed while scrolling. Without JavaScript, the native toolbar remains
-available below the header for sidebar and page links; its sticky offset still
-overrides mdBook's default. Mobile chapter drawers start below the shared header.
-
-When upgrading mdBook, check 320/390/620/760/820/1440px layouts, navigation and
-control overlap, initial headings and fragment offsets, search via click and `/`,
-themes via mouse/keyboard, chapter toggling, scrolled reload, print/edit links,
-and navigation without JavaScript. The adapter moves upstream nodes rather than
-forking the book template or replacing the control implementations.
 
 The oversized side-of-page chapter arrows are hidden; sidebar links and the
 end-of-page navigation provide the chapter routes.
 
 Anchor navigation scrolls smoothly, matching benchmarks. The reduced-motion
 preference disables this animation. Both sites use 20px Open Sans main prose
-and compact 14px Open Sans navigation with a 300px default sidebar width;
+and compact 15px Open Sans navigation with a 300px default sidebar width;
 their content layouts remain independent.
 
 The docs and benchmark homepages use the shared landing-title styles: a large

--- a/theme/README.md
+++ b/theme/README.md
@@ -62,3 +62,9 @@ The docs and benchmark homepages use the shared landing-title styles: a large
 blue Manrope wordmark above an Open Sans title. This adds character to the
 homepages while retaining the compact navigation and normal article headings.
 The docs homepage preserves its copy-files-with-syq fragment for existing links.
+
+The homepage leads with fast, programmable file operations and a short
+description of copying, reorganizing, removing, resuming and automation.
+Shared landing-actions buttons offer installation, benchmarks, sending files
+home, server-to-server copies and programmable file placement. Quickstart
+examples follow under Try a copy.

--- a/theme/brand.css
+++ b/theme/brand.css
@@ -53,3 +53,16 @@ code{font-family:var(--mono);font-size:.8em}
  .hero h1.landing-title,.content h1.landing-title{font-size:36px}
  .landing-title .landing-wordmark{font-size:48px}
 }
+
+/* Homepage shortcuts share their treatment across both renderers. */
+.landing-actions{display:flex;flex-wrap:wrap;gap:10px;margin:24px 0 32px;padding:0}
+.landing-actions a,.content .landing-actions a{
+ display:inline-flex;align-items:center;justify-content:center;min-height:44px;
+ padding:9px 16px;box-sizing:border-box;border:1px solid var(--line);border-radius:3px;
+ background:var(--panel);color:var(--ink);font:600 15px/1.4 var(--display);
+ text-decoration:none;letter-spacing:0}
+.landing-actions a:hover,.content .landing-actions a:hover{border-color:var(--syq);color:var(--syq)}
+.landing-actions a.landing-primary,.content .landing-actions a.landing-primary{
+ background:var(--syq);color:var(--fast-fg);border-color:var(--syq)}
+.landing-actions a:focus-visible{outline:2px solid var(--syq);outline-offset:4px}
+@media print{.landing-actions{display:none}}

--- a/theme/brand.css
+++ b/theme/brand.css
@@ -40,3 +40,16 @@ html{font-family:var(--sans);background:var(--bg);color:var(--ink)}
 body{font:400 20px/1.65 var(--sans);background:var(--bg);color:var(--ink)}
 h1,h2,h3,h4{font-family:var(--display);letter-spacing:-.025em}
 code{font-family:var(--mono);font-size:.8em}
+
+/* Shared homepage title: keep the wordmark prominent without changing prose. */
+.hero h1.landing-title,.content h1.landing-title{
+ font:700 clamp(38px,4.1vw,58px)/1.12 var(--display);
+ letter-spacing:-.045em;margin:0 0 24px;text-wrap:balance}
+.landing-title .landing-wordmark{
+ display:block;color:var(--syq);font:800 clamp(64px,6vw,80px)/1 "Manrope",sans-serif;
+ letter-spacing:-.06em;margin-bottom:10px}
+.landing-title .landing-subtitle{display:block}
+@media print{
+ .hero h1.landing-title,.content h1.landing-title{font-size:36px}
+ .landing-title .landing-wordmark{font-size:48px}
+}

--- a/theme/check-site-ui.py
+++ b/theme/check-site-ui.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Compare the shared UI toolkit in syq-bench and syq; no network or writes."""
+
+import argparse
+import json
+from pathlib import Path
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("bench", type=Path, help="syq-bench's src/syq_bench directory")
+parser.add_argument("docs", type=Path, help="syq's theme directory")
+args = parser.parse_args()
+mapping = json.loads(Path(__file__).with_name("site-ui.json").read_text())
+failures = []
+count = 0
+for source, target in mapping.items():
+    left, right = args.bench / source, args.docs / target
+    pairs = [(left, right)]
+    if left.is_dir():
+        names = {p.relative_to(left) for p in left.rglob("*") if p.is_file()}
+        names |= {p.relative_to(right) for p in right.rglob("*") if p.is_file()}
+        pairs = [(left / name, right / name) for name in sorted(names)]
+    for left, right in pairs:
+        count += 1
+        if not left.is_file() or not right.is_file() or left.read_bytes() != right.read_bytes():
+            failures.append(f"{left} differs from {right}")
+if failures:
+    print("\n".join(failures))
+    raise SystemExit(1)
+print(f"Shared UI toolkit matches ({count} files).")

--- a/theme/controls.css
+++ b/theme/controls.css
@@ -1,0 +1,31 @@
+.site-controls{display:flex;align-items:center;gap:6px;position:relative;margin-left:auto;flex:none}
+.site-controls>button,.site-controls .site-contents-toggle{
+ height:40px;padding:0 10px;border:1px solid var(--line);border-radius:3px;
+ background:var(--panel);color:var(--ink);font:600 14px/1.4 var(--display);cursor:pointer}
+.site-controls button:hover{color:var(--syq);border-color:var(--syq)}
+.site-controls button:focus-visible{outline:2px solid var(--syq);outline-offset:2px}
+.site-theme-options{position:absolute;right:0;top:46px;padding:6px;min-width:140px;
+ background:var(--bg);border:1px solid var(--line);border-radius:3px}
+.site-theme-options button{display:block;width:100%;padding:8px 12px;border:0;text-align:left;
+ background:transparent;color:var(--ink);font:400 15px/1.5 var(--display);cursor:pointer}
+.site-theme-options button[aria-pressed="true"]{color:var(--syq);background:var(--accent-soft)}
+.site-theme-options[hidden],.site-search-panel[hidden],.docs-controls[hidden]{display:none!important}
+.site-search-panel{box-sizing:border-box;margin:0 auto 28px;padding:16px;
+ max-width:820px;background:var(--panel);border:1px solid var(--line);font:400 16px/1.6 var(--display)}
+.site-search-panel input[type="search"],.site-search-panel #mdbook-searchbar{
+ box-sizing:border-box;width:100%;height:42px;padding:8px 12px;border:1px solid var(--line);
+ border-radius:2px;background:var(--bg);color:var(--ink);font:400 16px/1.5 var(--display)}
+.site-search-panel a{color:var(--syq);text-decoration:underline}
+.site-search-panel ul{padding-left:22px}
+.site-search-panel:focus-within{scroll-margin-top:calc(var(--site-header-height) + 16px)}
+@media(max-width:760px){
+ .site-sidebar-ready .site-header{display:grid;grid-template-columns:1fr auto;grid-template-rows:44px auto;
+ align-content:center;gap:4px 12px}
+ .site-sidebar-ready{--site-header-height:108px}
+ .site-sidebar-ready .site-wordmark{grid-column:1;grid-row:1}
+ .site-sidebar-ready .site-nav{grid-column:1/-1;grid-row:2}
+ .site-controls{grid-column:2;grid-row:1;gap:4px}
+ .site-controls>button,.site-controls .site-contents-toggle{padding:0 8px;font-size:13px}
+}
+@media(max-width:480px){.site-sidebar-ready .site-nav{font-size:14px;gap:8px}}
+@media print{.site-controls,.site-search-panel{display:none!important}}

--- a/theme/controls.js
+++ b/theme/controls.js
@@ -1,0 +1,138 @@
+// Shared header controls. Search uses each renderer's own document index.
+(() => {
+  const root = document.documentElement;
+  const header = document.querySelector('.site-header');
+  const contents = document.querySelector('.site-contents-toggle');
+  const nativeTheme = document.getElementById('mdbook-theme-toggle');
+  const nativeSearch = document.getElementById('mdbook-search-toggle');
+  const controls = document.createElement('div');
+  controls.className = 'site-controls';
+  header.append(controls);
+  controls.append(contents);
+  function button(text, label) {
+    const el = document.createElement('button');
+    el.type = 'button';
+    el.textContent = text;
+    el.setAttribute('aria-label', label);
+    controls.append(el);
+    return el;
+  }
+  const theme = button('Theme', 'Choose color theme');
+  const popup = document.createElement('div');
+  popup.id = 'site-theme-options';
+  popup.className = 'site-theme-options';
+  popup.hidden = true;
+  popup.setAttribute('role', 'group');
+  popup.setAttribute('aria-label', 'Color theme');
+  theme.setAttribute('aria-controls', popup.id);
+  theme.setAttribute('aria-expanded', 'false');
+  controls.append(popup);
+  const search = button('Search', 'Search this site');
+  search.setAttribute('aria-keyshortcuts', '/');
+  search.setAttribute('aria-expanded', 'false');
+  function read(key) {
+    try { return localStorage.getItem(key); } catch { return null; }
+  }
+  const legacy = read('mdbook-theme');
+  let selected = read('syq-color-theme') || (['coal','navy','ayu'].includes(legacy) ? 'dark' : ['light','rust'].includes(legacy) ? 'light' : 'auto');
+  if (!['auto','light','dark'].includes(selected)) selected = 'auto';
+  const osTheme = matchMedia('(prefers-color-scheme:dark)');
+  function applyTheme(value) {
+    selected = value;
+    try { localStorage.setItem('syq-color-theme', value); } catch { /* Optional. */ }
+    const actual = value === 'auto' ? (osTheme.matches ? 'dark' : 'light') : value;
+    root.dataset.theme = actual;
+    if (nativeTheme) document.getElementById('mdbook-theme-' + ({auto:'default_theme',light:'light',dark:'navy'}[value])).click();
+    for (const option of popup.querySelectorAll('button')) option.setAttribute('aria-pressed', String(option.dataset.theme === value));
+  }
+  function closeTheme() {
+    popup.hidden = true;
+    theme.setAttribute('aria-expanded', 'false');
+  }
+  for (const [value, label] of [['auto','System'],['light','Light'],['dark','Dark']]) {
+    const option = document.createElement('button');
+    option.type = 'button';
+    option.textContent = label;
+    option.dataset.theme = value;
+    option.addEventListener('click', () => {applyTheme(value); closeTheme(); theme.focus();});
+    popup.append(option);
+  }
+  theme.addEventListener('click', () => {
+    popup.hidden = !popup.hidden;
+    theme.setAttribute('aria-expanded', String(!popup.hidden));
+    if (!popup.hidden) popup.querySelector('[aria-pressed="true"]').focus();
+  });
+  applyTheme(selected);
+  osTheme.addEventListener('change', () => applyTheme(selected));
+  window.addEventListener('storage', event => {
+    if (event.key === 'syq-color-theme' && ['auto','light','dark'].includes(event.newValue)) applyTheme(event.newValue);
+  });
+
+  let panel, input;
+  if (nativeSearch) {
+    panel = document.getElementById('mdbook-search-wrapper');
+    input = document.getElementById('mdbook-searchbar');
+    panel.classList.add('site-search-panel');
+    input.placeholder = 'Search this site';
+    input.setAttribute('aria-label', 'Search this site');
+    search.setAttribute('aria-controls', panel.id);
+    new MutationObserver(() => search.setAttribute('aria-expanded', nativeSearch.getAttribute('aria-expanded')))
+      .observe(nativeSearch, {attributes:true, attributeFilter:['aria-expanded']});
+    search.addEventListener('click', () => nativeSearch.click());
+  } else {
+    panel = document.createElement('section');
+    panel.id = 'site-search';
+    panel.className = 'site-search-panel';
+    panel.hidden = true;
+    input = document.createElement('input');
+    input.type = 'search';
+    input.placeholder = 'Search this site';
+    input.setAttribute('aria-label', 'Search this site');
+    const status = document.createElement('p');
+    status.setAttribute('aria-live','polite');
+    const results = document.createElement('ul');
+    panel.append(input, status, results);
+    document.querySelector('main').prepend(panel);
+    const index = JSON.parse(document.getElementById('site-search-index').textContent);
+    input.addEventListener('input', () => {
+      const terms = input.value.toLocaleLowerCase().trim().split(/\s+/).filter(Boolean);
+      results.replaceChildren();
+      const found = terms.length ? index.filter(entry => terms.every(term => entry.text.toLocaleLowerCase().includes(term))) : [];
+      status.textContent = terms.length ? found.length + (found.length === 1 ? ' result' : ' results') : '';
+      for (const entry of found) {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = entry.href;
+        a.textContent = entry.title;
+        li.append(a);
+        results.append(li);
+      }
+    });
+    search.setAttribute('aria-controls', panel.id);
+    search.addEventListener('click', () => {
+      panel.hidden = !panel.hidden;
+      search.setAttribute('aria-expanded', String(!panel.hidden));
+      if (!panel.hidden) input.focus();
+    });
+  }
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+      if (!popup.hidden) {closeTheme(); theme.focus();}
+      if (search.getAttribute('aria-expanded') === 'true') {search.click();search.focus();}
+    }
+    if (!nativeSearch && event.key === '/' && !event.ctrlKey && !event.metaKey &&
+        !event.altKey && !event.target.closest('input,textarea,[contenteditable="true"]')) {
+      event.preventDefault();
+      if (panel.hidden) search.click();
+      else input.focus();
+    }
+  });
+  document.addEventListener('click', event => {
+    if (!controls.contains(event.target)) closeTheme();
+  });
+  if (nativeTheme) {
+    // Keep the native theme/search handlers as adapters, but show one shared UI.
+    document.querySelector('.docs-controls').hidden = true;
+    document.querySelector('.docs-controls').setAttribute('aria-hidden','true');
+  }
+})();

--- a/theme/docs.css
+++ b/theme/docs.css
@@ -129,3 +129,7 @@ a:focus-visible,button:focus-visible,label:focus-visible {outline:2px solid var(
   .docs-compact-header .site-nav {font-size:14px;gap:8px}
 }
 @media print {.docs-page-actions{display:none}}
+
+/* Align the homepage title's top spacing with the benchmark introduction. */
+.content h1.landing-title{margin-top:44px}
+@media(max-width:820px){.content h1.landing-title{margin-top:32px}}

--- a/theme/docs.css
+++ b/theme/docs.css
@@ -1,4 +1,5 @@
 /* mdBook adapter; the shared palette, fonts and site header live in brand.css. */
+html {scroll-behavior:smooth}
 :root {
   --sidebar-target-width: 300px;
   --content-max-width: 820px;

--- a/theme/docs.css
+++ b/theme/docs.css
@@ -49,13 +49,7 @@ h1,h2,h3,h4,h5,h6 {font-family:var(--display);font-weight:700;letter-spacing:-.0
 .content table {font-family:var(--display);font-size:16px;line-height:1.6}
 .content th,.content td {padding:10px 14px}
 .content blockquote {margin-inline:0;padding:12px 20px;border-left:2px solid var(--syq)}
-/* Preserve mdBook's compact sidebar rather than restyling it as benchmark navigation. */
-.sidebar {top:var(--site-header-height);font:14px var(--display)}
-.sidebar .sidebar-scrollbox {padding:10px}
-.chapter {font:14px/2.2em var(--display);margin:1em 0;padding:0}
-.chapter li a {display:block}
-.chapter li a strong {font-weight:700}
-.chapter-link-wrapper>a {flex:1;min-width:0}
+.sidebar {top:var(--site-header-height)}
 .copy-demo {padding:22px;border-radius:2px}
 .copy-demo legend {font-family:var(--display)}
 .copy-demo-choices {font:500 17px/1.4 var(--display)}

--- a/theme/sidebar.css
+++ b/theme/sidebar.css
@@ -1,0 +1,74 @@
+/* Shared sidebar presentation. Loaded after each renderer's layout adapter. */
+:root{--site-sidebar-width:300px;--sidebar-width:var(--site-sidebar-width)}
+.app{grid-template-columns:var(--site-sidebar-width) minmax(0,1fr)}
+#mdbook-sidebar,#benchmark-sidebar{
+ box-sizing:border-box;background:var(--docs-sidebar);color:var(--ink);
+ border:0;border-right:1px solid var(--line);font:400 15px/1.6 var(--display)}
+#mdbook-sidebar .sidebar-scrollbox,#benchmark-sidebar .sidebar-scrollbox{
+ box-sizing:border-box;padding:24px 12px 24px 24px;overflow:auto;height:100%;
+ scrollbar-width:thin}
+#benchmark-sidebar{padding:0;overflow:visible}
+#benchmark-sidebar nav{display:block;margin:0}
+.chapter,#benchmark-sidebar nav{font:400 15px/1.6 var(--display);margin:0;padding:0}
+.chapter li.chapter-item,.chapter li.header-item{margin:0;line-height:1.6}
+.chapter li a,#benchmark-sidebar .nav-item,#benchmark-sidebar .page-link{
+ font:400 15px/1.6 var(--display);color:var(--ink);padding:5px 0;margin:0;
+ border:0;border-radius:0;text-decoration:none;background:transparent;box-shadow:none}
+.chapter li a:hover,#benchmark-sidebar a:hover{color:var(--syq);text-decoration:underline}
+.chapter li a.active,.chapter a.current-header,
+#benchmark-sidebar a[aria-current]{color:var(--syq)}
+.chapter .part-title,#benchmark-sidebar .page-link{
+ font:700 16px/1.5 var(--display);margin:18px 0 4px;padding:0}
+#benchmark-sidebar .page-link:first-child{margin-top:0}
+.chapter .section,#benchmark-sidebar .scenario-links{padding-left:16px}
+.chapter .on-this-page{
+ margin:2px 0 8px 12px;border-left:2px solid var(--line);padding-left:12px}
+.chapter .on-this-page>ol{padding-left:0}
+#benchmark-sidebar .scenario-links{
+ margin:2px 0 8px 12px;border-left:2px solid var(--line);padding-left:12px}
+#benchmark-sidebar .nav-num{font:700 15px/1.6 var(--display);color:inherit}
+#benchmark-sidebar .nav-item{display:flex;align-items:baseline;gap:6px}
+#benchmark-sidebar .aside-links{margin:18px 0 0;padding:14px 0 0;font:400 15px/1.6 var(--display)}
+.sidebar-iframe-inner{padding:24px 12px 24px 24px;font:400 15px/1.6 var(--display)}
+.site-sidebar-ready #mdbook-sidebar.site-sidebar,
+.site-sidebar-ready #benchmark-sidebar.site-sidebar{
+ position:fixed;left:0;top:var(--site-header-height);bottom:0;
+ width:var(--site-sidebar-width);height:auto;transform:none;z-index:105;display:block!important;visibility:visible;
+ transition:transform .22s ease,visibility 0s}
+.site-sidebar-ready:not(.sidebar-visible) #mdbook-sidebar.site-sidebar,
+.site-sidebar-ready:not(.sidebar-visible) #benchmark-sidebar.site-sidebar{
+ transform:translateX(-100%);visibility:hidden;transition:transform .22s ease,visibility 0s .22s}
+.site-sidebar-ready .app{display:block;margin-left:var(--site-sidebar-width);transition:margin-left .22s ease}
+.site-sidebar-ready:not(.sidebar-visible) .app{margin-left:0}
+.site-sidebar-ready #mdbook-sidebar-toggle-anchor ~ .page-wrapper{
+ transform:none;margin-inline-start:var(--site-sidebar-width);transition:margin-inline-start .22s ease}
+.site-sidebar-ready:not(.sidebar-visible) #mdbook-sidebar-toggle-anchor ~ .page-wrapper{margin-inline-start:0}
+.site-contents-toggle,.docs-controls .site-contents-toggle{
+ display:inline-flex;align-items:center;justify-content:center;flex:none;
+ width:auto;height:40px;padding:0 12px;border:1px solid var(--line);border-radius:3px;
+ background:var(--panel);color:var(--ink);font:600 14px/1.4 var(--display);cursor:pointer}
+.site-header>.site-contents-toggle{margin-left:auto}
+.site-contents-toggle:hover{color:var(--syq);border-color:var(--syq)}
+.site-contents-toggle:focus-visible,.site-sidebar-resize:focus-visible{outline:2px solid var(--syq);outline-offset:2px}
+.site-sidebar-resize{position:absolute;right:-4px;top:0;bottom:0;width:8px;
+ cursor:col-resize;touch-action:none;z-index:1}
+.site-sidebar-resize:after{content:"";position:absolute;left:3px;top:calc(50% - 20px);
+ height:40px;border-left:2px solid var(--faint)}
+.site-sidebar-resize:hover,.site-sidebar-resize:focus-visible{background:var(--accent-soft)}
+.site-sidebar-resizing{user-select:none;cursor:col-resize}
+@media(max-width:619px){
+ .site-sidebar-ready .app{margin-left:0}
+ .site-sidebar-ready #mdbook-sidebar-toggle-anchor ~ .page-wrapper{margin-inline-start:0}
+ .site-sidebar-resize{display:none}
+}
+@media(max-width:760px){.site-header>.site-contents-toggle{grid-column:2;grid-row:1}}
+@media print{
+ .site-sidebar-ready .app,.site-sidebar-ready #mdbook-sidebar-toggle-anchor ~ .page-wrapper{margin-inline-start:0}
+ .site-sidebar,.site-contents-toggle{display:none!important}
+}
+
+.site-sidebar-resizing .app,.site-sidebar-resizing #mdbook-sidebar-toggle-anchor ~ .page-wrapper{transition:none}
+@media(prefers-reduced-motion:reduce){
+ .site-sidebar-ready .app,.site-sidebar-ready #mdbook-sidebar-toggle-anchor ~ .page-wrapper,
+ .site-sidebar-ready #mdbook-sidebar.site-sidebar,.site-sidebar-ready #benchmark-sidebar.site-sidebar{transition:none}
+}

--- a/theme/sidebar.js
+++ b/theme/sidebar.js
@@ -1,0 +1,134 @@
+// Shared sidebar behavior for the docs and self-contained benchmark reports.
+(() => {
+  const root = document.documentElement;
+  const sidebar = document.querySelector('#mdbook-sidebar, #benchmark-sidebar');
+  if (!sidebar) return;
+  const mobile = matchMedia('(max-width:619px)');
+  const checkbox = document.getElementById('mdbook-sidebar-toggle-anchor');
+  const oldToggle = document.getElementById('mdbook-sidebar-toggle');
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'site-contents-toggle';
+  toggle.textContent = 'Contents';
+  toggle.setAttribute('aria-controls', sidebar.id);
+  if (oldToggle) {
+    toggle.id = oldToggle.id;
+    oldToggle.replaceWith(toggle);
+  } else {
+    document.querySelector('.site-header').append(toggle);
+  }
+  sidebar.classList.add('site-sidebar');
+  root.classList.add('site-sidebar-ready', 'sidebar-enhanced');
+  const oldHandle = document.getElementById('mdbook-sidebar-resize-handle');
+  const handle = document.createElement('div');
+  handle.className = 'site-sidebar-resize';
+  handle.tabIndex = 0;
+  handle.setAttribute('role', 'separator');
+  handle.setAttribute('aria-orientation', 'vertical');
+  handle.setAttribute('aria-label', 'Contents width');
+  handle.setAttribute('aria-controls', sidebar.id);
+  handle.title = 'Drag to resize; use arrow keys, or double-click to reset';
+  if (oldHandle) oldHandle.replaceWith(handle);
+  else sidebar.append(handle);
+
+  function read(key) {
+    try { return localStorage.getItem(key); } catch { return null; }
+  }
+  function save(key, value) {
+    try { localStorage.setItem(key, String(value)); } catch { /* Storage is optional. */ }
+  }
+  let desktopOpen = read('mdbook-sidebar') !== 'hidden';
+  const stored = Number(read('syq-sidebar-width'));
+  let preferredWidth = Number.isFinite(stored) && stored >= 240 && stored <= 480 ? stored : 300;
+  function applyWidth() {
+    const max = Math.min(480, innerWidth - (mobile.matches ? 32 : 100));
+    const width = Math.min(preferredWidth, max);
+    root.style.setProperty('--site-sidebar-width', width + 'px');
+    root.style.setProperty('--sidebar-target-width', width + 'px');
+    handle.setAttribute('aria-valuemin', String(Math.min(240, max)));
+    handle.setAttribute('aria-valuemax', String(max));
+    handle.setAttribute('aria-valuenow', String(Math.round(width)));
+  }
+  function resize(width) {
+    preferredWidth = Math.round(Math.max(240, Math.min(480, innerWidth - 100, width)));
+    save('syq-sidebar-width', preferredWidth);
+    applyWidth();
+  }
+  function sync() {
+    const open = root.classList.contains('sidebar-visible');
+    if (checkbox) checkbox.checked = open;
+    sidebar.style.removeProperty('display');
+    sidebar.inert = !open;
+    sidebar.setAttribute('aria-hidden', String(!open));
+    toggle.setAttribute('aria-expanded', String(open));
+    toggle.setAttribute('aria-label', (open ? 'Hide' : 'Show') + ' contents');
+    sidebar.querySelectorAll('a').forEach(link => link.removeAttribute('tabindex'));
+    if (!mobile.matches) desktopOpen = open;
+    save('mdbook-sidebar', desktopOpen ? 'visible' : 'hidden');
+  }
+  function setOpen(open) {
+    root.classList.toggle('sidebar-visible', open);
+    sync();
+  }
+  applyWidth();
+  setOpen(!mobile.matches && desktopOpen);
+  toggle.addEventListener('click', () => setOpen(!root.classList.contains('sidebar-visible')));
+  // Reconcile mdBook's native touch gestures with the shared state and checkbox.
+  new MutationObserver(sync).observe(root, {attributes: true, attributeFilter: ['class']});
+  mobile.addEventListener('change', () => {
+    applyWidth();
+    setOpen(!mobile.matches && desktopOpen);
+  });
+  window.addEventListener('resize', applyWidth);
+  sidebar.addEventListener('click', event => {
+    if (mobile.matches && event.target.closest('a')) setOpen(false);
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && mobile.matches && root.classList.contains('sidebar-visible')) {
+      setOpen(false);
+      toggle.focus();
+    }
+  });
+  let pointer = null;
+  handle.addEventListener('pointerdown', event => {
+    if (event.button !== 0 || mobile.matches) return;
+    event.preventDefault();
+    pointer = event.pointerId;
+    handle.setPointerCapture(pointer);
+    root.classList.add('site-sidebar-resizing');
+  });
+  handle.addEventListener('pointermove', event => {
+    if (event.pointerId === pointer) resize(event.clientX);
+  });
+  function stop() {
+    pointer = null;
+    root.classList.remove('site-sidebar-resizing');
+  }
+  handle.addEventListener('pointerup', stop);
+  handle.addEventListener('pointercancel', stop);
+  handle.addEventListener('lostpointercapture', stop);
+  handle.addEventListener('dblclick', () => resize(300));
+  handle.addEventListener('keydown', event => {
+    const delta = event.shiftKey ? 40 : 10;
+    if (event.key === 'ArrowLeft') resize(preferredWidth - delta);
+    else if (event.key === 'ArrowRight') resize(preferredWidth + delta);
+    else if (event.key === 'Home') resize(300);
+    else return;
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  // Match the docs' edge-swipe gesture on benchmark pages too.
+  let contact = null;
+  document.addEventListener('touchstart', event => {
+    contact = {x: event.touches[0].clientX, time: Date.now()};
+  }, {passive: true});
+  document.addEventListener('touchmove', event => {
+    if (!contact || !mobile.matches) return;
+    const x = event.touches[0].clientX;
+    if (Date.now() - contact.time < 250 && Math.abs(x - contact.x) >= 150) {
+      if (x > contact.x && contact.x < Math.min(innerWidth * .25, 300)) setOpen(true);
+      else if (x < contact.x && x < 300) setOpen(false);
+      contact = null;
+    }
+  }, {passive: true});
+})();

--- a/theme/site-ui.json
+++ b/theme/site-ui.json
@@ -1,0 +1,11 @@
+{
+  "brand.css": "brand.css",
+  "sidebar.css": "sidebar.css",
+  "sidebar.js": "sidebar.js",
+  "controls.css": "controls.css",
+  "controls.js": "controls.js",
+  "site-nav.html": "header.hbs",
+  "fonts": "fonts",
+  "site-ui.json": "site-ui.json",
+  "check-site-ui.py": "check-site-ui.py"
+}


### PR DESCRIPTION
The docs homepage now explains syq as fast, programmable file operations, with a large blue wordmark and feature buttons for installation, benchmarks, sending files home, server-to-server copies, file placement and the Python SDK. A new Python SDK page provides installation, a dry-run example and links to full guide/reference web pages, and has a dedicated SDKs section at the bottom of the sidebar. The guide, API reference and compatibility pages render the existing SDK Markdown through mdBook includes, keeping package and website documentation in sync. Rename and reorganize links to the SDK. The SDK reference introduction also reflects the published package and its pinned executable.

Both repos commit an identical UI toolkit for fonts, colors, homepage buttons, sidebars and header controls. Sidebars share spacing, larger section labels, a 300px default, draggable/keyboard resizing, saved width and animated visibility. Labeled Contents, Theme and Search controls replace the inconsistent icons; docs retain mdBook search and theme handlers behind these controls. Anchor scrolling respects reduced motion. A manifest and comparison script detect drift between copies, while the sites retain distinct content layouts and independent builds.

Paired benchmark change: https://github.com/greaber/syq-bench/pull/23

Validation at f743e60:
- Pinned mdBook build and documentation link check passed (17 files, zero problems).
- All 20 toolkit files match the benchmark copy.
- Chromium at 320, 390, 820 and 1440px: navigation, overflow, resizing/persistence, keyboard controls, themes and search passed. Additional checks cover actual animation, reduced motion, invalid stored widths, cross-site width persistence, SDK links and navigation without JavaScript.
- SDK claims checked against the existing SDK code/docs and published package metadata; no SDK runtime code changed.
- Public preview page bodies match staged files. No Rust, SDK runtime, SSH or performance tests run for these documentation/UI changes.

Follow-up at c4521b9: give SDKs a distinct sidebar heading. Rebuilt docs, passed the 17-file link check, and verified the heading and Python SDK navigation in the public preview at 390 and 1440px. Worktree clean and pushed; latest master workflows at 1417176 are in progress.

SDK web pages at f53b740: pinned mdBook build and 20-file link check passed; live desktop/mobile checks verify all three sidebar links and rendered source content. Worktree clean and pushed. No SDK runtime changes.
