### PR TITLE
Retry return connections after socket timeouts

### DIFF
--- a/docs/receive.md
+++ b/docs/receive.md
@@ -157,12 +157,18 @@ syq persist off
 persistence scopes also own return connections and end them when closed.
 
 Return connections have no idle expiry. After a network interruption or laptop
-sleep, the laptop reconnects with delays of one to thirty seconds. Ordinary
+sleep, the laptop reconnects with delays of one to thirty seconds, including
+when a return-connection heartbeat times out. Ordinary
 reusable SSH logins still expire after ten idle minutes. An interrupted copy
 fails: rerun it after reconnection to reuse eligible partial files. Copies are
 not queued while offline. A copy must open its control channel within sixty
 seconds of authorization and finish within seven days. Closing that control
 channel revokes its workers and prevents further requests.
+
+If `syq persist status` reports a failed return connection, fix the reported
+configuration or permission problem and run `syq recv on` to retry previously
+connected endpoints. This keeps ordinary SSH persistence enabled; there is no
+need to toggle `persist off` and `persist on`.
 
 On the server, `syq destination list` shows availability and
 `syq destination wait laptop --timeout 30` waits with a deadline. Stale records

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -1068,6 +1068,33 @@ impl Drop for RegistrationGuard {
     }
 }
 fn register(name: &str, socket: &Path, secret: &str) -> Result<i32> {
+    match register_inner(name, socket, secret) {
+        Err(error)
+            if error.downcast_ref::<std::io::Error>().is_some_and(|error| {
+                matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::TimedOut
+                        | std::io::ErrorKind::UnexpectedEof
+                        | std::io::ErrorKind::BrokenPipe
+                        | std::io::ErrorKind::ConnectionReset
+                        | std::io::ErrorKind::ConnectionAborted
+                        | std::io::ErrorKind::ConnectionRefused
+                        | std::io::ErrorKind::NotConnected
+                )
+            }) =>
+        {
+            // Socket timeouts are WouldBlock on Unix. A failed handshake or
+            // heartbeat is a transport interruption, not a policy rejection.
+            // Reuse the retry status understood by existing return clients.
+            crate::output::diagnostic!("syq: return connection interrupted: {error:#}");
+            Ok(RECONNECT_PENDING)
+        }
+        result => result,
+    }
+}
+
+fn register_inner(name: &str, socket: &Path, secret: &str) -> Result<i32> {
     validate_name(name)?;
     let metadata = fs::symlink_metadata(socket)?;
     if !metadata.file_type().is_socket()
@@ -1247,6 +1274,47 @@ mod tests {
     use crate::cli::{Args, Interface, Location, Placement};
     use crate::conn::Conn;
     use crate::proto::{Request, Response};
+
+    #[test]
+    fn registration_retries_socket_timeout_but_not_peer_rejection() {
+        for reject in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("return.sock");
+            let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+            let (stop, stopped) = mpsc::channel();
+            let peer = std::thread::spawn(move || {
+                let (mut stream, _) = listener.accept().unwrap();
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(15)))
+                    .unwrap();
+                let _: Envelope = read_message(&mut stream).unwrap();
+                if reject {
+                    write_message(
+                        &mut stream,
+                        &Reply::Error(
+                            "Resource temporarily unavailable is a rejection here".into(),
+                        ),
+                    )
+                    .unwrap();
+                } else {
+                    // Leave the connection open without a reply: read_exact
+                    // must hit the real Unix socket timeout (EAGAIN/EWOULDBLOCK).
+                    let _ = stopped.recv_timeout(Duration::from_secs(15));
+                }
+            });
+            let result = register("laptop", &path, "test-credential");
+            let _ = stop.send(());
+            peer.join().unwrap();
+            if reject {
+                assert!(format!("{:#}", result.unwrap_err()).contains("receiving machine:"));
+            } else {
+                assert_eq!(result.unwrap(), RECONNECT_PENDING);
+            }
+            assert!(!path.exists(), "failed registration must remove its socket");
+        }
+    }
 
     pub(super) fn args(source: &Path, destination: &str) -> Args {
         let mut args =

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -15298,6 +15298,12 @@ fn remote_completion_uses_normal_ssh_and_learns_a_disposable_endpoint() {
     write(&t.path("remote-home/data/name with spaces"), b"remote");
     write(&t.path("from-local"), b"local");
     let ssh = fake_ssh(&t);
+    // An SSH command starts in the remote account's home.
+    let script = fs::read_to_string(&ssh)
+        .unwrap()
+        .replace("exec /bin/sh -c", "cd \"$HOME\" || exit 1\nexec /bin/sh -c");
+    executable(&ssh, script.as_bytes());
+
     let path = format!("{}/n", t.s("remote-home/data"));
     let executable = env!("CARGO_BIN_EXE_syq");
     let output = completion_command(
@@ -15420,6 +15426,47 @@ fn remote_completion_uses_normal_ssh_and_learns_a_disposable_endpoint() {
             (b'p', b"nested/".to_vec()),
         ]
     );
+
+    fs::create_dir_all(t.path("go/local-only")).unwrap();
+    fs::create_dir_all(t.path("remote-home/go/remote-only")).unwrap();
+    for mode in ["__complete", "__complete-bash"] {
+        let words = [
+            "syq",
+            "cp",
+            "--syq-path",
+            executable,
+            "--src",
+            "AGENTS.md",
+            "--to",
+            "fake.example",
+            "--into",
+            "go/",
+        ];
+        let line = shell_words::join(words);
+        let args = if mode == "__complete-bash" {
+            vec![mode, "go/", "--", &line]
+        } else {
+            let mut args = vec![mode, "bash", "9", "--"];
+            args.extend(words);
+            args
+        };
+        let output = completion_command(&t, &args)
+            .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+            )
+            .run()
+            .unwrap();
+        assert_output_ok(&output);
+        assert_eq!(
+            completion_values(&output.stdout),
+            vec![(b'p', b"go/remote-only/".to_vec())],
+            "{mode}"
+        );
+    }
 
     let destination = completion_command(
         &t,

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -61,7 +61,8 @@ keeps forwarding disabled. The runner has no SSH server. Return scenarios cover
 copies from independent source shells without a forwarded agent, destination
 background startup through persistence, `--root` traversal refusal, unconfined
 `--cwd` paths, conflicting names, reconnection after killing the owned SSH
-transport, and stopping receiving with persistence. Approval cases cover local
+transport, recovery after a server heartbeat times out while the client is
+paused, and stopping receiving with persistence. Approval cases cover local
 allow/deny, one-use IDs, disconnect and settings cancellation, and explicit
 automatic approval. An isolated D-Bus notification service exercises the real
 Linux `notify-send` client with Allow, Deny, dismissal, unexpected actions, and

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -285,6 +285,42 @@ ssh source 'cat /tmp/syq-real-ssh/return-source/resume.bin' | cmp - "$receive_ro
 test "$(find "$receive_root" -maxdepth 1 -type f -name '.interrupted.syq-part.*' | wc -l)" -eq 0
 ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as after-reconnect'
 printf 'return\n' | cmp - "$receive_root/after-reconnect"
+printf 'case: return heartbeat timeout reconnects without toggling persistence\n'
+python3 - <<'PYTEST'
+import json
+import os
+import signal
+import subprocess
+import time
+
+state = json.loads(subprocess.check_output(["syq", "recv", "status", "--json"]))
+wrapper = next(s["connection"]["ssh_pid"] for s in state["connections"] if s["endpoint"] == "source")
+transport = int(subprocess.check_output(["pgrep", "-P", str(wrapper), "-x", "ssh"]))
+# Pause the real client so the server can open its forwarded socket but cannot
+# receive a heartbeat reply. This produces a server-side socket timeout, unlike
+# killing SSH, which usually gives the client a transport exit status of 255.
+os.kill(transport, signal.SIGSTOP)
+try:
+    deadline = time.monotonic() + 40
+    while True:
+        result = subprocess.run(["ssh", "source", "test ! -e ~/.syq-destinations-v2/laptop.json"], timeout=5)
+        if result.returncode == 0:
+            break
+        assert result.returncode == 1, result.returncode
+        assert time.monotonic() < deadline, "heartbeat deadline: old registration still advertised"
+        print("waiting for the paused return connection's heartbeat to time out", flush=True)
+        time.sleep(2)
+finally:
+    os.kill(transport, signal.SIGCONT)
+subprocess.run(["ssh", "source", "syq destination wait laptop --timeout 40"], check=True, timeout=45)
+subprocess.run(["syq", "recv", "wait", "source", "--timeout", "10"], check=True, timeout=15)
+with open("/tmp/syq-real-ssh-ssh.trace") as trace:
+    ends = [dict(field.split("=", 1) for field in line.strip().split("\t")) for line in trace if line.startswith("phase=end\t")]
+assert any(row["pid"] == str(wrapper) and row["status"] == "75" for row in ends), "heartbeat did not report retry status 75"
+print("return connection recovered after the server heartbeat timed out", flush=True)
+PYTEST
+ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as after-heartbeat-timeout'
+printf 'return\n' | cmp - "$receive_root/after-heartbeat-timeout"
 printf 'case: cwd permits destinations outside its starting directory\n'
 syq recv on --cwd "$receive_root"
 syq recv wait source --timeout 30

--- a/tests/real-ssh/test-completion-display.py
+++ b/tests/real-ssh/test-completion-display.py
@@ -21,10 +21,32 @@ def main():
         root = Path(temporary)
         (root / 'alpha').write_bytes(b'x' * 2048)
         (root / 'alpine').mkdir()
+        (root / 'go' / 'local-only').mkdir(parents=True)
+        remote = root / 'remote'
+        (remote / 'go' / 'remote-only').mkdir(parents=True)
+        bindir = root / 'bin'
+        bindir.mkdir()
+        ssh = bindir / 'ssh'
+        ssh.write_text("""#!/bin/sh
+if [ "$1" = -V ]; then echo OpenSSH_9.9p1 >&2; exit 0; fi
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o|-l|-p|-S) shift 2 ;;
+        --) shift; break ;;
+        -*) shift ;;
+        *) break ;;
+    esac
+done
+shift
+cd "$SYQ_TEST_REMOTE_HOME" || exit 1
+HOME="$SYQ_TEST_REMOTE_HOME" exec /bin/sh -c "$1"
+""")
+        ssh.chmod(0o700)
         pid, terminal = pty.fork()
         if pid == 0:
             os.chdir(root)
-            os.environ['PATH'] = str(binary.parent) + os.pathsep + os.environ['PATH']
+            os.environ['PATH'] = str(bindir) + os.pathsep + str(binary.parent) + os.pathsep + os.environ['PATH']
+            os.environ['SYQ_TEST_REMOTE_HOME'] = str(remote)
             os.environ['TERM'] = 'xterm'
             os.environ['HOME'] = temporary
             os.environ['XDG_CONFIG_HOME'] = str(root / 'config')
@@ -83,6 +105,11 @@ def main():
             output = send(b'\n')
             assert b'ARG=<alpha>' in output, output
             assert b'KiB' not in output and b'UTC' not in output, output
+            print(f'{args.shell}: checking remote destination insertion', flush=True)
+            send(b'syq cp --src AGENTS.md --to j5 --into go/\t')
+            output = send(b'\n')
+            assert b'ARG=<go/remote-only/>' in output, output
+            assert b'local-only' not in output, output
             print(f'{args.shell}: detailed display and path-only insertion passed', flush=True)
         finally:
             # The PTY shell owns a separate process group, including its helpers.


### PR DESCRIPTION
A return-connection heartbeat that timed out after laptop sleep or a network interruption previously surfaced as `Resource temporarily unavailable (os error 11)`, exited with status 1, and left background receiving permanently failed. Classify typed transient socket failures as the existing reconnect status 75 so the laptop retries with its existing backoff. Explicit peer rejections still fail, even if their text resembles an I/O error. Document `syq recv on` as the receiving restart command.

Add a real socket-timeout test and a real-SSH regression that pauses the owned SSH client, waits for the server heartbeat to expire, resumes the client, verifies automatic reconnection and exit 75, and copies successfully afterward. Also cover the reported `syq cp --src AGENTS.md --to j5 --into go/` command with distinct local and remote directories in backend and interactive shell tests. That completion problem is not reproduced with a freshly loaded adapter; no completion implementation change is claimed, and the user's loaded Bash adapter remains to be inspected.

Validation for `d1eac67`:

- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo test --all-targets` passed: 478 unit, 418 local, 4 help, 5 output, and 7 update tests; one existing opt-in old-binary unit probe ignored.
- Documentation links: 16 files, zero problems.
- Default `scripts/test-real-ssh.sh`: passed, including the new timeout/reconnect regression, Bash/zsh/fish remote-directory insertion, and benchmark cleanup cases. This run built the unchanged working tree before it was committed as `d1eac67`.
- Native macOS and alternate SSH profile were not run.

Compatibility baseline: published v0.4.0 (`f4aee996`). Its unchanged return client already recognizes status 75 as retryable; no new exit status or state migration is introduced. CLI/SDK names, completion framing/caches, helper and return wire schemas, enrollment/replay state, signed grants, receipts, resume identities, receiving/persistence preferences, tuning caches, release/update interfaces, and documentation URLs are unchanged. Existing old fixtures remain unchanged. New/old live peers continue to require matching build identities; version-specific helper caches continue to isolate coexisting builds. No old/new mixed-binary interoperability is claimed or newly tested.

Branch status before opening:

```
Worktree: /home/grant/repos/syq/.worktrees/completion-persist-recovery
Branch:   completion-persist-recovery at d1eac67 (clean)
Upstream: origin/completion-persist-recovery (ahead 0, behind 0)
Master:   4b34ea9 from refs/heads/master (branch is ahead 1, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      1417176  https://github.com/greaber/syq/actions/runs/34046144167
  rsync-compat.yml success      1417176  https://github.com/greaber/syq/actions/runs/34046144124
  macos.yml        success      1417176  https://github.com/greaber/syq/actions/runs/34046144168

Pull request: none for completion-persist-recovery
```
