### PR TITLE
Prepare syq 0.4.1 release

### DIFF
--- a/.github/release-notes/v0.4.1.md
+++ b/.github/release-notes/v0.4.1.md
@@ -1,0 +1,15 @@
+syq 0.4.1 makes copies through connected machines more reliable and easier to
+start, and improves the interactive benchmark and Python documentation.
+
+- Return connections now retry temporary socket exhaustion. Return-copy setup
+  also handles delayed handshakes, home-relative SSH paths, and helper recovery
+  more reliably.
+- A source machine can automatically choose an eligible connected machine to
+  authorize a copy. Use `--auth-from @name` when you want to select one; the
+  existing `--via @name` option remains available.
+- The interactive benchmark chooses a useful data size automatically, reports
+  setup progress, and records clearer comparable results.
+- The documentation site now includes a focused Python guide and API reference.
+
+Existing copy commands keep their behavior. Remote helpers and return peers
+must use the same syq build as the command that starts the copy.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -146,6 +146,7 @@ run() {
 }
 # Fixed-size argument batches avoid both one process per file and ARG_MAX.
 # The same POSIX shell program runs at both ends; LC_ALL=C fixes glob order.
+# shellcheck disable=SC2016 # This is a literal program for bash -c on each host.
 manifest_command='set -eu
 export LC_ALL=C
 set --
@@ -471,7 +472,7 @@ main() {
                 printf 'WARNING: available scratch space limits test size. Short copies may mostly measure startup; interpret speeds cautiously.\n' >&2
                 break
             fi
-            rm -rf -- "$local_root/$case_name"
+            rm -rf -- "${local_root:?}/${case_name:?}"
             [[ $mode != pull ]] || remote "rm -rf $(quote "$source")"
             amount=$next
             printf 'Increasing the dataset automatically...\n'


### PR DESCRIPTION
Prepares syq 0.4.1: updates Cargo metadata and lockfile, and adds curated release notes. Local checks: cargo fmt --all -- --check; cargo clippy --locked --all-targets --all-features -- -D warnings; cargo test --locked --bin syq (479 passed, 1 opt-in v0.3.2 test ignored); exact-tree default real-SSH release certification passed.\n\nThe current master ci.yml run is red at a706e11 and will be investigated before merge.