### PR TITLE
Automatically size interactive benchmarks with syq

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -197,6 +197,14 @@ This observes destination state; it does not attest source completeness.
 Exactly one terminal record, always last when the stream completes. Common
 fields are `status`, `exit_code`, `dry_run`, `errors`, and `elapsed_ms`.
 
+Copy terminals may also include `copying_elapsed_ms`: the wall-clock span from
+first file work to last completed file work across workers, including per-file
+checks, finalization and gaps. Initial setup before file work is excluded;
+planning and connections can overlap this interval. It is not a sum of worker
+times or pure network time. The field is absent when no bytes moved or the
+coordinator does not supply it, including older releases and attested terminals.
+Use `elapsed_ms` for end-to-end throughput comparisons.
+
 Copy totals include transferred/unchanged/excluded files, created directories,
 symlinks and specials, transferred/unchanged bytes, and on pruning runs
 `deletions_planned`, `deletions_completed`, and `deletions_blocked`. A fatal

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,8 +26,8 @@ Compare syq with rsync on your own machines, or with rsync and cp locally:
 curl --proto '=https' --tlsv1.2 -fLsS https://raw.githubusercontent.com/greaber/syq/master/scripts/try-benchmark.sh | bash
 ```
 
-Choose a local or SSH copy, a workload, and a test size. The script uses
-throwaway data and cleans up afterward. No syq-bench install is needed;
+Choose a local or SSH copy and a workload. The script automatically sizes
+throwaway data with syq and cleans up afterward. No syq-bench install is needed;
 if syq is missing, it offers to install it.
 
 <figure class="benchmark-example">
@@ -37,9 +37,9 @@ if syq is missing, it offers to install it.
 <dl class="benchmark-choices">
 <dt>Copy where?</dt><dd>local</dd>
 <dt>Workloads?</dt><dd>both</dd>
-<dt>Size?</dt><dd>quick</dd>
+<dt>Test size</dt><dd>automatic by default</dd>
 </dl>
-<p class="visual-note">One 64 MiB file<br>1,024 files of 8 KiB</p>
+<p class="visual-note">Results pictured: fixed-size sample<br>64 MiB + 1,024 files of 8 KiB</p>
 </section>
 <section aria-label="Example benchmark results">
 <div class="visual-step">2 <span>Compare the results</span></div>
@@ -55,7 +55,7 @@ if syq is missing, it offers to install it.
 <p class="visual-note">✓ Copied contents checked</p>
 </section>
 </div>
-<figcaption>Example from one local run, not a speed promise. Your results will differ.</figcaption>
+<figcaption>Speeds from a fixed-size local sample, not a speed promise. Your results will differ.</figcaption>
 </figure>
 
 For requirements, options and how to read the results, see

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -25,12 +25,13 @@ comparison without installing a benchmark package. After downloading the
 script, you can repeat the same choices explicitly:
 
 ```sh
-bash try-benchmark.sh --yes --mode push --host server --workload both --size medium --rounds 3
+bash try-benchmark.sh --yes --mode push --host server --workload both --rounds 3
 bash try-benchmark.sh --yes --mode local --source-dir /data --dest-dir /mnt/nfs --workload small
 ```
 
 The script needs Bash, rsync, OpenSSL and standard Unix utilities locally;
-terminal runs also use Perl to keep SSH prompts interruptible. Remote tests
+automatic sizing uses Perl with its core JSON::PP module. Terminal runs also
+use Perl to keep SSH prompts interruptible. Remote tests
 need SSH access and rsync on the other machine. Syq prepares a helper matching
 your local build and shows installation progress when one is needed.
 Use an SSH config alias for custom ports or IPv6. `--install` installs syq
@@ -38,9 +39,28 @@ locally if missing; `--help` lists the choices.
 
 Scratch parents must already exist. For SSH tests, `--dest-dir` is the remote
 scratch parent, including when pulling; `--source-dir` is always the local
-scratch parent. Budget roughly twice the selected data size locally and one
-copy remotely. Sizes are quick (64 MiB and 8 MiB), medium (1 GiB and 32 MiB),
-and large (8 GiB and 128 MiB), for the large-file and small-file workloads.
+scratch parent.
+
+By default, the script starts with 64 MiB for the large file and 1,024 files
+of 8 KiB for the small-file workload. It makes verified, unscored syq copies
+and increases each workload until syq's copying interval reaches about five
+seconds. Each increase is between 25% and tenfold, avoiding repeated
+near-identical tests when timings fluctuate. Available space at both ends limits
+growth, with room reserved for the copies and filesystem overhead; if space
+prevents a long enough copy, the script warns and uses the tested size.
+There is no fixed total-data or runtime limit. A slow first copy can take longer
+than five seconds, and generation and verification also take time.
+
+All tools then copy the same dataset into empty destinations. Three rounds mean
+six scored copies per workload over SSH (syq and rsync), or nine locally (also
+cp). Choosing both workloads doubles those counts. A faster cp result does not
+cause further growth.
+
+Automatic sizing requires syq to report `copying_elapsed_ms` in its automation
+results. Older builds can use `--size quick`, `--size medium`, or `--size large`
+for fixed workloads: respectively 64 MiB / 1,024 files, 1 GiB / 4,096 files,
+and 8 GiB / 16,384 files. Small files remain 8 KiB each. These flags also let
+you repeat a fixed-size comparison.
 
 Data comes from a fixed AES-CTR byte stream, making it reproducible and
 hard to compress. Every trial has an empty, pre-created destination; interrupted trials are
@@ -53,11 +73,11 @@ minimum and maximum trial speeds. Higher is faster. It uses
 syq's defaults with permissions preserved, `rsync -rpt`, and local `cp -pR`.
 These copy the same regular files and request permissions and modification
 times; the tools still differ in compression, integrity checks, and filesystem
-optimizations. Syq prints its transfer statistics.
+optimizations.
 
-Generation, a single 14-byte syq setup copy, and POSIX `cksum` comparisons are
-outside the timer. The setup copy prepares the helper and exercises transfer
-setup; it is labeled separately and shows helper installation messages without a throughput result. A failed command or content check stops the comparison.
+Generation, preparation, calibration, and POSIX `cksum` comparisons are
+outside the scored timers. Preparation shows helper installation messages without
+a throughput result. A failed command or content check stops the comparison.
 Caches are not flushed, so this is a cache-friendly test rather than a cold
 disk benchmark. Times include process startup and buffered writes, without
 waiting for durable storage. Small tests can mostly measure startup costs;
@@ -84,7 +104,11 @@ syq cp -vv --stats data --to server --into /backup
 
 `-vv` shows helper selection, reachable addresses, the chosen transport, and
 initial parallelism. `--stats` shows totals, connection count, and TCP
-statistics where available. `SYQ_DEBUG=1` adds engineering timings for a
+statistics where available. It also reports the copying interval when bytes moved:
+the span from first file work to last completed file work across all workers.
+This includes per-file checks, finalization and gaps; it may overlap planning
+and connection setup. It is not pure network time or a separate phase you can
+add to setup time. `SYQ_DEBUG=1` adds engineering timings for a
 detailed investigation.
 
 | Symptom | Try |

--- a/schemas/automation.schema.json
+++ b/schemas/automation.schema.json
@@ -883,6 +883,9 @@
         },
         "receipt_records": {
           "$ref": "#/$defs/u64"
+        },
+        "copying_elapsed_ms": {
+          "$ref": "#/$defs/u64"
         }
       },
       "required": [

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -18,7 +18,7 @@ import unittest
 
 SCRIPT = Path(__file__).resolve().with_name('try-benchmark.sh')
 FAKE_SYQ = r'''#!/usr/bin/env python3
-import os, pathlib, shutil, subprocess, sys, time
+import json, os, pathlib, shutil, subprocess, sys, time
 args=sys.argv[1:]
 if args in (['--version'], ['--build-identity']):
     print('syq test double'); sys.exit(0)
@@ -38,6 +38,11 @@ if mode == 'hang':
     pathlib.Path(os.environ['BENCH_TEST_PID']).write_text(str(child.pid))
     child.wait(); sys.exit(1)
 shutil.copytree(src,dst,dirs_exist_ok=True)
+if '--results' in args:
+    result={'type': 'result', 'status': 'success'}
+    if not os.environ.get('BENCH_TEST_OLD'):
+        result['copying_elapsed_ms']=2500 if os.environ.get('BENCH_TEST_GROW') and len(list(src.iterdir())) == 1024 else 5000
+    pathlib.Path(args[args.index('--results')+1]).write_text(json.dumps(result)+'\n')
 if '--quiet' not in args and src.name == 'probe':
     print('test double: preparing matching remote helper', flush=True)
 if '--quiet' not in args and '--suppress-summary' not in args:
@@ -73,7 +78,7 @@ class BenchmarkTests(unittest.TestCase):
         # missing-install test. All other commands use the host's real tools.
         for name in ['bash', 'rsync', 'openssl', 'dd', 'split', 'cksum', 'cmp',
                      'awk', 'mktemp', 'mkdir', 'rm', 'cat', 'ps', 'sleep', 'sed',
-                     'cp', 'mv', 'python3', 'sh', 'perl']:
+                     'cp', 'mv', 'python3', 'sh', 'perl', 'df']:
             executable = shutil.which(name)
             if executable is None:
                 self.fail(f'Missing test prerequisite: {name}')
@@ -83,13 +88,65 @@ class BenchmarkTests(unittest.TestCase):
     def invoke(self, *args, env=None):
         return subprocess.run(
             ['/bin/bash', str(SCRIPT), '--yes', '--source-dir', str(self.scratch),
-             '--dest-dir', str(self.scratch), '--rounds', '1', '--workload', 'large', *args],
+             '--dest-dir', str(self.scratch), '--rounds', '1', '--workload', 'large', '--size', 'quick', *args],
             env=env or self.env, capture_output=True, text=True, timeout=60,
         )
 
     def assert_clean(self):
         self.assertEqual(self.sentinel.read_text(), 'existing user data')
         self.assertEqual(list(self.scratch.iterdir()), [self.sentinel])
+
+    def test_auto_sizes_with_syq_for_each_direction(self):
+        for mode in ['local', 'push', 'pull']:
+            with self.subTest(mode=mode):
+                result = self.invoke('--mode', mode, '--host', 'test-host',
+                                     '--workload', 'small', '--size', 'auto',
+                                     env=dict(self.env, BENCH_TEST_GROW='1'))
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn('Generating 2048 files', result.stdout)
+                self.assertEqual(result.stdout.count('Verified sizing copy'), 2)
+                self.assertIn('small: 16777216 bytes per trial', result.stdout)
+                self.assertEqual(result.stdout.count('trial 1/1'), 3 if mode == 'local' else 2)
+                self.assert_clean()
+
+    def test_auto_rejects_missing_timing_with_fixed_size_recovery(self):
+        result = self.invoke('--size', 'auto', '--workload', 'small',
+                             env=dict(self.env, BENCH_TEST_OLD='1'))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('--size quick', result.stderr)
+        self.assertNotIn('Results (', result.stdout)
+        self.assert_clean()
+
+    def test_auto_stops_at_available_space(self):
+        (self.bin / 'df').unlink()
+        (self.bin / 'df').write_text('#!/bin/sh\necho "Filesystem 1024-blocks Used Available Capacity Mounted"\necho "test 36409 0 36409 0% /"\n')
+        (self.bin / 'df').chmod(0o755)
+        result = self.invoke('--size', 'auto', '--workload', 'small',
+                             env=dict(self.env, BENCH_TEST_GROW='1'))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn('WARNING: available scratch space', result.stderr)
+        self.assertEqual(result.stdout.count('Verified sizing copy'), 1)
+        self.assert_clean()
+
+    def test_sizing_math_caps_growth_and_handles_timer_resolution(self):
+        definitions = SCRIPT.read_text().removesuffix('main "$@"\n')
+        for current, ms, capacity, expected in [(64, 0, 10000, 640),
+                (64, 2500, 10000, 128), (64, 2500, 100, 100),
+                (64, 4999, 10000, 80), (64, 1, 32, 32)]:
+            result = subprocess.run(['/bin/bash', '-c', definitions +
+                                     '\nnext_amount "$1" "$2" "$3"', 'sizing-test',
+                                     str(current), str(ms), str(capacity)],
+                                    env=self.env, capture_output=True, text=True, timeout=10)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(int(result.stdout), expected)
+
+    def test_auto_corruption_is_not_used_for_sizing(self):
+        result = self.invoke('--size', 'auto', '--workload', 'small',
+                             env=dict(self.env, BENCH_TEST_FAILURE='corrupt'))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('Sizing copy content check failed', result.stderr)
+        self.assertNotIn('Increasing', result.stdout)
+        self.assert_clean()
 
     def test_speed_summary_uses_decimal_bytes_and_mean_trial_speeds(self):
         records = self.root / 'results'
@@ -109,7 +166,7 @@ class BenchmarkTests(unittest.TestCase):
     def test_local_both_and_rotation(self):
         result = self.invoke('--workload', 'both', '--rounds', '3')
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        lines = [line for line in result.stdout.splitlines() if line.startswith('large: ')]
+        lines = [line for line in result.stdout.splitlines() if line.startswith('large: ') and ', trial ' in line]
         self.assertEqual([line.split()[1].rstrip(',') for line in lines],
                          ['syq', 'rsync', 'cp', 'rsync', 'cp', 'syq', 'cp', 'syq', 'rsync'])
         self.assertIn('small cp', result.stdout)
@@ -321,8 +378,8 @@ class BenchmarkTests(unittest.TestCase):
             os.execvpe('/bin/bash', ['/bin/bash', '-c', f'cat {shlex.quote(str(SCRIPT))} | /bin/bash'], dict(self.env, BENCH_TEST_ASK='1'))
         output = b''
         prompts_answered = 0
-        # All five default answers are read from /dev/tty, not the script pipe.
-        os.write(fd, b'\n' * 5)
+        # All four default answers are read from /dev/tty, not the script pipe.
+        os.write(fd, b'\n' * 4)
         deadline = time.monotonic() + 45
         try:
             while time.monotonic() < deadline:

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -173,18 +173,18 @@ make_data() {
 }
 copy_with() {
     local tool=$1 source=$2 destination=$3
-    local command=() syq_options=()
+    local command=() syq_options=(--preserve=permissions)
     # This repository-owned caller suppresses only the tiny copy's summary,
     # keeping bootstrap diagnostics and authentication prompts live. Supported
     # by the released v0.3.2 CLI as well as current builds.
-    [[ ${4:-} != setup ]] || syq_options=(--suppress-summary --no-progress)
-    [[ ${4:-} != calibration ]] || syq_options=(--suppress-summary --results "$local_root/calibration.json")
+    [[ ${4:-} != setup ]] || syq_options=(--preserve=permissions --suppress-summary --no-progress)
+    [[ ${4:-} != calibration ]] || syq_options=(--preserve=permissions --suppress-summary --results "$local_root/calibration.json")
     case $tool in
         syq)
             case $mode in
-                local) command=(syq cp --preserve=permissions --srcs-in "$source" --into-existing "$destination" "${syq_options[@]}") ;;
-                push) command=(syq cp --preserve=permissions --srcs-in "$source" --to "$host" --into-existing "$destination" "${syq_options[@]}") ;;
-                pull) command=(syq cp --preserve=permissions --from "$host" --srcs-in "$source" --into-existing "$destination" "${syq_options[@]}") ;;
+                local) command=(syq cp "${syq_options[@]}" --srcs-in "$source" --into-existing "$destination") ;;
+                push) command=(syq cp "${syq_options[@]}" --srcs-in "$source" --to "$host" --into-existing "$destination") ;;
+                pull) command=(syq cp "${syq_options[@]}" --from "$host" --srcs-in "$source" --into-existing "$destination") ;;
             esac ;;
         rsync)
             case $mode in

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -16,7 +16,9 @@ Without --yes, unanswered choices are prompted through /dev/tty (also with curl 
   --mode local|push|pull    Copy locally, to an SSH host, or from an SSH host
   --host USER@HOST          SSH host or config alias (configure ports in ~/.ssh/config)
   --workload large|small|both
-  --size quick|medium|large Quick: 64 MiB + 1,024 files; medium: 1 GiB + 4,096;
+  --size auto|quick|medium|large
+                           Auto sizes with syq (default). Quick: 64 MiB + 1,024 files;
+                           medium: 1 GiB + 4,096;
                            large: 8 GiB + 16,384. Small files are 8 KiB each.
   --source-dir DIR         Local scratch parent (default: current directory)
   --dest-dir DIR           Destination scratch parent (default: current directory)
@@ -27,8 +29,8 @@ Without --yes, unanswered choices are prompted through /dev/tty (also with curl 
   --yes                    Use defaults for unspecified choices; do not prompt
   --help                   Show this help
 
-Requires Bash, rsync, OpenSSL, and standard Unix utilities locally; terminal runs
-also need Perl (for terminal process-group control). Remote tests
+Requires Bash, rsync, OpenSSL, and standard Unix utilities locally. Automatic
+sizing needs Perl with its core JSON::PP module; terminal runs also need Perl. Remote tests
 also need SSH locally and rsync plus standard utilities on the remote host.
 Only newly created syq-bench.* directories are used. Existing data is not copied.
 HELP
@@ -161,11 +163,12 @@ make_data() {
 }
 copy_with() {
     local tool=$1 source=$2 destination=$3
-    local command=() syq_options=(--stats)
+    local command=() syq_options=()
     # This repository-owned caller suppresses only the tiny copy's summary,
     # keeping bootstrap diagnostics and authentication prompts live. Supported
     # by the released v0.3.2 CLI as well as current builds.
     [[ ${4:-} != setup ]] || syq_options=(--suppress-summary --no-progress)
+    [[ ${4:-} != calibration ]] || syq_options=(--suppress-summary --results "$local_root/calibration.json")
     case $tool in
         syq)
             case $mode in
@@ -194,6 +197,51 @@ timed_copy() {
     copy_with "$@" show
     TIMEFORMAT='%R'
     { time copy_with "$@" 1>&4 2>&5; } 2> "$local_root/time"
+}
+
+# Allow two copies on each filesystem and leave 10% free. For small files,
+# allow extra allocation for metadata. Rechecking with the current source still
+# present is conservative: it may stop growth slightly before the disk limit.
+space_capacity() {
+    local workload=$1 local_free destination_free unit
+    local_free=$(df -Pk "$local_root" | available_kib) || fail 'Cannot determine local free space.'
+    if [[ $mode == local ]]; then
+        destination_free=$(df -Pk "$dest_root" | available_kib) || fail 'Cannot determine destination free space.'
+    else
+        destination_free=$(remote "df -Pk $(quote "$remote_root")" | available_kib) || fail 'Cannot determine remote free space.'
+    fi
+    if [[ $workload == large ]]; then unit=1024; else unit=16; fi
+    awk -v a="$local_free" -v b="$destination_free" -v unit="$unit" \
+        'BEGIN {free=(a < b ? a : b); printf "%.0f\n", int(free * 0.45 / unit)}'
+}
+available_kib() {
+    awk 'NR > 1 && $4 ~ /^[0-9]+$/ {available=$4; found=1}
+         END {if (!found) exit 1; print available}'
+}
+next_amount() {
+    awk -v current="$1" -v ms="$2" -v capacity="$3" 'BEGIN {
+        estimate=current * 5000 / (ms > 0 ? ms : 1);
+        amount=int(estimate); if (amount < estimate) amount++;
+        minimum=int(current * 1.25); if (minimum < current * 1.25) minimum++;
+        if (amount < minimum) amount=minimum;
+        if (amount > current*10) amount=current*10;
+        if (amount > capacity) amount=capacity;
+        printf "%.0f\n", amount;
+    }'
+}
+calibration_interval() {
+    perl -MJSON::PP -e '
+        my $result;
+        while (<>) {
+            my $record=decode_json($_);
+            $result=$record if ($record->{type} // "") eq "result";
+        }
+        die "Missing successful copying timing\n" unless
+            $result && $result->{status} eq "success" &&
+            defined($result->{copying_elapsed_ms}) &&
+            $result->{copying_elapsed_ms} =~ /^\d+$/;
+        print $result->{copying_elapsed_ms}, "\n";
+    ' "$1"
 }
 
 summarize_results() {
@@ -251,7 +299,6 @@ main() {
         if [[ -z $mode ]]; then ask 'Copy where? local / push / pull' local; mode=$REPLY; fi
         if [[ $mode != local && -z $host ]]; then ask 'SSH host or config alias' ''; host=$REPLY; fi
         if [[ -z $workload ]]; then ask 'Workloads? large / small / both' both; workload=$REPLY; fi
-        if [[ -z $size ]]; then ask 'Size? quick (64 MiB + 8 MiB) / medium (1 GiB + 32 MiB) / large (8 GiB + 128 MiB)' quick; size=$REPLY; fi
         if [[ -z $source_dir ]]; then ask 'Local scratch parent' "$PWD"; source_dir=$REPLY; fi
         if [[ -z $dest_dir ]]; then
             if [[ $mode == local ]]; then ask 'Destination scratch parent (can be another disk or NFS mount)' "$source_dir"
@@ -259,14 +306,18 @@ main() {
             dest_dir=$REPLY
         fi
     fi
-    mode=${mode:-local}; workload=${workload:-both}; size=${size:-quick}
+    mode=${mode:-local}; workload=${workload:-both}; size=${size:-auto}
     source_dir=${source_dir:-$PWD}; dest_dir=${dest_dir:-.}
     case $mode in local|push|pull) ;; *) fail 'Mode must be local, push or pull.' ;; esac
     case $workload in large|small|both) ;; *) fail 'Workload must be large, small or both.' ;; esac
-    case $size in quick) large_mib=64; small_files=1024 ;; medium) large_mib=1024; small_files=4096 ;; large) large_mib=8192; small_files=16384 ;; *) fail 'Size must be quick, medium or large.' ;; esac
+    case $size in auto|quick) large_mib=64; small_files=1024 ;; medium) large_mib=1024; small_files=4096 ;; large) large_mib=8192; small_files=16384 ;; *) fail 'Size must be auto, quick, medium or large.' ;; esac
     [[ $rounds =~ ^[1-9]$ ]] || fail 'Rounds must be between 1 and 9.'
     for tool in bash rsync openssl dd split cksum cmp awk mktemp mkdir rm cat ps sleep sed; do need "$tool"; done
     [[ $mode != local ]] || need cp
+    if [[ $size == auto ]]; then
+        need df; need perl
+        perl -MJSON::PP -e 1 || fail 'Automatic sizing needs Perl with JSON::PP.'
+    fi
     if [[ $mode != local ]]; then
         need ssh
         [[ $host =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.@-]*$ ]] || fail 'Use an SSH config alias or USER@HOST; configure ports/IPv6 in ~/.ssh/config.'
@@ -322,19 +373,6 @@ main() {
     [[ $workload == both ]] || workloads=("$workload")
     : > "$local_root/results"
     for case_name in "${workloads[@]}"; do
-        if [[ $case_name == large ]]; then printf 'Generating one %s MiB file...\n' "$large_mib"
-        else printf 'Generating %s files of 8 KiB each...\n' "$small_files"; fi
-        if [[ $case_name == large ]]; then run make_data large "$large_mib"; bytes=$((large_mib * 1048576))
-        else run make_data small "$small_files"; bytes=$((small_files * 8192)); fi
-        manifest "$local_root/$case_name" > "$local_root/expected"
-        source=$local_root/$case_name
-        if [[ $mode == pull ]]; then
-            printf 'Staging source on remote host (untimed)...\n'
-            run rsync -rpt -- "$source/" "$host:$(quote "$remote_root/$case_name/")"
-            source=$remote_root/$case_name
-            remote_manifest "$source" > "$local_root/actual"
-            cmp "$local_root/expected" "$local_root/actual" || fail 'Remote staging verification failed.'
-        fi
         if [[ $case_name == "${workloads[0]}" ]]; then
             # Do this once, not once per workload. Keep the measured copy's full
             # transport path, but suppress meaningless throughput for the 14-byte probe.
@@ -362,11 +400,66 @@ main() {
             fi
             rm -rf -- "$local_root/probe"
             if [[ $mode != local ]]; then
-                printf 'Setup complete: syq %s is ready on %s. Benchmark trials start next.\n' "$syq_identity" "$host"
+                printf 'Setup complete: syq %s is ready on %s.\n' "$syq_identity" "$host"
             else
-                printf 'Setup complete. Benchmark trials start next.\n'
+                printf 'Setup complete.\n'
             fi
         fi
+        local amount capacity next copying_ms
+        if [[ $case_name == large ]]; then amount=$large_mib; else amount=$small_files; fi
+        if [[ $size == auto ]]; then
+            capacity=$(space_capacity "$case_name")
+            [[ $capacity -ge 1 ]] || fail 'Not enough scratch space for a test dataset.'
+            [[ $amount -le $capacity ]] || amount=$capacity
+            printf '\nChoosing the %s workload size with syq (aiming for 5 seconds of copying)...\n' "$case_name"
+        fi
+        while :; do
+            if [[ $case_name == large ]]; then
+                printf 'Generating one %s MiB file...\n' "$amount"
+                bytes=$((amount * 1048576))
+            else
+                printf 'Generating %s files of 8 KiB each...\n' "$amount"
+                bytes=$((amount * 8192))
+            fi
+            run make_data "$case_name" "$amount"
+            printf 'Preparing content checks...\n'
+            manifest "$local_root/$case_name" > "$local_root/expected"
+            source=$local_root/$case_name
+            if [[ $mode == pull ]]; then
+                printf 'Staging source on remote host (untimed)...\n'
+                run rsync -rpt -- "$source/" "$host:$(quote "$remote_root/$case_name/")"
+                source=$remote_root/$case_name
+                remote_manifest "$source" > "$local_root/actual"
+                cmp "$local_root/expected" "$local_root/actual" || fail 'Remote staging verification failed.'
+            fi
+            [[ $size == auto ]] || break
+            destination=$dest_root/calibration
+            if [[ $mode == push ]]; then destination=$remote_root/calibration; remote "mkdir $(quote "$destination")"
+            else mkdir "$destination"; fi
+            rm -f -- "$local_root/calibration.json"
+            run copy_with syq "$source" "$destination" calibration || fail 'syq sizing copy failed.'
+            printf 'Checking copied data...\n'
+            if [[ $mode == push ]]; then remote_manifest "$destination" > "$local_root/actual"
+            else manifest "$destination" > "$local_root/actual"; fi
+            cmp "$local_root/expected" "$local_root/actual" || fail 'Sizing copy content check failed.'
+            copying_ms=$(calibration_interval "$local_root/calibration.json") ||
+                fail 'Automatic sizing needs syq with copying-interval timing. Update syq, or use --size quick for a fixed-size comparison.'
+            if [[ $mode == push ]]; then remote "rm -rf $(quote "$destination")"
+            else rm -rf -- "$destination"; fi
+            awk -v ms="$copying_ms" 'BEGIN {printf "Verified sizing copy; copying interval %.3f seconds.\n", ms / 1000}'
+            [[ $copying_ms -lt 5000 ]] || break
+            capacity=$(space_capacity "$case_name")
+            next=$(next_amount "$amount" "$copying_ms" "$capacity")
+            if [[ $next -le $amount ]]; then
+                printf 'WARNING: available scratch space limits test size. Short copies may mostly measure startup; interpret speeds cautiously.\n' >&2
+                break
+            fi
+            rm -rf -- "$local_root/$case_name"
+            [[ $mode != pull ]] || remote "rm -rf $(quote "$source")"
+            amount=$next
+            printf 'Increasing the dataset automatically...\n'
+        done
+        printf '%s: %s bytes per trial, %s tools × %s rounds.\n' "$case_name" "$bytes" "${#tools[@]}" "$rounds"
         for ((round=1; round<=rounds; round++)); do
             for ((offset=0; offset<${#tools[@]}; offset++)); do
                 index=$(((round - 1 + offset) % ${#tools[@]}))
@@ -377,6 +470,7 @@ main() {
                 printf '\n%s: %s, trial %s/%s (%s bytes)\n' "$case_name" "$tool" "$round" "$rounds" "$bytes"
                 run timed_copy "$tool" "$source" "$destination" || fail "$tool failed; no successful result recorded for this trial."
                 seconds=$(cat "$local_root/time")
+                printf 'Checking copied data...\n'
                 if [[ $mode == push ]]; then remote_manifest "$destination" > "$local_root/actual"
                 else manifest "$destination" > "$local_root/actual"; fi
                 cmp "$local_root/expected" "$local_root/actual" || fail "$tool destination content check failed."

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -144,8 +144,18 @@ run() {
     [[ $status -eq 0 ]] || return "$status"
     active_pid=
 }
-manifest() { (cd "$1"; for file in *; do cksum "$file"; done); }
-remote_manifest() { remote "cd $(quote "$1") && for file in *; do cksum \"\$file\" || exit; done"; }
+# Fixed-size argument batches avoid both one process per file and ARG_MAX.
+# The same POSIX shell program runs at both ends; LC_ALL=C fixes glob order.
+manifest_command='set -eu
+export LC_ALL=C
+set --
+for file in *; do
+    set -- "$@" "$file"
+    if [ "$#" -eq 128 ]; then cksum "$@" || exit; set --; fi
+done
+if [ "$#" -gt 0 ]; then cksum "$@"; fi'
+manifest() { (cd "$1"; bash -c "$manifest_command"); }
+remote_manifest() { remote "cd $(quote "$1") && $manifest_command"; }
 
 make_data() {
     local workload=$1 amount=$2

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -45,11 +45,25 @@ pub struct Progress {
     /// Workers currently allowed to take work (0 = fixed -j, not shown).
     pub active_workers: AtomicU64,
     pub start: Instant,
+    copy_first_ns: AtomicU64,
+    copy_last_ns: AtomicU64,
     term: Mutex<TermState>,
     stop: AtomicBool,
     /// `--results`: machine-readable NDJSON outcome stream, set once after
     /// construction so workers and the planner reach it with no plumbing.
     results: std::sync::OnceLock<Arc<crate::results::ResultsWriter>>,
+}
+
+/// Span from the first file-work operation to the last completed operation,
+/// including gaps/overlap across workers, rather than a sum of worker times.
+pub struct CopyingInterval<'a>(&'a Progress);
+
+impl Drop for CopyingInterval<'_> {
+    fn drop(&mut self) {
+        self.0
+            .copy_last_ns
+            .fetch_max(self.0.copy_clock_ns(), Relaxed);
+    }
 }
 
 struct TermState {
@@ -109,6 +123,8 @@ impl Progress {
             specials_created: AtomicU64::new(0),
             active_workers: AtomicU64::new(0),
             start: Instant::now(),
+            copy_first_ns: AtomicU64::new(u64::MAX),
+            copy_last_ns: AtomicU64::new(0),
             term: Mutex::new(TermState {
                 samples: VecDeque::from([(Instant::now(), 0)]),
                 last_json: None,
@@ -125,6 +141,21 @@ impl Progress {
 
     pub fn results_writer(&self) -> Option<&Arc<crate::results::ResultsWriter>> {
         self.results.get()
+    }
+
+    fn copy_clock_ns(&self) -> u64 {
+        self.start.elapsed().as_nanos().min(u64::MAX as u128 - 1) as u64
+    }
+
+    pub fn copying_interval(&self) -> CopyingInterval<'_> {
+        self.copy_first_ns.fetch_min(self.copy_clock_ns(), Relaxed);
+        CopyingInterval(self)
+    }
+
+    pub fn copying_elapsed_ms(&self) -> Option<u64> {
+        let first = self.copy_first_ns.load(Relaxed);
+        let last = self.copy_last_ns.load(Relaxed);
+        (self.bytes_done.load(Relaxed) > 0 && last >= first).then(|| (last - first) / 1_000_000)
     }
 
     pub fn add_bytes(&self, n: u64) {
@@ -478,6 +509,30 @@ impl crate::tune::Meter for Progress {
 mod tests {
     use super::*;
     use crate::tune::Meter;
+
+    #[test]
+    fn copying_interval_excludes_initial_setup_and_counts_overlap_once() {
+        let mut progress = Progress::new(false, false, None, false);
+        // Move the origin back without sleeping: setup must not enter the span.
+        Arc::get_mut(&mut progress).unwrap().start = Instant::now() - Duration::from_secs(60);
+        assert_eq!(progress.copying_elapsed_ms(), None);
+        let first = progress.copying_interval();
+        let began = progress.copy_first_ns.load(Relaxed);
+        assert!(began >= 60_000_000_000);
+        let overlapping = progress.copying_interval();
+        drop(first);
+        let first_end = progress.copy_last_ns.load(Relaxed);
+        drop(overlapping);
+        assert_eq!(progress.copy_first_ns.load(Relaxed), began);
+        assert!(progress.copy_last_ns.load(Relaxed) >= first_end);
+        assert_eq!(progress.copying_elapsed_ms(), None);
+        progress.add_bytes(1);
+        let span = (progress.copy_last_ns.load(Relaxed) - began) / 1_000_000;
+        assert_eq!(progress.copying_elapsed_ms(), Some(span));
+        // A measured sub-millisecond copy is distinct from absent timing.
+        progress.copy_last_ns.store(began + 999_999, Relaxed);
+        assert_eq!(progress.copying_elapsed_ms(), Some(0));
+    }
 
     #[test]
     fn rollback_resets_display_rate_and_retries_do_not_inflate_tuning_progress() {

--- a/src/results.rs
+++ b/src/results.rs
@@ -135,6 +135,7 @@ pub struct ResultRecord {
     pub errors: u64,
     pub bytes_transferred: u64,
     pub bytes_unchanged: u64,
+    pub copying_elapsed_ms: Option<u64>,
     pub elapsed_ms: u64,
     /// `--prune` runs only; None keeps the fields out of the record.
     pub deletions_planned: Option<u64>,
@@ -500,6 +501,9 @@ impl ResultsWriter {
             "elapsed_ms": result.elapsed_ms,
         });
         let object = record.as_object_mut().expect("record is an object");
+        if let Some(ms) = result.copying_elapsed_ms {
+            object.insert("copying_elapsed_ms".into(), ms.into());
+        }
         if let Some(planned) = result.deletions_planned {
             object.insert("deletions_planned".into(), planned.into());
         }
@@ -663,6 +667,7 @@ mod tests {
             errors: 1,
             bytes_transferred: 0,
             bytes_unchanged: 0,
+            copying_elapsed_ms: None,
             elapsed_ms: 0,
             deletions_planned: None,
             deletions_completed: None,
@@ -695,6 +700,7 @@ mod tests {
             errors: 0,
             bytes_transferred: 0,
             bytes_unchanged: 0,
+            copying_elapsed_ms: None,
             elapsed_ms: 0,
             deletions_planned: None,
             deletions_completed: None,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1028,6 +1028,7 @@ fn attempt_small_copy(
             len: entry.size as u32,
         })
         .collect();
+    let copying = progress.copying_interval();
     let mut blocks = if reads.is_empty() {
         Vec::new()
     } else {
@@ -1265,6 +1266,7 @@ fn attempt_small_copy(
     } else {
         ("success", 0)
     };
+    drop(copying);
     let terminal = crate::results::ResultRecord {
         status,
         exit_code,
@@ -1278,6 +1280,7 @@ fn attempt_small_copy(
         errors,
         bytes_transferred: progress.bytes_done.load(Relaxed),
         bytes_unchanged: progress.bytes_unchanged.load(Relaxed),
+        copying_elapsed_ms: progress.copying_elapsed_ms(),
         elapsed_ms: progress.start.elapsed().as_millis() as u64,
         deletions_planned: None,
         deletions_completed: None,
@@ -1486,6 +1489,11 @@ pub fn run(args: Args) -> Result<i32> {
                     progress.bytes_done.load(Relaxed)
                 },
                 bytes_unchanged: progress.bytes_unchanged.load(Relaxed),
+                copying_elapsed_ms: if verify_only || dry_run {
+                    None
+                } else {
+                    progress.copying_elapsed_ms()
+                },
                 elapsed_ms: progress.start.elapsed().as_millis() as u64,
                 // What the deletion pass did before the run died; zeros
                 // mean it never got that far, and status "failed" already
@@ -3396,6 +3404,11 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             progress.bytes_done.load(Relaxed)
         },
         bytes_unchanged: progress.bytes_unchanged.load(Relaxed),
+        copying_elapsed_ms: if opts.verify_only || opts.dry_run {
+            None
+        } else {
+            progress.copying_elapsed_ms()
+        },
         elapsed_ms: progress.start.elapsed().as_millis() as u64,
         deletions_planned,
         deletions_completed,
@@ -3464,6 +3477,14 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 &terminal,
                 elapsed,
                 &deletion_summary(delete_plan, deleted, opts.max_delete),
+            );
+        }
+    }
+    if args.stats && !args.quiet && !opts.verify_only && !opts.dry_run {
+        if let Some(ms) = progress.copying_elapsed_ms() {
+            crate::output::human_stdout!(
+                "  copying interval: {:.3}s (may overlap planning)",
+                ms as f64 / 1000.0
             );
         }
     }
@@ -7370,6 +7391,8 @@ impl Worker {
                     return Ok(());
                 }
                 Item::File(idx) => {
+                    let progress = self.progress.clone();
+                    let _copying = progress.copying_interval();
                     if self.fast_eligible(idx) {
                         let target = self
                             .sched
@@ -7434,6 +7457,8 @@ impl Worker {
                     }
                 }
                 Item::Range(h) => {
+                    let progress = self.progress.clone();
+                    let _copying = progress.copying_interval();
                     let (idx, start) = {
                         let range = h.lock().unwrap();
                         (range.idx, range.pos)
@@ -7461,6 +7486,8 @@ impl Worker {
                     }
                 }
                 Item::Finish { idx, matched } => {
+                    let progress = self.progress.clone();
+                    let _copying = progress.copying_interval();
                     let result = if matched {
                         self.finish_matched_file(idx)
                     } else {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -7737,7 +7737,13 @@ fn small_pushes_take_one_turn_and_match_the_engine() {
             .collect();
         operations.sort();
         let mut terminal = records.last().unwrap().clone();
-        for key in ["seq", "elapsed_ms"] {
+        if terminal["bytes_transferred"].as_u64().unwrap() > 0 {
+            let span = terminal["copying_elapsed_ms"]
+                .as_u64()
+                .expect("copy timing");
+            assert!(span <= terminal["elapsed_ms"].as_u64().unwrap());
+        }
+        for key in ["seq", "elapsed_ms", "copying_elapsed_ms"] {
             terminal.as_object_mut().unwrap().remove(key);
         }
         assert_eq!(terminal["type"], "result");
@@ -8249,7 +8255,13 @@ fn small_push_refusals_and_failures_match_the_engine() {
             .collect();
         operations.sort();
         let mut terminal = records.last().unwrap().clone();
-        for key in ["seq", "elapsed_ms"] {
+        if terminal["bytes_transferred"].as_u64().unwrap() > 0 {
+            let span = terminal["copying_elapsed_ms"]
+                .as_u64()
+                .expect("copy timing");
+            assert!(span <= terminal["elapsed_ms"].as_u64().unwrap());
+        }
+        for key in ["seq", "elapsed_ms", "copying_elapsed_ms"] {
             terminal.as_object_mut().unwrap().remove(key);
         }
         assert_eq!(terminal["type"], "result");
@@ -13646,6 +13658,45 @@ fn native_cp_mapping_end_to_end_map_pipeline() {
 }
 
 // ---- syq cp --results ----
+
+#[test]
+fn native_cp_results_copying_interval_covers_paced_content_but_not_unchanged_files() {
+    let t = Tmp::new();
+    write(&t.path("src/data"), &vec![42; 2 * 1024 * 1024]);
+    for (result, moved) in [("first.ndjson", true), ("second.ndjson", false)] {
+        let out = syq_cp_in(
+            &t.path(""),
+            &[
+                "--srcs-in",
+                "src",
+                "--into",
+                "dst",
+                "--results",
+                result,
+                "--bwlimit",
+                "1M",
+                "--stats",
+                "--no-progress",
+            ],
+            None,
+        );
+        assert!(out.status.success(), "{}", stderr_of(&out));
+        let contents = String::from_utf8(read(&t.path(result))).unwrap();
+        let terminal: serde_json::Value =
+            serde_json::from_str(contents.lines().last().unwrap()).unwrap();
+        if moved {
+            let interval = terminal["copying_elapsed_ms"]
+                .as_u64()
+                .expect("copy timing");
+            assert!(interval >= 1_000, "paced copy interval: {interval}ms");
+            assert!(interval <= terminal["elapsed_ms"].as_u64().unwrap());
+            assert!(String::from_utf8_lossy(&out.stdout).contains("copying interval:"));
+        } else {
+            assert!(terminal.get("copying_elapsed_ms").is_none());
+        }
+        assert_eq!(read(&t.path("src/data")), read(&t.path("dst/data")));
+    }
+}
 
 #[test]
 fn native_cp_results_stream_success_and_partial() {

--- a/tests/real-ssh/Dockerfile
+++ b/tests/real-ssh/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update \
         openssh-client \
         openssh-server \
         procps \
+        perl \
         python3 \
         python3-dbus \
         python3-gi \

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -747,6 +747,12 @@ for benchmark_mode in push pull; do
         --mode "$benchmark_mode" --host destination --workload both --size quick \
         --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's"
 done
+# Automatic sizing uses the real terminal timing from each remote direction.
+for benchmark_mode in push pull; do
+    bash /usr/local/libexec/syq-try-benchmark --yes \
+        --mode "$benchmark_mode" --host destination --workload small \
+        --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's"
+done
 test -z "$(find "$benchmark_parent" -mindepth 1 -print)"
 ssh destination 'test -z "$(find "/tmp/benchmark scratch'"'"'s" -mindepth 1 -print)"'
 rmdir "$benchmark_parent"
@@ -759,7 +765,7 @@ cancel_parent=$home/benchmark-cancel
 mkdir "$cancel_parent"
 ssh destination 'mkdir /tmp/benchmark-cancel; printf keep > /tmp/benchmark-cancel/keep'
 bash /usr/local/libexec/syq-try-benchmark --yes --mode push --host destination \
-    --workload large --rounds 1 --source-dir "$cancel_parent" \
+    --workload large --size quick --rounds 1 --source-dir "$cancel_parent" \
     --dest-dir /tmp/benchmark-cancel &
 benchmark_pid=$!
 attempt=0

--- a/theme/README.md
+++ b/theme/README.md
@@ -62,5 +62,6 @@ run (release-profile syq `9e73649`, three trials, 1 × 64 MiB and 1,024 × 8 KiB
 original mean times: syq 0.095/0.167 s, rsync 0.118/0.118 s, cp 0.049/0.052 s).
 The figure shows arithmetic mean trial speeds in decimal MB/s, calculated
 from the individual recorded durations rather than those rounded mean times. It illustrates
-the workflow, not comparative performance evidence: the run shared the machine
+the workflow, not comparative performance evidence. The choices now show automatic
+sizing; the example speeds still come from that fixed-size sample: the run shared the machine
 with other work. Preserve the example caption if updating its presentation.


### PR DESCRIPTION
The interactive benchmark now chooses its workload sizes with syq. It starts with 64 MiB or 1,024 small files and grows verified, unscored copies until the copying interval reaches five seconds. Users choose the direction and workloads; each scored tool then copies the same dataset into fresh destinations. Local comparisons include cp.

Growth follows measured copying time, increasing by 25%–10× per step. Available scratch space at both ends limits growth; a space-limited short run gets a warning. There is no arbitrary total-data or runtime cap. Verification batches POSIX cksum calls to keep large file counts practical. Calibration and trials retain live progress and cancellation cleanup. Results remain end-to-end decimal MB/s.

The new optional automation result field `copying_elapsed_ms` measures the wall-clock span of file work across workers, including gaps, per-file checks and finalization. It excludes initial setup and can overlap planning/connections; it is not an additive phase or pure network time. `--stats` also displays it. The benchmark avoids `--stats` because that flag disables the small-copy shortcut.

Compatibility: helper wire formats, persistence and resume state are unchanged. Existing v0.3.2 automation fixtures are unchanged and validate against the schema; the unchanged v0.3.2 Python SDK accepts results with the optional field. Automatic sizing requires the new binary timing; older syq builds receive a clear error with `--size quick` as recovery. Explicit quick/medium/large sizes remain supported.

#248 has merged into master with the shorter install section, visual walkthrough and MB/s output. This PR now targets master.

Validation:
- Rust formatting, all-target/all-feature Clippy, and `cargo test --all-targets` passed (475 unit tests, one ignored; 418 local integration tests; output/update suites passed).
- 19 standalone script tests passed, including local/push/pull sizing, missing timing, space limits, corruption, piped prompts and terminal cancellation.
- Documentation links and pinned mdBook build passed; visual checks passed at four widths, both themes and without JavaScript.
- One pre-existing pending-request socket test failed once under concurrent load, then passed both individually and in the complete rerun.
- Full three-container real-SSH suite passed for the timing implementation; after checksum batching, focused real-SSH benchmark push/pull and interruption cleanup passed at `6caadcf`. The final `602adfb` only keeps option arrays nonempty for Bash 3.2 and passes all 19 script tests.
- Actual local automatic small-file comparison completed with syq, rsync and cp; calibration reached 5.022 seconds and all scratch was removed. These debug-build runs check behavior, not comparative performance.

Merge head: `b1b10c1`, clean and pushed, synchronized with the merged docs stack and newer master changes. Conflict resolution preserves automatic sizing alongside the smaller private test fixtures and the longer terminal-test deadline. The 19 script tests, documentation links/build/visuals, Rust formatting, all-target/all-feature Clippy and 479 unit tests passed after synchronization. Focused copy-interval and small-push tests cover the merged transfer code.
