### PR TITLE
Automatically discover copy authorizers

### DIFF
--- a/docs/receive.md
+++ b/docs/receive.md
@@ -82,7 +82,9 @@ limits. The server receives neither your SSH agent nor an interface for running
 arbitrary laptop commands.
 
 To send files from that server to another SSH host using this machine's
-permission, use `syq cp results --to hostB --via @laptop`. These requests always
+permission, use `syq cp results --to hostB`. Eligible copies discover a live
+receiving machine automatically; `--auth-from @laptop` selects one explicitly
+and `--auth-from ssh` uses the server's own SSH access. These requests always
 need a local decision. See [Start a copy from the source server](remote-to-remote.md#start-a-copy-from-the-source-server).
 
 ## Names and paths

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -93,8 +93,12 @@ Enclose IPv6 addresses in brackets: `alice@[2001:db8::1]:2222`.
 A colon in a native path is simply part of the path.
 
 For two remote endpoints, see [Copy between servers](remote-to-remote.md).
-From a server shell, `syq cp results --to hostB --via @laptop` can ask a live
-receiving machine to authorize the copy while data flows directly to hostB.
+From a server shell, `syq cp results --to hostB` automatically looks for a live
+receiving machine that can authorize the copy while data flows directly to
+hostB. Use `--auth-from @laptop` to select one, or `--auth-from ssh` to use
+SSH from this machine. See [authorization selection](remote-to-remote.md#start-a-copy-from-the-source-server)
+for ordering, supported options, and approval behavior. `--via @laptop` remains
+an alias for the explicit receiving-machine selection.
 
 ## Progress
 

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -27,14 +27,31 @@ you can inspect files in any server shell and send them to another SSH host:
 ```sh
 # Run on hostA, including in an existing tmux shell.
 ls -lh results
-syq cp results --to hostB --via @laptop --into /archive
+syq cp results --to hostB --into /archive
 ```
 
-The laptop asks for approval before contacting hostB. Approve with the desktop
+Syq looks for a live receiving machine automatically before trying SSH from
+hostA. It checks names in alphabetical order, allowing up to two seconds for
+each readiness reply, and uses the first available matching build. Offline or
+incompatible registrations are skipped. With none available, it uses ordinary
+SSH. Options this route cannot support also use ordinary SSH automatically.
+A copy addressed to a live receiving name still goes to that machine itself.
+
+These choices apply to `syq cp` with local sources and an SSH destination.
+To choose explicitly, use `--auth-from @laptop` (or `--auth-from laptop`).
+`--auth-from ssh` uses hostA's SSH access and interprets `--to` as an SSH
+endpoint, even if its bare name matches a receiving name. `--auth-from auto`
+is the default. Names `ssh` and `auto` need `@` with this option.
+The older `--via NAME` spelling remains an alias for `--auth-from @NAME`;
+every bare `--via` value is still a receiving name.
+
+The selected laptop asks for approval before contacting hostB. Approve with the desktop
 prompt or `syq recv pending` and `syq recv approve REQUEST_ID` on the laptop.
 These requests require a decision even when `recv --approve always` permits
-automatic copies onto the laptop itself. `--via laptop` also works; both forms
-require a live return connection and never fall back to an SSH host named laptop.
+automatic copies onto the laptop itself. Once an approval request is sent,
+a refusal, interrupted connection, setup failure, or copy failure ends that
+attempt; syq does not try another authorizer or SSH. Explicit receiving names
+require a live return connection and never fall back to DNS lookup.
 
 The laptop uses its own SSH configuration, credentials, and trusted host keys
 to connect to hostB and install the matching syq helper. Connect to hostB with
@@ -48,7 +65,8 @@ The prompt shows the requested SSH endpoint and destination path. Relative
 destination paths start in that account's home directory on hostB. A quoted
 `~` or `~/archive` also uses hostB's home directory; use `./~/archive` to name a
 literal directory called `~`. On this route, `~//archive` also stays under that
-home directory. Receiving `--cwd` and `--root` govern copies onto the laptop;
+home directory. Automatic selection leaves `~//archive` on ordinary SSH,
+where that spelling resolves to `/archive`. Receiving `--cwd` and `--root` govern copies onto the laptop;
 they do not describe hostB's filesystem. Receiving byte, entry, and deletion
 ceilings still apply. The helper on hostB checks the approved copy permissions and protects its own
 control and SSH authority files. The source verifies its signed receipt before
@@ -62,7 +80,10 @@ Retry with a new approval to resume eligible partial files. This route accepts
 local sources and an ordinary SSH `--to` endpoint. It does not accept `--detach`, custom `--rsh`/`--syq-path`,
 `--no-bootstrap`, `--pscope`, alternative `--peer-auth`/`--coordinate-at`,
 `--no-tcp`, or `--tcp-plain`. Copy permissions and supported filesystem options
-match [return copies](receive.md#copy-permissions-and-limits).
+match [return copies](receive.md#copy-permissions-and-limits). These restrictions
+also determine whether automatic selection can use a receiving machine.
+Destination path completion never asks a receiving machine for authorization;
+use `--auth-from ssh` for completion through hostA's own SSH access.
 
 ## What you need
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -129,8 +129,11 @@ self-updates is verified against a signed release manifest before use.
 That verification cannot protect a machine whose trusted account or programs
 have already been compromised.
 
-A server can also request a copy to another SSH host with `--via @name`.
-This always needs a local decision, even if automatic receiving is enabled.
+A server can also request a copy to another SSH host using a live receiving
+machine's SSH access. Eligible copies discover that machine automatically;
+`--auth-from @name` chooses it explicitly. This always needs a local decision,
+even if automatic receiving is enabled. Refusing the request ends the attempt;
+syq does not try another authorization source.
 Approval authorizes a connection using the receiving machine's SSH access and
 installation of a matching helper. The destination helper enforces one copy's
 paths, permissions and limits. The server gets a restricted control stream

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -57,7 +57,9 @@ learn a second set of names for concepts that syq already names.
 | `--into-existing` | `into_existing=` |
 | `--no-compress` | `no_compress=` |
 | `--max-delete` | `max_delete=` |
-| `--via @laptop` | `via="@laptop"` |
+| `--auth-from @laptop` | `auth_from="@laptop"` |
+| `--auth-from ssh` | `auth_from="ssh"` |
+| `--via @laptop` (alias) | `via="@laptop"` (alias) |
 | `--from` | `from_=` |
 | `--as` | `as_=` |
 | `class` event field | `class_` attribute |

--- a/sdk/python/native-api.json
+++ b/sdk/python/native-api.json
@@ -27,6 +27,7 @@
         "max-delete",
         "dry-run",
         "connections",
+        "auth-from",
         "via",
         "coordinate-at",
         "rsh",

--- a/sdk/python/src/syq/async_client.py
+++ b/sdk/python/src/syq/async_client.py
@@ -626,6 +626,7 @@ class AsyncClient:
         no_compress: bool = False,
         bwlimit: str | int | None = None,
         connections: int | None = None,
+        auth_from: str | None = None,
         via: str | None = None,
         coordinate_at: str | None = None,
         rsh: str | None = None,
@@ -707,6 +708,10 @@ class AsyncClient:
             min_size=min_size,
             max_delete=max_delete,
         )
+        if auth_from is not None and via is not None:
+            raise SyqInvocationError("auth_from conflicts with via")
+        if auth_from is not None:
+            argv.extend(("--auth-from", _text_arg(auth_from, label="auth_from")))
         if via is not None:
             argv.extend(("--via", _text_arg(via, label="via")))
         _append_remote_arguments(

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -1047,6 +1047,7 @@ class Client:
         no_compress: bool = False,
         bwlimit: str | int | None = None,
         connections: int | None = None,
+        auth_from: str | None = None,
         via: str | None = None,
         coordinate_at: str | None = None,
         rsh: str | None = None,
@@ -1126,6 +1127,10 @@ class Client:
             min_size=min_size,
             max_delete=max_delete,
         )
+        if auth_from is not None and via is not None:
+            raise SyqInvocationError("auth_from conflicts with via")
+        if auth_from is not None:
+            argv.extend(("--auth-from", _text_arg(auth_from, label="auth_from")))
         if via is not None:
             argv.extend(("--via", _text_arg(via, label="via")))
         _append_remote_arguments(

--- a/sdk/python/tests/test_async.py
+++ b/sdk/python/tests/test_async.py
@@ -238,6 +238,13 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(entries), 1)
         self.assertEqual(stream.cwd, home / "selected")
 
+    async def test_cp_selects_an_authorizer_and_rejects_conflicting_selectors(self) -> None:
+        await self.client.cp("source", to="backup", auth_from="@laptop", into="out")
+        argv = self.argv()
+        self.assertEqual(argv[argv.index("--auth-from") + 1], "@laptop")
+        with self.assertRaises(syq.SyqInvocationError):
+            await self.client.cp("source", to="backup", auth_from="ssh", via="laptop", into="out")
+
     async def test_cp_can_request_permission_via_a_return_connection(self) -> None:
         await self.client.cp("source", to="backup", via="@laptop", into="out")
         argv = self.argv()

--- a/sdk/python/tests/test_native.py
+++ b/sdk/python/tests/test_native.py
@@ -518,6 +518,13 @@ class NativeClientTests(unittest.TestCase):
         self.assertEqual(operation.disposition, syq.Disposition.SUCCEEDED)
         self.assertEqual(operation.kind, syq.EntryKind.FILE)
 
+    def test_cp_selects_an_authorizer_and_rejects_conflicting_selectors(self) -> None:
+        self.client.cp("source", to="backup", auth_from="@laptop", into="out")
+        argv = self.argv()
+        self.assertEqual(argv[argv.index("--auth-from") + 1], "@laptop")
+        with self.assertRaises(syq.SyqInvocationError):
+            self.client.cp("source", to="backup", auth_from="ssh", via="laptop", into="out")
+
     def test_cp_can_request_permission_via_a_return_connection(self) -> None:
         self.client.cp("source", to="backup", via="@laptop", into="out")
         argv = self.argv()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -888,7 +888,7 @@ struct NativeRemoteArgs {
     #[arg(long, value_name = "auto|ssh|@NAME", value_parser = parse_auth_from, conflicts_with = "via")]
     auth_from: Option<AuthFrom>,
     /// Alias for --auth-from @NAME; every bare value remains a receiving name
-    #[arg(long, value_name = "@NAME", help_heading = REMOTE_TO_REMOTE_HEADING)]
+    #[arg(long, value_name = "@NAME")]
     via: Option<String>,
     /// Choose the endpoint that runs the coordinator
     #[arg(long, value_enum, default_value_t = CoordinateAt::Auto, help_heading = REMOTE_TO_REMOTE_HEADING)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,7 +68,7 @@ pub struct Args {
     #[arg(skip)]
     pub(crate) named_receipt: Option<std::sync::Arc<crate::destination::NamedReceipt>>,
     #[arg(skip)]
-    pub(crate) via: Option<String>,
+    pub(crate) auth_from: AuthFrom,
     /// Which public command produced this execution request.
     #[arg(skip)]
     pub interface: Interface,
@@ -857,10 +857,38 @@ struct NativeRemoteHelperArgs {
     no_bootstrap: bool,
 }
 
+/// A process-local choice of authority; no credentials or durable preferences.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) enum AuthFrom {
+    #[default]
+    Auto,
+    Ssh,
+    Return(String),
+}
+
+impl AuthFrom {
+    fn receiving(value: &str) -> Result<Self> {
+        let name = value.strip_prefix('@').unwrap_or(value);
+        crate::destination::validate_name(name)?;
+        Ok(Self::Return(name.to_owned()))
+    }
+}
+
+fn parse_auth_from(value: &str) -> Result<AuthFrom> {
+    match value {
+        "auto" => Ok(AuthFrom::Auto),
+        "ssh" => Ok(AuthFrom::Ssh),
+        _ => AuthFrom::receiving(value),
+    }
+}
+
 #[derive(clap::Args, Debug, Default)]
 struct NativeRemoteArgs {
-    /// Ask a receiving machine to authorize a copy to another SSH host; file data goes directly to that host
-    #[arg(long, value_name = "@NAME")]
+    /// Authorize with a live receiving machine, or use SSH from this machine (default: auto)
+    #[arg(long, value_name = "auto|ssh|@NAME", value_parser = parse_auth_from, conflicts_with = "via")]
+    auth_from: Option<AuthFrom>,
+    /// Alias for --auth-from @NAME; every bare value remains a receiving name
+    #[arg(long, value_name = "@NAME", help_heading = REMOTE_TO_REMOTE_HEADING)]
     via: Option<String>,
     /// Choose the endpoint that runs the coordinator
     #[arg(long, value_enum, default_value_t = CoordinateAt::Auto, help_heading = REMOTE_TO_REMOTE_HEADING)]
@@ -1798,7 +1826,10 @@ fn apply_native_remote(args: &mut Args, remote: NativeRemoteArgs) -> Result<()> 
             "--detach cannot be combined with --peer-auth broker or full-agent; a brokered or forwarded agent exists only while syq stays attached"
         );
     }
-    args.via = remote.via;
+    args.auth_from = match remote.via {
+        Some(name) => AuthFrom::receiving(&name)?,
+        None => remote.auth_from.unwrap_or_default(),
+    };
     args.coordinate_at = remote.coordinate_at;
     args.rsh = remote.rsh;
     args.syq_path = remote.helper.syq_path;

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -856,6 +856,7 @@ enum EndpointSyntax {
 }
 
 enum ValueCompletion {
+    AuthFrom,
     ReturnName,
     NamedOrSshDestination,
     Endpoint(EndpointSyntax),
@@ -1214,6 +1215,7 @@ fn value_completion(
             b"--from" => Some(ValueCompletion::Endpoint(EndpointSyntax::Native)),
             b"--to" => Some(ValueCompletion::NamedOrSshDestination),
             b"--via" => Some(ValueCompletion::ReturnName),
+            b"--auth-from" => Some(ValueCompletion::AuthFrom),
             b"-C" | b"--cwd" | b"--root" => Some(ValueCompletion::SourcePath { apply_base: false }),
             b"--src" | b"--srcs-in" | b"--src-file" | b"--src-dir" | b"--srcs" | b"--src-files"
             | b"--src-dirs" => Some(ValueCompletion::SourcePath { apply_base: true }),
@@ -1308,6 +1310,15 @@ fn complete_value(
     kind: ValueCompletion,
 ) -> Result<Vec<Candidate>> {
     match kind {
+        ValueCompletion::AuthFrom => Ok([b"auto".to_vec(), b"ssh".to_vec()]
+            .into_iter()
+            .filter(|value| value.starts_with(current))
+            .map(Candidate::text)
+            .chain(
+                return_name_candidates(current)
+                    .filter(|candidate| candidate.value != b"auto" && candidate.value != b"ssh"),
+            )
+            .collect()),
         ValueCompletion::ReturnName => Ok(return_name_candidates(current).collect()),
         ValueCompletion::NamedOrSshDestination => {
             let mut candidates = endpoint_candidates(
@@ -1385,9 +1396,6 @@ fn complete_path_for(
     if source {
         return complete_source_path(command, args, current, true);
     }
-    if find_option_value(args, b"--via").is_some() {
-        return Ok(Vec::new());
-    }
     let Some(endpoint_text) = find_option_value(args, b"--to") else {
         return Ok(local_path_candidates_at(
             current,
@@ -1404,8 +1412,19 @@ fn complete_path_for(
             path_policy(command, args, false),
         ));
     };
+    let authorizer = find_option_value(args, b"--auth-from");
+    if find_option_value(args, b"--via").is_some()
+        || (authorizer != Some("ssh")
+            && (authorizer.is_some_and(|value| value != "auto")
+                || (command == "cp" && !crate::destination::registered_names().is_empty())))
+    {
+        // Completion must never request copy approval or inspect hostB through
+        // an automatically selected authorizer. Explicit SSH keeps normal completion.
+        return Ok(Vec::new());
+    }
     if endpoint.host.starts_with('@')
-        || crate::destination::registered_names().contains(&endpoint.host)
+        || (authorizer != Some("ssh")
+            && crate::destination::registered_names().contains(&endpoint.host))
     {
         return Ok(Vec::new());
     }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2822,7 +2822,7 @@ impl Endpoint {
                             if spec.restricted_grant.is_some() {
                                 return Err(e).with_context(|| {
                                     let reason = if spec.forwarded.is_some() {
-                                        "TCP data connection failed; --via requires direct encrypted TCP and cannot fall back to SSH data"
+                                        "TCP data connection failed; return authorization requires direct encrypted TCP and cannot fall back to SSH data"
                                     } else {
                                         "signed receiver TCP data connection failed; its one-time SSH grant cannot be replayed as a fallback"
                                     };
@@ -2858,7 +2858,7 @@ impl Endpoint {
                     && !crate::destination::is_named(&spec.restricted_grant)
                 {
                     let reason = if spec.forwarded.is_some() {
-                        "--via has no authorized encrypted TCP data connection"
+                        "return authorization has no authorized encrypted TCP data connection"
                     } else {
                         "signed receiver has no authorized TCP data connection"
                     };

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -461,8 +461,30 @@ pub(crate) fn is_named(grant: &Option<String>) -> bool {
 }
 
 pub(crate) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
-    if args.via.is_some() {
-        return forward::prepare(args);
+    match &args.auth_from {
+        crate::cli::AuthFrom::Return(_) => return forward::prepare(args),
+        crate::cli::AuthFrom::Ssh => {
+            let (destination, sources) = args
+                .locations
+                .split_last()
+                .context("copy endpoints missing")?;
+            if args.interface != crate::cli::Interface::NativeCp
+                || sources.iter().any(|source| source.is_remote())
+                || !destination.is_remote()
+                || destination
+                    .host
+                    .as_deref()
+                    .is_some_and(|host| host.starts_with('@'))
+            {
+                bail!(
+                    "--auth-from ssh requires local sources and an ordinary SSH --to destination"
+                );
+            }
+            // This explicit choice also disambiguates an SSH host whose name
+            // happens to match a receiving machine's advertisement.
+            return Ok(());
+        }
+        crate::cli::AuthFrom::Auto => {}
     }
     let Some(destination) = args.locations.last() else {
         return Ok(());
@@ -485,11 +507,11 @@ pub(crate) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
                 .any(|l| l.is_remote())
             || !registered_names().contains(&name)
         {
-            return Ok(());
+            return forward::prepare(args);
         }
         let registration = load_registration(&name)?;
         if exchange(&registration, Message::Ping, Duration::from_secs(2)).is_err() {
-            return Ok(());
+            return forward::prepare(args);
         }
         registration
     };
@@ -877,7 +899,7 @@ const RETURN_SSH_OPTIONS: &[&str] = &[
 fn ssh_command(endpoint: &crate::persistence::EndpointRecord) -> Command {
     let mut cmd = Command::new("ssh");
     // This connection installs a remote forward and follows the user's host-key
-    // policy. The outbound --via connection adds stricter options of its own.
+    // policy. The outbound return-authorized connection adds stricter options of its own.
     cmd.args(RETURN_SSH_OPTIONS)
         .args(["-o", "ControlMaster=no", "-o", "ControlPath=none"]);
     if let Some(user) = &endpoint.user {

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -36,16 +36,13 @@ fn target_endpoint(target: &str) -> Result<crate::cli::NativeEndpoint> {
                     .all(|b| b.is_ascii_alphanumeric() || b"._-".contains(&b))
         })
     {
-        bail!("--via requires an ordinary SSH destination with a plain host and login name");
+        bail!("--auth-from requires an ordinary SSH destination with a plain host and login name");
     }
     Ok(endpoint)
 }
 
-pub(super) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
+fn eligible_target(args: &crate::cli::Args) -> Result<String> {
     use crate::cli::{CoordinateAt, Interface, PeerAuth};
-    let name = args.via.as_deref().unwrap();
-    let name = name.strip_prefix('@').unwrap_or(name).to_owned();
-    validate_name(&name)?;
     let (destination, sources) = args
         .locations
         .split_last()
@@ -54,7 +51,7 @@ pub(super) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
         || sources.iter().any(|s| s.is_remote())
         || !destination.is_remote()
     {
-        bail!("--via requires syq cp with local sources and an SSH --to destination");
+        bail!("--auth-from requires syq cp with local sources and an SSH --to destination");
     }
     if args.rsh.is_some()
         || args.syq_path.is_some()
@@ -67,14 +64,48 @@ pub(super) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
         || args.peer_auth != PeerAuth::Restricted
         || args.coordinate_at != CoordinateAt::Auto
     {
-        bail!("--via owns its SSH connection and requires encrypted direct TCP; it cannot be combined with --rsh, --syq-path, --no-bootstrap, --pscope, --detach, --no-tcp, --tcp-plain, --peer-auth, or --coordinate-at");
+        bail!("return authorization owns its SSH connection and requires encrypted direct TCP; it cannot be combined with --rsh, --syq-path, --no-bootstrap, --pscope, --detach, --no-tcp, --tcp-plain, --peer-auth, or --coordinate-at");
     }
     if args.connections_opt.is_some() && args.connections > 32 {
-        bail!("--via supports at most 32 workers per copy");
+        bail!("return authorization supports at most 32 workers per copy");
     }
+    if args.owner || args.group || args.devices || args.inplace {
+        bail!("return authorization does not accept ownership, special-file preservation, or --inplace");
+    }
+    crate::restricted::validate_restricted_args(args)?;
     let target = crate::remote_to_remote::endpoint_arg(destination, None, None);
     target_endpoint(&target)?;
-    let registration = load_registration(&name)?;
+    Ok(target)
+}
+
+pub(super) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
+    let explicit = match &args.auth_from {
+        crate::cli::AuthFrom::Return(name) => Some(name.clone()),
+        _ => None,
+    };
+    let target = match eligible_target(args) {
+        Ok(target) => target,
+        Err(_) if explicit.is_none() => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if explicit.is_none() && args.locations.last().unwrap().path.starts_with(b"~//") {
+        // Ordinary SSH interprets ~// as absolute. Do not change the copy's
+        // destination just because a return authorizer became available.
+        return Ok(());
+    }
+    let (name, registration) = if let Some(name) = explicit {
+        let registration = load_registration(&name)?;
+        (name, registration)
+    } else {
+        let Some(found) = registered_names().into_iter().find_map(|name| {
+            let registration = load_registration(&name).ok()?;
+            let (_, reply) = exchange(&registration, Message::Ping, Duration::from_secs(2)).ok()?;
+            matches!(reply, Reply::Ready).then_some((name, registration))
+        }) else {
+            return Ok(());
+        };
+        found
+    };
     let (secret, public) = crate::receipt::generate_recipient()?;
     let policy = crate::receipt::ReceiptPolicy {
         required: true,
@@ -105,6 +136,7 @@ pub(super) fn prepare(args: &mut crate::cli::Args) -> Result<()> {
     stream.set_read_timeout(None)?;
     stream.set_write_timeout(None)?;
     args.locations.last_mut().unwrap().path = approved.destination.clone();
+    args.auth_from = crate::cli::AuthFrom::Return(name);
     // The actual authority never leaves the destination helper. This internal
     // marker makes the engine require TCP and suppress ordinary SSH fallback.
     args.restricted_grant = Some("return-control-v1".into());

--- a/src/help.rs
+++ b/src/help.rs
@@ -88,6 +88,7 @@ pub(crate) fn filesystem(command: Command) -> Command {
                     | "from"
                     | "cwd"
                     | "to"
+                    | "auth_from"
                     | "into"
                     | "as"
                     | "dry_run"
@@ -114,8 +115,10 @@ pub(crate) fn filesystem(command: Command) -> Command {
             }
             "connections" | "connections_opt" | "block_size" | "bwlimit" => "Performance",
             "tuning_options" => "Benchmark tuning",
-            "rsh" | "syq_path" | "no_bootstrap" | "no_tcp" | "tcp_plain" | "tcp_ports"
-            | "tcp_congestion" | "pscope" | "compress" | "no_compress" => "SSH and transport",
+            "auth_from" | "via" | "rsh" | "syq_path" | "no_bootstrap" | "no_tcp" | "tcp_plain"
+            | "tcp_ports" | "tcp_congestion" | "pscope" | "compress" | "no_compress" => {
+                "SSH and transport"
+            }
             "coordinate_at"
             | "detach"
             | "peer_auth"

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -3772,7 +3772,7 @@ fn root_existence_for(existence: Existence) -> RootExistence {
     }
 }
 
-fn validate_restricted_args(args: &Args) -> Result<()> {
+pub(crate) fn validate_restricted_args(args: &Args) -> Result<()> {
     if args.no_tcp || args.tcp_plain {
         bail!("command-restricted transfers require encrypted TCP data connections");
     }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -201,7 +201,10 @@ pub fn endpoint(loc: &Location, args: &Args) -> Result<Endpoint> {
                 tcp: Default::default(),
                 diagnostics: Default::default(),
                 primed_control: Default::default(),
-                forwarded: args.via.as_ref().and(args.named_receipt.clone()),
+                forwarded: args
+                    .named_receipt
+                    .clone()
+                    .filter(|_| matches!(args.auth_from, crate::cli::AuthFrom::Return(_))),
                 read_ahead: args.tuning_options.unwrap_or_default().pipeline_depth(),
             })
         }
@@ -1387,7 +1390,7 @@ fn handle_tcp_setup_error(
         progress.stop();
         return Err(error).with_context(|| {
             let reason = if spec.forwarded.is_some() {
-                "--via requires direct encrypted TCP data connections"
+                "return authorization requires direct encrypted TCP data connections"
             } else {
                 "a signed receiver uses its one SSH authorization for the control connection, so encrypted TCP data connections are required"
             };

--- a/tests/fixtures/copy-via-v0.4.0.json
+++ b/tests/fixtures/copy-via-v0.4.0.json
@@ -1,0 +1,18 @@
+{
+  "producer": "v0.4.0 SDK at f4aee99684573bd4ebb0059fc57c2d44275191fc",
+  "kwargs": {
+    "to": "backup",
+    "via": "ssh",
+    "into": "out"
+  },
+  "argv": [
+    "cp",
+    "source",
+    "--to",
+    "backup",
+    "--into",
+    "out",
+    "--via",
+    "ssh"
+  ]
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -17946,34 +17946,36 @@ fn return_via_completes_bare_and_explicit_names_without_contacting_hosts() {
         b"#!/bin/sh\n: > \"$HOME/ssh-used\"\nexit 99\n",
     );
     fs::set_permissions(t.path("bin/ssh"), fs::Permissions::from_mode(0o755)).unwrap();
-    for (prefix, expected) in [
-        ("lap", b"laptop\0".as_slice()),
-        ("@lap", b"@laptop\0"),
-        ("absent", b""),
-    ] {
-        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
-            .args([
-                "completion",
-                "__complete",
-                "fish",
-                "6",
-                "--",
-                "syq",
-                "cp",
-                "source",
-                "--to",
-                "backup",
-                "--via",
-                prefix,
-            ])
-            .env("HOME", t.path(""))
-            .env("PATH", t.path("bin"))
-            .env("SYQ_NO_UPDATE_CHECK", "1")
-            .current_dir(t.path(""))
-            .output()
-            .unwrap();
-        assert_output_ok(&output);
-        assert_eq!(output.stdout, expected, "{prefix}");
+    for option in ["--via", "--auth-from"] {
+        for (prefix, expected) in [
+            ("lap", b"laptop\0".as_slice()),
+            ("@lap", b"@laptop\0"),
+            ("absent", b""),
+        ] {
+            let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+                .args([
+                    "completion",
+                    "__complete",
+                    "fish",
+                    "6",
+                    "--",
+                    "syq",
+                    "cp",
+                    "source",
+                    "--to",
+                    "backup",
+                    option,
+                    prefix,
+                ])
+                .env("HOME", t.path(""))
+                .env("PATH", t.path("bin"))
+                .env("SYQ_NO_UPDATE_CHECK", "1")
+                .current_dir(t.path(""))
+                .output()
+                .unwrap();
+            assert_output_ok(&output);
+            assert_eq!(output.stdout, expected, "{prefix}");
+        }
     }
     assert!(!t.path("ssh-used").exists());
 }
@@ -17987,34 +17989,36 @@ fn return_via_rejects_unsupported_routes_and_never_falls_back_to_ssh() {
         b"#!/bin/sh\ntouch \"$HOME/ssh-used\"\nexit 99\n",
     );
     fs::set_permissions(t.path("bin/ssh"), fs::Permissions::from_mode(0o755)).unwrap();
-    for extra in [
-        vec![],
-        vec!["--no-tcp"],
-        vec!["--tcp-plain"],
-        vec!["--detach"],
-        vec!["--rsh", "ssh"],
-        vec!["--syq-path", "/opt/syq"],
-        vec!["--no-bootstrap"],
-        vec!["--coordinate-at", "dst"],
-        vec!["--peer-auth", "full-agent"],
-    ] {
-        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
-            .args(["cp", "source", "--to", "backup", "--via", "@laptop"])
-            .args(extra)
-            .current_dir(t.path(""))
-            .env("HOME", t.path(""))
-            .env("XDG_CONFIG_HOME", t.path("config"))
-            .env("XDG_RUNTIME_DIR", t.path("runtime"))
-            .env("PATH", t.path("bin"))
-            .env("SYQ_NO_UPDATE_CHECK", "1")
-            .output()
-            .unwrap();
-        assert!(!output.status.success(), "{:?}", output);
-        assert!(
-            !t.path("ssh-used").exists(),
-            "--via attempted ordinary SSH: {:?}",
-            output
-        );
+    for option in ["--via", "--auth-from"] {
+        for extra in [
+            vec![],
+            vec!["--no-tcp"],
+            vec!["--tcp-plain"],
+            vec!["--detach"],
+            vec!["--rsh", "ssh"],
+            vec!["--syq-path", "/opt/syq"],
+            vec!["--no-bootstrap"],
+            vec!["--coordinate-at", "dst"],
+            vec!["--peer-auth", "full-agent"],
+        ] {
+            let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+                .args(["cp", "source", "--to", "backup", option, "@laptop"])
+                .args(extra)
+                .current_dir(t.path(""))
+                .env("HOME", t.path(""))
+                .env("XDG_CONFIG_HOME", t.path("config"))
+                .env("XDG_RUNTIME_DIR", t.path("runtime"))
+                .env("PATH", t.path("bin"))
+                .env("SYQ_NO_UPDATE_CHECK", "1")
+                .output()
+                .unwrap();
+            assert!(!output.status.success(), "{:?}", output);
+            assert!(
+                !t.path("ssh-used").exists(),
+                "--via attempted ordinary SSH: {:?}",
+                output
+            );
+        }
     }
     assert_eq!(fs::read(t.path("source")).unwrap(), b"payload");
 }
@@ -18040,4 +18044,226 @@ fn remote_copy_addition_preserves_approval_preferences_from_f752ee8() {
     let previous: serde_json::Value = serde_json::from_slice(old).unwrap();
     assert_eq!(status["settings"], previous);
     assert_eq!(fs::read(path).unwrap(), old);
+}
+
+#[test]
+fn automatic_authorization_selects_live_names_and_stops_after_a_refusal() {
+    use std::os::unix::net::UnixListener;
+    use std::time::{Duration, Instant};
+    let t = Tmp::new();
+    write(&t.path("source"), b"payload");
+    write(
+        &t.path("bin/ssh"),
+        b"#!/bin/sh\n: > \"$HOME/ssh-used\"\nexit 55\n",
+    );
+    fs::set_permissions(t.path("bin/ssh"), fs::Permissions::from_mode(0o700)).unwrap();
+    let mut paths = vec![t.path("bin")];
+    paths.extend(std::env::split_paths(&std::env::var_os("PATH").unwrap()));
+    let paths = std::env::join_paths(paths).unwrap();
+    let run = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(args)
+            .env("HOME", t.path(""))
+            .env("XDG_CONFIG_HOME", t.path("config"))
+            .env("XDG_RUNTIME_DIR", t.path("runtime"))
+            .env("PATH", &paths)
+            .env("SYQ_NO_UPDATE_CHECK", "1")
+            .current_dir(t.path(""))
+            .output()
+            .unwrap()
+    };
+    let identity = String::from_utf8(run(&["--build-identity"]).stdout).unwrap();
+    let registry = t.path(".syq-destinations-v2");
+    fs::create_dir(&registry).unwrap();
+    fs::set_permissions(&registry, fs::Permissions::from_mode(0o700)).unwrap();
+    let socket_path = t.path("return.sock");
+    for name in ["a-offline", "b-old-build", "laptop", "ssh", "z-other"] {
+        let registration = serde_json::json!({
+            "version": 2,
+            "identity": if name == "b-old-build" { "another-build" } else { identity.trim() },
+            "socket": if name == "a-offline" { t.path("absent.sock") } else { socket_path.clone() },
+            "secret": name,
+        });
+        let file = registry.join(format!("{name}.json"));
+        write(&file, &serde_json::to_vec(&registration).unwrap());
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let responder = std::thread::spawn(move || {
+        let mut messages = Vec::new();
+        for _ in 0..4 {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            let mut progress = Instant::now() + Duration::from_secs(5);
+            let mut socket = loop {
+                match listener.accept() {
+                    Ok((socket, _)) => break socket,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        assert!(
+                            Instant::now() < deadline,
+                            "authorizer expected another request; saw {messages:?}"
+                        );
+                        if Instant::now() >= progress {
+                            eprintln!("Waiting for authorization request; saw {messages:?}");
+                            progress += Duration::from_secs(5);
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("{error}"),
+                }
+            };
+            socket
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut length = [0; 4];
+            socket.read_exact(&mut length).unwrap();
+            let mut bytes = vec![0; u32::from_be_bytes(length) as usize];
+            socket.read_exact(&mut bytes).unwrap();
+            let envelope: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            let response = if envelope["message"] == "Ping" {
+                serde_json::json!("Ready")
+            } else {
+                assert!(envelope["message"].get("Forward").is_some(), "{envelope}");
+                serde_json::json!({"Error": "copy denied by fixture"})
+            };
+            messages.push(envelope);
+            let bytes = serde_json::to_vec(&response).unwrap();
+            socket
+                .write_all(&(bytes.len() as u32).to_be_bytes())
+                .unwrap();
+            socket.write_all(&bytes).unwrap();
+        }
+        messages
+    });
+    let refused = run(&[
+        "cp",
+        "source",
+        "--to",
+        "backup",
+        "--results",
+        "result.ndjson",
+    ]);
+    assert!(
+        stderr_of(&refused).contains("copy denied by fixture"),
+        "{}",
+        stderr_of(&refused)
+    );
+    assert!(!refused.status.success());
+    assert!(!t.path("ssh-used").exists());
+    let records: Vec<serde_json::Value> = fs::read_to_string(t.path("result.ndjson"))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(records.last().unwrap()["status"], "failed");
+
+    // Unsupported options and explicit SSH never ask a receiving machine.
+    for extra in [
+        vec!["--auth-from", "ssh"],
+        vec!["--no-tcp"],
+        vec!["--update"],
+        vec!["--preserve", "ownership"],
+        vec!["--inplace"],
+        vec!["--min-size", "1"],
+        vec!["--prune", "--into", "out"],
+        vec!["--into", "~//archive"],
+    ] {
+        let mut args = vec!["cp", "source", "--to", "backup"];
+        args.extend(extra);
+        let output = run(&args);
+        assert!(!output.status.success());
+        assert!(
+            t.path("ssh-used").exists(),
+            "{args:?}: {}",
+            stderr_of(&output)
+        );
+        fs::remove_file(t.path("ssh-used")).unwrap();
+    }
+    let selected = run(&["cp", "source", "--to", "backup", "--auth-from", "@z-other"]);
+    assert!(stderr_of(&selected).contains("copy denied by fixture"));
+    assert!(!t.path("ssh-used").exists());
+
+    // Captured from the unchanged released v0.4.0 SDK, not this CLI/SDK writer.
+    let old: serde_json::Value =
+        serde_json::from_str(include_str!("fixtures/copy-via-v0.4.0.json")).unwrap();
+    let argv: Vec<_> = old["argv"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|arg| arg.as_str().unwrap())
+        .collect();
+    let legacy = run(&argv);
+    assert!(
+        stderr_of(&legacy).contains("copy denied by fixture"),
+        "{}",
+        stderr_of(&legacy)
+    );
+    assert!(!t.path("ssh-used").exists());
+    let messages = responder.join().unwrap();
+    assert_eq!(messages[0]["secret"], "laptop");
+    assert_eq!(messages[0]["message"], "Ping");
+    assert_eq!(messages[1]["secret"], "laptop");
+    assert_eq!(messages[2]["secret"], "z-other");
+    assert_eq!(messages[3]["secret"], "ssh");
+    // The registry remains, but every socket is now unavailable. Discovery
+    // must allow ordinary SSH instead of treating stale names as reservations.
+    let offline = run(&["cp", "source", "--to", "backup"]);
+    assert!(!offline.status.success());
+    assert!(t.path("ssh-used").exists(), "{}", stderr_of(&offline));
+}
+
+#[test]
+fn automatic_authorization_completion_keeps_local_paths_and_never_prompts() {
+    let t = Tmp::new();
+    write(&t.path("local-folder/file"), b"payload");
+    for name in ["laptop", "ssh"] {
+        write(
+            &t.path(&format!("home/.syq-destinations-v2/{name}.json")),
+            b"{}",
+        );
+    }
+    fs::set_permissions(
+        t.path("home/.syq-destinations-v2"),
+        fs::Permissions::from_mode(0o700),
+    )
+    .unwrap();
+    assert_completion_candidates(&t, &["syq", "cp", "source", "--auth-f"], &["--auth-from"]);
+    assert_completion_candidates(&t, &["syq", "cp", "source", "--auth-from", "ss"], &["ssh"]);
+    assert_completion_candidates(
+        &t,
+        &["syq", "cp", "source", "--auth-from", "@ss"],
+        &["@ssh"],
+    );
+    assert_completion_candidates(&t, &["syq", "cp", "source", "--auth-from", "au"], &["auto"]);
+    assert_completion_candidates(
+        &t,
+        &["syq", "cp", "source", "--into", "local-f"],
+        &["local-folder/"],
+    );
+    write(
+        &t.path("bin/ssh"),
+        b"#!/bin/sh\n: > \"$HOME/ssh-used\"\nexit 55\n",
+    );
+    fs::set_permissions(t.path("bin/ssh"), fs::Permissions::from_mode(0o700)).unwrap();
+    for selector in [
+        vec![],
+        vec!["--auth-from", "@laptop"],
+        vec!["--auth-from", "auto"],
+        vec!["--via", "laptop"],
+    ] {
+        let mut words = vec!["syq", "cp", "source", "--to", "backup"];
+        words.extend(selector);
+        words.extend(["--into", "anything"]);
+        let index = (words.len() - 1).to_string();
+        let mut args = vec!["__complete", "fish", &index, "--"];
+        args.extend(words);
+        let output = completion_command(&t, &args)
+            .current_dir(t.path(""))
+            .env("PATH", t.path("bin"))
+            .output()
+            .unwrap();
+        assert_output_ok(&output);
+        assert!(output.stdout.is_empty(), "{output:?}");
+        assert!(!t.path("home/ssh-used").exists());
+    }
 }

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -110,8 +110,11 @@ python3 tests/real-ssh/test-completion-display.py --syq target/debug/syq
 
 The shell dependencies are installed only in the test image.
 
-The source-shell remote-copy checks use `--via @laptop` without a source key or
-agent. They cover local approval despite automatic local receiving, denial,
+The source-shell remote-copy checks discover the authorizer automatically
+without a source key or agent. Explicit `--auth-from @laptop` and the released
+`--via @laptop` spelling exercise the same route; `--auth-from ssh` fails without
+those source credentials and creates no approval request. The automatic cached
+helper case still needs just one destination SSH connection. The checks cover local approval despite automatic local receiving, denial,
 direct TCP, cached and missing helper startup, a second approval during slow
 SSH setup, preview/verification, protected destination authority files,
 unreachable data ports, and revocation followed by an approved retry.

--- a/tests/real-ssh/test-forward-copy.py
+++ b/tests/real-ssh/test-forward-copy.py
@@ -20,9 +20,9 @@ def remote(command, *, success=True):
 
 
 def copy(path, *, allow=True, success=True, extra=(), cancel=False,
-         source="/tmp/syq-real-ssh/return-source/subdir/chunks.bin", prefix=None, after_approval=None):
+         source="/tmp/syq-real-ssh/return-source/subdir/chunks.bin", prefix=None, after_approval=None, auth=()):
     argv = ["syq", "cp", "-vv", source, "--to", "destination",
-            "--via", "@laptop", "--as", path, "--connections", "2", *extra]
+            *auth, "--as", path, "--connections", "2", *extra]
     command = "test -z \"${SSH_AUTH_SOCK:-}\" && test ! -e ~/.ssh/id_ed25519 && exec timeout 75 " + shlex.join(argv)
     with tempfile.TemporaryFile() as output:
         process = subprocess.Popen(["ssh", "source", command], stdout=output, stderr=output, start_new_session=True)
@@ -85,10 +85,15 @@ def copy(path, *, allow=True, success=True, extra=(), cancel=False,
                     process.wait(timeout=3)
 
 
-print("case: source-shell remote copy requires approval even with automatic local receiving", flush=True)
+print("case: automatic authorization requires approval even with automatic local receiving", flush=True)
 run("syq", "recv", "on", "--approve", "always", "--notify", "off")
 run("syq", "recv", "wait", "source", "--timeout", "30")
 remote("mkdir -p /tmp/syq-real-ssh/forward")
+print("case: explicit SSH fails without source credentials and never requests approval", flush=True)
+run("ssh", "source", "timeout 15 syq cp /tmp/syq-real-ssh/return-source/subdir/chunks.bin "
+    "--to destination --as /tmp/syq-real-ssh/forward/direct-ssh --auth-from ssh", success=False)
+assert json.loads(run("syq", "recv", "pending", "--json")) == []
+remote("test ! -e /tmp/syq-real-ssh/forward/direct-ssh")
 copy("/tmp/syq-real-ssh/forward/denied", allow=False, success=False)
 remote("test ! -e /tmp/syq-real-ssh/forward/denied")
 
@@ -104,6 +109,11 @@ copy("/tmp/syq-real-ssh/forward/approved", extra=("--stats",))
 assert destination_connections() - before == 1, "a cached helper must need only the copy's SSH connection"
 expected = run("ssh", "source", "sha256sum /tmp/syq-real-ssh/return-source/subdir/chunks.bin").split()[0]
 assert remote("sha256sum /tmp/syq-real-ssh/forward/approved").split()[0] == expected
+
+print("case: explicit authorizer and released --via spelling use the same restricted route", flush=True)
+for option, name in [("--auth-from", "selected"), ("--via", "legacy")]:
+    copy("/tmp/syq-real-ssh/forward/" + name, auth=(option, "@laptop"))
+    assert remote("sha256sum /tmp/syq-real-ssh/forward/" + name).split()[0] == expected
 
 print("case: a missing helper is installed once after its launcher reports the cache miss", flush=True)
 helpers = remote('find "$HOME/.cache/syq/helpers" -type f -name syq').splitlines()


### PR DESCRIPTION
A source server can now run `syq cp results --to hostB` and use a live receiving machine's SSH access without supplying `--via`. For supported copies, syq checks receiving names alphabetically and uses the first matching build that answers its readiness probe. Otherwise it uses ordinary SSH. Selection happens before requesting approval or starting destination work; a refusal or any failure after submitting the copy request ends the attempt.

`--auth-from @laptop` selects an authorizer, `--auth-from ssh` uses the source's SSH access, and `--auth-from auto` is the default. The released `--via NAME` spelling and Python `via=` keyword remain supported, including bare receiving names `ssh` and `auto`. Both authorization options appear under “SSH and transport” in full copy help; `--auth-from` also appears in short help to expose the SSH override. Python's sync and async APIs also expose `auth_from=`. Completion lists names locally and does not ask for approval or suppress local destination paths.

Automatic selection uses the existing restricted receiver, encrypted direct TCP workers, receipt checks, approval policy and cancellation. Unsupported return options stay on ordinary SSH. The unusual `~//archive` spelling also stays on ordinary SSH automatically so discovering an authorizer cannot change its existing absolute-path interpretation. Readiness checks have a two-second budget per name; this version adds no SSH credential probe or persistent cache. The real-SSH cached-helper assertion verifies automatic selection still uses just one destination SSH connection.

Compatibility baseline: released v0.4.0 (`f4aee996`). `tests/fixtures/copy-via-v0.4.0.json` was captured from that unchanged SDK; a CLI integration test verifies its invocation still selects the receiver named `ssh`. Existing receiving-state fixtures remain byte-identical and are covered by the baseline. No wire schema, persistent state, replay protection, signing domain, receipt, resume identity, cache format, release manifest, or documentation URL changes. Existing mixed-build rejection still requires matching live peers. New `auth_from=` calls require the matching new binary; the default managed SDK pin is updated by release preparation.

Validation at `d835364`:

- Rust formatting and all-target/all-feature Clippy passed.
- Full Rust all-target suite: 913 tests passed (477 unit, 420 local integration, 4 help, 5 output, 7 updater); one pre-existing opt-in v0.3.2 binary probe remains ignored.
- Default three-container real-SSH suite passed, including automatic and explicit authorization, refusal, direct TCP, helper recovery, delayed Hello, revocation/resume, benchmark copies and interruption cleanup. All test containers were removed.
- Python sync/async, native API inventory and candidate integration suite: 90 tests passed using pinned uv 0.11.6 and frozen dependencies.
- Documentation links passed; Python SSH fixture syntax compiled.
- Candidate macOS and separate JavaScript/Go suites were not run locally.

Validation of the help presentation update at `81f4ec3`:

- Formatting and all-target/all-feature Clippy passed.
- All 477 unit tests passed when run serially; the existing opt-in old-binary probe remains ignored. The initial parallel run failed `destination::tests::pending_request_disconnect_and_trailing_data_are_detected_without_blocking`; that unchanged test passed in isolation and in the serial run. Its cause was not established in this help-only update.
- All four help tests and both focused completion tests passed. Rendered short/full copy help confirms the grouping and short-help visibility.
- Full all-target, real-SSH and Python suites were not rerun for this presentation-only update; their results above cover `d835364`.

Branch-status output at review handoff:

```text
Worktree: /home/grant/repos/syq/.worktrees/automatic-copy-auth
Branch:   automatic-copy-auth at 81f4ec3 (clean)
Upstream: origin/automatic-copy-auth (ahead 0, behind 0)
Master:   4b34ea9 from refs/heads/master (branch is ahead 2, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      4b34ea9  https://github.com/greaber/syq/actions/runs/34040394469
  rsync-compat.yml success      4b34ea9  https://github.com/greaber/syq/actions/runs/34040394482
  macos.yml        success      4b34ea9  https://github.com/greaber/syq/actions/runs/34040394477

Pull request: #250 https://github.com/greaber/syq/pull/250
  base master, open, review none, merge state clean
  GitHub head 81f4ec3: matches local 81f4ec3
  checks: none registered yet
```
