### PR TITLE
Run approved commands on receiving machines over return connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It is built for large files, large trees, and fast networks.
 - **Parallel copies and removal**, with automatic connection tuning.
 - **Resume interrupted copies** by rerunning the command.
 - **Direct server-to-server transfers** without forwarding your SSH agent.
+- **Approved commands on your receiving machine**, for local builds and opening artifacts.
 - **Gitignore-style filters**, programmable file placement, and JSON results.
 
 [Documentation](https://greaber.github.io/syq/) ·

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Copy files](reference.md)
 - [Remove files](remove.md)
 - [Send files home from a server](receive.md)
+- [Run commands on your receiving machine](exec.md)
 - [Copy between servers](remote-to-remote.md)
 - [Rename and reorganize](mappings.md)
 

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -25,8 +25,10 @@ completion does not contact the receiving machine or request approval.
 
 Each command waits for approval on the receiving machine. Its desktop prompt
 shows the server account, program and literal arguments, working directory,
-and the permission being granted. You can also inspect and decide requests
-from a terminal there:
+and the permission being granted. Desktop notifications may truncate long
+commands and hide trailing arguments. Use `syq recv pending` on the receiving
+machine to inspect the complete request before approving a command whose full
+text is not visible. You can inspect and decide requests from a terminal there:
 
 ```sh
 syq recv pending
@@ -50,8 +52,9 @@ safe. Commands have a separate approval type in `recv pending --json`, with
 strings in that summary are escaped for display.
 
 Older clients that only understand copies cannot approve command requests.
-Use the matching new binary to list and approve them; old clients may show no
-pending requests while a command is pending. Their stop request still works.
+Use the matching new binary to list and approve them; old clients omit command
+requests from their pending list. They can still list and approve copies from
+other server connections, and their stop request still works.
 
 ## Arguments and working directories
 
@@ -88,8 +91,9 @@ an error even if some output arrived successfully.
 
 Interrupting the requesting syq process, losing the connection, changing
 receiving settings, `recv off`, or `persist off` cancels execution. Syq kills
-the command's process group and reaps its leader. It also cleans up that group
-when the foreground program exits. A program that deliberately creates a
+the command's process group with `SIGKILL` and reaps its leader. It also kills
+remaining processes in that group when the foreground program exits, without
+giving them time to run cleanup handlers. A program that deliberately creates a
 separate process session, or an application launched through macOS `open`, can
 outlive that group. Syq does not manage detached jobs.
 

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -1,0 +1,117 @@
+# Run commands on your receiving machine
+
+From a server shell, ask your Mac or Linux desktop to run a command:
+
+```sh
+syq exec --on @laptop --cwd work/project -- cargo test
+syq exec --on @laptop --cwd work/project -- open report.html
+```
+
+The second command uses macOS's `open` program to display an artifact. Any
+program installed on the receiving machine can be requested, including a
+native application or a version of syq you have just built there.
+
+Commands use the same background connection as [return copies](receive.md).
+Turn on persistence on the receiving machine and connect to the server with
+syq. No SSH server or incoming network port is needed on the receiving machine.
+Requests work from independent server shells, including existing tmux sessions.
+
+`--on` selects a receiving name. Both `laptop` and `@laptop` require a live
+return connection; neither falls back to DNS or an SSH connection. Both ends
+must run the same syq build. Names and options complete from local information;
+completion does not contact the receiving machine or request approval.
+
+## Approve each command locally
+
+Each command waits for approval on the receiving machine. Its desktop prompt
+shows the server account, program and literal arguments, working directory,
+and the permission being granted. You can also inspect and decide requests
+from a terminal there:
+
+```sh
+syq recv pending
+syq recv approve REQUEST_ID
+syq recv deny REQUEST_ID
+```
+
+Command requests are available whenever receiving is enabled. Every command
+requires its own decision, even with `syq recv on --approve always` for copies.
+Approving a copy does not approve commands. A missing or dismissed desktop
+prompt never grants permission; use the local terminal commands. Pending
+requests expire after five minutes and are cancelled when the requester
+disconnects or receiving restarts or stops.
+
+An approved command runs with your local user's permissions, including access
+to files and credentials. **The receiving `--root` and copy limits do not
+contain commands.** Build tools and scripts can execute code from their input
+files; approving a displayed command does not establish that those files are
+safe. Commands have a separate approval type in `recv pending --json`, with
+`kind: "command"`, `argv`, `cwd`, and `permission` fields. Argument and directory
+strings in that summary are escaped for display.
+
+Older clients that only understand copies cannot approve command requests.
+Use the matching new binary to list and approve them; old clients may show no
+pending requests while a command is pending. Their stop request still works.
+
+## Arguments and working directories
+
+Put `--` before the program. Everything after it is passed as a literal
+argument, including strings starting with `--`. There is no implicit shell
+expansion on the receiving machine. To use shell syntax, request a shell:
+
+```sh
+syq exec --on @laptop --cwd work/project -- sh -c 'cargo build && ./target/debug/demo'
+```
+
+`--cwd DIR` (or `-C DIR`) is relative to the directory selected by `recv on
+--cwd` or `recv on --root`. Its default is that directory. Absolute paths and
+`..` can select elsewhere. The directory must exist. Syq does not expand `~`
+on the receiving machine; use a relative path or an absolute path instead.
+
+The command inherits the receiving service's local environment, including
+`PATH` and its desktop session. It does not inherit the server's environment.
+Restart receiving from a terminal in the desired desktop session when those
+values change. Stdin is closed and there is no interactive terminal.
+
+A request supports at most 256 arguments, including the program, with at most
+16 KiB of argument bytes and a working-directory path of at most 4096 bytes.
+Each server connection permits one pending approval and eight active commands.
+Active commands do not prevent a new approval or an ordinary copy.
+
+## Output, completion and cancellation
+
+Stdout and stderr stream back separately without text conversion. Syq returns
+the command's exit code; when the command is killed by a signal it reports the
+signal and returns `128 + signal`. A setup error or connection failure is a
+nonzero result. A connection that closes before delivering the exit status is
+an error even if some output arrived successfully.
+
+Interrupting the requesting syq process, losing the connection, changing
+receiving settings, `recv off`, or `persist off` cancels execution. Syq kills
+the command's process group and reaps its leader. It also cleans up that group
+when the foreground program exits. A program that deliberately creates a
+separate process session, or an application launched through macOS `open`, can
+outlive that group. Syq does not manage detached jobs.
+
+A command may already have changed files when interrupted. It is never retried
+automatically after a lost connection. Inspect the outcome before requesting
+it again. Commands do not produce copy receipts or copy automation records.
+
+Python callers can use the SDK's existing raw process interface with their
+chosen executable:
+
+```python
+import syq
+
+result = syq.run(
+    ["exec", "--on", "@laptop", "--cwd", "work/project", "--", "cargo", "test"],
+    executable="/path/to/syq",
+    timeout=600,
+)
+print(result.stdout.decode())
+```
+
+The raw SDK call captures byte output and raises on a nonzero exit by default.
+The async client's `run` method accepts the same command arguments. For live
+terminal output, invoke the CLI directly or use a subprocess with inherited
+stdout and stderr.

--- a/docs/receive.md
+++ b/docs/receive.md
@@ -37,6 +37,9 @@ permission, and limits. Choose **Allow once** or **Deny**. Allowing a copy trust
 the server to supply its contents: syq cannot prove what you typed in the remote
 shell or that the files contain what you intended.
 
+You can also [run commands on the receiving machine](exec.md), with separate
+local approval, to build a project there or open a copied artifact.
+
 ## Approving copies
 
 On Linux, desktop prompts use `/usr/bin/notify-send` with action support
@@ -78,8 +81,9 @@ syq recv on --approve ask   # require approval again
 Automatic approval trusts every process running as those server accounts,
 including for overwrites. An approved copy can inspect destination entries
 needed for copying, write unwanted content, or consume disk space within its
-limits. The server receives neither your SSH agent nor an interface for running
-arbitrary laptop commands.
+limits. The server does not receive your SSH agent. [Command requests](exec.md) require
+a separate local decision for every execution, including when copies are
+automatically approved.
 
 To send files from that server to another SSH host using this machine's
 permission, use `syq cp results --to hostB`. Eligible copies discover a live

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -25,6 +25,8 @@ To initiate a copy from a server to your laptop, use a [named receiving
 destination](receive.md), such as `syq cp results --to laptop`. `persist on`
 enables background receiving automatically. Bare names prefer live return
 connections; `@laptop` requires one and fails while offline.
+You can also [request a command on the receiving machine](exec.md), such as
+`syq exec --on @laptop --cwd work/project -- cargo test`, with local approval.
 
 ## See where files go
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -142,3 +142,25 @@ key, or command-running interface. Host trust and SSH configuration are those
 of the approving machine. The destination account remains trusted, including
 its interpretation of relative paths. A compromised source can substitute
 content within the approved scope, just as with other return copies.
+
+## Approved commands on receiving machines
+
+[`syq exec`](exec.md) uses an existing return connection and always asks for a
+local decision before starting a program. Command approval is separate from
+copy approval, including when copies are automatically approved. The prompt
+shows the server account, argument list and working directory. A server
+account can request commands from any of its processes; syq cannot establish
+what a person typed in a remote shell.
+
+Approving execution grants the command your local user's authority. Copy root
+confinement, file protection and transfer limits do not restrict that program.
+Scripts and build files can change what it does. Commands receive the local
+service environment and closed stdin. They do not expose a general SSH agent
+forwarding interface, but an approved program can access credentials available
+to the local user.
+
+Disconnecting cancels the foreground process group; commands are never
+replayed automatically. Completed effects cannot be rolled back, and programs
+that create separate process sessions can outlive cancellation. See the
+[command reference](exec.md#output-completion-and-cancellation) for execution
+and interruption behavior.

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -104,7 +104,11 @@ The typed interface covers native `cp`, including its `--prune` mode, `rm`,
 and `map`. It does not wrap `syq rsync`, which remains available through
 `Client.run` and the module-level `syq.run` function. Enrollment and other
 administrative commands also remain raw operations until they have a stable
-machine contract that benefits from Python types.
+machine contract that benefits from Python types. `syq exec` is available through
+those raw `run` methods: its stdout, stderr and exit status are a process result,
+not a copy automation stream. Pass `--cwd` in the argument list to select the
+receiving working directory; the SDK's `cwd=` parameter selects the local
+working directory of the requesting syq process.
 
 Module functions and client methods have the same operation names and
 signatures. A module function uses a default `Client`; applications that need

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -560,7 +560,7 @@ fn candidates(index: usize, words: &[OsString]) -> Result<Vec<Candidate>> {
     };
     let args_before = &words[2..index];
     match command {
-        "completion" | "persist" | "receiver" | "recv" | "destination" => {
+        "completion" | "persist" | "receiver" | "recv" | "destination" | "exec" => {
             management_candidates(command, args_before, current)
         }
         "help" => Ok(help_candidates(args_before, current)),
@@ -706,6 +706,7 @@ fn bash_replacement_candidates(
 fn root_candidates(current: &[u8]) -> Vec<Candidate> {
     [
         "cp",
+        "exec",
         "rm",
         "map",
         "rsync",
@@ -732,6 +733,7 @@ fn public_command(name: &str) -> Option<clap::Command> {
         "persist" => Some(crate::persistence::command_for_help()),
         "receiver" => Some(crate::help::receiver()),
         "recv" => Some(crate::receive_service::command_for_help()),
+        "exec" => Some(crate::destination::exec::command_for_help()),
         "destination" => Some(crate::destination::destination_help()),
         "--self-update" => Some(crate::help::lifecycle()),
         _ => crate::cli::command_for_completion(name),
@@ -1211,6 +1213,10 @@ fn value_completion(
     command_meta: &clap::Command,
 ) -> Option<ValueCompletion> {
     let known = match command {
+        "exec" => match option {
+            b"--on" => Some(ValueCompletion::ReturnName),
+            _ => None,
+        },
         "cp" => match option {
             b"--from" => Some(ValueCompletion::Endpoint(EndpointSyntax::Native)),
             b"--to" => Some(ValueCompletion::NamedOrSshDestination),

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 use crate::delegation::{CopyOperation, DestinationPlacement, GrantConstraints};
 use crate::private_broker::{PrivateBroker, PrivateBrokerConfig, TrackedStream};
 
+pub(crate) mod exec;
 mod forward;
 
 const VERSION: u16 = 2;
@@ -119,6 +120,7 @@ struct Envelope {
 #[derive(Serialize, Deserialize)]
 enum Message {
     Ping,
+    Exec(exec::ExecRequest),
     Request(Box<CopyRequest>),
     Forward {
         target: String,
@@ -673,7 +675,8 @@ struct Receiver {
     #[cfg(test)]
     prompts: mpsc::SyncSender<Prompt>,
     sessions: Mutex<HashMap<String, Session>>,
-    forwarded: Arc<crate::private_broker::ConnectionRegistry>,
+    active_streams: Arc<crate::private_broker::ConnectionRegistry>,
+    exec_count: AtomicU64,
     forward_count: std::sync::atomic::AtomicUsize,
     request_lock: Mutex<()>,
     stop: Arc<AtomicBool>,
@@ -715,7 +718,7 @@ impl Receiver {
     fn revoke_all(&self) {
         let mut sessions = self.sessions.lock().unwrap();
         self.generation.fetch_add(1, Ordering::AcqRel);
-        self.forwarded.shutdown_all();
+        self.active_streams.shutdown_all();
         for (_, session) in sessions.drain() {
             session.authority.close_control();
             session.channels.shutdown_all();
@@ -732,6 +735,7 @@ impl Receiver {
             bail!("named destination authentication failed");
         }
         match envelope.message {
+            Message::Exec(request) => self.execute(request, stream),
             Message::Ping => write_message(&mut stream, &Reply::Ready),
             Message::Forward { target, request } => self.forward(target, *request, stream),
             Message::Request(request) => {
@@ -936,9 +940,10 @@ pub(crate) fn serve_background(
         #[cfg(test)]
         prompts,
         sessions: Mutex::new(HashMap::new()),
-        forwarded: Arc::new(crate::private_broker::ConnectionRegistry::new(
+        active_streams: Arc::new(crate::private_broker::ConnectionRegistry::new(
             Duration::from_secs(10),
         )),
+        exec_count: AtomicU64::new(0),
         forward_count: std::sync::atomic::AtomicUsize::new(0),
         request_lock: Mutex::new(()),
         stop: stop.clone(),
@@ -1326,9 +1331,10 @@ mod tests {
             approval,
             prompts,
             sessions: Mutex::new(HashMap::new()),
-            forwarded: Arc::new(crate::private_broker::ConnectionRegistry::new(
+            active_streams: Arc::new(crate::private_broker::ConnectionRegistry::new(
                 Duration::from_secs(10),
             )),
+            exec_count: AtomicU64::new(0),
             forward_count: std::sync::atomic::AtomicUsize::new(0),
             request_lock: Mutex::new(()),
             stop: Arc::new(AtomicBool::new(false)),

--- a/src/destination/exec.rs
+++ b/src/destination/exec.rs
@@ -1,0 +1,588 @@
+//! Individually approved foreground commands over an existing return connection.
+use super::*;
+use clap::FromArgMatches;
+use std::fs::File;
+use std::os::fd::{FromRawFd, IntoRawFd};
+use std::os::unix::process::ExitStatusExt;
+
+const OUTPUT_CHUNK: usize = 16 * 1024;
+const MAX_ARG_BYTES: usize = 16 * 1024;
+
+#[derive(Parser)]
+#[command(
+    name = "syq exec",
+    about = "Run a command on a named receiving machine after local approval"
+)]
+struct ExecCommand {
+    /// Receiving name; requires a live return connection (never falls back to SSH)
+    #[arg(long, value_name = "@NAME")]
+    on: String,
+    /// Working directory on that machine, relative to its receiving directory
+    #[arg(long, short = 'C', default_value = ".", value_name = "DIR")]
+    cwd: OsString,
+    /// Program and literal arguments; use sh -c explicitly for shell syntax
+    #[arg(last = true, required = true, num_args = 1.., value_name = "PROGRAM")]
+    argv: Vec<OsString>,
+}
+
+pub(crate) fn command_for_help() -> clap::Command {
+    crate::help::configure(ExecCommand::command().bin_name("syq exec"))
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ExecRequest {
+    pub argv: Vec<Vec<u8>>,
+    pub cwd: Vec<u8>,
+}
+impl ExecRequest {
+    fn validate(&self) -> Result<()> {
+        if self.argv.is_empty() || self.argv.len() > 256 || self.argv[0].is_empty() {
+            bail!("exec requires a program and at most 256 arguments");
+        }
+        if self.argv.iter().any(|arg| arg.contains(&0))
+            || self.argv.iter().map(Vec::len).sum::<usize>() > MAX_ARG_BYTES
+        {
+            bail!("exec arguments contain NUL or exceed 16 KiB");
+        }
+        if self.cwd.is_empty() || self.cwd.len() > 4096 || self.cwd.contains(&0) {
+            bail!("exec working directory must be nonempty, without NUL, and at most 4096 bytes");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum Event {
+    Stdout(Vec<u8>),
+    Stderr(Vec<u8>),
+    Exited {
+        code: Option<i32>,
+        signal: Option<i32>,
+    },
+    // Also accepts errors from the return broker before streaming starts.
+    Error(String),
+}
+
+pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
+    let matches = command_for_help().try_get_matches_from(argv)?;
+    let command = ExecCommand::from_arg_matches(&matches)?;
+    let name = command.on.strip_prefix('@').unwrap_or(&command.on);
+    validate_name(name)?;
+    let request = ExecRequest {
+        argv: command.argv.iter().map(|a| a.as_bytes().to_vec()).collect(),
+        cwd: command.cwd.as_bytes().to_vec(),
+    };
+    request.validate()?;
+    let registration = load_registration(name)?;
+    crate::output::diagnostic!("syq: requesting command permission from @{name}; approve on that machine with its desktop prompt or syq recv pending");
+    let (mut stream, reply) = exchange(
+        &registration,
+        Message::Exec(request),
+        REQUEST_TIMEOUT + Duration::from_secs(10),
+    )?;
+    if !matches!(reply, Reply::Ready) {
+        bail!("unexpected command approval response");
+    }
+    stream.set_read_timeout(None)?;
+    stream.set_write_timeout(None)?;
+    receive_output(&mut stream, &mut std::io::stdout(), &mut std::io::stderr())
+}
+
+fn receive_output(
+    stream: &mut impl Read,
+    stdout: &mut impl Write,
+    stderr: &mut impl Write,
+) -> Result<i32> {
+    loop {
+        let event: Event = read_message(stream).context(
+            "command connection ended without an exit status; the command may have run; it will not be retried",
+        )?;
+        match event {
+            Event::Stdout(bytes) | Event::Stderr(bytes) if bytes.len() > OUTPUT_CHUNK => {
+                bail!("oversized command output frame");
+            }
+            Event::Stdout(bytes) => {
+                stdout.write_all(&bytes)?;
+                stdout.flush()?;
+            }
+            Event::Stderr(bytes) => {
+                stderr.write_all(&bytes)?;
+                stderr.flush()?;
+            }
+            Event::Exited { code, signal } => match (code, signal) {
+                (Some(code @ 0..=255), None) => return Ok(code),
+                (None, Some(signal @ 1..=127)) => {
+                    crate::output::diagnostic!("syq: command terminated by signal {signal}");
+                    return Ok(128 + signal);
+                }
+                _ => bail!("invalid command exit status"),
+            },
+            Event::Error(error) => bail!("receiving machine: {error}"),
+        }
+    }
+}
+
+struct Slot<'a>(&'a AtomicU64);
+impl Drop for Slot<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+impl Receiver {
+    pub(super) fn execute(&self, request: ExecRequest, mut stream: TrackedStream) -> Result<()> {
+        request.validate()?;
+        let request_lock = self.request_lock.try_lock().map_err(|_| {
+            anyhow::anyhow!("another request is awaiting approval; retry after it is decided")
+        })?;
+        let count = self.exec_count.fetch_add(1, Ordering::AcqRel);
+        let _slot = Slot(&self.exec_count);
+        if count >= 8 {
+            bail!("too many active commands; wait for one to finish");
+        }
+        let (generation, _channel) = {
+            let _sessions = self.sessions.lock().unwrap();
+            (
+                self.generation.load(Ordering::Acquire),
+                self.active_streams.track(stream.try_clone()?)?,
+            )
+        };
+        let socket = stream.try_clone()?;
+        let cancelled = || {
+            self.stop.load(Ordering::Acquire)
+                || self.generation.load(Ordering::Acquire) != generation
+                || requester_closed(&socket)
+        };
+        let cwd = self.cwd.join(OsString::from_vec(request.cwd.clone()));
+        // This is command authority, not the restricted copy executor. Root
+        // and copy --approve always do not change a command's permission.
+        self.approvals.request_command(
+            &self.requester,
+            &request.argv,
+            &cwd,
+            self.notifications,
+            cancelled,
+        )?;
+        if cancelled() {
+            bail!("command disconnected before execution");
+        }
+        drop(request_lock);
+        write_message(&mut stream, &Reply::Ready)?;
+        let result = execute_command(&request, &cwd, socket.try_clone()?, cancelled);
+        if let Err(error) = &result {
+            crate::output::diagnostic!("syq: command from {:?}: {error:#}", self.requester);
+        }
+        result
+    }
+}
+
+fn nonblocking(fd: std::os::fd::RawFd) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn execute_command(
+    request: &ExecRequest,
+    cwd: &Path,
+    mut socket: UnixStream,
+    cancelled: impl Fn() -> bool,
+) -> Result<()> {
+    let mut command = Command::new(OsString::from_vec(request.argv[0].clone()));
+    command
+        .args(
+            request.argv[1..]
+                .iter()
+                .map(|a| OsString::from_vec(a.clone())),
+        )
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if cancelled() {
+        bail!("command disconnected before execution");
+    }
+    let mut child = crate::process_group::ProcessGroup::spawn(&mut command)
+        .context("start approved command")?;
+    let mut pipes = [
+        Some(unsafe { File::from_raw_fd(child.child.stdout.take().unwrap().into_raw_fd()) }),
+        Some(unsafe { File::from_raw_fd(child.child.stderr.take().unwrap().into_raw_fd()) }),
+    ];
+    for pipe in pipes.iter().flatten() {
+        nonblocking(pipe.as_raw_fd())?;
+    }
+    socket.set_nonblocking(true)?;
+    let mut pending = Vec::new();
+    let mut offset = 0;
+    let mut next_pipe = 0;
+    let mut terminal = false;
+    loop {
+        if cancelled() {
+            bail!("command cancelled: requester disconnected or receiving stopped");
+        }
+        let status = child.poll()?;
+        if offset == pending.len() {
+            if terminal {
+                return Ok(());
+            }
+            pending.clear();
+            offset = 0;
+            for index in [next_pipe, 1 - next_pipe] {
+                let Some(pipe) = &mut pipes[index] else {
+                    continue;
+                };
+                let mut bytes = vec![0; OUTPUT_CHUNK];
+                match pipe.read(&mut bytes) {
+                    Ok(0) => pipes[index] = None,
+                    Ok(n) => {
+                        bytes.truncate(n);
+                        write_message(
+                            &mut pending,
+                            &if index == 0 {
+                                Event::Stdout(bytes)
+                            } else {
+                                Event::Stderr(bytes)
+                            },
+                        )?;
+                        next_pipe = 1 - index;
+                        break;
+                    }
+                    Err(error)
+                        if matches!(
+                            error.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+                        ) => {}
+                    Err(error) => return Err(error).context("read command output"),
+                }
+            }
+            if pending.is_empty() && pipes.iter().all(Option::is_none) {
+                if let Some(status) = status {
+                    write_message(
+                        &mut pending,
+                        &Event::Exited {
+                            code: status.code(),
+                            signal: status.signal(),
+                        },
+                    )?;
+                    terminal = true;
+                }
+            }
+        }
+        if offset < pending.len() {
+            match socket.write(&pending[offset..]) {
+                Ok(0) => bail!("command output connection closed"),
+                Ok(n) => {
+                    offset += n;
+                    continue;
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+                    ) => {}
+                Err(error) => return Err(error).context("send command output"),
+            }
+        }
+        let mut fds = vec![libc::pollfd {
+            fd: socket.as_raw_fd(),
+            events: libc::POLLIN
+                | if offset < pending.len() {
+                    libc::POLLOUT
+                } else {
+                    0
+                },
+            revents: 0,
+        }];
+        if offset == pending.len() {
+            for pipe in pipes.iter().flatten() {
+                fds.push(libc::pollfd {
+                    fd: pipe.as_raw_fd(),
+                    events: libc::POLLIN,
+                    revents: 0,
+                });
+            }
+        }
+        let result = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, 100) };
+        if result < 0 && std::io::Error::last_os_error().kind() != std::io::ErrorKind::Interrupted {
+            return Err(std::io::Error::last_os_error()).context("wait for command output");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::receive_approval::Kind;
+
+    fn request(script: &str) -> ExecRequest {
+        ExecRequest {
+            argv: vec![b"sh".to_vec(), b"-c".to_vec(), script.as_bytes().to_vec()],
+            cwd: b".".to_vec(),
+        }
+    }
+    fn pending(receiver: &Receiver) -> crate::receive_approval::Summary {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            if let Some(summary) = receiver.approvals.snapshots().first() {
+                return summary.clone();
+            }
+            assert!(Instant::now() < deadline, "command did not become pending");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+    fn wait_finished(receiver: &Receiver) {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while receiver.exec_count.load(Ordering::Acquire) != 0 {
+            assert!(
+                Instant::now() < deadline,
+                "command did not release its slot after cancellation"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+    fn wait_file(path: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while !path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "command did not create {}",
+                path.display()
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[test]
+    fn command_permission_is_distinct_from_copy_autoapproval_and_one_use() {
+        let root = tempfile::tempdir().unwrap();
+        let (_broker, receiver, registration, _) =
+            super::super::tests::broker(root.path(), Approval::Always);
+        for allow in [false, true] {
+            let registration = registration.clone();
+            let task = std::thread::spawn(move || {
+                exchange(
+                    &registration,
+                    Message::Exec(request("printf done > marker; printf output; exit 17")),
+                    Duration::from_secs(5),
+                )
+            });
+            let summary = pending(&receiver);
+            assert_eq!(summary.kind(), Kind::Command);
+            let json = serde_json::to_value(&summary).unwrap();
+            assert_eq!(json["kind"], "command");
+            assert!(json.get("destination").is_none());
+            assert!(summary.description().contains("Runs as your local user"));
+            assert!(!root.path().join("marker").exists());
+            assert!(receiver
+                .approvals
+                .decide(&summary.id, true, Kind::Copy)
+                .is_err());
+            receiver
+                .approvals
+                .decide(&summary.id, allow, Kind::Command)
+                .unwrap();
+            assert!(receiver
+                .approvals
+                .decide(&summary.id, allow, Kind::Command)
+                .is_err());
+            let result = task.join().unwrap();
+            if allow {
+                let (mut stream, reply) = result.unwrap();
+                assert!(matches!(reply, Reply::Ready));
+                let mut output = Vec::new();
+                assert_eq!(
+                    receive_output(&mut stream, &mut output, &mut Vec::new()).unwrap(),
+                    17
+                );
+                assert_eq!(output, b"output");
+                assert_eq!(fs::read(root.path().join("marker")).unwrap(), b"done");
+            } else {
+                assert!(result.is_err());
+                assert!(!root.path().join("marker").exists());
+            }
+        }
+    }
+
+    #[test]
+    fn pending_command_disconnect_and_revocation_never_spawn() {
+        for revoke in [false, true] {
+            let root = tempfile::tempdir().unwrap();
+            let (_broker, receiver, registration, _) =
+                super::super::tests::broker(root.path(), Approval::Always);
+            let mut stream = UnixStream::connect(&registration.socket).unwrap();
+            write_message(
+                &mut stream,
+                &Envelope {
+                    version: VERSION,
+                    identity: crate::identity::build().into(),
+                    secret: registration.secret,
+                    message: Message::Exec(request("touch marker")),
+                },
+            )
+            .unwrap();
+            let summary = pending(&receiver);
+            if revoke {
+                receiver.revoke_all();
+            } else {
+                stream.shutdown(std::net::Shutdown::Both).unwrap();
+            }
+            wait_finished(&receiver);
+            assert!(receiver
+                .approvals
+                .decide(&summary.id, true, Kind::Command)
+                .is_err());
+            assert!(!root.path().join("marker").exists());
+        }
+    }
+
+    #[test]
+    fn command_cleanup_handles_disconnect_revocation_and_output_backpressure() {
+        for mode in 0..3 {
+            let root = tempfile::tempdir().unwrap();
+            let (_broker, receiver, registration, _) =
+                super::super::tests::broker(root.path(), Approval::Always);
+            let script = if mode == 2 {
+                "echo $$ > leader; (sleep 1; touch survived) & touch ready; exec yes"
+            } else {
+                "echo $$ > leader; (sleep 1; touch survived) & touch ready; wait"
+            };
+            let task = std::thread::spawn(move || {
+                exchange(
+                    &registration,
+                    Message::Exec(request(script)),
+                    Duration::from_secs(5),
+                )
+            });
+            let summary = pending(&receiver);
+            receiver
+                .approvals
+                .decide(&summary.id, true, Kind::Command)
+                .unwrap();
+            let (stream, _) = task.join().unwrap().unwrap();
+            wait_file(&root.path().join("ready"));
+            let leader: i32 = fs::read_to_string(root.path().join("leader"))
+                .unwrap()
+                .trim()
+                .parse()
+                .unwrap();
+            if mode == 0 {
+                drop(stream);
+            } else if mode == 1 {
+                receiver.revoke_all();
+            } else {
+                // Let the socket fill while nobody reads its output.
+                std::thread::sleep(Duration::from_millis(150));
+                receiver.stop.store(true, Ordering::Release);
+            }
+            wait_finished(&receiver);
+            assert_eq!(
+                unsafe { libc::kill(leader, 0) },
+                -1,
+                "command leader was not reaped"
+            );
+            std::thread::sleep(Duration::from_millis(1100));
+            assert!(
+                !root.path().join("survived").exists(),
+                "command descendant survived cancellation"
+            );
+        }
+    }
+
+    fn run_direct(request: ExecRequest, cwd: &Path) -> (i32, Vec<u8>, Vec<u8>) {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let cwd = cwd.to_owned();
+        let monitor = server.try_clone().unwrap();
+        let task = std::thread::spawn(move || {
+            execute_command(&request, &cwd, server, || requester_closed(&monitor))
+        });
+        let (mut stdout, mut stderr) = (Vec::new(), Vec::new());
+        let status = receive_output(&mut client, &mut stdout, &mut stderr).unwrap();
+        task.join().unwrap().unwrap();
+        (status, stdout, stderr)
+    }
+
+    #[test]
+    fn command_preserves_cwd_literal_byte_arguments_and_binary_output() {
+        let root = tempfile::tempdir().unwrap();
+        let cwd = root.path().join("with spaces");
+        fs::create_dir(&cwd).unwrap();
+        let mut req = request("pwd -P; printf '%s' \"$1\"; printf '\\000\\377' >&2; exit 17");
+        req.argv
+            .extend([b"arg0".to_vec(), b"$(touch injected)\n\xff".to_vec()]);
+        let (code, output, errors) = run_direct(req, &cwd);
+        assert_eq!(code, 17);
+        let mut expected = fs::canonicalize(&cwd)
+            .unwrap()
+            .as_os_str()
+            .as_bytes()
+            .to_vec();
+        expected.extend_from_slice(b"\n$(touch injected)\n\xff");
+        assert_eq!(output, expected);
+        assert_eq!(errors, [0, 255]);
+        assert!(!cwd.join("injected").exists());
+    }
+
+    #[test]
+    fn relative_program_runs_in_selected_directory_with_closed_stdin() {
+        use std::os::unix::fs::PermissionsExt;
+        let root = tempfile::tempdir().unwrap();
+        let program = root.path().join("probe");
+        fs::write(
+            &program,
+            b"#!/bin/sh\nif read -r input; then exit 99; fi\nprintf '%s' \"$1\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&program, fs::Permissions::from_mode(0o700)).unwrap();
+        let request = ExecRequest {
+            argv: vec![b"./probe".to_vec(), b"literal value".to_vec()],
+            cwd: b".".to_vec(),
+        };
+        let (status, stdout, stderr) = run_direct(request, root.path());
+        assert_eq!(status, 0);
+        assert_eq!(stdout, b"literal value");
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn both_output_streams_are_drained_past_pipe_capacity() {
+        let root = tempfile::tempdir().unwrap();
+        let (code, stdout, stderr) = run_direct(
+            request("head -c 262144 /dev/zero; head -c 262145 /dev/zero >&2"),
+            root.path(),
+        );
+        assert_eq!(code, 0);
+        assert_eq!(stdout, vec![0; 262144]);
+        assert_eq!(stderr, vec![0; 262145]);
+    }
+
+    #[test]
+    fn command_status_reports_signal_and_rejects_truncated_output() {
+        let root = tempfile::tempdir().unwrap();
+        assert_eq!(run_direct(request("kill -TERM $$"), root.path()).0, 143);
+        let mut bytes = Vec::new();
+        write_message(&mut bytes, &Event::Stdout(b"partial".to_vec())).unwrap();
+        let mut output = Vec::new();
+        let error =
+            receive_output(&mut bytes.as_slice(), &mut output, &mut Vec::new()).unwrap_err();
+        assert_eq!(output, b"partial");
+        assert!(error.to_string().contains("will not be retried"));
+    }
+
+    #[test]
+    fn malformed_command_is_refused_before_prompting() {
+        let root = tempfile::tempdir().unwrap();
+        let (_broker, receiver, registration, _) =
+            super::super::tests::broker(root.path(), Approval::Always);
+        let mut req = request("touch marker");
+        req.argv[0].push(0);
+        assert!(exchange(&registration, Message::Exec(req), Duration::from_secs(2)).is_err());
+        assert!(receiver.approvals.snapshots().is_empty());
+        assert!(!root.path().join("marker").exists());
+    }
+}

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -199,7 +199,7 @@ impl Receiver {
             let _sessions = self.sessions.lock().unwrap();
             (
                 self.generation.load(Ordering::Acquire),
-                self.forwarded.track(stream.try_clone()?)?,
+                self.active_streams.track(stream.try_clone()?)?,
             )
         };
         let socket = stream.try_clone()?;
@@ -914,13 +914,17 @@ mod tests {
                 );
                 std::thread::sleep(Duration::from_millis(5));
             };
-            assert!(pending.destination.contains("backup"));
-            assert!(pending.destination.contains("output"));
-            assert!(pending.permission.contains("SSH access"));
+            let description = pending.description();
+            assert!(description.contains("backup"));
+            assert!(description.contains("output"));
+            assert!(description.contains("SSH access"));
             if revoke {
                 receiver.revoke_all();
             } else {
-                receiver.approvals.decide(&pending.id, false).unwrap();
+                receiver
+                    .approvals
+                    .decide(&pending.id, false, crate::receive_approval::Kind::Copy)
+                    .unwrap();
             }
             assert!(task.join().unwrap().is_err());
             let deadline = Instant::now() + Duration::from_secs(2);

--- a/src/help.rs
+++ b/src/help.rs
@@ -156,6 +156,7 @@ pub(crate) fn root() -> Command {
             .help("Install the newest signed release (standalone installs); Homebrew: brew upgrade syq"))
         .disable_help_subcommand(true)
         .subcommand(Command::new("cp").about("Copy files and directories, optionally removing destination-only files"))
+        .subcommand(Command::new("exec").about("Run a command on a named receiving machine after local approval"))
         .subcommand(Command::new("rm").about("Remove selected files and directory trees"))
         .subcommand(Command::new("map").about("Print source-to-destination mappings as NDJSON"))
         .subcommand(Command::new("rsync").about("Copy using rsync-compatible syntax"))
@@ -233,6 +234,7 @@ pub(crate) fn show_topic(topics: &[std::ffi::OsString]) -> anyhow::Result<()> {
     }
     let mut command = match topics.first().copied() {
         None => root(),
+        Some("exec") => crate::destination::exec::command_for_help(),
         Some("recv") => crate::receive_service::command_for_help(),
         Some("destination") => crate::destination::destination_help(),
         Some("persist") => crate::persistence::command_for_help(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod native_rm;
 mod output;
 mod persistence;
 mod private_broker;
+mod process_group;
 mod progress;
 mod proto;
 mod receipt;
@@ -203,6 +204,18 @@ fn main() {
             std::process::exit(1);
         }
         return;
+    }
+    if argv.get(1).and_then(|arg| arg.to_str()) == Some("exec") {
+        match destination::exec::run(&argv[1..]) {
+            Ok(code) => std::process::exit(code),
+            Err(error) => {
+                if let Some(error) = error.downcast_ref::<clap::Error>() {
+                    error.exit();
+                }
+                crate::output::diagnostic!("syq exec: {error:#}");
+                std::process::exit(1);
+            }
+        }
     }
     if argv.get(1).and_then(|arg| arg.to_str()) == Some("cat") {
         match janky_cat::run(&argv[2..]) {

--- a/src/process_group.rs
+++ b/src/process_group.rs
@@ -1,0 +1,53 @@
+//! Own a foreground child and kill its process group before reaping its leader.
+use std::process::{Child, Command, ExitStatus};
+
+pub(crate) struct ProcessGroup {
+    pub child: Child,
+    status: Option<ExitStatus>,
+}
+impl ProcessGroup {
+    pub fn spawn(command: &mut Command) -> std::io::Result<Self> {
+        use std::os::unix::process::CommandExt;
+        Ok(Self {
+            child: command.process_group(0).spawn()?,
+            status: None,
+        })
+    }
+    pub fn close(&mut self) -> std::io::Result<ExitStatus> {
+        if let Some(status) = self.status {
+            return Ok(status);
+        }
+        // Nobody else may reap this child. Keeping its PID reserved prevents
+        // cleanup from killing an unrelated group after PID reuse.
+        unsafe { libc::kill(-(self.child.id() as i32), libc::SIGKILL) };
+        let status = self.child.wait()?;
+        self.status = Some(status);
+        Ok(status)
+    }
+    pub fn poll(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        if self.status.is_some() {
+            return Ok(self.status);
+        }
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                self.child.id() as libc::id_t,
+                &mut info,
+                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+            )
+        };
+        if result < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if info.si_signo == 0 {
+            return Ok(None);
+        }
+        self.close().map(Some)
+    }
+}
+impl Drop for ProcessGroup {
+    fn drop(&mut self) {
+        let _ = self.close();
+    }
+}

--- a/src/receive_approval.rs
+++ b/src/receive_approval.rs
@@ -6,8 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::process::CommandExt;
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
@@ -39,18 +38,58 @@ pub(crate) enum Notifications {
     Off,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Kind {
+    #[default]
+    Copy,
+    Command,
+}
+impl Kind {
+    pub(crate) fn is_copy(&self) -> bool {
+        *self == Self::Copy
+    }
+    fn title(self) -> &'static str {
+        match self {
+            Self::Copy => "syq: incoming copy",
+            Self::Command => "syq: incoming command",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Summary {
     pub id: String,
     pub from: String,
-    pub destination: String,
-    pub permission: String,
-    pub max_bytes: u64,
-    pub max_entries: u64,
-    pub max_delete: u64,
-    pub preserve_permissions: bool,
     pub expires_at: u64,
     pub notification: String,
+    #[serde(flatten)]
+    pub details: Details,
+}
+// Preserve the released copy JSON fields. Commands have their own explicit
+// kind and no fabricated copy fields: old copy-only readers reject them.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum Details {
+    Command {
+        kind: CommandKind,
+        argv: Vec<String>,
+        cwd: String,
+        permission: String,
+    },
+    Copy {
+        destination: String,
+        permission: String,
+        max_bytes: u64,
+        max_entries: u64,
+        max_delete: u64,
+        preserve_permissions: bool,
+    },
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CommandKind {
+    Command,
 }
 impl Summary {
     fn new(
@@ -78,23 +117,39 @@ impl Summary {
             // Debug formatting preserves unusual bytes and escapes terminal
             // control characters. Do not interpret remote text as UI markup.
             from: format!("{from:?}"),
-            destination: format!(
-                "{:?}",
-                std::ffi::OsStr::from_bytes(&request.copy.destination)
-            ),
-            permission: permission.into(),
-            max_bytes: request.copy.limits.max_total_bytes,
-            max_entries: request.copy.limits.max_entries,
-            max_delete: request.copy.limits.max_deletions,
-            preserve_permissions: request.copy.options.preserve_permissions,
+            details: Details::Copy {
+                destination: format!(
+                    "{:?}",
+                    std::ffi::OsStr::from_bytes(&request.copy.destination)
+                ),
+                permission: permission.into(),
+                max_bytes: request.copy.limits.max_total_bytes,
+                max_entries: request.copy.limits.max_entries,
+                max_delete: request.copy.limits.max_deletions,
+                preserve_permissions: request.copy.options.preserve_permissions,
+            },
             expires_at: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs()
                 + lifetime.as_secs(),
             notification: "starting".into(),
         })
     }
+    pub(crate) fn kind(&self) -> Kind {
+        match self.details {
+            Details::Copy { .. } => Kind::Copy,
+            Details::Command { .. } => Kind::Command,
+        }
+    }
     pub(crate) fn description(&self) -> String {
-        format!("From: {}\nDestination: {}\n{}\nLimits: {} bytes, {} entries; at most {} deletions.\nPreserve permissions: {}.\nSource contents have not been inspected by this machine.\n\nAllow this copy once?\nLocal command: syq recv approve {}", self.from, self.destination, self.permission,
-            self.max_bytes, self.max_entries, self.max_delete, self.preserve_permissions, self.id)
+        let body = match &self.details {
+            Details::Copy { destination, permission, max_bytes, max_entries, max_delete, preserve_permissions } =>
+                format!("Destination: {destination}\n{permission}\nLimits: {max_bytes} bytes, {max_entries} entries; at most {max_delete} deletions.\nPreserve permissions: {preserve_permissions}.\nSource contents have not been inspected by this machine.\n\nAllow this copy once?"),
+            Details::Command { argv, cwd, permission, .. } =>
+                format!("Command (literal arguments): {}\nWorking directory: {cwd}\n{permission}\nScripts and build files used by this command have not been inspected by syq.\n\nRun this command once?", argv.join(" ")),
+        };
+        format!(
+            "From: {}\n{body}\nLocal command: syq recv approve {}",
+            self.from, self.id
+        )
     }
 }
 struct Pending {
@@ -116,13 +171,18 @@ impl Queue {
             .map(|p| p.summary.clone())
             .collect()
     }
-    pub(crate) fn decide(&self, id: &str, allow: bool) -> Result<()> {
+    pub(crate) fn decide(&self, id: &str, allow: bool, kind: Kind) -> Result<()> {
         let mut pending = self.pending.lock().unwrap();
         let entry = pending
             .get_mut(id)
             .context("approval is unknown, expired, or already answered")?;
         if entry.decision.is_some() || Instant::now() >= entry.deadline {
             bail!("approval is expired or already answered");
+        }
+        if entry.summary.kind() != kind {
+            bail!(
+                "approval request kind differs; use a matching syq client to inspect and decide it"
+            );
         }
         entry.decision = Some(allow);
         Ok(())
@@ -155,12 +215,42 @@ impl Queue {
         cancelled: impl Fn() -> bool,
     ) -> Result<()> {
         let mut summary = Summary::new(from, request, TIMEOUT)?;
-        summary.destination = format!(
-            "SSH {target:?}, path {:?} (relative paths and ~ refer to the destination login home)",
-            std::ffi::OsStr::from_bytes(&request.destination)
-        );
-        summary.permission.push_str(". Connect using this machine's SSH access and install the matching syq helper if needed");
+        if let Details::Copy {
+            destination,
+            permission,
+            ..
+        } = &mut summary.details
+        {
+            *destination = format!(
+                "SSH {target:?}, path {:?} (relative paths and ~ refer to the destination login home)",
+                std::ffi::OsStr::from_bytes(&request.destination)
+            );
+            permission.push_str(". Connect using this machine's SSH access and install the matching syq helper if needed");
+        }
         self.wait(summary, notifications, TIMEOUT, cancelled)
+    }
+    pub(crate) fn request_command(
+        &self,
+        from: &str,
+        argv: &[Vec<u8>],
+        cwd: &std::path::Path,
+        notifications: Notifications,
+        cancelled: impl Fn() -> bool,
+    ) -> Result<()> {
+        let mut id = [0; 16];
+        getrandom::fill(&mut id).map_err(|e| anyhow::anyhow!("approval ID: {e}"))?;
+        self.wait(Summary {
+            id: id.iter().map(|b| format!("{b:02x}")).collect(),
+            from: format!("{from:?}"),
+            expires_at: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() + TIMEOUT.as_secs(),
+            notification: "starting".into(),
+            details: Details::Command {
+                kind: CommandKind::Command,
+                argv: argv.iter().map(|arg| format!("{:?}", std::ffi::OsStr::from_bytes(arg))).collect(),
+                cwd: format!("{cwd:?}"),
+                permission: "Runs as your local user with access to your files, programs and credentials. Copy root and copy limits do not contain this command. Stdin is closed.".into(),
+            },
+        }, notifications, TIMEOUT, cancelled)
     }
     fn wait(
         &self,
@@ -170,14 +260,14 @@ impl Queue {
         cancelled: impl Fn() -> bool,
     ) -> Result<()> {
         if cancelled() {
-            bail!("copy disconnected before approval");
+            bail!("request disconnected before approval");
         }
         let id = summary.id.clone();
         let deadline = Instant::now() + lifetime;
         {
             let mut pending = self.pending.lock().unwrap();
             if pending.len() >= 8 {
-                bail!("too many copies awaiting approval");
+                bail!("too many requests awaiting approval");
             }
             pending.insert(
                 id.clone(),
@@ -202,7 +292,7 @@ impl Queue {
             id: id.clone(),
         };
         let mut notification = if notifications == Notifications::Desktop {
-            match Notification::spawn(&summary.description(), lifetime) {
+            match Notification::spawn(&summary.description(), lifetime, summary.kind().title()) {
                 Ok(notification) => {
                     self.notification_status(&id, "desktop prompt requested; use local recv approve/deny if it is not visible".into());
                     Some(notification)
@@ -221,10 +311,13 @@ impl Queue {
         };
         loop {
             if cancelled() {
-                bail!("copy disconnected or receiving stopped while awaiting approval");
+                bail!("request disconnected or receiving stopped while awaiting approval");
             }
             if Instant::now() >= deadline {
-                bail!("copy approval expired after {} seconds", lifetime.as_secs());
+                bail!(
+                    "request approval expired after {} seconds",
+                    lifetime.as_secs()
+                );
             }
             if let Some(allow) = self
                 .pending
@@ -234,11 +327,11 @@ impl Queue {
                 .and_then(|p| p.decision)
             {
                 if !allow {
-                    bail!("copy denied on the receiving machine");
+                    bail!("request denied on the receiving machine");
                 }
                 // An answer that races disconnect/expiry cannot survive it.
                 if cancelled() || Instant::now() >= deadline {
-                    bail!("copy approval expired or was cancelled");
+                    bail!("request approval expired or was cancelled");
                 }
                 return Ok(());
             }
@@ -256,7 +349,7 @@ impl Queue {
                     notification.take();
                     match result {
                         Ok(Some(allow)) => {
-                            let _ = self.decide(&id, allow);
+                            let _ = self.decide(&id, allow, summary.kind());
                         }
                         Ok(None) => self.notification_status(
                             &id,
@@ -286,7 +379,7 @@ fn escape_markup(text: &str) -> String {
 #[cfg(target_os = "macos")]
 const APPLESCRIPT: &str = r#"on run argv
     try
-        set answer to display dialog (item 1 of argv) with title "syq: incoming copy" buttons {"Deny", "Allow once"} default button "Deny" cancel button "Deny" giving up after (item 2 of argv as integer)
+        set answer to display dialog (item 1 of argv) with title (item 3 of argv) buttons {"Deny", "Allow once"} default button "Deny" cancel button "Deny" giving up after (item 2 of argv as integer)
         if gave up of answer then return "expired"
         if button returned of answer is "Allow once" then return "allow"
         return "deny"
@@ -294,7 +387,7 @@ const APPLESCRIPT: &str = r#"on run argv
         return "deny"
     end try
 end run"#;
-fn notification_command(description: &str, lifetime: Duration) -> Command {
+fn notification_command(description: &str, lifetime: Duration, title: &str) -> Command {
     #[cfg(target_os = "macos")]
     {
         let mut cmd = Command::new("/usr/bin/osascript");
@@ -304,6 +397,7 @@ fn notification_command(description: &str, lifetime: Duration) -> Command {
             "--",
             description,
             &lifetime.as_secs().max(1).to_string(),
+            title,
         ]);
         cmd
     }
@@ -318,7 +412,7 @@ fn notification_command(description: &str, lifetime: Duration) -> Command {
         ])
         .arg(format!("--expire-time={}", lifetime.as_millis()))
         .arg("--")
-        .arg("syq: incoming copy")
+        .arg(title)
         .arg(escape_markup(description));
         cmd
     }
@@ -344,68 +438,42 @@ fn capture(
     })
 }
 struct Notification {
-    child: Child,
-    closed: bool,
+    child: crate::process_group::ProcessGroup,
     error_seen: Arc<AtomicBool>,
     output: Option<std::thread::JoinHandle<Vec<u8>>>,
     errors: Option<std::thread::JoinHandle<Vec<u8>>>,
 }
 impl Notification {
-    fn spawn(description: &str, lifetime: Duration) -> Result<Self> {
-        Self::spawn_command(notification_command(description, lifetime))
+    fn spawn(description: &str, lifetime: Duration, title: &str) -> Result<Self> {
+        Self::spawn_command(notification_command(description, lifetime, title))
     }
     fn spawn_command(mut command: std::process::Command) -> Result<Self> {
         command
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .process_group(0);
-        let mut child = command.spawn().context("start desktop approval prompt")?;
+            .stderr(Stdio::piped());
+        let mut child = crate::process_group::ProcessGroup::spawn(&mut command)
+            .context("start desktop approval prompt")?;
         let error_seen = Arc::new(AtomicBool::new(false));
-        let output = Some(capture(child.stdout.take().unwrap(), None));
+        let output = Some(capture(child.child.stdout.take().unwrap(), None));
         let errors = Some(capture(
-            child.stderr.take().unwrap(),
+            child.child.stderr.take().unwrap(),
             Some(error_seen.clone()),
         ));
         Ok(Self {
             child,
-            closed: false,
             error_seen,
             output,
             errors,
         })
     }
     fn close(&mut self) -> std::io::Result<std::process::ExitStatus> {
-        if !self.closed {
-            self.closed = true;
-            // Keep the leader unreaped until after killing its process group.
-            // Its PID therefore cannot name an unrelated, newly created group.
-            unsafe {
-                libc::kill(-(self.child.id() as i32), libc::SIGKILL);
-            }
-        }
-        self.child.wait()
+        self.child.close()
     }
     fn poll(&mut self) -> Option<Result<Option<bool>>> {
-        // Observe exit without reaping: descendants may still hold our output
-        // pipes, and close must kill them before joining the capture threads.
-        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
-        let result = unsafe {
-            libc::waitid(
-                libc::P_PID,
-                self.child.id() as libc::id_t,
-                &mut info,
-                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
-            )
-        };
-        if result < 0 {
-            return Some(Err(std::io::Error::last_os_error().into()));
-        }
-        if info.si_signo == 0 {
-            return None;
-        }
-        let status = match self.close() {
-            Ok(status) => status,
+        let status = match self.child.poll() {
+            Ok(None) => return None,
+            Ok(Some(status)) => status,
             Err(error) => return Some(Err(error.into())),
         };
         let output = self.output.take().unwrap().join().unwrap_or_default();
@@ -443,12 +511,14 @@ mod tests {
         Summary {
             id: "request".into(),
             from: "server".into(),
-            destination: "/tmp/receiving".into(),
-            permission: "May create and overwrite".into(),
-            max_bytes: 100,
-            max_entries: 3,
-            max_delete: 0,
-            preserve_permissions: false,
+            details: Details::Copy {
+                destination: "/tmp/receiving".into(),
+                permission: "May create and overwrite".into(),
+                max_bytes: 100,
+                max_entries: 3,
+                max_delete: 0,
+                preserve_permissions: false,
+            },
             expires_at: 0,
             notification: String::new(),
         }
@@ -474,7 +544,7 @@ mod tests {
             assert!(Instant::now() < deadline, "prompt did not exit");
             std::thread::sleep(Duration::from_millis(5));
         }
-        assert!(prompt.closed);
+        assert!(prompt.child.poll().unwrap().is_some());
     }
     #[test]
     fn decisions_are_local_one_use_and_expire() {
@@ -490,9 +560,9 @@ mod tests {
                 )
             });
             wait_pending(&queue);
-            assert!(queue.decide("unknown", true).is_err());
-            queue.decide("request", allow).unwrap();
-            assert!(queue.decide("request", !allow).is_err());
+            assert!(queue.decide("unknown", true, Kind::Copy).is_err());
+            queue.decide("request", allow, Kind::Copy).unwrap();
+            assert!(queue.decide("request", !allow, Kind::Copy).is_err());
             assert_eq!(task.join().unwrap().is_ok(), allow);
             assert!(queue.snapshots().is_empty());
         }
@@ -505,7 +575,7 @@ mod tests {
                 || false
             )
             .is_err());
-        assert!(queue.decide("request", true).is_err());
+        assert!(queue.decide("request", true, Kind::Copy).is_err());
         assert!(queue.snapshots().is_empty());
     }
     #[test]
@@ -525,7 +595,7 @@ mod tests {
         });
         wait_pending(&queue);
         stopped.store(true, Ordering::Release);
-        let _ = queue.decide("request", true);
+        let _ = queue.decide("request", true, Kind::Copy);
         assert!(task.join().unwrap().is_err());
         assert!(queue.snapshots().is_empty());
     }
@@ -548,7 +618,7 @@ mod tests {
     #[test]
     fn remote_text_is_data_in_desktop_commands() {
         let text = "<a>&\"; do shell script \"touch /tmp/not-code\"";
-        let command = notification_command(text, TIMEOUT);
+        let command = notification_command(text, TIMEOUT, Kind::Copy.title());
         let args: Vec<_> = command
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())

--- a/src/receive_service.rs
+++ b/src/receive_service.rs
@@ -55,7 +55,7 @@ struct ReceiveCommand {
 }
 #[derive(Subcommand)]
 enum Action {
-    /// Show incoming copies awaiting approval on this machine
+    /// Show incoming copy and command requests awaiting approval on this machine
     Pending {
         #[arg(long)]
         json: bool,
@@ -330,6 +330,11 @@ struct LocalRequest {
 struct Decision {
     id: String,
     allow: bool,
+    #[serde(
+        default,
+        skip_serializing_if = "crate::receive_approval::Kind::is_copy"
+    )]
+    kind: crate::receive_approval::Kind,
 }
 fn status(control: &Path, stop: bool) -> Result<Status> {
     query(control, stop, None)
@@ -641,7 +646,7 @@ fn run(control: &Path) -> Result<()> {
                             }
                             let decision_error = request.decision.and_then(|decision| {
                                 approvals
-                                    .decide(&decision.id, decision.allow)
+                                    .decide(&decision.id, decision.allow, decision.kind)
                                     .err()
                                     .map(|e| e.to_string())
                             });
@@ -764,7 +769,7 @@ fn pending(json: bool, wait: bool, timeout: u64) -> Result<()> {
             if json {
                 println!("{}", serde_json::to_string(&requests)?);
             } else if requests.is_empty() {
-                println!("No copies awaiting approval");
+                println!("No requests awaiting approval");
             } else {
                 for request in requests {
                     println!(
@@ -781,7 +786,7 @@ fn pending(json: bool, wait: bool, timeout: u64) -> Result<()> {
             bail!("timed out waiting for approval requests: none pending");
         }
         if progress.elapsed() >= Duration::from_secs(5) {
-            crate::output::diagnostic!("syq: waiting for incoming copies: none pending");
+            crate::output::diagnostic!("syq: waiting for incoming requests: none pending");
             progress = Instant::now();
         }
         std::thread::sleep(Duration::from_millis(100));
@@ -795,13 +800,14 @@ fn decide(id: &str, allow: bool) -> Result<()> {
         let Ok(state) = status(&control, false) else {
             continue;
         };
-        if state.pending.iter().any(|request| request.id == id) {
+        if let Some(request) = state.pending.iter().find(|request| request.id == id) {
             let response = query(
                 &control,
                 false,
                 Some(Decision {
                     id: id.into(),
                     allow,
+                    kind: request.kind(),
                 }),
             )?;
             if let Some(error) = response.decision_error {
@@ -934,6 +940,18 @@ pub(crate) fn dispatch(argv: &[OsString]) -> Option<Result<i32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn released_copy_decision_remains_copy_only() {
+        // Actual v0.4.0 client bytes checked by tests/receive-control-compat.py.
+        let old = include_str!("../tests/fixtures/receive-copy-decision-v0.4.0.json").trim();
+        let request: LocalRequest = serde_json::from_str(old).unwrap();
+        assert_eq!(
+            request.decision.as_ref().unwrap().kind,
+            crate::receive_approval::Kind::Copy
+        );
+        assert_eq!(serde_json::to_string(&request).unwrap(), old);
+    }
 
     #[test]
     fn stop_and_status_preserve_the_previous_daemon_request_format() {

--- a/tests/fixtures/receive-copy-decision-v0.4.0.json
+++ b/tests/fixtures/receive-copy-decision-v0.4.0.json
@@ -1,0 +1,1 @@
+{"version":2,"stop":false,"decision":{"id":"11111111111111111111111111111111","allow":true}}

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -26,6 +26,7 @@ fn short_and_long_help_spellings_are_identical_at_every_public_level() {
     for path in [
         vec![],
         vec!["cp"],
+        vec!["exec"],
         vec!["rm"],
         vec!["map"],
         vec!["--self-update"],
@@ -116,6 +117,7 @@ fn lifecycle_and_root_help_describe_the_real_commands() {
     assert!(!run(&["--self-update", "unexpected"]).status.success());
     for path in [
         vec!["cp"],
+        vec!["exec"],
         vec!["receiver", "enroll"],
         vec!["persist", "on"],
         vec!["completion", "cache", "forget"],

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -18267,3 +18267,56 @@ fn automatic_authorization_completion_keeps_local_paths_and_never_prompts() {
         assert!(!t.path("home/ssh-used").exists());
     }
 }
+
+#[test]
+fn return_exec_completion_and_offline_selection_never_contact_ssh() {
+    let t = Tmp::new();
+    write(&t.path("home/.syq-destinations-v2/laptop.json"), b"{}");
+    fs::set_permissions(
+        t.path("home/.syq-destinations-v2"),
+        fs::Permissions::from_mode(0o700),
+    )
+    .unwrap();
+    assert_completion_candidates(&t, &["syq", "ex"], &["exec"]);
+    assert_completion_candidates(&t, &["syq", "exec", "--on", "lap"], &["laptop"]);
+    assert_completion_candidates(&t, &["syq", "exec", "--on", "@lap"], &["@laptop"]);
+    assert_completion_candidates(&t, &["syq", "exec", "--cw"], &["--cwd"]);
+    assert_completion_candidates(&t, &["syq", "exec", "--on", "laptop", "--", "--he"], &[]);
+    write(
+        &t.path("bin/ssh"),
+        b"#!/bin/sh\n: > \"$HOME/ssh-used\"\nexit 55\n",
+    );
+    fs::set_permissions(t.path("bin/ssh"), fs::Permissions::from_mode(0o700)).unwrap();
+    for name in ["absent", "@absent", "user@host", "host:22"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(["exec", "--on", name, "--", "true"])
+            .env("HOME", t.path("home"))
+            .env("PATH", t.path("bin"))
+            .env("SYQ_NO_UPDATE_CHECK", "1")
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        assert!(!t.path("home/ssh-used").exists());
+    }
+    let output = completion_command(
+        &t,
+        &[
+            "__complete",
+            "fish",
+            "5",
+            "--",
+            "syq",
+            "exec",
+            "--on",
+            "laptop",
+            "--cwd",
+            "anything",
+        ],
+    )
+    .env("PATH", t.path("bin"))
+    .output()
+    .unwrap();
+    assert_output_ok(&output);
+    assert!(output.stdout.is_empty());
+    assert!(!t.path("home/ssh-used").exists());
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -14770,6 +14770,7 @@ fn completion_covers_public_command_routes_and_parser_value_grammar() {
         &["syq", "help", ""],
         &[
             "cp",
+            "exec",
             "rm",
             "map",
             "rsync",

--- a/tests/real-ssh/Dockerfile
+++ b/tests/real-ssh/Dockerfile
@@ -52,4 +52,6 @@ COPY tests/real-ssh/test-receive-notifications.py /usr/local/libexec/syq-test-re
 
 COPY tests/real-ssh/test-forward-copy.py /usr/local/libexec/syq-test-forward-copy.py
 
+COPY tests/real-ssh/test-return-exec.py /usr/local/libexec/syq-test-return-exec.py
+
 ENTRYPOINT ["/usr/local/libexec/syq-real-ssh-entrypoint"]

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -126,3 +126,12 @@ debug binary, not performance measurements.
 
 A cancellation case waits for an active remote partial file, interrupts the
 benchmark, and checks that scratch is removed while an unrelated file remains.
+
+
+Return command scenarios exercise local Allow/Deny even under automatic copy
+approval, literal arguments, command working directories beyond the copy root,
+binary stdout/stderr larger than pipe buffers, exit codes and signals, missing
+programs, sender interruption, receiving shutdown, process-group cleanup, and
+execution after reconnect. The D-Bus fixture also verifies separate command
+notification titles and Allow/Deny behavior. macOS UI rendering is not tested
+by this Linux container suite.

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -196,6 +196,7 @@ printf 'case: native Linux notification actions control return copies\n'
 dbus-run-session -- python3 /usr/local/libexec/syq-test-receive-notifications.py
 
 python3 /usr/local/libexec/syq-test-forward-copy.py
+python3 /usr/local/libexec/syq-test-return-exec.py
 
 printf 'case: explicit automatic approval supports unattended copies\n'
 syq recv on --approve always

--- a/tests/real-ssh/test-receive-notifications.py
+++ b/tests/real-ssh/test-receive-notifications.py
@@ -125,6 +125,23 @@ def tests():
                     pass
                 copy.wait()
         assert len(observed) == 5, observed
+        for choice in ["allow", "deny"]:
+            marker = Path("/tmp/syq-real-ssh-receive") / ("exec-desktop-" + choice)
+            command = shlex.join(["syq", "exec", "--on", "@laptop", "--", "touch", str(marker)])
+            process = subprocess.Popen(["ssh", "source", command], start_new_session=True)
+            try:
+                assert (process.wait(timeout=20) == 0) == (choice == "allow")
+                assert marker.exists() == (choice == "allow")
+                _, title, body, _, _ = observed[-1]
+                assert title == "syq: incoming command", title
+                assert "literal arguments" in body and "local user" in body, body
+                assert "Run this command once?" in body and "Allow this copy" not in body, body
+                print(f"Command notification {choice}: passed", flush=True)
+            finally:
+                if process.poll() is None:
+                    os.killpg(process.pid, signal.SIGKILL)
+                process.wait()
+        assert len(observed) == 7, observed
     except BaseException:
         errors.append(traceback.format_exc())
     finally:

--- a/tests/real-ssh/test-return-exec.py
+++ b/tests/real-ssh/test-return-exec.py
@@ -106,7 +106,9 @@ assert err.endswith(b"e" * 262145)
 for cancellation in ["interrupt", "stop"]:
     print("case: command group cleanup after", cancellation, flush=True)
     script = "echo $$ > leader; (sleep 1; touch survived) & touch ready; wait"
-    execute(["sh", "-c", script], status=130 if cancellation == "interrupt" else 1, cancel=cancellation)
+    # OpenSSH reports the killed requesting client as exit-signal (255),
+    # distinct from an executed program whose exit status syq returns normally.
+    execute(["sh", "-c", script], status=255 if cancellation == "interrupt" else 1, cancel=cancellation)
     leader = int((root / "leader").read_text())
     def gone():
         try:

--- a/tests/real-ssh/test-return-exec.py
+++ b/tests/real-ssh/test-return-exec.py
@@ -1,0 +1,127 @@
+"""Approved commands over the laptop-initiated connection, in disposable paths."""
+import json
+import os
+from pathlib import Path
+import shlex
+import signal
+import subprocess
+import tempfile
+import time
+
+
+def run(*args):
+    return subprocess.check_output(args, text=True, timeout=40)
+
+
+def ready():
+    run("syq", "recv", "wait", "source", "--timeout", "30")
+
+
+def wait_for(description, predicate, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(.05)
+    raise AssertionError(f"Timed out: {description}")
+
+
+root = Path("/tmp/syq-real-ssh-receive/exec-fixture")
+root.mkdir()
+client_pid = "/tmp/syq-real-ssh/exec-client-pid"
+
+
+def execute(argv, *, cwd="exec-fixture", allow=True, status=0, cancel=None):
+    command = ('test -z "${SSH_AUTH_SOCK:-}" && test ! -e ~/.ssh/id_ed25519 && '
+               'echo $$ > ' + client_pid + ' && exec ' + shlex.join([
+                   "syq", "exec", "--on", "@laptop", "--cwd", cwd, "--", *argv]))
+    with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+        process = subprocess.Popen(["ssh", "source", command], stdout=stdout, stderr=stderr, start_new_session=True)
+        try:
+            pending = json.loads(run("syq", "recv", "pending", "--json", "--wait", "--timeout", "15"))
+            assert len(pending) == 1, pending
+            summary = pending[0]
+            assert summary["kind"] == "command" and "destination" not in summary, summary
+            assert "source" in summary["from"] and "local user" in summary["permission"], summary
+            assert argv[0] in summary["argv"][0], summary
+            assert process.poll() is None
+            run("syq", "recv", "approve" if allow else "deny", summary["id"])
+            if cancel:
+                wait_for("running command", lambda: (root / "ready").exists())
+                if cancel == "interrupt":
+                    run("ssh", "source", "kill -INT $(cat " + client_pid + ")")
+                else:
+                    run("syq", "recv", "off")
+            deadline = time.monotonic() + 30
+            while True:
+                try:
+                    actual = process.wait(timeout=5)
+                    break
+                except subprocess.TimeoutExpired:
+                    print("Waiting for approved command:", argv[0], flush=True)
+                    assert time.monotonic() < deadline, "command exceeded fixture deadline"
+            stdout.seek(0)
+            stderr.seek(0)
+            out, err = stdout.read(), stderr.read()
+            assert actual == status, (actual, status, out, err)
+            assert json.loads(run("syq", "recv", "pending", "--json")) == []
+            return out, err
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5)
+
+
+print("case: exec always needs command approval, even with automatic copies", flush=True)
+run("syq", "recv", "on", "--approve", "always", "--notify", "off")
+ready()
+execute(["sh", "-c", "touch denied"], allow=False, status=1)
+assert not (root / "denied").exists()
+
+print("case: literal argv, cwd, binary stdout/stderr and nonzero status cross real SSH", flush=True)
+script = "import os,sys; assert sys.stdin.buffer.read() == b''; sys.stdout.buffer.write(os.getcwdb()+b'\\n'+os.fsencode(sys.argv[1])+b'\\x00\\xff'); sys.stderr.buffer.write(b'error\\x00\\xff'); sys.exit(17)"
+argument = '$(touch injected) <b>&\n--help'
+out, err = execute(["python3", "-c", script, argument], status=17)
+assert out == os.fsencode(root) + b"\n" + argument.encode() + b"\x00\xff", out
+assert err.endswith(b"error\x00\xff"), err
+assert not (root / "injected").exists()
+
+print("case: approved commands may run beyond the copy root", flush=True)
+out, _ = execute(["pwd"], cwd="/tmp")
+assert out == b"/tmp\n", out
+
+print("case: execute the installed native syq binary", flush=True)
+assert execute(["/usr/local/bin/syq", "--version"])[0] == run("syq", "--version").encode()
+
+print("case: missing programs and signalled commands fail visibly", flush=True)
+_, err = execute(["/no/such/syq-test-program"], status=1)
+assert b"start approved command" in err, err
+execute(["sh", "-c", "kill -TERM $$"], status=143)
+
+print("case: both command output streams exceed pipe capacity without truncation", flush=True)
+out, err = execute(["python3", "-c", "import sys; sys.stdout.buffer.write(b'o'*262144); sys.stderr.buffer.write(b'e'*262145)"])
+assert out == b"o" * 262144
+assert err.endswith(b"e" * 262145)
+
+for cancellation in ["interrupt", "stop"]:
+    print("case: command group cleanup after", cancellation, flush=True)
+    script = "echo $$ > leader; (sleep 1; touch survived) & touch ready; wait"
+    execute(["sh", "-c", script], status=130 if cancellation == "interrupt" else 1, cancel=cancellation)
+    leader = int((root / "leader").read_text())
+    def gone():
+        try:
+            os.kill(leader, 0)
+            return False
+        except ProcessLookupError:
+            return True
+    wait_for("command leader reaped", gone)
+    time.sleep(1.1)
+    assert not (root / "survived").exists()
+    (root / "ready").unlink()
+    if cancellation == "stop":
+        run("syq", "recv", "on", "--notify", "off")
+        ready()
+
+print("case: exec works again after receiving restarts", flush=True)
+assert execute(["printf", "reconnected"])[0] == b"reconnected"
+print("Return command execution passed", flush=True)

--- a/tests/receive-control-compat.py
+++ b/tests/receive-control-compat.py
@@ -1,0 +1,130 @@
+"""Exercise released/local approval clients against a bounded disposable service.
+
+The old executable must be the verified v0.4.0 release. This checks actual old
+serialization and deserialization, independently of the candidate's Rust types.
+"""
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import socket
+import struct
+import subprocess
+import tempfile
+import threading
+import time
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--old", required=True, type=Path)
+parser.add_argument("--candidate", required=True, type=Path)
+options = parser.parse_args()
+old, candidate = options.old.resolve(), options.candidate.resolve()
+assert subprocess.check_output([old, "--version"], text=True).strip() == "syq 0.4.0"
+fixture = json.loads((Path(__file__).parent / "fixtures/receive-copy-decision-v0.4.0.json").read_text())
+request_id = fixture["decision"]["id"]
+errors, observed = [], []
+stop = threading.Event()
+
+with tempfile.TemporaryDirectory(prefix="syq-old-") as tmp:
+    home = Path(tmp)
+    runtime = home / "r"
+    parent = runtime / f"syq-persist-{os.geteuid()}"
+    scope = parent / "global"
+    for directory in [runtime, parent, scope]:
+        directory.mkdir(mode=0o700)
+    (scope / ".syq-persistence").write_text("syq persistence scope\n")
+    key = "cm-" + hashlib.sha256(b"@server").hexdigest()[:16]
+    record = scope / (key + ".json")
+    record.write_text(json.dumps({"host": "server", "user": None, "port": None}))
+    record.chmod(0o600)
+    lock = (scope / (key + ".recv-lock")).open("w")
+    os.chmod(lock.name, 0o600)
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    listener = socket.socket(socket.AF_UNIX)
+    listener.bind(str(scope / (key + ".recv")))
+    listener.listen()
+    listener.settimeout(.1)
+    copy = {"id": request_id, "from": '"server"', "destination": '"/tmp/output"',
+            "permission": "May create and overwrite matching entries", "max_bytes": 100,
+            "max_entries": 10, "max_delete": 0, "preserve_permissions": False,
+            "expires_at": int(time.time()) + 300, "notification": "disabled"}
+    command = {key: copy[key] for key in ["id", "from", "expires_at", "notification"]}
+    command.update(kind="command", argv=['"true"'], cwd='"/tmp"', permission="Runs as your local user")
+    pending = [copy]
+
+    def read_exact(peer, length):
+        result = b""
+        while len(result) < length:
+            piece = peer.recv(length - len(result))
+            assert piece, "truncated request"
+            result += piece
+        return result
+
+    def serve():
+        deadline = time.monotonic() + 30
+        progress = time.monotonic() + 5
+        try:
+            while not stop.is_set():
+                assert time.monotonic() < deadline, ("compatibility service timed out", observed)
+                if time.monotonic() > progress:
+                    print("Compatibility service waiting; requests:", len(observed), flush=True)
+                    progress += 5
+                try:
+                    peer, _ = listener.accept()
+                except socket.timeout:
+                    continue
+                with peer:
+                    peer.settimeout(2)
+                    size = struct.unpack(">I", read_exact(peer, 4))[0]
+                    assert 0 < size < 256 * 1024
+                    request = json.loads(read_exact(peer, size))
+                    observed.append(request)
+                    response = {"version": 2, "identity": "compatibility-test", "pid": os.getpid(),
+                                "endpoint": "server", "name": "laptop", "approval": "ask",
+                                "pending": list(pending), "decision_error": None,
+                                "connection": {"phase": "online", "error": None, "ssh_pid": None}}
+                    data = json.dumps(response).encode()
+                    peer.sendall(struct.pack(">I", len(data)) + data)
+                    if request.get("stop"):
+                        fcntl.flock(lock, fcntl.LOCK_UN)
+        except BaseException as error:
+            errors.append(error)
+
+    worker = threading.Thread(target=serve)
+    worker.start()
+    env = {**os.environ, "HOME": tmp, "XDG_RUNTIME_DIR": str(runtime),
+           "XDG_CONFIG_HOME": str(home / "config"), "SYQ_NO_UPDATE_CHECK": "1"}
+
+    def run(binary, *args, success=True):
+        result = subprocess.run([binary, *args], env=env, cwd=home, capture_output=True, timeout=5)
+        assert (result.returncode == 0) == success, (args, result)
+        return result
+
+    try:
+        for binary in [old, candidate]:
+            result = run(binary, "recv", "pending", "--json")
+            assert json.loads(result.stdout) == [copy]
+            run(binary, "recv", "approve", request_id)
+            assert observed[-1] == fixture, observed[-1]
+        print("Released copy status/decision bytes preserved in both directions", flush=True)
+        pending[:] = [command]
+        before = len([r for r in observed if r.get("decision")])
+        run(old, "recv", "approve", request_id, success=False)
+        assert len([r for r in observed if r.get("decision")]) == before
+        assert json.loads(run(old, "recv", "pending", "--json").stdout) == []
+        assert json.loads(run(candidate, "recv", "pending", "--json").stdout) == [command]
+        run(candidate, "recv", "approve", request_id)
+        assert observed[-1]["decision"]["kind"] == "command", observed[-1]
+        print("Old client cannot display/approve a command; new decision identifies command kind", flush=True)
+        run(old, "recv", "off")
+        assert any(r.get("stop") for r in observed)
+        print("Released client can still stop receiving while a command is pending", flush=True)
+    finally:
+        stop.set()
+        worker.join(timeout=3)
+        listener.close()
+        lock.close()
+        assert not worker.is_alive()
+    assert not errors, errors

--- a/tests/receive-control-compat.py
+++ b/tests/receive-control-compat.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import select
 import socket
 import struct
 import subprocess
@@ -35,17 +36,24 @@ with tempfile.TemporaryDirectory(prefix="syq-old-") as tmp:
     for directory in [runtime, parent, scope]:
         directory.mkdir(mode=0o700)
     (scope / ".syq-persistence").write_text("syq persistence scope\n")
-    key = "cm-" + hashlib.sha256(b"@server").hexdigest()[:16]
-    record = scope / (key + ".json")
-    record.write_text(json.dumps({"host": "server", "user": None, "port": None}))
-    record.chmod(0o600)
-    lock = (scope / (key + ".recv-lock")).open("w")
-    os.chmod(lock.name, 0o600)
-    fcntl.flock(lock, fcntl.LOCK_EX)
-    listener = socket.socket(socket.AF_UNIX)
-    listener.bind(str(scope / (key + ".recv")))
-    listener.listen()
-    listener.settimeout(.1)
+
+    def service(host):
+        key = "cm-" + hashlib.sha256(("@" + host).encode()).hexdigest()[:16]
+        record = scope / (key + ".json")
+        record.write_text(json.dumps({"host": host, "user": None, "port": None}))
+        record.chmod(0o600)
+        lock = (scope / (key + ".recv-lock")).open("w")
+        os.chmod(lock.name, 0o600)
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        listener = socket.socket(socket.AF_UNIX)
+        listener.bind(str(scope / (key + ".recv")))
+        listener.listen()
+        listener.settimeout(.1)
+        return listener, lock
+
+    listener, lock = service("server")
+    other_listener, other_lock = service("other-server")
+    other_pending = []
     copy = {"id": request_id, "from": '"server"', "destination": '"/tmp/output"',
             "permission": "May create and overwrite matching entries", "max_bytes": 100,
             "max_entries": 10, "max_delete": 0, "preserve_permissions": False,
@@ -71,10 +79,11 @@ with tempfile.TemporaryDirectory(prefix="syq-old-") as tmp:
                 if time.monotonic() > progress:
                     print("Compatibility service waiting; requests:", len(observed), flush=True)
                     progress += 5
-                try:
-                    peer, _ = listener.accept()
-                except socket.timeout:
+                readable, _, _ = select.select([listener, other_listener], [], [], .1)
+                if not readable:
                     continue
+                selected = readable[0]
+                peer, _ = selected.accept()
                 with peer:
                     peer.settimeout(2)
                     size = struct.unpack(">I", read_exact(peer, 4))[0]
@@ -82,13 +91,15 @@ with tempfile.TemporaryDirectory(prefix="syq-old-") as tmp:
                     request = json.loads(read_exact(peer, size))
                     observed.append(request)
                     response = {"version": 2, "identity": "compatibility-test", "pid": os.getpid(),
-                                "endpoint": "server", "name": "laptop", "approval": "ask",
-                                "pending": list(pending), "decision_error": None,
+                                "endpoint": "server" if selected is listener else "other-server",
+                                "name": "laptop", "approval": "ask",
+                                "pending": list(pending if selected is listener else other_pending),
+                                "decision_error": None,
                                 "connection": {"phase": "online", "error": None, "ssh_pid": None}}
                     data = json.dumps(response).encode()
                     peer.sendall(struct.pack(">I", len(data)) + data)
                     if request.get("stop"):
-                        fcntl.flock(lock, fcntl.LOCK_UN)
+                        fcntl.flock(lock if selected is listener else other_lock, fcntl.LOCK_UN)
         except BaseException as error:
             errors.append(error)
 
@@ -118,6 +129,16 @@ with tempfile.TemporaryDirectory(prefix="syq-old-") as tmp:
         run(candidate, "recv", "approve", request_id)
         assert observed[-1]["decision"]["kind"] == "command", observed[-1]
         print("Old client cannot display/approve a command; new decision identifies command kind", flush=True)
+        # Each server connection has its own service and approval queue. A
+        # command the old client cannot decode must not hide another server's copy.
+        other_copy = {**copy, "id": "2" * 32, "from": '"other-server"'}
+        other_pending[:] = [other_copy]
+        assert json.loads(run(old, "recv", "pending", "--json").stdout) == [other_copy]
+        combined = json.loads(run(candidate, "recv", "pending", "--json").stdout)
+        assert sorted(combined, key=lambda item: item["id"]) == [command, other_copy]
+        run(old, "recv", "approve", other_copy["id"])
+        assert observed[-1]["decision"] == {"id": other_copy["id"], "allow": True}
+        print("Old client still lists and approves another server's copy while a command is pending", flush=True)
         run(old, "recv", "off")
         assert any(r.get("stop") for r in observed)
         print("Released client can still stop receiving while a command is pending", flush=True)
@@ -125,6 +146,8 @@ with tempfile.TemporaryDirectory(prefix="syq-old-") as tmp:
         stop.set()
         worker.join(timeout=3)
         listener.close()
+        other_listener.close()
         lock.close()
+        other_lock.close()
         assert not worker.is_alive()
     assert not errors, errors


### PR DESCRIPTION
A server-side shell or agent can now ask a receiving Mac or Linux machine to run a program over its existing return connection. This supports building and testing native code or opening a copied artifact without exposing an SSH server on the receiving machine.

```sh
syq exec --on @mac --cwd work/project -- cargo test
syq exec --on @mac --cwd work/project -- open report.html
```

Each command requires an individual decision on the receiving machine, through the existing desktop prompt or `recv pending` / `recv approve` / `recv deny`. Copy `--approve always` never approves a command. The prompt shows the literal arguments, working directory, and the authority granted: the program runs as the local user, with access to local files and credentials; receiving copy roots and limits do not sandbox it.

Programs receive literal argument vectors, the receiving service's environment, and closed stdin. Stdout and stderr stream separately as bytes, and the requesting process reports the command's exit or signal status. Disconnect, receiving changes, and stop cancel the process group; a missing terminal status is a visible failure, and commands are never retried automatically. Output buffering is bounded and cancellation continues under output backpressure. This slice has no TTY, stdin forwarding, managed detached jobs, or tunnels. Programs that create a separate session, including applications opened by macOS `open`, may outlive the foreground group.

The implementation shares the existing request approval queue and return connection lifecycle. A small process-group owner serves both execution and desktop prompts, preserving kill-before-reap ownership. CLI dispatch, help, name completion, user documentation, and the Python raw-run API documentation include the new command. Bare names and `@names` both require a live return connection; neither falls back to DNS or ordinary SSH.

Compatibility baseline: published **v0.4.0 (`f4aee996`)**. Return execution messages use the existing matching-build connection check. Local control IPC is not build-pinned: copy summary fields, copy decision bytes, and stop/status messages remain compatible. Command summaries omit copy-only fields, and command approval decisions carry an explicit kind. Old clients cannot mistake a command for a copy or approve it, but can still stop the service; use the new binary to list and decide command requests. No changes to persistent preferences, enrollment, signing/replay state, receipts, resume identities, or cache formats. The released executable was checksum-verified and exercised against old/new control fixtures; the old receiving preference fixtures are unchanged.

Production validation at **`e234018`** (production code is unchanged in the documentation/test follow-up `b23cc62`):

- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `cargo test --all-targets -- --test-threads=1`: **926 passed** (488 unit, 422 local integration, 4 help, 5 output, 7 updater); one pre-existing opt-in v0.3.2 binary probe remains ignored.
- `scripts/test-real-ssh.sh`, default three-container suite: passed on this exact commit. Covers existing copy/transport/reconnect scenarios plus command approval/denial, real Linux notification actions, literal argv/cwd, binary output, closed stdin, command exit/signal status, missing programs, native program invocation, interruption/stop cleanup, and reconnect. Test containers were removed.
- Full [macOS workflow](https://github.com/greaber/syq/actions/runs/34049251361): passed on this exact commit, including native tests, Clippy, Python/JavaScript/Go SDK suites, benchmark tests, and release-tool tests.
- `scripts/check-doc-links.py`: 20 files, 0 problems. `tests/receive-control-compat.py` with the checksum-verified published v0.4.0 executable and current candidate: passed.
- Local Python candidate SDK suite: 90 passed against the unchanged feature implementation at `35e4624`; the macOS run above also tested the SDK against the final combined commit.
- Actual macOS desktop interaction has not been exercised; automated macOS tests validate native execution and prompt argument handling.

Follow-up at **`b23cc62`**: clarified that desktop notifications can truncate commands and that `recv pending` displays the complete request; documented immediate `SIGKILL` cleanup explicitly. Extended the released-v0.4.0 compatibility probe with two simultaneous server services. The old client omits an unsupported command but still lists and approves a copy from the other server; approval queues are separate per connection. The probe and documentation link check passed. No Rust or SSH behavior changed, so the full-suite evidence above is reused.

The possible loss of a final error diagnostic after streaming starts remains a nonblocking limitation: the requester still fails visibly without a terminal status. Preserving a diagnostic after a partial frame would need framing-aware, bounded shutdown handling. Immediate group cleanup is retained for this foreground execution slice; adding a SIGTERM grace period would change cancellation and completion behavior.

The branch includes `master` through `a706e11`. Its Python reference conflict was resolved by preserving the rewritten layout and placing execution usage under `run`.

Ready for review; not merged. The latest master workflows at `79a126a` all pass; the earlier benchmark ShellCheck failures are resolved on master. The manually dispatched macOS run above passed even though GitHub registers no PR checks here.

Final branch status:

```text
Worktree: /home/grant/repos/syq/.worktrees/return-exec
Branch:   return-exec at b23cc62 (clean)
Upstream: origin/return-exec (ahead 0, behind 0)
Master:   79a126a from refs/heads/master (branch is ahead 5, behind 9)

Master CI (latest post-merge run per workflow):
  ci.yml           success      79a126a  https://github.com/greaber/syq/actions/runs/34051188311
  rsync-compat.yml success      79a126a  https://github.com/greaber/syq/actions/runs/34051188292
  macos.yml        success      79a126a  https://github.com/greaber/syq/actions/runs/34051188293

Pull request: #256 https://github.com/greaber/syq/pull/256
  base master, open, review none, merge state clean
  GitHub head b23cc62: matches local b23cc62
  checks: none registered yet
```
