### PR TITLE
Simplify Python docs for learning and API lookup

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -17,3 +17,6 @@ edit-url-template = "https://github.com/greaber/syq/edit/master/{path}"
 # Shared branding and mdBook layout, plus the interactive copy examples.
 additional-css = ["theme/copy-demo.css", "theme/brand.css", "theme/docs.css", "theme/sidebar.css", "theme/controls.css"]
 additional-js = ["theme/docs.js", "theme/copy-demo.js", "theme/sidebar.js", "theme/controls.js"]
+
+[output.html.redirect]
+"sdk-compatibility.html" = "python-reference.html#compatibility"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,7 +31,7 @@
 
 # SDKs
 
-- [Python SDK](python.md)
+- [Python](python.md)
   - [Guide and examples](python-guide.md)
   - [API reference](python-reference.md)
   - [Compatibility](sdk-compatibility.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,4 +34,3 @@
 - [Python](python.md)
   - [Guide and examples](python-guide.md)
   - [API reference](python-reference.md)
-  - [Compatibility](sdk-compatibility.md)

--- a/docs/python.md
+++ b/docs/python.md
@@ -18,6 +18,3 @@ python -m pip install syq
 
 On first use, it downloads and verifies the matching syq executable, then caches
 it for later calls. You do not need to install the command-line tool separately.
-
-Start with [Guide and examples](python-guide.md), or look up arguments and
-return values in the [API reference](python-reference.md).

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,29 +1,23 @@
-# Python SDK
+<a id="python-sdk"></a>
 
-Use syq from Python to copy, remove or reorganize files, with typed results
-and streaming events. Synchronous and asyncio clients are available.
+# Python
+
+Copy, remove, and reorganize files from Python, with typed results and streaming
+events. Synchronous and asyncio clients are available.
+
+<a id="preview-a-copy"></a>
 
 ## Install
 
 The [syq package on PyPI](https://pypi.org/project/syq/) supports Python 3.10+
 on Linux and macOS:
 
-    python -m pip install syq
+```sh
+python -m pip install syq
+```
 
-On first use, the default client downloads and verifies the matching syq
-executable, then caches it. It does not use an unrelated syq from your PATH.
+On first use, it downloads and verifies the matching syq executable, then caches
+it for later calls. You do not need to install the command-line tool separately.
 
-## Preview a copy
-
-    import syq
-
-    plan = syq.cp("data", into="backup", dry_run=True)
-    print(plan.files_transferred, plan.bytes_transferred)
-
-Remove `dry_run=True` to perform the copy. Use `to="server"` for an SSH destination;
-the same placement options are described in [Copy files](reference.md).
-
-The typed API includes `syq.cp()`, `syq.rm()` and `syq.map()`. Call `syq.run([...])`
-for other commands. Asyncio programs use `await syq.AsyncClient().cp(...)`.
-Failures raise exceptions; typed calls also check the complete results stream
-rather than treating a truncated stream as success.
+Start with [Guide and examples](python-guide.md), or look up arguments and
+return values in the [API reference](python-reference.md).

--- a/docs/sdk-compatibility.md
+++ b/docs/sdk-compatibility.md
@@ -1,1 +1,0 @@
-{{#include ../sdk/README.md}}

--- a/scripts/prepare-python-sdk-release.py
+++ b/scripts/prepare-python-sdk-release.py
@@ -145,26 +145,7 @@ def prepare(root: Path, manifest_path: Path) -> bool:
         label="Python package version",
     )
 
-    python_readme_path = root / "sdk/python/README.md"
-    python_readme = python_readme_path.read_text(encoding="utf-8")
-    python_readme = replace_once(
-        python_readme,
-        f"package `{current_python_version}`\nmanages syq `{current_syq_version}`.",
-        f"package `{new_python_version}`\nmanages syq `{new_syq_version}`.",
-        label="Python README release mapping",
-    )
-    old_cache_path = f"syq/sdk/python/v{current_syq_version}/"
-    if python_readme.count(old_cache_path) != 2:
-        raise ValueError("expected two Python README cache-version markers")
-    python_readme = python_readme.replace(
-        old_cache_path,
-        f"syq/sdk/python/v{new_syq_version}/",
-    )
-    if old_cache_path in python_readme:
-        raise ValueError("the Python README retained the old cache version")
-
     pyproject_path.write_text(pyproject, encoding="utf-8")
-    python_readme_path.write_text(python_readme, encoding="utf-8")
     packaged_manifest.write_bytes(raw_manifest)
     print(
         f"prepared Python SDK {new_python_version} for syq {new_syq_version}"

--- a/scripts/test-python-sdk-release-tools.sh
+++ b/scripts/test-python-sdk-release-tools.sh
@@ -42,12 +42,7 @@ python3 "$script_dir/prepare-python-sdk-release.py" \
 
 grep -Fx "version = \"$next_python_version\"" \
   "$work/sdk/python/pyproject.toml" >/dev/null
-grep -F "package \`$next_python_version\`" \
-  "$work/sdk/python/README.md" >/dev/null
-grep -F "manages syq \`$next_syq_version\`." \
-  "$work/sdk/python/README.md" >/dev/null
-test "$(grep -Fc "syq/sdk/python/v$next_syq_version/" \
-  "$work/sdk/python/README.md")" -eq 2
+cmp "$repo_dir/sdk/python/README.md" "$work/sdk/python/README.md"
 cmp "$candidate" "$work/sdk/python/src/syq/syq-release-manifest.json"
 
 # Portable tree fingerprint: GNU coreutils on Linux, Perl shasum on macOS.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,38 +1,7 @@
-<a id="syq-language-sdks"></a>
+# SDKs
 
-# Compatibility
+Use syq from Python with synchronous or asyncio clients:
 
-The Python package supports Python 3.10+ on Linux and macOS and has no runtime
-Python dependencies.
-
-## Managed executable
-
-Each package version uses the same version of syq. Pin the Python package in
-your dependency file to keep that pairing.
-`syq.__version__` and `syq.PINNED_SYQ_VERSION` report these versions.
-
-The default client downloads the matching official executable on first use,
-verifies it against the release manifest embedded in the package, and caches it.
-It checks the cached binary before each use and replaces a missing or corrupt
-entry. It does not search `PATH`.
-
-The default cache is `$XDG_CACHE_HOME/syq/sdk/python/v<version>/` when
-`XDG_CACHE_HOME` is absolute, or `~/.cache/syq/sdk/python/v<version>/` otherwise.
-Set `Client(cache_dir=...)` to choose a different cache root. Call
-`syq.managed_executable()` to download ahead of time and get the executable path.
-
-## Custom executable
-
-Pass `executable=` to use a local build or an offline-provisioned executable:
-
-```python
-import syq
-
-client = syq.Client(executable="/opt/bin/syq")
-print(client.version())
-```
-
-`executable="syq"` explicitly selects syq from `PATH`. An override bypasses the
-managed download and verification; you are responsible for its compatibility
-and origin. Typed calls still reject unsupported or invalid automation output.
-The client does not fall back to another executable if the selected one fails.
+- [Install](https://greaber.github.io/syq/python.html)
+- [Guide and examples](https://greaber.github.io/syq/python-guide.html)
+- [API reference](https://greaber.github.io/syq/python-reference.html), including executable selection and compatibility

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,44 +1,38 @@
-# syq language SDKs
+<a id="syq-language-sdks"></a>
 
-This directory contains the Python client for syq. It invokes the syq
-executable rather than inventing a second transfer implementation, and it
-implements synchronous and asyncio clients for typed
-`cp` (including `prune=True`), `rm`, and `map` against syq's machine
-interfaces. Other commands and modes, such as a detached remote-to-remote
-copy, remain available through raw `run`. The executable remains authoritative
-for argument semantics, filesystem behavior, exit status, and safety checks.
+# Compatibility
 
-The Python-native surface is documented in
-[`python/NATIVE_API.md`](https://greaber.github.io/syq/python-reference.html).
+The Python package supports Python 3.10+ on Linux and macOS and has no runtime
+Python dependencies.
 
-| Ecosystem | Package/module | Source |
-|---|---|---|
-| Python | `syq` | [`python/`](https://github.com/greaber/syq/tree/master/sdk/python) |
+## Managed executable
 
-Every SDK release pins one exact, tested syq release. The default client does
-not search `PATH` or adopt a separately installed syq. On first use it downloads
-the pinned official binary for the current platform into an SDK-owned cache,
-verifies its archive and decompressed bytes against the release manifest
-embedded in the package, checks its version and release identity, and then
-always invokes that cached binary.
+Each package version uses the same version of syq. Pin the Python package in
+your dependency file to keep that pairing.
+`syq.__version__` and `syq.PINNED_SYQ_VERSION` report these versions.
 
-The Python package uses the same version as the syq release it manages. Its
-package version, `syq.__version__`, and `syq.PINNED_SYQ_VERSION` therefore agree.
-The embedded mapping remains immutable for a published package. Every
-successful official syq release automatically prepares the matching Python SDK
-release pull request with its exact signed manifest. Maintainers review and
-merge that release before creating the signed Python SDK tag.
+The default client downloads the matching official executable on first use,
+verifies it against the release manifest embedded in the package, and caches it.
+It checks the cached binary before each use and replaces a missing or corrupt
+entry. It does not search `PATH`.
 
-Callers that need a local build, a newer syq, or an offline-provisioned binary
-may pass `executable=` explicitly. That opts out of the tested pairing; the
-caller owns compatibility and provenance for the override.
+The default cache is `$XDG_CACHE_HOME/syq/sdk/python/v<version>/` when
+`XDG_CACHE_HOME` is absolute, or `~/.cache/syq/sdk/python/v<version>/` otherwise.
+Set `Client(cache_dir=...)` to choose a different cache root. Call
+`syq.managed_executable()` to download ahead of time and get the executable path.
 
-This makes the supported SDK/runtime combination hermetic. SDK consumers can
-pin the Python package version in their own lockfile and choose when to adopt a
-new SDK-plus-syq release. The supported subprocess behavior is never exposed
-to untested executable drift.
+## Custom executable
 
-The Python package implements this model.
+Pass `executable=` to use a local build or an offline-provisioned executable:
 
-See [`RELEASING.md`](https://github.com/greaber/syq/blob/master/sdk/RELEASING.md) for the one-time registry setup and exact
-tag conventions.
+```python
+import syq
+
+client = syq.Client(executable="/opt/bin/syq")
+print(client.version())
+```
+
+`executable="syq"` explicitly selects syq from `PATH`. An override bypasses the
+managed download and verification; you are responsible for its compatibility
+and origin. Typed calls still reject unsupported or invalid automation output.
+The client does not fall back to another executable if the selected one fails.

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -14,8 +14,6 @@ except `map`, which returns an async context manager.
 
 <a id="synchrony-asyncio-and-resource-ownership"></a>
 
-<a id="compatibility-and-versioning"></a>
-
 ## Client and executable selection
 
 `Client(*, executable=None, cache_dir=None, process_cwd=None, env=None, timeout=None)`
@@ -32,9 +30,7 @@ and `AsyncClient(...)` accept:
 `client.version()` returns the executable version as text.
 `syq.version(executable=None)` does the same without a client.
 `syq.managed_executable(cache_dir=None)` returns the verified executable path,
-downloading it if needed. See
-[Compatibility](https://greaber.github.io/syq/sdk-compatibility.html) for version
-selection and caching.
+downloading it if needed. See [Compatibility](https://greaber.github.io/syq/python-reference.html#compatibility) for version selection and caching.
 
 <a id="the-native-vocabulary-is-the-python-vocabulary"></a>
 
@@ -67,7 +63,7 @@ filesystem and remote checks happen in syq.
 
 ## cp
 
-`cp(*sources, **options) → CpResult` copies files. Choose one placement option.
+`cp(*sources, **options)` → [CpResult](https://greaber.github.io/syq/python-reference.html#cpresult) copies files. Choose one placement option.
 In addition to the shared arguments above, it accepts:
 
 | Options | Values / purpose |
@@ -101,12 +97,15 @@ Typed remote-to-remote copies require an enrolled receiver or
 `coordinate_at="local"`. With `dry_run=True` or `verify_only=True`, they require
 `coordinate_at="local"`. Use `run` for detached commands and human output options.
 
-To interleave rule files and inline patterns:
+`IgnoreFrom(path)` is a frozen dataclass holding a rule-file path (`str`,
+`bytes`, or `os.PathLike`). To interleave rule files and inline patterns:
 `ignore=[syq.IgnoreFrom("rules"), "!keep.tmp"]`. The last matching rule wins.
 
-## Removal
+<a id="removal"></a>
 
-`rm(*sources, **options) → RmResult` removes selected entries. Besides the shared
+## rm
+
+`rm(*sources, **options)` → [RmResult](https://greaber.github.io/syq/python-reference.html#rmresult) removes selected entries. Besides the shared
 arguments, it accepts `from_`, `dry_run`, `connections`, `syq_path`,
 `no_bootstrap`, `pscope`, `on_event`, `results`, and `check` with the types above.
 It supports local and ordinary SSH endpoints. Command-restricted receivers
@@ -114,21 +113,52 @@ reject removal. See [Remove files](https://greaber.github.io/syq/remove.html).
 
 <a id="complete-input-guarantee"></a>
 
-## Mapping, transformation, and copy
+<a id="mapping-transformation-and-copy"></a>
+
+## map
 
 `map(*sources, **options) → MapStream` lists local mapping entries without
 copying. Besides the shared arguments, it accepts `as_` to rename a selected
 object. `srcs_in` must be the sole selector when used.
 
-| Type / member | Meaning |
-|---|---|
-| `MapStream` | Iterable context manager yielding `MappingEntry`; use `with` |
-| `AsyncMapStream` | Async iterable context manager; use `async with` |
-| `mapping.cwd` | Absolute source-base spelling to pass unchanged to `cp(cwd=...)` |
-| `MappingEntry(src, dst, kind=None, size=None, mtime=None)` | Frozen dataclass; `src` and `dst` are `RelativePath`; size and mtime are informational |
-| `EntryKind` | `FILE`, `DIR`, `SYMLINK`, or `SPECIAL` |
-| `RelativePath(value)` | Mapping-relative path from text, bytes, or a path-like object; `/` joins components; `.raw` gives bytes; `.text` decodes UTF-8 strictly |
-| `PathValue` | Event path; `.raw` gives bytes, `.text` decodes UTF-8 strictly, `.display` provides readable text |
+`MapStream` is an iterable context manager yielding [MappingEntry](https://greaber.github.io/syq/python-reference.html#mappingentry); use `with`.
+`AsyncMapStream` is its async equivalent; use `async with`. Both expose `cwd`
+(`str | bytes`), the absolute source-base spelling to pass to `cp(cwd=...)`.
+
+### MappingEntry
+
+Frozen dataclass describing one source-to-destination mapping. Pass an iterable
+of these to `cp(mapping=...)`; use `dataclasses.replace` to change an entry.
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `src` | `RelativePath` | Path relative to the copy's source base |
+| `dst` | `RelativePath` | Path relative to the destination container |
+| `kind` | `EntryKind` or `None` | Object kind, when known; default `None` |
+| `size` | `int` or `None` | Informational size in bytes; default `None` |
+| `mtime` | `int` or `None` | Informational modification time in Unix seconds; default `None` |
+
+`MappingEntry(src, dst, kind=None, size=None, mtime=None)` also accepts text or
+byte paths for `src` and `dst` and converts them to `RelativePath`. `size` and
+`mtime` do not impose preconditions on the copy.
+
+### RelativePath and PathValue
+
+`RelativePath(value)` accepts text, bytes, or `os.PathLike`. It rejects empty
+paths, absolute paths, NUL bytes, and empty, `.` or `..` components. Join paths
+with `/`, for example `syq.RelativePath("archive") / entry.dst`.
+
+`PathValue(raw: bytes)` holds a path received in an event, which may be absolute.
+Both types are immutable and provide:
+
+| Member | Type | Meaning |
+|---|---|---|
+| `raw` | `bytes` | Original filename bytes; also returned by `bytes(path)` |
+| `text` | `str` | UTF-8 decoding; raises `UnicodeDecodeError` for invalid UTF-8 |
+| `str(path)` | `str` | Filesystem decoding with `os.fsdecode` |
+| `PathValue.display` | `str` | Same as `str(path)` |
+
+`RelativePath` also implements `os.PathLike`, returning bytes.
 
 Normal end of iteration checks the mapping process status. Leaving the context
 early stops the process. Pass `mapping.cwd` through without normalizing it.
@@ -149,35 +179,104 @@ file directly. See [mapping rules](https://greaber.github.io/syq/mappings.html).
 stream and process exit status. A truncated stream raises even if the process
 exits successfully. Dry runs return the same types, with planned totals.
 
-| Result | Attributes |
-|---|---|
-| Both | `status`, `exit_code`, `dry_run`, `errors`, `elapsed_ms`, `schema`, `schema_version`, `seq`, `type` |
-| `CpResult` | `files_transferred`, `files_unchanged`, `files_excluded`, `directories_created`, `symlinks_created`, `specials_created`, `bytes_transferred`, `bytes_unchanged` |
-| Copy deletion totals | `deletions_planned`, `deletions_completed`, `deletions_blocked`; `None` when inapplicable |
-| Receiver-attested copy fields | `provenance`, `receipt_status`, `operations`, `final_states`, `receipt_records`; `None` on ordinary results |
-| `RmResult` | `selectors_total`, `selectors_resolved`, `selectors_missing`, `entries_planned`, `entries_removed`, `entries_already_absent`, `entries_failed`, `mode` |
+### CpResult
 
-`status` is `OperationStatus.SUCCESS`, `PARTIAL`, `REFUSED`, `ABORTED`, or `FAILED`.
-Ordinary prune results have all three deletion totals; receiver-attested
-results have only `deletions_completed`.
+Returned by `cp()`, or available as `SyqOperationError.result` after an
+unsuccessful copy. Read attributes directly, for example
+`result.files_transferred`. It includes the common result fields below plus:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `files_transferred` | `int` | Regular files transferred |
+| `files_unchanged` | `int` | Regular files skipped as unchanged |
+| `files_excluded` | `int` | Files excluded from copying |
+| `directories_created` | `int` | Directories created |
+| `symlinks_created` | `int` | Symbolic links created |
+| `specials_created` | `int` | Special filesystem objects created |
+| `bytes_transferred` | `int` | File-content bytes transferred, not compressed network traffic |
+| `bytes_unchanged` | `int` | Bytes in unchanged files |
+| `deletions_planned` | `int` or `None` | Entries selected for pruning |
+| `deletions_completed` | `int` or `None` | Entries pruned |
+| `deletions_blocked` | `int` or `None` | Pruning deletions blocked by a safety limit |
+| `provenance` | `str` or `None` | `"receiver_attested"` for results from a verified receiver receipt |
+| `receipt_status` | `ReceiptStatus` or `None` | Receiver receipt outcome |
+| `operations` | `int` or `None` | Attested operation record count |
+| `final_states` | `int` or `None` | Attested final-state record count |
+| `receipt_records` | `int` or `None` | Total receipt record count |
+
+With `dry_run=True`, mutation totals describe planned changes. With
+`verify_only=True`, matching files count as unchanged; transfer and creation
+totals are zero. A failed call reports work completed before it stopped.
+
+Ordinary copies have all three deletion fields only with `prune=True`;
+otherwise they are `None`. Receiver-attested results have only
+`deletions_completed`, and their unchanged/excluded totals are always zero
+because the receiver cannot observe source-side skips. The receipt fields are
+`None` for ordinary copies.
+
+### RmResult
+
+Returned by `rm()`, or available as `SyqOperationError.result` after an
+unsuccessful removal. It includes the common result fields below plus:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `selectors_total` | `int` | Explicit source selectors supplied |
+| `selectors_resolved` | `int` | Selectors that resolved to an object |
+| `selectors_missing` | `int` | Selectors already missing; this is not an error |
+| `entries_planned` | `int` | Entries a dry run would remove; zero in live runs |
+| `entries_removed` | `int` | Entries removed; zero in dry runs |
+| `entries_already_absent` | `int` | Entries gone by removal time; zero in dry runs |
+| `entries_failed` | `int` | Removal or inspection failures, including during dry runs |
+| `mode` | `str` | Always `"rm"` |
+
+Selectors identify requests; entries count individual filesystem objects. One
+directory selector can account for many entries. Duplicate and overlapping
+selectors have separate indexes.
+
+### Common result fields
+
+Both `CpResult` and `RmResult` include:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `status` | `OperationStatus` | Outcome from the table below |
+| `exit_code` | `int` | syq process exit code |
+| `dry_run` | `bool` | Whether this was a preview |
+| `errors` | `int` | Counted errors |
+| `elapsed_ms` | `int` | Run duration in milliseconds |
+| `schema` | `str` | `"syq.automation"` |
+| `schema_version` | `int` | `1` |
+| `seq` | `int` | Record sequence number, starting at zero |
+| `type` | `str` | `"result"` |
+
+### OperationStatus
+
+String enum: compare with `syq.OperationStatus.SUCCESS`, or use `.value` for
+`"success"`.
+
+| Member | Value | Exit code | Meaning |
+|---|---|---|---|
+| `SUCCESS` | `"success"` | `0` | Requested operation succeeded |
+| `PARTIAL` | `"partial"` | `23` | Per-entry failures; independent work finished |
+| `REFUSED` | `"refused"` | `25` | A safety cap refused deletions; copy only |
+| `ABORTED` | `"aborted"` | `1` | Operation aborted; copy only |
+| `FAILED` | `"failed"` | `1` | Fatal failure |
+
+### Event callbacks
 
 `on_event(event)` receives an `AutomationEvent` in stream order. Events are not
 stored in the result. `AsyncClient` accepts synchronous or awaitable callbacks;
 awaitable callbacks count toward the timeout.
 
-| Event types | Content |
-|---|---|
-| `RunEvent`, `ProgressEvent` | Run description and sampled progress |
-| `TraceEvent`, `OperationResult` | Planned or completed copy operation |
-| `SelectionResult` | Removal selector resolution |
-| `RemovalTrace`, `RemovalResult` | Planned removal or settled entry, including preview inspection failures |
-| `ErrorEvent` | Diagnostic |
-| `FinalStateEvent` | Receiver-attested final object state |
-| `CpResult`, `RmResult` | Terminal totals |
+`AutomationEvent` is the union of the event classes below and `CpResult` and
+`RmResult`. Each event is a frozen dataclass. Its fields are listed below;
+all events also carry `schema: str`, `schema_version: int`, `seq: int`, and
+`type: str`. The envelope has the same meaning as on results, with `type`
+identifying the event. Optional fields use `None` when unavailable.
 
-See [Automation results](https://greaber.github.io/syq/automation.html) for field
-meanings. Python exposes `class` as `class_`, paths as `PathValue`, and enum
-values as string enums.
+See [Automation results](https://greaber.github.io/syq/automation.html) for stream
+semantics. Python exposes `class` as `class_` and paths as `PathValue`.
 
 `results=` accepts a binary file-like object with `write(bytes)` returning a
 positive byte count for nonempty writes, and optional `flush()`. The client
@@ -190,6 +289,219 @@ returns a `MappingEntry` when a complete mapping identity is available, otherwis
 `None`. Only use collected entries after the call returns a validated `success`
 or `partial` result. A terminal callback alone does not establish completion.
 The client does not retry automatically.
+
+
+## Event types
+
+### RunEvent
+
+Invocation details. `started_at` is Unix seconds; `mode` is `"cp"` or `"rm"`.
+`prune` and `mapping` are `None` for removal; `verify_only` defaults to `False`.
+
+`type = "run"`. Fields in addition to the common envelope:
+
+```python
+run_id: str
+started_at: int
+syq_version: str
+mode: str
+prune: bool | None
+mapping: bool | None
+dry_run: bool
+endpoints: tuple[Endpoint, ...]
+verify_only: bool
+```
+
+### ProgressEvent
+
+Sampled progress for displays; use the terminal result for final totals.
+Byte fields measure file content (comparison work with `verify_only=True`),
+`scanned` counts scanned entries, and `elapsed_ms` is milliseconds.
+
+`type = "progress"`. Fields in addition to the common envelope:
+
+```python
+bytes_done: int
+bytes_total: int
+bytes_unchanged: int
+files_done: int
+files_total: int
+files_unchanged: int
+files_excluded: int
+scanned: int
+scan_done: bool
+elapsed_ms: int
+```
+
+### TraceEvent
+
+One planned copy change. `dst` is relative to the destination container;
+`src` is the mapping source when available. `bytes` is the planned file size,
+and `reason` describes why the change is needed.
+
+`type = "trace"`. Fields in addition to the common envelope:
+
+```python
+action: OperationAction
+dst: PathValue
+src: PathValue | None
+kind: EntryKind
+bytes: int | None
+reason: TraceReason
+```
+
+### OperationResult
+
+One copy outcome. `dst` is destination-relative, or relative to the signed
+destination `scope` for a receiver receipt. `src` is present for mapping entries
+when available. `bytes` and `attempts` give transfer information. Error details
+are present when known; `message` is display text. `provenance`, `scope`, and
+`code` apply to receiver-attested outcomes.
+
+`type = "operation_result"`. Fields in addition to the common envelope:
+
+```python
+action: OperationAction
+dst: PathValue
+src: PathValue | None
+kind: EntryKind | None
+disposition: Disposition
+bytes: int | None
+attempts: int | None
+retryable: Retryability | None
+class_: ErrorClass | None
+os_kind: OsKind | None
+message: str | None
+provenance: str | None
+scope: int | None
+code: ReceiptCode | None
+```
+
+### SelectionResult
+
+One removal selector, indexed from zero. `path` is the original selector;
+`status` says whether it resolved. `kind` is `None` for a missing selector.
+
+`type = "selection_result"`. Fields in addition to the common envelope:
+
+```python
+selector: int
+path: PathValue
+status: SelectionStatus
+kind: EntryKind | None
+```
+
+### RemovalTrace
+
+One entry a preview would remove. `selector` identifies its source selector;
+`path` identifies the entry. `disposition` is always `WOULD_REMOVE`.
+
+`type = "removal_trace"`. Fields in addition to the common envelope:
+
+```python
+selector: int
+path: PathValue
+kind: EntryKind
+disposition: RemovalDisposition
+```
+
+### RemovalResult
+
+One removal outcome or preview inspection failure. `selector` identifies its
+source selector; `path` identifies the entry. `attempts` counts attempts;
+`retryable`, `class_`, `os_kind`, and `message` describe failures when available.
+
+`type = "removal_result"`. Fields in addition to the common envelope:
+
+```python
+selector: int
+path: PathValue
+kind: EntryKind | None
+disposition: RemovalDisposition
+attempts: int
+retryable: Retryability | None
+class_: ErrorClass | None
+os_kind: OsKind | None
+message: str | None
+```
+
+### ErrorEvent
+
+One counted error. `message` is display text; `class_` and `os_kind` classify
+it when known. Receiver errors can also carry `provenance` and `code`.
+
+`type = "error"`. Fields in addition to the common envelope:
+
+```python
+message: str
+class_: ErrorClass | None
+os_kind: OsKind | None
+provenance: str | None
+code: ReceiptCode | None
+```
+
+### FinalStateEvent
+
+Receiver-attested destination state. `dst` is relative to the signed `scope`.
+`provenance` is `"receiver_attested"`. Present objects have `kind` and byte
+`size`; `metadata`, `digest`, and `symlink_target` are present where available.
+`observation_error` describes a partial observation. Absent objects have no
+object details; failed observations have `code` and optional `message`.
+
+`type = "final_state"`. Fields in addition to the common envelope:
+
+```python
+provenance: str
+scope: int
+dst: PathValue
+state: FinalObjectState
+kind: FinalObjectKind | None
+size: int | None
+metadata: ObjectMetadata | None
+digest: AttestedDigest | None
+symlink_target: PathValue | None
+observation_error: str | None
+code: ReceiptCode | None
+message: str | None
+```
+
+### Endpoint, ObjectMetadata, and AttestedDigest
+
+Nested frozen dataclasses used by events:
+
+| Type | Fields | Meaning |
+|---|---|---|
+| `Endpoint` | `role: EndpointRole`, `kind: EndpointKind`, `host: str \| None`, `user: str \| None` | Source/destination and local/SSH identity; host and user are optional |
+| `ObjectMetadata` | `mode: int`, `uid: int`, `gid: int`, `mtime: int`, `mtime_nsec: int`, `rdev: int` | Unix mode, owner/group IDs, modification time (seconds plus nanoseconds), and device ID |
+| `AttestedDigest` | `algorithm: str`, `value: str` | `"blake3"` and its 64 lowercase hexadecimal digest characters |
+
+## Enums
+
+All enums are string enums exported by `syq`. Members use uppercase names;
+values use lowercase, for example `EntryKind.FILE.value == "file"`.
+`OperationStatus` is defined with the result types above.
+
+| Type | Members |
+|---|---|
+| `EntryKind` | `FILE`, `DIR`, `SYMLINK`, `SPECIAL` |
+| `EndpointKind` | `LOCAL`, `SSH` |
+| `EndpointRole` | `SOURCE`, `DESTINATION` |
+| `OperationAction` | `TRANSFER_FILE`, `CREATE_DIRECTORY`, `CREATE_SYMLINK`, `CREATE_SPECIAL`, `DELETE`, `SET_METADATA`, `OBSERVE_HASH` |
+| `Disposition` | `SUCCEEDED`, `FAILED`, `BLOCKED`, `INCOMPLETE`, `OBSERVED` |
+| `ReceiptCode` | `NONE`, `EXECUTION_FAILED`, `AUTHORIZATION_REFUSED`, `FILE_LIFECYCLE_INCOMPLETE`, `OBSERVATION_FAILED` |
+| `FinalObjectState` | `PRESENT`, `ABSENT`, `OBSERVATION_FAILED` |
+| `FinalObjectKind` | `DIR`, `FILE`, `SYMLINK`, `FIFO`, `SOCKET`, `CHARACTER_DEVICE`, `BLOCK_DEVICE`, `OTHER` |
+| `ReceiptStatus` | `CLEAN`, `FAILED`, `INCOMPLETE` |
+| `Retryability` | `YES`, `NO`, `UNKNOWN` |
+| `ErrorClass` | `IO`, `TRANSPORT`, `CONFLICT`, `INTEGRITY`, `SAFETY_LIMIT`, `USAGE`, `INTERNAL` |
+| `OsKind` | `NOT_FOUND`, `PERMISSION_DENIED`, `ALREADY_EXISTS`, `INVALID_INPUT`, `NO_SPACE`, `QUOTA_EXCEEDED`, `READ_ONLY`, `OTHER` |
+| `TraceReason` | `DESTINATION_MISSING`, `TYPE_DIFFERS`, `CONTENT_DIFFERS`, `METADATA_DIFFERS`, `DESTINATION_ONLY` |
+| `SelectionStatus` | `RESOLVED`, `MISSING` |
+| `RemovalDisposition` | `WOULD_REMOVE`, `REMOVED`, `ALREADY_ABSENT`, `FAILED` |
+
+`ReceiptStatus.CLEAN` means a clean receipt, `FAILED` reports receiver failures,
+and `INCOMPLETE` reports an incomplete lifecycle. `Retryability.YES`, `NO`, and
+`UNKNOWN` state whether a failed entry can be retried.
 
 ## Failure model
 
@@ -213,13 +525,55 @@ completed are not rolled back.
 
 <a id="deliberate-exclusions"></a>
 
-## Raw execution
+<a id="raw-execution"></a>
+
+## run
 
 `client.run(args, *, check=True, cwd=None, env=None, timeout=None, input=None)`
-returns `Result(argv, returncode, stdout, stderr)`. `stdout` and `stderr` are
-fully captured bytes; `input` accepts bytes. `args` is a sequence of arguments
+returns [Result](https://greaber.github.io/syq/python-reference.html#result). `input` accepts bytes. `args` is a sequence of arguments
 after the executable name, passed without a shell.
 
 Here, `cwd` is the local subprocess directory. `cwd`, `env`, and `timeout`
 use the client defaults when omitted or `None`. Module-level `syq.run` takes
 the same arguments plus `executable=None`.
+
+### Result
+
+Frozen dataclass returned by `run()` and held in `SyqProcessError.result`:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `argv` | `tuple[str \| bytes, ...]` | Executed argument list, including the executable |
+| `returncode` | `int` | Process exit status |
+| `stdout` | `bytes` | Complete captured standard output |
+| `stderr` | `bytes` | Complete captured standard error |
+
+<a id="compatibility-and-versioning"></a>
+<a id="syq-language-sdks"></a>
+
+## Compatibility
+
+Python 3.10+ on Linux and macOS; no runtime Python dependencies. Each Python
+package uses the matching syq release. `syq.__version__` and
+`syq.PINNED_SYQ_VERSION` report those versions. Pin the package in your dependency
+file to keep the pairing.
+
+### Managed executable
+
+The default client downloads the matching executable on first use and verifies
+it against the package's embedded release manifest. It checks the cached binary
+before every use and replaces missing or corrupt entries. It does not search
+`PATH`.
+
+The default cache is `$XDG_CACHE_HOME/syq/sdk/python/v<version>/` when
+`XDG_CACHE_HOME` is absolute, or `~/.cache/syq/sdk/python/v<version>/` otherwise.
+Use `Client(cache_dir=...)` to change the cache root, or
+`syq.managed_executable()` to download ahead of time and get the path.
+
+### Custom executable
+
+`Client(executable="/opt/bin/syq")` uses that binary;
+`Client(executable="syq")` searches `PATH`. Overrides bypass managed download
+and verification, so you are responsible for compatibility and origin. Typed
+calls still validate automation output. A failed executable selection does not
+fall back to another binary.

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -1,789 +1,225 @@
-# Python native API
+<a id="python-native-api"></a>
 
-The Python package pins a matching syq executable. To use a custom development
-build, pass executable= explicitly; see the [Python guide](https://greaber.github.io/syq/python-guide.html).
+<a id="positioning"></a>
 
-This document describes the Python interface to syq's native filesystem
-commands.
+<a id="scope"></a>
 
-## Positioning
+<a id="product-readiness"></a>
 
-Direct subprocess execution remains a good syq API:
+# API reference
 
-```python
-import subprocess
+Module functions `syq.cp`, `syq.rm`, and `syq.map` use a default `Client`.
+`AsyncClient` has the same arguments and result types; await its operations
+except `map`, which returns an async context manager.
 
-subprocess.run(
-    ["syq", "cp", "project", "--to", "server", "--into", "/backup"],
-    check=True,
-)
-```
+<a id="synchrony-asyncio-and-resource-ownership"></a>
 
-A caller that only needs to start one command and fail when it fails does not
-need a Python abstraction. The Python package is for callers that need one or
-more of these additional guarantees:
-
-- a verified syq executable pinned to the Python package;
-- lossless structured mapping input and output;
-- typed, streaming operation events and terminal results;
-- detection of malformed, unsupported, or incomplete machine output;
-- safe process cancellation and cleanup; or
-- composition of map, transform, copy, and retry workflows in Python.
-
-The library invokes the syq executable. It does not reimplement copying, path
-resolution, conflict detection, remote access, or retry policy in Python.
-
-## The native vocabulary is the Python vocabulary
-
-The typed API mirrors the native command grammar. It must not require users to
-learn a second set of names for concepts that syq already names.
-
-| Native spelling | Python spelling |
-|---|---|
-| `syq cp` | `syq.cp()` or `Client.cp()` |
-| `syq cp --verify-only` | `syq.cp(verify_only=True)` |
-| `--ignore-existing` | `ignore_existing=True` |
-| `--existing` | `existing=True` |
-| `--update` | `update=True` |
-| `syq cp --prune` | `syq.cp(prune=True)` or `Client.cp(prune=True)` |
-| `syq rm` | `syq.rm()` or `Client.rm()` |
-| `syq map` | `syq.map()` or `Client.map()` |
-| `--root` | `root=` |
-| `--srcs-in` | `srcs_in=` |
-| `--follow-src` | `follow_src=` |
-| `--follow-dst` | `follow_dst=` |
-| `--into-existing` | `into_existing=` |
-| `--no-compress` | `no_compress=` |
-| `--max-delete` | `max_delete=` |
-| `--auth-from @laptop` | `auth_from="@laptop"` |
-| `--auth-from ssh` | `auth_from="ssh"` |
-| `--via @laptop` (alias) | `via="@laptop"` (alias) |
-| `--from` | `from_=` |
-| `--as` | `as_=` |
-| `class` event field | `class_` attribute |
-
-The only spelling transformations are mechanical:
-
-1. Replace hyphens with underscores because Python identifiers cannot contain
-   hyphens.
-2. Add a trailing underscore when the result is a Python keyword.
-
-This rule excludes semantic aliases such as `copy`, `remove`, `mapping`,
-`Sources`, `Remote`, `Into`, `Exact`, `comparison`, `compression`, and
-`bandwidth_limit`. Those names may read naturally in isolation, but they make
-every caller translate between two APIs.
-
-SDK-only controls have Python names because they have no native spelling. The
-initial ones are `on_event`, `timeout`, and `check`; their documentation must
-identify them as process- or library-level behavior rather than syq options.
-The typed `results=` parameter keeps the native concept and spelling, but
-accepts a Python binary file-like object instead of a path so applications can
-choose files, in-memory buffers, and their own stream adapters naturally.
-
-Not every command-line parsing convenience needs another Python parameter.
-The plural options `--srcs`, `--src-files`, and `--src-dirs`
-only batch values on a command line. Python passes a sequence to the matching
-singular keyword instead. This removes redundant syntax without renaming a
-product concept:
-
-```python
-syq.cp(src=["a", "b"], src_dir=["assets", "fonts"], into="archive")
-```
-
-The implementation serializes this as repeated `--src` and `--src-dir`
-options. When a path begins with `-`, it uses the native attached spelling such
-as `--src-dir=-`; callers still pass the path itself. A keyword accepts either
-one path or an iterable of paths; `str`, `bytes`, and path-like objects are
-always treated as scalar paths rather than iterables.
-
-## Scope
-
-The typed interface covers native `cp`, including its `--prune` mode, `rm`,
-and `map`. It does not wrap `syq rsync`, which remains available through
-`Client.run` and the module-level `syq.run` function. Enrollment and other
-administrative commands also remain raw operations until they have a stable
-machine contract that benefits from Python types.
-
-Module functions and client methods have the same operation names and
-signatures. A module function uses a default `Client`; applications that need
-shared configuration or an explicit executable construct a client.
-
-## A normal copy
-
-```python
-import syq
-
-result = syq.cp(
-    "project",
-    to="server",
-    into="/backup",
-)
-
-print(result.files_transferred, result.bytes_transferred)
-```
-
-The corresponding native command is:
-
-```text
-syq cp project --to server --into /backup
-```
-
-There are no endpoint or placement wrapper objects. Endpoint strings use the
-native `[USER@]HOST` grammar, paths remain separate arguments, and omission of
-`from_` or `to` means local exactly as it does on the command line:
-
-```python
-syq.cp(
-    src=["a", "b"],
-    from_="grant@server",
-    cwd="/data",
-    into="./data",
-)
-
-syq.cp(
-    "report",
-    to="grant@[2001:db8::1]",
-    as_new="/reports/final",
-    hash=True,
-)
-```
-
-`cp` returns only after it has received and validated the terminal result and
-reaped the process. By default, a non-successful terminal result raises
-`SyqOperationError`; the exception retains the same typed result. Pass
-`check=False` when a partial or refused outcome is expected program logic.
+<a id="compatibility-and-versioning"></a>
 
 ## Client and executable selection
 
-```python
-client = syq.Client(
-    cache_dir="/var/cache/my-application",
-    process_cwd="/srv/jobs",
-    timeout=3600,
-)
+`Client(*, executable=None, cache_dir=None, process_cwd=None, env=None, timeout=None)`
+and `AsyncClient(...)` accept:
 
-result = client.cp("project", to="server", into="/backup")
-```
+| Argument | Meaning |
+|---|---|
+| `executable` | Custom executable path, or name to find on `PATH`; default: managed syq |
+| `cache_dir` | Managed executable cache root |
+| `process_cwd` | Local subprocess working directory; default: inherit |
+| `env` | Subprocess environment mapping; default: inherit |
+| `timeout` | Operation timeout in seconds; default: no limit |
 
-`Client()` lazily installs and uses the exact official syq release pinned by
-the Python package. Each operation verifies the cached executable according to
-the package's existing complete-byte manifest policy before it starts. A
-`Client` may reuse configuration and safe validation metadata, but it does not
-turn path reuse into a weaker executable check.
+`client.version()` returns the executable version as text.
+`syq.version(executable=None)` does the same without a client.
+`syq.managed_executable(cache_dir=None)` returns the verified executable path,
+downloading it if needed. See
+[Compatibility](https://greaber.github.io/syq/sdk-compatibility.html) for version
+selection and caching.
 
-An explicit executable opts out of the supported binary pairing:
-
-```python
-client = syq.Client(executable="/opt/syq/bin/syq")
-```
-
-Typed operations still validate the automation schema they receive, but the
-package makes no behavioral compatibility or provenance guarantee for an
-override. It never silently falls back from an override to the managed binary
-or from the managed binary to `PATH`.
-
-Client defaults may be overridden for one operation. A client is safe to use
-for independent sequential calls. Concurrent-call and thread-safety promises
-must be decided from the implementation rather than implied by this document.
-
-`process_cwd` is the local subprocess working directory. It is deliberately
-not called `cwd`: on typed commands, `cwd` always means native `--cwd`.
-The existing raw `run(cwd=...)` spelling retains its subprocess meaning for
-backward compatibility.
+<a id="the-native-vocabulary-is-the-python-vocabulary"></a>
 
 ## Arguments and validation
 
-The conceptual `cp` signature is:
+Options use CLI names with hyphens replaced by underscores. Python keywords
+get a trailing underscore: `from_`, `as_`. Paths accept `str`, `bytes`, or
+`os.PathLike`; selector keywords accept one path or an iterable of paths.
+Use `src=["a", "b"]` for CLI `--srcs a b`, and likewise `src_file` and `src_dir`.
 
-```python
-syq.cp(
-    *sources,
-    src=None,
-    srcs_in=None,
-    src_file=None,
-    src_dir=None,
-    from_=None,
-    cwd=None,
-    root=None,
-    follow=False,
-    follow_src=False,
-    follow_dst=False,
-    to=None,
-    into=None,
-    into_new=None,
-    into_existing=None,
-    as_=None,
-    as_new=None,
-    as_existing=None,
-    mapping=None,
-    results=None,
-    prune=False,
-    dry_run=False,
-    hash=False,
-    no_compress=False,
-    bwlimit=None,
-    connections=None,
-    coordinate_at=None,
-    rsh=None,
-    pscope=None,
-    syq_path=None,
-    no_bootstrap=False,
-    tcp_plain=False,
-    no_tcp=False,
-    tcp_ports=None,
-    tcp_congestion=None,
-    peer_auth=None,
-    receiver_max_entries=None,
-    receiver_max_bytes=None,
-    receiver_receipt=None,
-    ignore=None,
-    ignore_from=None,
-    preserve=None,
-    inplace=False,
-    max_size=None,
-    min_size=None,
-    max_delete=None,
-    on_event=None,
-    timeout=None,
-    check=True,
-)
-```
+| Shared by `cp`, `rm`, and `map` | Meaning |
+|---|---|
+| `*sources`, `src` | Select named objects |
+| `srcs_in` | Select a directory's contents |
+| `src_file`, `src_dir` | Require non-directory objects or directories |
+| `cwd` | Source resolution base; may be remote for `cp` and `rm` |
+| `root` | Confine source resolution beneath this directory; requires relative selectors; conflicts with `cwd` |
+| `follow`, `follow_src` | Follow source symlinks; `follow` also enables destination following for `cp` |
+| `timeout` | Override the client timeout in seconds; `None` uses the client default |
 
-The conceptual `rm` signature keeps the subset of that grammar which native
-removal accepts:
+Boolean flags default to `False`; other optional arguments default to `None`,
+except `check=True`. Invalid argument combinations raise `SyqInvocationError`;
+filesystem and remote checks happen in syq.
 
-```python
-syq.rm(
-    *sources,
-    src=None,
-    srcs_in=None,
-    src_file=None,
-    src_dir=None,
-    from_=None,
-    cwd=None,
-    root=None,
-    follow=False,
-    follow_src=False,
-    results=None,
-    dry_run=False,
-    connections=None,
-    syq_path=None,
-    no_bootstrap=False,
-    pscope=None,
-    on_event=None,
-    timeout=None,
-    check=True,
-)
-```
+<a id="a-normal-copy"></a>
 
-Bare positional paths have the native bare-source meaning. Selector keywords
-retain the native meanings:
+<a id="copy-and-prune"></a>
 
-| Python keyword | Native option | Meaning |
-|---|---|---|
-| `src` | `--src` | Select a named object |
-| `srcs_in` | `--srcs-in` | Select a directory's contents |
-| `src_file` | `--src-file` | Require a non-directory object |
-| `src_dir` | `--src-dir` | Require a directory |
+<a id="dry-runs"></a>
 
-Placement is expressed by exactly one of the six native placement keywords:
-`into`, `into_new`, `into_existing`, `as_`, `as_new`, or `as_existing`.
-Their behavior, including the `new` and `existing` pathname checks, is the
-native behavior. The Python package does not strengthen them into locks or
-compare-and-swap operations.
+## cp
 
-Python performs structural validation that requires no filesystem or network
-access, such as conflicting placement parameters, `as_` with multiple
-sources, and selectors or `prune=True` combined with `mapping`. The executable
-remains authoritative for path resolution, type checks, endpoint behavior,
-and filesystem state. Errors use native option names so they remain searchable
-in `syq --help` and the README.
+`cp(*sources, **options) → CpResult` copies files. Choose one placement option.
+In addition to the shared arguments above, it accepts:
 
-`cwd` and `root` are mutually exclusive and retain the native source-base
-meanings for `cp`, `rm`, and `map`. `cwd` is a resolution base rather than a
-containment boundary; relative selectors may leave it through `..`, and
-absolute selectors ignore it. `root` confines component-by-component
-resolution beneath the pinned directory, so its selectors must be relative.
-Directly supplied selectors may otherwise contain `.` and `..`; mapping-entry
-paths retain their separate strict relative grammar. Input paths accept text
-and byte path-like objects on supported Unix systems; byte paths are not
-decoded merely to build argv.
+| Options | Values / purpose |
+|---|---|
+| `from_`, `to` | SSH endpoint strings; omitted endpoints are local |
+| `into`, `into_new`, `into_existing` | Destination directory paths |
+| `as_`, `as_new`, `as_existing` | Exact destination paths |
+| `mapping` | Manifest path or iterable of `MappingEntry`; replaces selectors; conflicts with `as_*` and `prune` |
+| `follow_dst` | Boolean: follow destination symlinks |
+| `prune`, `dry_run`, `hash`, `verify_only` | Boolean: mirror, preview, compare content, or verify without copying |
+| `ignore_existing`, `existing`, `update` | Boolean: skip existing, require existing, or skip newer destination files |
+| `ignore` | Pattern string, `IgnoreFrom(path)`, or ordered iterable of either |
+| `ignore_from` | Rule file path or iterable of paths; applied after `ignore` |
+| `preserve` | Preservation string or iterable of strings |
+| `inplace`, `no_compress` | Boolean: update destination files in place or disable compression |
+| `bwlimit`, `min_size`, `max_size` | Native rate/size strings or integers |
+| `max_delete` | Nonnegative integer deletion limit; requires `prune=True` |
+| `connections` | Positive integer connection count |
+| `auth_from`, `via` | Credential source string; aliases, so use only one |
+| `coordinate_at`, `rsh`, `peer_auth` | Coordinator, SSH command, and peer authentication strings |
+| `pscope`, `syq_path` | SSH persistence scope path and remote executable path |
+| `no_bootstrap`, `tcp_plain`, `no_tcp` | Boolean remote/transport controls |
+| `tcp_ports`, `tcp_congestion` | Port range and congestion-control strings |
+| `receiver_max_entries`, `receiver_max_bytes` | Receiver ceilings: integer entries, native size string or integer bytes |
+| `receiver_receipt` | `"sizes"` or `"digests"` |
+| `on_event`, `results`, `check` | See events and failures below |
 
-`follow`, `follow_src`, `follow_dst`, `hash`, `no_compress`, `bwlimit`,
-`connections`, `ignore`, `ignore_from`, `preserve`, `inplace`, `max_size`,
-`min_size`, and `dry_run` retain the exact native meanings. `receiver_max_entries` and
-`receiver_max_bytes` expose the native command-restricted receiver ceilings and are
-therefore accepted only for a direct remote-to-remote copy using an enrolled
-receiver. Rate, size, and duration values accept the native spellings; the
-Python API does not replace them with differently defined unit types.
-`pscope` selects an ephemeral SSH persistence scope created by
-`syq persist on --ephemeral` for `cp` or `rm`. It cannot be combined with
-`rsh`, and the executable remains authoritative for whether the selected
-topology can use the scope. `receiver_receipt` accepts `"sizes"` or `"digests"` and has
-the native receiver-only meaning; `"digests"` asks the receiver to include
-closure-time BLAKE3 file digests.
+Option behavior is covered in [Copy files](https://greaber.github.io/syq/reference.html)
+and [Remote copy details](https://greaber.github.io/syq/remote-reference.html).
+Typed remote-to-remote copies require an enrolled receiver or
+`coordinate_at="local"`. With `dry_run=True` or `verify_only=True`, they require
+`coordinate_at="local"`. Use `run` for detached commands and human output options.
 
-Native ignore rules form one ordered stream: `--ignore` and `--ignore-from`
-take effect in command-line order, and the last matching rule wins. A simple
-`ignore_from=` value follows every pattern supplied through `ignore=`. When
-the two option kinds must be interleaved, put `syq.IgnoreFrom(path)` values in
-the ordered `ignore=` sequence:
-
-```python
-syq.cp(
-    "source",
-    into="destination",
-    ignore=[syq.IgnoreFrom("rules"), "!keep.tmp"],
-)
-```
-
-This serializes as `--ignore-from rules --ignore '!keep.tmp'`. Python cannot
-recover the order in which separately named keyword arguments appeared in a
-call, so `IgnoreFrom` is the native `--ignore-from` occurrence used inside the
-single ordered stream rather than a new filtering concept.
-
-Native remote controls keep their command names mechanically (a
-remote-to-remote copy needs either a command-restricted receiver
-enrollment — its verified receipt becomes the receiver-attested
-results stream — or an explicit `coordinate_at="local"`; syq refuses the
-combination at runtime otherwise): `coordinate_at`, `rsh`,
-`syq_path`, `no_bootstrap`, `tcp_plain`, `no_tcp`, `tcp_ports`,
-`tcp_congestion`, and `peer_auth`. Endpoint strings passed through `from_` and `to` include
-the native optional port syntax. The executable remains authoritative for
-topology, transport, platform, enrollment, and credential-policy constraints.
-
-Human presentation options such as `verbose`, `quiet`, `stats`, `progress`,
-`no_progress`, and `progress_json` are initially omitted from typed methods.
-Typed methods consume structured results and applications render their own
-presentation. Callers that specifically want native human output use `run`.
-If a presentation option is later useful on a typed method, it must appear
-under its native name rather than under a Python synonym.
-
-Typed `cp` and `rm` always consume the automation stream to produce their
-`CpResult` and `RmResult`.
-Passing `results=` also copies the validated NDJSON records to a caller-owned
-binary file-like object:
-
-```python
-with open("run.ndjson", "wb") as records:
-    result = syq.cp("source", into="destination", results=records)
-```
-
-The object must provide `write(bytes)` and may provide `flush()`. The SDK
-flushes it after a complete stream but never closes it. A valid `partial` or
-`refused` terminal record is written before `SyqOperationError` is raised, so
-the saved stream and the exception's result agree. The terminal record is
-withheld if the stream, process exit, or callback does not complete
-consistently. Sink failures abort the operation rather than making an
-incomplete saved stream look successful.
-
-Internally, each typed operation creates a dedicated pipe and passes its write end using
-native `--results-fd`. It never asks syq to put machine output on stdout and
-never parses stdout as automation data. `--results-fd` is an implementation
-detail rather than a caller parameter. Callers that specifically need native
-`--results FILE` path behavior use `run`. Native and Python typed results both
-remain attached operations, so `detach` remains available only through raw
-`run`. A live direct remote-to-remote copy may coordinate remotely: the
-receiver's verified receipt returns as receiver-attested records in the same
-local stream. A remote-to-remote dry run has no such receipt stream and must
-use `coordinate_at="local"`. The SDK mirrors that refusal rather than silently
-opting into a local relay.
-
-## Mapping, transformation, and copy
-
-A mapping entry is a frozen dataclass. It represents the native NDJSON record,
-not a replacement command vocabulary:
-
-```python
-@dataclass(frozen=True, slots=True)
-class MappingEntry:
-    src: RelativePath
-    dst: RelativePath
-    kind: EntryKind | None = None
-    size: int | None = None
-    mtime: int | None = None
-```
-
-`size` and `mtime` are informational when emitted by `syq map`; `syq cp` does
-not turn them into preconditions. `kind` retains the manifest's current
-disambiguation semantics.
-
-`RelativePath` stores raw path bytes, validates mapping-relative syntax, and
-provides explicit text access plus byte-preserving joins. A valid UTF-8 path is
-convenient to construct from `str`; a non-UTF-8 path is constructed from
-`bytes`. Callers do not encode or inspect the NDJSON `{encoding, value}` form.
-
-`map` returns a context-managed `MapStream`:
-
-```python
-from dataclasses import replace
-
-import syq
-
-prefix = syq.RelativePath("by-year")
-
-with syq.map(srcs_in="photos") as mapping:
-    entries = (
-        replace(entry, dst=prefix / entry.dst)
-        for entry in mapping
-        if entry.kind is syq.EntryKind.FILE
-    )
-    result = syq.cp(
-        mapping=entries,
-        cwd=mapping.cwd,
-        to="storage",
-        into="/archive",
-    )
-```
-
-This corresponds to `syq map --srcs-in photos` followed by a transformed
-manifest and `syq cp --mapping ... -C photos --to storage --into /archive`.
-`MapStream.cwd` is the absolute, unresolved spelling of the source base needed
-to execute its emitted `src` paths. Keeping that property named `cwd` makes it
-directly usable as the native `cwd=` parameter. If `map(root=...)` was used,
-that root confines the mapping producer. The separate consumer process cannot
-inherit the producer's pinned descriptor, so it resolves this spelling again
-under its own source follow policy. If the spelling contains a symlink that the
-producer followed, pass `follow_src=True` to the consumer too; use `realpath`
-explicitly when a stable referent spelling is preferable.
-
-`MapStream` yields entries as `syq map` emits them. Reaching normal EOF
-verifies the producer's process status. Leaving the context early kills and
-reaps the owned process. A parse error, nonzero producer status, timeout, or
-interruption raises instead of presenting the yielded prefix as a complete
-mapping.
-
-The method retains `syq map`'s native limits for the pinned binary, including
-`follow_src=True` (or the `follow=True` umbrella) for resolving explicitly
-selected symlink paths. Initially,
-mapping emission is local and read-only, and the accepted selector and
-placement combinations are the ones documented for the executable. The
-client may reject a known-invalid combination before launch, but it does not
-invent a broader mapping operation.
-
-### Complete-input guarantee
-
-When `mapping` is a Python iterable, `cp` consumes and serializes the entire
-iterable into a secure temporary manifest before launching the mutating syq
-command. If iteration, transformation, serialization, or the `syq map`
-producer fails, no copy process has started and the destination is untouched.
-
-This is load-bearing. A pipe cannot distinguish a producer that cleanly
-finished from one that failed after writing a valid prefix. Launching the copy
-first could therefore apply an incomplete mapping. Materializing the complete
-mapping matches syq's whole-manifest conflict preflight and scales on disk
-rather than retaining another complete Python object graph.
-
-After successful materialization, syq performs its own authoritative manifest
-validation and conflict checks. The temporary file remains available until the
-child exits and is then removed. Its SDK-generated path is canonicalized before
-launch so a symlink in the system temporary-directory path does not require
-`follow=True`; this does not alter the treatment of caller-supplied paths.
-Passing a manifest path to `mapping` skips Python materialization and passes
-that file to syq unchanged.
-
-Callers that intentionally want raw stdin behavior can use:
-
-```python
-client.run(["cp", "--mapping", "-", "--into", "dst"], input=manifest)
-```
-
-That low-level call does not acquire typed `cp`'s complete-generator guarantee.
-The typed API does not initially expose a `stream=True` switch.
-
-## Copy and prune
-
-```python
-result = syq.cp(
-    srcs_in="build",
-    to="server",
-    into_existing="/srv/app",
-    prune=True,
-    max_delete=100,
-)
-```
-
-There is no `cp_prune` Python method because there is no `cp-prune` native
-command. `prune=True` serializes as `--prune` on `cp`; `max_delete` serializes
-as `--max-delete` and is valid only with `prune=True`. Prune does not accept
-`mapping`, because native mappings do not define deletion scopes. The library
-does not infer a deletion scope or retry a refused prune.
+To interleave rule files and inline patterns:
+`ignore=[syq.IgnoreFrom("rules"), "!keep.tmp"]`. The last matching rule wins.
 
 ## Removal
 
-Typed removal uses the native selector and endpoint grammar and returns a
-validated `RmResult`:
+`rm(*sources, **options) → RmResult` removes selected entries. Besides the shared
+arguments, it accepts `from_`, `dry_run`, `connections`, `syq_path`,
+`no_bootstrap`, `pscope`, `on_event`, `results`, and `check` with the types above.
+It supports local and ordinary SSH endpoints. Command-restricted receivers
+reject removal. See [Remove files](https://greaber.github.io/syq/remove.html).
 
-```python
-result = client.rm(
-    src_dir="old-output",
-    from_="server",
-    root="/srv",
-)
-print(result.entries_removed, result.selectors_missing)
-```
+<a id="complete-input-guarantee"></a>
 
-`SelectionResult` attributes every explicit selector by its zero-based order
-and records whether it resolved or was already missing. A live removal emits
-`RemovalResult` for each settled entry; a preview emits `RemovalTrace` for each
-entry it could inspect and a failed `RemovalResult` for an inspection failure.
-Duplicate and overlapping selectors remain distinct, and an entry removed by
-one before another reaches it has `ALREADY_ABSENT` disposition rather than
-being silently lost from the account.
+## Mapping, transformation, and copy
 
-Local and ordinary SSH endpoints support typed removal. A command-restricted
-receiver rejects native `rm`: the current signed receiver grants authorize
-copy mutations, not arbitrary deletion, and the SDK does not weaken that
-boundary or fall back to parsing human output. Designing an explicit signed
-delete scope and safety ceiling is separate product work.
+`map(*sources, **options) → MapStream` lists local mapping entries without
+copying. Besides the shared arguments, it accepts `as_` to rename a selected
+object. `srcs_in` must be the sole selector when used.
 
-## Dry runs
+| Type / member | Meaning |
+|---|---|
+| `MapStream` | Iterable context manager yielding `MappingEntry`; use `with` |
+| `AsyncMapStream` | Async iterable context manager; use `async with` |
+| `mapping.cwd` | Absolute source-base spelling to pass unchanged to `cp(cwd=...)` |
+| `MappingEntry(src, dst, kind=None, size=None, mtime=None)` | Frozen dataclass; `src` and `dst` are `RelativePath`; size and mtime are informational |
+| `EntryKind` | `FILE`, `DIR`, `SYMLINK`, or `SPECIAL` |
+| `RelativePath(value)` | Mapping-relative path from text, bytes, or a path-like object; `/` joins components; `.raw` gives bytes; `.text` decodes UTF-8 strictly |
+| `PathValue` | Event path; `.raw` gives bytes, `.text` decodes UTF-8 strictly, `.display` provides readable text |
 
-`--dry-run` remains `dry_run=True` on the same operation:
+Normal end of iteration checks the mapping process status. Leaving the context
+early stops the process. Pass `mapping.cwd` through without normalizing it.
+A consuming copy resolves that path again; `map(root=...)` does not transfer its
+confinement to the copy. Pass `follow_src=True` to both calls when the source
+base requires following symlinks.
 
-```python
-preview = syq.cp(srcs_in="build", into="staging", dry_run=True)
-preview = syq.cp(
-    srcs_in="build",
-    into_existing="staging",
-    prune=True,
-    max_delete=100,
-    dry_run=True,
-)
-removal_preview = syq.rm(src_dir="old-output", root="/srv", dry_run=True)
-```
+For `cp(mapping=iterable)`, the entire iterable is saved to a temporary manifest
+before copying starts. An iteration or serialization failure starts no copy.
+`AsyncClient.cp` also accepts async iterables. Passing a manifest path uses that
+file directly. See [mapping rules](https://greaber.github.io/syq/mappings.html).
 
-There are no `preview_copy` or `preview_copy_prune` commands. Those would
-rename the native operation and make flags change the Python verb. `CpResult`
-or `RmResult` carries `dry_run=True`; copy uses `TraceEvent` while removal uses
-`RemovalTrace` to describe planned mutations. Live runs use their corresponding
-`OperationResult` or `RemovalResult` records.
-
-A dry run describes what syq observed and would have done. It is not an
-executable transaction, authorization token, or promise that the filesystem
-will remain unchanged before a later operation. The automation results stream
-supplies the shared execution trace and terminal result.
+<a id="retry-data-not-automatic-retry-policy"></a>
 
 ## Events and terminal results
 
-Typed operations consume the stable automation stream. `on_event` receives
-frozen dataclasses corresponding to its known records: `RunEvent`, sampled
-`ProgressEvent`, copy `TraceEvent` or `OperationResult`, removal
-`SelectionResult`, `RemovalTrace`, or `RemovalResult` (including inspection
-failures during a preview), `ErrorEvent`,
-receiver-attested `FinalStateEvent`, and the terminal `CpResult` or `RmResult`.
-Additive unknown record types are validated for a well-formed envelope and
-sequence position, then ignored.
+`cp` and `rm` return frozen dataclasses after validating the complete results
+stream and process exit status. A truncated stream raises even if the process
+exits successfully. Dry runs return the same types, with planned totals.
 
-The product's [automation results contract](https://greaber.github.io/syq/automation.html) and
-[JSON Schema](https://github.com/greaber/syq/blob/master/schemas/automation.schema.json), not this document, own
-their exact fields and enum members. The Python types expose every stable
-schema field without parsing display text.
+| Result | Attributes |
+|---|---|
+| Both | `status`, `exit_code`, `dry_run`, `errors`, `elapsed_ms`, `schema`, `schema_version`, `seq`, `type` |
+| `CpResult` | `files_transferred`, `files_unchanged`, `files_excluded`, `directories_created`, `symlinks_created`, `specials_created`, `bytes_transferred`, `bytes_unchanged` |
+| Copy deletion totals | `deletions_planned`, `deletions_completed`, `deletions_blocked`; `None` when inapplicable |
+| Receiver-attested copy fields | `provenance`, `receipt_status`, `operations`, `final_states`, `receipt_records`; `None` on ordinary results |
+| `RmResult` | `selectors_total`, `selectors_resolved`, `selectors_missing`, `entries_planned`, `entries_removed`, `entries_already_absent`, `entries_failed`, `mode` |
 
-The client validates at least these stream invariants:
+`status` is `OperationStatus.SUCCESS`, `PARTIAL`, `REFUSED`, `ABORTED`, or `FAILED`.
+Ordinary prune results have all three deletion totals; receiver-attested
+results have only `deletions_completed`.
 
-- the schema identifier and supported major version;
-- the required first record;
-- strictly increasing sequence numbers starting at zero;
-- path tags and unsigned 64-bit integer ranges;
-- required fields and documented enum values;
-- the final-state object's per-state field variants and the
-  receiver-attested terminal shape (receipt status vocabulary, required
-  bookkeeping, and `deletions_completed`);
-- agreement between the invocation and the run's `mode`, command-specific
-  fields, and `dry_run` flag;
-- agreement between removal selector, per-path, and error records and every
-  corresponding terminal counter;
-- exactly one terminal result, with nothing after it; and
-- agreement between the terminal exit code and the reaped process status.
+`on_event(event)` receives an `AutomationEvent` in stream order. Events are not
+stored in the result. `AsyncClient` accepts synchronous or awaitable callbacks;
+awaitable callbacks count toward the timeout.
 
-EOF without a terminal result is never success, even if every observed
-operation succeeded or the process status is zero.
+| Event types | Content |
+|---|---|
+| `RunEvent`, `ProgressEvent` | Run description and sampled progress |
+| `TraceEvent`, `OperationResult` | Planned or completed copy operation |
+| `SelectionResult` | Removal selector resolution |
+| `RemovalTrace`, `RemovalResult` | Planned removal or settled entry, including preview inspection failures |
+| `ErrorEvent` | Diagnostic |
+| `FinalStateEvent` | Receiver-attested final object state |
+| `CpResult`, `RmResult` | Terminal totals |
 
-Successful operation events are not retained by default. A copy or removal
-may contain millions of entries; callers that need a ledger consume `on_event`
-and write one. Terminal aggregates are retained in the returned command-specific
-result. `RmResult` separates selector resolution from planned, removed,
-already-absent, and failed entry totals. Prune-only
-deletion totals are optional fields on that same type. An ordinary terminal
-carries all three exactly when the run has `prune=True`; a receiver-attested
-terminal carries only `deletions_completed` (planning and `--max-delete`
-blocking are coordinator concepts a receipt cannot attest).
+See [Automation results](https://greaber.github.io/syq/automation.html) for field
+meanings. Python exposes `class` as `class_`, paths as `PathValue`, and enum
+values as string enums.
+
+`results=` accepts a binary file-like object with `write(bytes)` returning a
+positive byte count for nonempty writes, and optional `flush()`. The client
+copies validated NDJSON records, flushes after completion, and leaves it open.
+It withholds the terminal record if stream validation, process completion, or
+a callback fails. Sink failures raise and abort the operation.
+
+`OperationResult.is_retryable` identifies retryable failures; `retry_entry()`
+returns a `MappingEntry` when a complete mapping identity is available, otherwise
+`None`. Only use collected entries after the call returns a validated `success`
+or `partial` result. A terminal callback alone does not establish completion.
+The client does not retry automatically.
 
 ## Failure model
 
-The exception families have distinct meanings:
-
-| Exception | Meaning |
+| Exception | Meaning / useful attributes |
 |---|---|
-| `SyqInstallError` | The managed executable could not be installed or verified |
-| `SyqInvocationError` | Python inputs cannot form a valid native operation |
-| `SyqProcessError` | Raw `run` completed with a nonzero status, preserving its current meaning |
-| `SyqOutputError` | A raw helper such as `version()` could not interpret its expected output |
-| `SyqProtocolError` | Machine output was malformed, unsupported, inconsistent, or incomplete |
-| `SyqOperationError` | A valid terminal result reports a non-successful operation |
+| `SyqInstallError` | Managed executable installation or verification failed |
+| `SyqInvocationError` | Invalid Python arguments |
+| `SyqOperationError` | Typed operation was unsuccessful; `.result` and `.stderr` (last 8 KiB) |
+| `SyqProtocolError` | Invalid, unsupported, inconsistent, or incomplete results; `.returncode`, `.stderr` |
+| `SyqProcessError` | Raw `run` exited nonzero; `.result` contains complete output |
+| `SyqOutputError` | A helper such as `version()` received unexpected output |
 
-`SyqOperationError.result` contains the typed terminal result and its `stderr`
-attribute retains up to the final 8 KiB of diagnostic output.
-`SyqProtocolError` retains the raw process status and bounded diagnostic
-context needed to investigate. Typed streaming calls drain stderr concurrently
-into that bounded in-memory tail rather than spooling the complete stream to
-temporary storage. Process spawn failures and timeouts retain the existing
-standard Python exception behavior of the raw adapter.
+For `cp` and `rm`, `check=False` returns unsuccessful typed results; for `run`,
+it returns nonzero process results. It does not suppress other errors.
+Spawn failures and timeouts use standard Python exceptions. Callback exceptions
+are re-raised after stopping the operation.
 
-`check=False` affects only `SyqOperationError`. It cannot turn install,
-invocation, process, or protocol failures into successful return values.
+Timeout, cancellation, early mapping exit, and streaming failures terminate and
+reap the local process group, including SSH children. Filesystem changes already
+completed are not rolled back.
 
-If an event callback raises, the client stops scheduling through process
-termination, kills and reaps the owned process group, and re-raises the
-callback exception. Filesystem operations already committed by syq are not
-rolled back.
-
-## Retry data, not automatic retry policy
-
-A failed `OperationResult` exposes its structured retryability and can produce
-a `MappingEntry` only when it contains a complete mapping identity:
-
-```python
-retryable = []
-
-def collect_retryable(event: syq.AutomationEvent) -> None:
-    if isinstance(event, syq.OperationResult) and event.is_retryable:
-        entry = event.retry_entry()
-        if entry is not None:
-            retryable.append(entry)
-```
-
-The package may provide a disk-backed `RetryManifest` convenience, but it does
-not automatically rerun operations. Retry timing, attempt limits, and whether
-the source/destination state is still appropriate belong to the application.
-
-An incomplete stream cannot produce a complete retry manifest: unobserved
-operations may exist. Collected entries must not be used until the terminal
-result arrives with status `success` or `partial`, the two statuses for which
-the automation contract guarantees that every queued operation settled.
+<a id="deliberate-exclusions"></a>
 
 ## Raw execution
 
-The existing escape hatch remains small and transparent:
+`client.run(args, *, check=True, cwd=None, env=None, timeout=None, input=None)`
+returns `Result(argv, returncode, stdout, stderr)`. `stdout` and `stderr` are
+fully captured bytes; `input` accepts bytes. `args` is a sequence of arguments
+after the executable name, passed without a shell.
 
-```python
-result = client.run(
-    ["receiver", "list"],
-    check=True,
-    timeout=30,
-)
-```
-
-`Client.run` and `syq.run` accept only arguments after the executable name and
-never construct a shell command. The process layer also supports:
-
-- `input=` for bounded bytes;
-- text and byte path-like argv entries on Unix; and
-- complete byte stdout and stderr capture for callers that deliberately need
-  the raw process output.
-
-Raw execution returns raw bytes and a process status. It does not parse human
-output, infer native objects from argv, or claim the structured completion
-guarantees of typed methods.
-
-## Synchrony, asyncio, and resource ownership
-
-`Client` and `AsyncClient` both expose `run`, `version`, typed `cp` (including
-`prune=True`), `rm`, and `map`. Their public method names, parameter names,
-defaults, result objects, validation, and failure types match. `AsyncClient`
-uses native asyncio subprocesses rather than wrapping the synchronous client
-in a thread.
-
-```python
-client = syq.AsyncClient(process_cwd="/srv/jobs")
-result = await client.cp("project", to="server", into="/backup")
-removed = await client.rm("old-project", from_="server")
-
-async with client.map(srcs_in="photos") as mapping:
-    result = await client.cp(mapping=mapping, cwd=mapping.cwd, into="photos")
-```
-
-`AsyncClient.map()` returns `AsyncMapStream` directly; the subprocess starts
-lazily on context entry or first iteration, so there is no extra `await`
-before `async with`. Its `on_event` accepts either an ordinary callback or an
-awaitable callback. Awaitable callbacks run in record order and count toward
-the operation timeout. An ordinary callback runs on the event-loop thread and
-should return quickly.
-
-The deliberately asynchronous additions are support for async mapping
-iterables, awaitable event callbacks, and async iteration/context management.
-Writes to a synchronous `results=` object are buffered to a bounded size and
-performed off the event-loop thread. Both clients preserve record order and
-leave the object open.
-
-Normal method calls reap before returning. Early mapping-context exit,
-timeout, cancellation, callback failure, or decoder failure kills and reaps
-the whole owned process group so SSH transports and other descendants cannot
-survive as stale work. Python mapping iterables are fully materialized in a
-worker thread before `cp` starts. Async iterables are consumed incrementally
-and flushed in bounded chunks, also before process launch. Cancellation asks
-synchronous materialization to stop between iterator and temporary-file
-operations, then waits only for an in-flight operation before removing the
-file.
-
-## Compatibility and versioning
-
-Every published Python package has the same version as the exact syq release it
-pins. That is the tested default pairing, and a published Python version never
-changes its pin. Python-only changes ship with the next syq release rather than
-creating an independently numbered package.
-
-The automation schema has its own version. The Python package supports stated
-schema major versions rather than guessing compatibility from the executable's
-marketing version. Additive fields and enum values follow the automation
-schema's compatibility policy.
-
-Mapping entries are supported at the exact SDK/binary pairing. A separately
-versioned mapping schema can broaden that compatibility boundary later.
-
-The Python package does not maintain a compatibility version separate from the
-syq product release. Python API and native changes still follow their documented
-compatibility contracts; sharing a release number does not make the executable
-version a substitute for the automation schema version.
-
-The naming rule is part of compatibility. A new native command `foo-bar`
-reserves `foo_bar`; a new semantic `--some-option` reserves `some_option`.
-SDK-only concepts must not occupy names that are the mechanical Python form of
-current or planned native grammar. A parsing-only alias may be omitted, as with
-the plural selector options, but must not be exposed under a different name.
-
-## Deliberate exclusions
-
-The initial typed API does not provide:
-
-- a Python implementation of the transfer engine;
-- FFI or an in-process Rust runtime;
-- a typed mirror of `syq rsync`;
-- semantic aliases for native commands or options;
-- a generic `extra_args` hole in typed methods—use `run` instead;
-- automatic retries or rollback;
-- an unbounded in-memory operation ledger;
-- implicit confirmation for destructive operations;
-- implicit selection of a newer syq from `PATH`; or
-- API promises for human stdout, stderr, or progress formatting.
-
-## Product readiness
-
-| Layer | Product dependency | Current readiness |
-|---|---|---|
-| Managed executable and raw `run` | Released binary manifest | Implemented |
-| Raw stdin and safe streaming | Process behavior only | Implemented |
-| `RelativePath` and mapping codecs | Exact binary pairing | Implemented |
-| `map` and safe `cp(mapping=...)` input | Native mapping commands | Implemented |
-| Typed `cp`, including `prune=True` | Automation results stream | Implemented |
-| Typed `rm` | Native `rm` result stream | Implemented for local and ordinary SSH endpoints |
-| Typed `dry_run=True` | Automation trace records | Implemented |
-| Asyncio native commands and mapping stream | Same contracts as `Client` | Implemented |
-
-The source inventory `native-api.json` records the disposition of every native
-option. Rust tests require new options to appear there. A feature PR may put an
-option in `follow_up` instead of implementing Python immediately, but the syq
-release workflow rejects any remaining follow-up. A post-merge workflow keeps
-one GitHub tracking issue open while follow-ups exist. Python signature tests
-and candidate execution tests verify the other side of the contract.
+Here, `cwd` is the local subprocess directory. `cwd`, `env`, and `timeout`
+use the client defaults when omitted or `None`. Module-level `syq.run` takes
+the same arguments plus `executable=None`.

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -123,7 +123,7 @@ object. `srcs_in` must be the sole selector when used.
 
 `MapStream` is an iterable context manager yielding [MappingEntry](https://greaber.github.io/syq/python-reference.html#mappingentry); use `with`.
 `AsyncMapStream` is its async equivalent; use `async with`. Both expose `cwd`
-(`str | bytes`), the absolute source-base spelling to pass to `cp(cwd=...)`.
+(`pathlib.Path`), the absolute source-base spelling to pass to `cp(cwd=...)`.
 
 ### MappingEntry
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -181,7 +181,7 @@ base, which may be on a remote host.
 
 To use an existing executable, pass `Client(executable="/opt/bin/syq")`.
 This bypasses the managed version; see
-[Compatibility](https://greaber.github.io/syq/sdk-compatibility.html).
+[Compatibility](https://greaber.github.io/syq/python-reference.html#compatibility).
 
 <a id="native-api-reference"></a>
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,128 +1,125 @@
-# syq for Python
+<a id="syq-for-python"></a>
 
-The official Python client for [syq](https://github.com/greaber/syq), a fast
-file transfer tool. Call `syq.cp(...)` (including `cp --prune`), `syq.rm(...)`,
-and `syq.map(...)` and get typed results back; every other syq command remains
-one `syq.run([...])` away.
+# Guide and examples
 
-```sh
-python -m pip install syq
-```
+Use the `syq` package to call syq from Python. See
+[installation](https://greaber.github.io/syq/python.html#install) if you have not
+installed it yet.
 
-Installing the package does not install syq itself. The first default call that
-needs syq downloads the matching syq release if it is not
-already cached, checks it against the signed release manifest, and uses that
-managed binary for subsequent default calls.
-The Python package and its managed syq executable share one version: package `0.4.0`
-manages syq `0.4.0`.
-syq always runs as a subprocess with an argument list, never through a shell.
+## Copy files
+
+Copy a directory named `data` into `backup`, producing `backup/data`:
 
 ```python
 import syq
 
-print(syq.__version__)           # Python package version
-print(syq.PINNED_SYQ_VERSION)    # tested executable version
-print(syq.managed_executable())  # downloads once, then returns the cached path
-
-plan = syq.cp("project", to="server", into="/backup", dry_run=True)
-print(plan.files_transferred, plan.bytes_transferred)
+result = syq.cp("data", into="backup")
+print(result.files_transferred, result.bytes_transferred)
 ```
 
-The typed API validates syq's complete automation results stream and its agreement
-with the process status. Dry and live calls return the same `CpResult` type;
-dry runs report planned mutation totals and emit `TraceEvent` records:
+To copy just its contents, use `srcs_in`:
 
 ```python
-client = syq.Client(process_cwd="/srv/jobs")
-
-preview = client.cp(
-    srcs_in="build",
-    to="server",
-    into_existing="/srv/app",
-    prune=True,
-    max_delete=100,
-    dry_run=True,
-)
-
-removal = client.rm(
-    src_dir="old-output",
-    from_="server",
-    root="/srv",
-)
-print(removal.entries_removed, removal.selectors_missing)
+result = syq.cp(srcs_in="data", into="backup")
 ```
 
-Typed `rm` works for local and ordinary SSH endpoints. A command-restricted
-receiver rejects native removal because its signed grants currently authorize
-copy mutations only.
+Arguments follow the command-line names: replace hyphens with underscores,
+and add a trailing underscore for Python keywords, such as `from_` and `as_`.
+The [copy guide](https://greaber.github.io/syq/reference.html) explains placement,
+filtering, and verification options.
 
-Remote-copy controls use the same names with underscores, including `coordinate_at`,
-`rsh`, `pscope`, `syq_path`, `no_bootstrap`, `tcp_plain`, `no_tcp`, `tcp_ports`,
-`tcp_congestion`, and `peer_auth`. `detach` stays
-on raw `run()` because a detached command cannot return typed attached results.
-`pscope` is also available on typed `rm`. Direct remote-to-remote copies can
-lower the enrolled receiver's entry and byte ceilings with
-`receiver_max_entries=` and `receiver_max_bytes=`, and can request receipt
-detail with `receiver_receipt="sizes"` or `receiver_receipt="digests"`.
-Ignore rules retain native ordering when interleaved by using
-`ignore=[syq.IgnoreFrom("rules"), "!keep.tmp"]`; `ignore_from=` remains the
-simple form when every file follows the inline patterns.
+## Copy over SSH
 
-`on_event` receives typed records as syq produces them without keeping a
-potentially enormous operation ledger in memory:
+Use `to` for an SSH destination and `from_` for an SSH source:
+
+```python
+syq.cp("data", to="user@server", into="/backup")
+syq.cp("report.csv", from_="user@server", cwd="/exports", into="downloads")
+```
+
+SSH hosts and paths are separate arguments. See
+[Copy between servers](https://greaber.github.io/syq/remote-to-remote.html)
+for copies with two remote endpoints. A typed remote-to-remote preview needs
+`coordinate_at="local"`; a live copy can also use an enrolled receiver.
+
+## Preview changes
+
+Pass `dry_run=True` to preview a copy or removal. The result has the same type
+as a live call, with counters describing the planned changes:
+
+```python
+preview = syq.cp("data", into="backup", dry_run=True)
+print(preview.files_transferred, preview.bytes_transferred)
+```
+
+Remove `dry_run=True` to apply the changes. syq checks the filesystem again
+when that call runs.
+
+## Mirror a directory
+
+Use `prune=True` to also remove destination entries absent from the source.
+Here, `staging` must already exist, and `max_delete` limits deletions:
+
+```python
+result = syq.cp(
+    srcs_in="build",
+    into_existing="staging",
+    prune=True,
+    max_delete=100,
+)
+```
+
+## Remove files
+
+```python
+result = syq.rm(src_dir="old-output", root="/srv/jobs")
+print(result.entries_removed, result.selectors_missing)
+```
+
+`root` confines removal to that directory. Add `from_="server"` to remove files
+over ordinary SSH. Command-restricted receivers do not support `rm`. See
+[Remove files](https://greaber.github.io/syq/remove.html) for selector behavior.
+
+## Handle failures
+
+A failed copy or removal raises `SyqOperationError` with its typed result:
+
+```python
+try:
+    result = syq.cp("data", into="backup")
+except syq.SyqOperationError as error:
+    print(error.result.status, error.result.errors)
+    print(error.stderr.decode(errors="replace"))
+```
+
+Use `check=False` to receive unsuccessful results without that exception.
+Invalid arguments, installation failures, and incomplete or invalid results
+still raise exceptions. Completed filesystem changes are not rolled back.
+
+## Watch events and save results
+
+`on_event` receives records as the operation runs. For example, show each copied
+entry or planned change:
 
 ```python
 def observe(event: syq.AutomationEvent) -> None:
     if isinstance(event, (syq.TraceEvent, syq.OperationResult)):
         print(event.action, event.dst)
-    elif isinstance(event, (syq.RemovalTrace, syq.RemovalResult)):
-        print(event.disposition, event.path)
 
 result = syq.cp("data", into="backup", on_event=observe)
 ```
 
-Pass a caller-owned binary file-like object as `results=` to retain the same
-validated NDJSON stream that produced the returned `CpResult` or `RmResult`:
+Events are not collected in the returned result. To save the validated NDJSON
+records, pass an open binary stream:
 
 ```python
 with open("run.ndjson", "wb") as records:
     result = syq.cp("data", into="backup", results=records)
 ```
 
-The object must report positive byte counts for non-empty writes. Nonblocking
-sinks that return `None` when full are rejected so an incomplete result stream
-cannot appear successful. The SDK flushes but never closes the object. Typed
-calls receive automation records through native `--results-fd`; stdout is not
-treated as machine output. Callers that need native `--results FILE` path
-behavior can use `run()`.
+## Rename while copying
 
-Asyncio applications use the same command names and result types. Native
-asyncio subprocesses keep the event loop responsive; async callbacks are
-awaited in stream order:
-
-```python
-import asyncio
-import syq
-
-client = syq.AsyncClient(process_cwd="/srv/jobs")
-events = asyncio.Queue()
-
-async def observe(event: syq.AutomationEvent) -> None:
-    await events.put(event)
-
-result = await client.cp(
-    "data",
-    to="server",
-    into="backup",
-    on_event=observe,
-)
-
-removed = await client.rm("old-data", from_="server", on_event=observe)
-```
-
-Mapping output is streaming and context-managed. Passing Python mapping
-entries to `cp` first materializes the complete iterable on disk, so a failed
-transform cannot launch a copy with only a valid prefix:
+Create a mapping, change its destination paths, then copy:
 
 ```python
 from dataclasses import replace
@@ -135,59 +132,69 @@ with syq.map(srcs_in="photos") as mapping:
     result = syq.cp(mapping=entries, cwd=mapping.cwd, into="published")
 ```
 
-The async mapping stream is lazy and uses an async context manager:
+This places the contents of `photos` under `published/archive`. Pass
+`mapping.cwd` through unchanged so the copy uses the mapping's source base.
+If the mapping required `follow_src=True`, use it on the copy too.
+The iterable must finish successfully before copying starts; a failed transform
+leaves the destination untouched. See
+[Rename and reorganize](https://greaber.github.io/syq/mappings.html) for mapping rules.
+
+## Use asyncio
+
+Await operations on `AsyncClient`. Its arguments and results match `Client`:
 
 ```python
-async with client.map(srcs_in="photos") as mapping:
-    result = await client.cp(
-        mapping=mapping,
-        cwd=mapping.cwd,
-        into="published",
-    )
+import asyncio
+import syq
+
+async def main():
+    client = syq.AsyncClient()
+    result = await client.cp("data", into="backup")
+    print(result.files_transferred)
+
+asyncio.run(main())
 ```
 
-`mapping.cwd` is the absolute source-base spelling to pass to the consuming
-copy. It preserves component order such as `link/../selected` so the native
-walker encounters the link before `..`, and it expands `~/` with the mapping
-subprocess's `HOME`. Do not normalize or resolve it between `map` and `cp`.
-
-The source tree may contain typed support ahead of the latest released syq
-pin. During that development interval, use `Client(executable=...)` or
-`AsyncClient(executable=...)` with the candidate binary; the next SDK release
-updates the immutable pin only after candidate conformance tests pass.
-
-The managed executable is stored below
-`$XDG_CACHE_HOME/syq/sdk/python/v0.4.0/` or, when `XDG_CACHE_HOME` is not an
-absolute path, `~/.cache/syq/sdk/python/v0.4.0/`. The SDK checks the complete
-cached binary against its embedded release manifest before every use. A corrupt
-or missing cache entry is replaced atomically with a freshly downloaded,
-verified binary.
-
-`run()` raises `SyqProcessError` for a nonzero process status by default. The
-exception retains the complete result, including stdout and stderr as bytes.
-Pass `check=False` when the caller wants to interpret the status directly.
-When `timeout` expires or the caller is interrupted, the SDK kills and reaps
-syq's local process group, including child processes such as SSH transports,
-before propagating the exception.
-
-## Custom executable override
-
-An explicit executable bypasses the managed version:
+Async event callbacks are awaited in record order. Mapping streams use
+`async with` and `async for`; there is no `await` before `client.map()`:
 
 ```python
-result = syq.run(["--help"], executable="/opt/custom/bin/syq")
-custom_version = syq.version(executable="syq")  # intentional PATH lookup
+async def copy_photos():
+    client = syq.AsyncClient()
+    async with client.map(srcs_in="photos") as mapping:
+        return await client.cp(mapping=mapping, cwd=mapping.cwd, into="published")
 ```
 
-The SDK makes no compatibility or provenance guarantee for an override. Use it
-for local development, controlled offline provisioning, or when deliberately
-testing a different syq release.
+<a id="custom-executable-override"></a>
 
-The package targets Python 3.10 or newer on Linux and macOS and has no runtime
-Python dependencies. See the [SDK compatibility policy](https://greaber.github.io/syq/sdk-compatibility.html) for the
-release mapping.
+## Configure a client
 
-## Native API reference
+Share a local working directory and timeout across calls:
 
-See [Python native API](https://greaber.github.io/syq/python-reference.html) for command signatures, mappings,
-failure behavior, resource ownership, and the CLI/SDK synchronization policy.
+```python
+client = syq.Client(process_cwd="/srv/jobs", timeout=3600)
+result = client.cp("data", into="backup")
+```
+
+`process_cwd` sets the local subprocess directory; typed `cwd` sets the source
+base, which may be on a remote host.
+
+To use an existing executable, pass `Client(executable="/opt/bin/syq")`.
+This bypasses the managed version; see
+[Compatibility](https://greaber.github.io/syq/sdk-compatibility.html).
+
+<a id="native-api-reference"></a>
+
+## Run other commands
+
+`run` accepts arguments after the executable name and returns captured bytes:
+
+```python
+result = syq.run(["--help"])
+print(result.stdout.decode())
+```
+
+Use it for commands without a typed method, including `rsync` and receiver
+administration. See the
+[API reference](https://greaber.github.io/syq/python-reference.html) for process
+options and exceptions.


### PR DESCRIPTION
The Python pages mixed examples and API lookup with design rationale, future ideas, and release administration. The introduction now covers installation, the guide starts with an actual local copy, and the reference defines command arguments and concrete return types.

- Rename the sidebar entry to Python and remove redundant introductory navigation.
- Remove positioning, naming debates, readiness, and planned API sections.
- Define CpResult, RmResult, MappingEntry, raw Result, event fields, and enums with Python types and field meanings. Explain optional fields and dry-run, verification, and receiver-receipt totals.
- Fold executable compatibility and caching into the API reference. Redirect the former compatibility page and preserve all existing heading anchors.
- Keep shared Markdown for the website and package/source README. Remove release preparation's obsolete version-marker rewrite from the guide; regression tests verify package/manifest updates and an unchanged README.

Validation at f200907:
- Pinned mdBook 0.5.4 build, 19-file Markdown link check, 83 rendered links, previous heading anchors, and compatibility redirect passed.
- Result/mapping field names and types, event fields, and enum members checked against Python definitions; command parameter coverage and Python snippet syntax passed.
- Copy, preview, and removal result behavior checked against managed syq 0.4.0 in disposable directories. Updated public preview pages verified.
- Whitespace check passed. Twelve guide examples, release-preparation regression tests, and changed-script ShellCheck passed at fbd2f94; their implementation is unchanged by the follow-up.
- Remote SSH examples and full Rust/SDK suites were not run; no runtime APIs or persisted formats changed.

Preview: https://chapter-tend-updating-paperbacks.trycloudflare.com/python.html
