### PR TITLE
Deploy the docs when included SDK sources change

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
     paths:
       - 'docs/**'
+      - 'sdk/README.md'
+      - 'sdk/python/README.md'
+      - 'sdk/python/NATIVE_API.md'
       - 'theme/**'
       - 'book.toml'
       - 'scripts/check-doc-links.py'


### PR DESCRIPTION
The docs now render three SDK Markdown files through mdBook includes. Add those source paths to the Pages workflow trigger so edits to the guide, API reference or compatibility information publish updated web pages. Validation: inspected the three include paths and matching workflow filters; git diff --check passed. Follow-up to #249.