### PR TITLE
Refine Python mapping context, errors, timeouts, and results

### DIFF
--- a/sdk/python/API_DESIGN.md
+++ b/sdk/python/API_DESIGN.md
@@ -1,0 +1,85 @@
+# Python API revision, September 2026
+
+The user authorized a breaking Python API cleanup before SDK adoption on
+2026-09-06. This exception applies to the four changes below; it is not a
+standing exemption from compatibility checks. The released baseline inspected
+for this work is `sdk-python-v0.4.0`, paired with syq `v0.4.0`.
+
+## Mapping source context
+
+`Mapping` and `AsyncMapping` combine entries with a local source base, optional
+root confinement, and source-following policy. `MapStream` and `AsyncMapStream`
+are their context-managed producer forms. `.transform()` is lazy and preserves
+that context; `None` omits an entry. Lazy async streams snapshot the producer
+directory, environment, and timeout so later client mutations cannot detach
+the entry stream from its recorded source base. A copy consumes the complete transformed
+input before starting its mutating subprocess. Closing a producer or exhausting
+it prevents it from being reused as an apparently complete empty mapping.
+
+The context uses absolute, unresolved source spellings, including symlinks and
+`..`. A producing `root` becomes a root on the consumer, narrowed to `srcs_in`
+when applicable. The consumer resolves and pins it again. This preserves the
+confinement policy, not directory identity across processes or a filesystem
+snapshot. Contextual mappings reject `from_`, `cwd`, and `root` on `cp`; an
+explicit source override must use a plain iterable or manifest instead.
+
+A caller-owned iterable can still be passed directly to `cp` with explicit
+source options. Its serialization and the manifest grammar are unchanged.
+
+Migration: replace a generator over a map stream plus `cwd=mapping.cwd` with
+`mapping.transform(function)` and omit `cwd`. List materialization discards
+context; wrap such entries in `Mapping(entries, cwd=...)` or supply source
+options explicitly. Async transforms may await their callbacks.
+
+## SDK exceptions
+
+`SyqError` is the common base of installation, invocation, process, output,
+protocol, and operation exceptions. Their existing standard-library base classes
+and diagnostic attributes remain. Application exceptions, standard type/value
+errors, spawn errors, timeouts, and cancellation are not wrapped. A broad SDK
+catch must not accidentally intercept an application's own callback failure.
+
+## Timeout inheritance
+
+On client methods that accept a timeout, omission inherits the client default;
+explicit `None` disables the timeout for that call. Numeric values override it.
+A shared internal sentinel keeps sync and async signatures consistent. Mapping
+streams snapshot the chosen timeout when constructed. The timeout covers the
+subprocess, not installation or full mapping materialization.
+
+Migration: callers previously passing `timeout=None` to mean inheritance should
+omit that argument. Raw module-level `run` and client constructors still default
+to no timeout.
+
+## Results and protocol metadata
+
+Every automation event and terminal result has a frozen `protocol` object with
+`schema`, `schema_version`, `seq`, and `type`. The uniform name allows a callback
+to inspect the envelope without special-casing terminal results. It also avoids
+colliding with the filesystem `metadata` on `FinalStateEvent`.
+
+Copy results have `receipt: ReceiptSummary | None`, containing `status`,
+`operations`, `final_states`, `records`, and `provenance`. Ordinary counts and
+operation status remain directly on the result. Receiver receipts continue to
+have distinct observable totals; grouping fields does not infer source-side
+information a receipt cannot attest.
+
+Migration: use `event.protocol.seq` instead of `event.seq`, and
+`result.receipt.status` instead of `result.receipt_status`, checking for `None`.
+No aliases retain the old flattened fields in this pre-adoption revision.
+
+## Compatibility boundaries
+
+Only Python call semantics and Python object shapes change. The native CLI,
+helper pinning and wire protocol, mapping NDJSON, automation NDJSON, enrollment,
+signed grants and redemption records, receiver receipts, replay protection,
+resume identities, caches, release manifests, package pin, and documentation
+URLs remain unchanged. Python objects are process-local and have no promised
+pickle/storage format.
+
+The new Python consumer is tested against the unchanged old automation fixtures
+and the actual managed syq 0.4.0 binary, as well as the current candidate binary.
+`results=` still writes the native NDJSON shape rather than serializing the new
+Python objects. An old Python package continues to use its own embedded pin and
+read the same saved files. Both packages can share the existing managed cache
+without migration or invalidation; no persisted authority is reset or redefined.

--- a/sdk/python/API_DESIGN.md
+++ b/sdk/python/API_DESIGN.md
@@ -3,7 +3,9 @@
 The user authorized a breaking Python API cleanup before SDK adoption on
 2026-09-06. This exception applies to the four changes below; it is not a
 standing exemption from compatibility checks. The released baseline inspected
-for this work is `sdk-python-v0.4.0`, paired with syq `v0.4.0`.
+for this work is Python SDK 0.4.1 (release preparation merged at `2c80e73`),
+paired with syq `v0.4.1`. This supersedes the initial 0.4.0 baseline; 0.4.1
+still has the old flattened API.
 
 ## Mapping source context
 
@@ -43,8 +45,9 @@ catch must not accidentally intercept an application's own callback failure.
 
 On client methods that accept a timeout, omission inherits the client default;
 explicit `None` disables the timeout for that call. Numeric values override it.
-A shared internal sentinel keeps sync and async signatures consistent. Mapping
-streams snapshot the chosen timeout when constructed. The timeout covers the
+The public `syq.CLIENT_DEFAULT` sentinel and `syq.Timeout` alias let wrappers
+forward inheritance without private imports. Sync and async signatures
+match. Mapping streams snapshot the chosen timeout when constructed. The timeout covers the
 subprocess, not installation or full mapping materialization.
 
 Migration: callers previously passing `timeout=None` to mean inheritance should
@@ -78,7 +81,7 @@ URLs remain unchanged. Python objects are process-local and have no promised
 pickle/storage format.
 
 The new Python consumer is tested against the unchanged old automation fixtures
-and the actual managed syq 0.4.0 binary, as well as the current candidate binary.
+and the actual managed syq 0.4.1 binary.
 `results=` still writes the native NDJSON shape rather than serializing the new
 Python objects. An old Python package continues to use its own embedded pin and
 read the same saved files. Both packages can share the existing managed cache

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -136,7 +136,9 @@ to `cp(mapping=...)`, even on a client with a different `process_cwd`.
 `Mapping(entries, *, cwd=None, root=None, follow_src=False)` accepts an iterable
 of `MappingEntry`. `AsyncMapping(...)` accepts an async iterable. If both `cwd`
 and `root` are omitted, the source base is the current directory at construction.
-Otherwise exactly one may be supplied. `root` confines source resolution.
+Otherwise exactly one may be supplied. Relative `cwd` and `root` paths resolve
+against the Python process directory at construction, not a client's
+`process_cwd`. `root` confines source resolution.
 
 | Member | Type | Meaning |
 |---|---|---|
@@ -589,9 +591,20 @@ after the executable name, passed without a shell.
 
 Here, `cwd` is the local subprocess directory. `cwd` and `env` use client
 defaults when omitted or `None`. `timeout` uses the client default only when
-omitted; explicit `None` disables it. `CLIENT_DEFAULT` denotes omission in the
-signature; callers do not need to import a sentinel. Module-level `syq.run`
-takes the same arguments plus `executable=None` and defaults to no timeout.
+omitted; explicit `None` disables it. Module-level `syq.run` takes the same
+arguments plus `executable=None` and defaults to no timeout.
+
+Wrappers can forward `syq.CLIENT_DEFAULT` to preserve client inheritance.
+`syq.Timeout` is the type alias for a number, `None`, or that sentinel:
+
+```python
+def copy_data(client: syq.Client, *, timeout: syq.Timeout = syq.CLIENT_DEFAULT):
+    return client.cp("data", into="backup", timeout=timeout)
+```
+
+`CLIENT_DEFAULT` applies to client methods (including module-level `cp`, `rm`,
+and `map`); client constructors and module-level `run` have no client default
+to inherit.
 
 Timeouts cover subprocess execution. Managed installation and mapping-input
 materialization happen before the copy process starts and are not covered by

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -49,10 +49,11 @@ Use `src=["a", "b"]` for CLI `--srcs a b`, and likewise `src_file` and `src_dir`
 | `cwd` | Source resolution base; may be remote for `cp` and `rm` |
 | `root` | Confine source resolution beneath this directory; requires relative selectors; conflicts with `cwd` |
 | `follow`, `follow_src` | Follow source symlinks; `follow` also enables destination following for `cp` |
-| `timeout` | Override the client timeout in seconds; `None` uses the client default |
+| `timeout` | Omitted: use client default; `None`: no timeout; number: timeout in seconds |
 
 Boolean flags default to `False`; other optional arguments default to `None`,
-except `check=True`. Invalid argument combinations raise `SyqInvocationError`;
+except `check=True` and `timeout`, whose omitted value inherits the client default.
+Invalid argument combinations raise `SyqInvocationError`;
 filesystem and remote checks happen in syq.
 
 <a id="a-normal-copy"></a>
@@ -71,7 +72,7 @@ In addition to the shared arguments above, it accepts:
 | `from_`, `to` | SSH endpoint strings; omitted endpoints are local |
 | `into`, `into_new`, `into_existing` | Destination directory paths |
 | `as_`, `as_new`, `as_existing` | Exact destination paths |
-| `mapping` | Manifest path or iterable of `MappingEntry`; replaces selectors; conflicts with `as_*` and `prune` |
+| `mapping` | `Mapping`, `MapStream`, manifest path, or iterable of `MappingEntry`; replaces selectors; conflicts with `as_*` and `prune`. Async clients also accept `AsyncMapping` and async iterables |
 | `follow_dst` | Boolean: follow destination symlinks |
 | `prune`, `dry_run`, `hash`, `verify_only` | Boolean: mirror, preview, compare content, or verify without copying |
 | `ignore_existing`, `existing`, `update` | Boolean: skip existing, require existing, or skip newer destination files |
@@ -121,9 +122,40 @@ reject removal. See [Remove files](https://greaber.github.io/syq/remove.html).
 copying. Besides the shared arguments, it accepts `as_` to rename a selected
 object. `srcs_in` must be the sole selector when used.
 
-`MapStream` is an iterable context manager yielding [MappingEntry](https://greaber.github.io/syq/python-reference.html#mappingentry); use `with`.
-`AsyncMapStream` is its async equivalent; use `async with`. Both expose `cwd`
-(`pathlib.Path`), the absolute source-base spelling to pass to `cp(cwd=...)`.
+`MapStream` is a `Mapping` and an iterable context manager; use `with`.
+`AsyncMapStream` is an `AsyncMapping` and an async context manager; use
+`async with`. Streams must be consumed inside their context and cannot be reused
+after completion or closure. Async streams capture the producer directory,
+environment, and timeout when created, even though execution starts later.
+
+### Mapping and AsyncMapping
+
+A mapping combines entries with their local source context. Pass it directly
+to `cp(mapping=...)`, even on a client with a different `process_cwd`.
+
+`Mapping(entries, *, cwd=None, root=None, follow_src=False)` accepts an iterable
+of `MappingEntry`. `AsyncMapping(...)` accepts an async iterable. If both `cwd`
+and `root` are omitted, the source base is the current directory at construction.
+Otherwise exactly one may be supplied. `root` confines source resolution.
+
+| Member | Type | Meaning |
+|---|---|---|
+| `cwd` | `pathlib.Path` | Absolute source-base spelling, preserving symlinks and `..` |
+| `root` | `pathlib.Path` or `None` | Confinement base, when created with `root` |
+| `follow_src` | `bool` | Whether the copy should follow source symlinks |
+| `transform(function)` | `Mapping` or `AsyncMapping` | Lazy transformation that keeps the source context |
+
+The context properties are read-only. A transform receives each `MappingEntry`
+and returns a replacement entry, or `None` to omit it. Transformations can be
+chained. Async transforms also accept awaitable callbacks and await them in
+entry order. Neither form caches entries; reuse depends on the supplied iterable.
+
+A context-carrying mapping rejects `from_`, `cwd`, and `root` overrides on `cp`.
+It automatically enables the source-following policy used by `map`; enabling
+`follow` or `follow_src` on the copy is also permitted. The destination options
+remain independent. `map(root=..., srcs_in=...)` carries the selected directory
+as the consuming copy's root. The copy resolves that root again; it does not
+inherit an open directory handle or a snapshot of the source tree.
 
 ### MappingEntry
 
@@ -160,16 +192,15 @@ Both types are immutable and provide:
 
 `RelativePath` also implements `os.PathLike`, returning bytes.
 
-Normal end of iteration checks the mapping process status. Leaving the context
-early stops the process. Pass `mapping.cwd` through without normalizing it.
-A consuming copy resolves that path again; `map(root=...)` does not transfer its
-confinement to the copy. Pass `follow_src=True` to both calls when the source
-base requires following symlinks.
+Normal end of stream iteration checks the mapping process status. Leaving its
+context early stops the process. An exhausted or closed stream cannot be copied
+as an empty mapping.
 
 For `cp(mapping=iterable)`, the entire iterable is saved to a temporary manifest
-before copying starts. An iteration or serialization failure starts no copy.
-`AsyncClient.cp` also accepts async iterables. Passing a manifest path uses that
-file directly. See [mapping rules](https://greaber.github.io/syq/mappings.html).
+before copying starts. An iteration, transformation, or serialization failure
+starts no copy. Plain iterables and manifest paths have no source context; pass
+`cwd`, `root`, or `from_` explicitly as needed. See
+[mapping rules](https://greaber.github.io/syq/mappings.html).
 
 <a id="retry-data-not-automatic-retry-policy"></a>
 
@@ -198,11 +229,7 @@ unsuccessful copy. Read attributes directly, for example
 | `deletions_planned` | `int` or `None` | Entries selected for pruning |
 | `deletions_completed` | `int` or `None` | Entries pruned |
 | `deletions_blocked` | `int` or `None` | Pruning deletions blocked by a safety limit |
-| `provenance` | `str` or `None` | `"receiver_attested"` for results from a verified receiver receipt |
-| `receipt_status` | `ReceiptStatus` or `None` | Receiver receipt outcome |
-| `operations` | `int` or `None` | Attested operation record count |
-| `final_states` | `int` or `None` | Attested final-state record count |
-| `receipt_records` | `int` or `None` | Total receipt record count |
+| `receipt` | `ReceiptSummary` or `None` | Verified receiver receipt details; `None` for ordinary copies |
 
 With `dry_run=True`, mutation totals describe planned changes. With
 `verify_only=True`, matching files count as unchanged; transfer and creation
@@ -211,7 +238,7 @@ totals are zero. A failed call reports work completed before it stopped.
 Ordinary copies have all three deletion fields only with `prune=True`;
 otherwise they are `None`. Receiver-attested results have only
 `deletions_completed`, and their unchanged/excluded totals are always zero
-because the receiver cannot observe source-side skips. The receipt fields are
+because the receiver cannot observe source-side skips. `receipt` is
 `None` for ordinary copies.
 
 ### RmResult
@@ -245,10 +272,32 @@ Both `CpResult` and `RmResult` include:
 | `dry_run` | `bool` | Whether this was a preview |
 | `errors` | `int` | Counted errors |
 | `elapsed_ms` | `int` | Run duration in milliseconds |
+| `protocol` | `ProtocolMetadata` | Automation envelope; also present on every event |
+
+### ProtocolMetadata
+
+Frozen dataclass accessed through `result.protocol` or `event.protocol`.
+The SDK checks these fields; applications normally only need them when recording
+or diagnosing a stream.
+
+| Attribute | Type | Meaning |
+|---|---|---|
 | `schema` | `str` | `"syq.automation"` |
 | `schema_version` | `int` | `1` |
 | `seq` | `int` | Record sequence number, starting at zero |
-| `type` | `str` | `"result"` |
+| `type` | `str` | Wire record type; `"result"` for terminal totals |
+
+### ReceiptSummary
+
+Frozen dataclass accessed through `CpResult.receipt` for receiver-attested copies.
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `status` | `ReceiptStatus` | Receiver receipt outcome |
+| `operations` | `int` | Attested operation record count |
+| `final_states` | `int` | Attested final-state record count |
+| `records` | `int` | Total receipt record count |
+| `provenance` | `str` | `"receiver_attested"` |
 
 ### OperationStatus
 
@@ -271,9 +320,8 @@ awaitable callbacks count toward the timeout.
 
 `AutomationEvent` is the union of the event classes below and `CpResult` and
 `RmResult`. Each event is a frozen dataclass. Its fields are listed below;
-all events also carry `schema: str`, `schema_version: int`, `seq: int`, and
-`type: str`. The envelope has the same meaning as on results, with `type`
-identifying the event. Optional fields use `None` when unavailable.
+all events also carry `protocol: ProtocolMetadata`, just like results.
+`event.protocol.type` identifies the wire record type. Optional fields use `None` when unavailable.
 
 See [Automation results](https://greaber.github.io/syq/automation.html) for stream
 semantics. Python exposes `class` as `class_` and paths as `PathValue`.
@@ -298,7 +346,7 @@ The client does not retry automatically.
 Invocation details. `started_at` is Unix seconds; `mode` is `"cp"` or `"rm"`.
 `prune` and `mapping` are `None` for removal; `verify_only` defaults to `False`.
 
-`type = "run"`. Fields in addition to the common envelope:
+`protocol.type = "run"`. Fields in addition to the common envelope:
 
 ```python
 run_id: str
@@ -318,7 +366,7 @@ Sampled progress for displays; use the terminal result for final totals.
 Byte fields measure file content (comparison work with `verify_only=True`),
 `scanned` counts scanned entries, and `elapsed_ms` is milliseconds.
 
-`type = "progress"`. Fields in addition to the common envelope:
+`protocol.type = "progress"`. Fields in addition to the common envelope:
 
 ```python
 bytes_done: int
@@ -339,7 +387,7 @@ One planned copy change. `dst` is relative to the destination container;
 `src` is the mapping source when available. `bytes` is the planned file size,
 and `reason` describes why the change is needed.
 
-`type = "trace"`. Fields in addition to the common envelope:
+`protocol.type = "trace"`. Fields in addition to the common envelope:
 
 ```python
 action: OperationAction
@@ -358,7 +406,7 @@ when available. `bytes` and `attempts` give transfer information. Error details
 are present when known; `message` is display text. `provenance`, `scope`, and
 `code` apply to receiver-attested outcomes.
 
-`type = "operation_result"`. Fields in addition to the common envelope:
+`protocol.type = "operation_result"`. Fields in addition to the common envelope:
 
 ```python
 action: OperationAction
@@ -382,7 +430,7 @@ code: ReceiptCode | None
 One removal selector, indexed from zero. `path` is the original selector;
 `status` says whether it resolved. `kind` is `None` for a missing selector.
 
-`type = "selection_result"`. Fields in addition to the common envelope:
+`protocol.type = "selection_result"`. Fields in addition to the common envelope:
 
 ```python
 selector: int
@@ -396,7 +444,7 @@ kind: EntryKind | None
 One entry a preview would remove. `selector` identifies its source selector;
 `path` identifies the entry. `disposition` is always `WOULD_REMOVE`.
 
-`type = "removal_trace"`. Fields in addition to the common envelope:
+`protocol.type = "removal_trace"`. Fields in addition to the common envelope:
 
 ```python
 selector: int
@@ -411,7 +459,7 @@ One removal outcome or preview inspection failure. `selector` identifies its
 source selector; `path` identifies the entry. `attempts` counts attempts;
 `retryable`, `class_`, `os_kind`, and `message` describe failures when available.
 
-`type = "removal_result"`. Fields in addition to the common envelope:
+`protocol.type = "removal_result"`. Fields in addition to the common envelope:
 
 ```python
 selector: int
@@ -430,7 +478,7 @@ message: str | None
 One counted error. `message` is display text; `class_` and `os_kind` classify
 it when known. Receiver errors can also carry `provenance` and `code`.
 
-`type = "error"`. Fields in addition to the common envelope:
+`protocol.type = "error"`. Fields in addition to the common envelope:
 
 ```python
 message: str
@@ -448,7 +496,7 @@ Receiver-attested destination state. `dst` is relative to the signed `scope`.
 `observation_error` describes a partial observation. Absent objects have no
 object details; failed observations have `code` and optional `message`.
 
-`type = "final_state"`. Fields in addition to the common envelope:
+`protocol.type = "final_state"`. Fields in addition to the common envelope:
 
 ```python
 provenance: str
@@ -505,6 +553,10 @@ and `INCOMPLETE` reports an incomplete lifecycle. `Retryability.YES`, `NO`, and
 
 ## Failure model
 
+`SyqError` is the base class for every SDK-defined exception below. Specific
+subclasses retain their details so callers can distinguish an unsuccessful
+operation from a broken results stream.
+
 | Exception | Meaning / useful attributes |
 |---|---|
 | `SyqInstallError` | Managed executable installation or verification failed |
@@ -516,8 +568,10 @@ and `INCOMPLETE` reports an incomplete lifecycle. `Retryability.YES`, `NO`, and
 
 For `cp` and `rm`, `check=False` returns unsuccessful typed results; for `run`,
 it returns nonzero process results. It does not suppress other errors.
-Spawn failures and timeouts use standard Python exceptions. Callback exceptions
-are re-raised after stopping the operation.
+Spawn failures, timeouts, and ordinary Python type/value errors use standard
+Python exceptions. Exceptions from application callbacks or mapping iterators
+are re-raised unchanged. Async cancellation remains `asyncio.CancelledError`.
+These exceptions are not wrapped in `SyqError`.
 
 Timeout, cancellation, early mapping exit, and streaming failures terminate and
 reap the local process group, including SSH children. Filesystem changes already
@@ -529,13 +583,19 @@ completed are not rolled back.
 
 ## run
 
-`client.run(args, *, check=True, cwd=None, env=None, timeout=None, input=None)`
+`client.run(args, *, check=True, cwd=None, env=None, timeout=CLIENT_DEFAULT, input=None)`
 returns [Result](https://greaber.github.io/syq/python-reference.html#result). `input` accepts bytes. `args` is a sequence of arguments
 after the executable name, passed without a shell.
 
-Here, `cwd` is the local subprocess directory. `cwd`, `env`, and `timeout`
-use the client defaults when omitted or `None`. Module-level `syq.run` takes
-the same arguments plus `executable=None`.
+Here, `cwd` is the local subprocess directory. `cwd` and `env` use client
+defaults when omitted or `None`. `timeout` uses the client default only when
+omitted; explicit `None` disables it. `CLIENT_DEFAULT` denotes omission in the
+signature; callers do not need to import a sentinel. Module-level `syq.run`
+takes the same arguments plus `executable=None` and defaults to no timeout.
+
+Timeouts cover subprocess execution. Managed installation and mapping-input
+materialization happen before the copy process starts and are not covered by
+its timeout. Async cancellation still stops mapping-input preparation.
 
 ### Result
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -94,7 +94,9 @@ except syq.SyqOperationError as error:
 
 Use `check=False` to receive unsuccessful results without that exception.
 Invalid arguments, installation failures, and incomplete or invalid results
-still raise exceptions. Completed filesystem changes are not rolled back.
+still raise exceptions. Catch `syq.SyqError` to handle any SDK-defined exception,
+or catch a specific subclass as above. Completed filesystem changes are not
+rolled back.
 
 ## Watch events and save results
 
@@ -125,18 +127,17 @@ Create a mapping, change its destination paths, then copy:
 from dataclasses import replace
 
 with syq.map(srcs_in="photos") as mapping:
-    entries = (
-        replace(entry, dst=syq.RelativePath("archive") / entry.dst)
-        for entry in mapping
+    renamed = mapping.transform(
+        lambda entry: replace(entry, dst=syq.RelativePath("archive") / entry.dst)
     )
-    result = syq.cp(mapping=entries, cwd=mapping.cwd, into="published")
+    result = syq.cp(mapping=renamed, into="published")
 ```
 
-This places the contents of `photos` under `published/archive`. Pass
-`mapping.cwd` through unchanged so the copy uses the mapping's source base.
-If the mapping required `follow_src=True`, use it on the copy too.
-The iterable must finish successfully before copying starts; a failed transform
-leaves the destination untouched. See
+This places the contents of `photos` under `published/archive`. The mapping
+carries its source base and symlink-following policy through the transform.
+Return `None` from the transform to skip an entry. The entire transform must
+finish successfully before copying starts; a failed transform leaves the
+destination untouched. See
 [Rename and reorganize](https://greaber.github.io/syq/mappings.html) for mapping rules.
 
 ## Use asyncio
@@ -162,7 +163,7 @@ Async event callbacks are awaited in record order. Mapping streams use
 async def copy_photos():
     client = syq.AsyncClient()
     async with client.map(srcs_in="photos") as mapping:
-        return await client.cp(mapping=mapping, cwd=mapping.cwd, into="published")
+        return await client.cp(mapping=mapping, into="published")
 ```
 
 <a id="custom-executable-override"></a>
@@ -177,7 +178,12 @@ result = client.cp("data", into="backup")
 ```
 
 `process_cwd` sets the local subprocess directory; typed `cwd` sets the source
-base, which may be on a remote host.
+base, which may be on a remote host. Omit `timeout` on a call to use the client
+default; pass `timeout=None` to disable it for that call:
+
+```python
+result = client.cp("data", into="backup", timeout=None)
+```
 
 To use an existing executable, pass `Client(executable="/opt/bin/syq")`.
 This bypasses the managed version; see

--- a/sdk/python/src/syq/__init__.py
+++ b/sdk/python/src/syq/__init__.py
@@ -2,10 +2,12 @@
 
 from importlib.metadata import version as distribution_version
 
+from ._mapping import Mapping, AsyncMapping
 from .async_client import AsyncClient, AsyncMapStream
 from .managed import PINNED_SYQ_VERSION, SyqInstallError, managed_executable
 from .client import Client, MapStream, Result, run, version
 from .errors import (
+    SyqError,
     SyqInvocationError,
     SyqOperationError,
     SyqOutputError,
@@ -14,6 +16,8 @@ from .errors import (
 )
 from .models import (
     AutomationEvent,
+    ProtocolMetadata,
+    ReceiptSummary,
     CpResult,
     Disposition,
     AttestedDigest,
@@ -60,6 +64,9 @@ __all__ = [
     "AsyncClient",
     "AsyncMapStream",
     "AutomationEvent",
+    "ProtocolMetadata",
+    "ReceiptSummary",
+    "SyqError",
     "Client",
     "CpResult",
     "Disposition",
@@ -75,6 +82,8 @@ __all__ = [
     "ErrorClass",
     "ErrorEvent",
     "IgnoreFrom",
+    "Mapping",
+    "AsyncMapping",
     "MapStream",
     "MappingEntry",
     "OperationAction",

--- a/sdk/python/src/syq/__init__.py
+++ b/sdk/python/src/syq/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import version as distribution_version
 
+from ._defaults import CLIENT_DEFAULT, Timeout
 from ._mapping import Mapping, AsyncMapping
 from .async_client import AsyncClient, AsyncMapStream
 from .managed import PINNED_SYQ_VERSION, SyqInstallError, managed_executable
@@ -60,6 +61,8 @@ rm = _default_client.rm
 map = _default_client.map
 
 __all__ = [
+    "CLIENT_DEFAULT",
+    "Timeout",
     "PINNED_SYQ_VERSION",
     "AsyncClient",
     "AsyncMapStream",

--- a/sdk/python/src/syq/_defaults.py
+++ b/sdk/python/src/syq/_defaults.py
@@ -1,0 +1,20 @@
+"""Shared client-default sentinel; None explicitly disables a timeout."""
+
+from enum import Enum
+
+
+class _ClientDefault(Enum):
+    TIMEOUT = "client timeout"
+
+    def __repr__(self) -> str:
+        return "CLIENT_DEFAULT"
+
+
+CLIENT_DEFAULT = _ClientDefault.TIMEOUT
+Timeout = float | None | _ClientDefault
+
+
+def resolve_timeout(value: Timeout, default: float | None) -> float | None:
+    if isinstance(value, _ClientDefault):
+        return default
+    return value

--- a/sdk/python/src/syq/_mapping.py
+++ b/sdk/python/src/syq/_mapping.py
@@ -1,0 +1,152 @@
+"""Lazy mapping transformations that preserve local source context."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import (
+    AsyncIterable, AsyncIterator, Awaitable, Callable, Iterable, Iterator,
+)
+from dataclasses import dataclass
+from pathlib import Path
+
+from ._paths import PathArgument, _map_stream_cwd
+from .errors import SyqInvocationError
+from .models import MappingEntry
+
+
+@dataclass(frozen=True, slots=True)
+class _Source:
+    base: Path
+    confined: bool
+    follow_src: bool
+
+
+class _ContextMapping:
+    def __init__(
+        self, *,
+        cwd: PathArgument | None = None,
+        root: PathArgument | None = None,
+        follow_src: bool = False,
+    ) -> None:
+        if cwd is not None and root is not None:
+            raise SyqInvocationError("cwd and root are mutually exclusive")
+        self._source = _Source(
+            _map_stream_cwd(None, None, root if root is not None else cwd, None),
+            root is not None, follow_src,
+        )
+
+    @property
+    def cwd(self) -> Path:
+        """Absolute source-base spelling, without resolving symlinks or '..'."""
+        return self._source.base
+
+    @property
+    def root(self) -> Path | None:
+        """Source confinement root, or None for an unconfined mapping."""
+        return self.cwd if self._source.confined else None
+
+    @property
+    def follow_src(self) -> bool:
+        return self._source.follow_src
+
+
+def _check_entry(entry: MappingEntry | None) -> MappingEntry | None:
+    if entry is not None and not isinstance(entry, MappingEntry):
+        if inspect.iscoroutine(entry):
+            entry.close()
+        raise SyqInvocationError("a mapping transform must return MappingEntry or None")
+    return entry
+
+
+@dataclass(frozen=True, slots=True)
+class _TransformedEntries(Iterable[MappingEntry]):
+    source: Iterable[MappingEntry]
+    function: Callable[[MappingEntry], MappingEntry | None]
+
+    def __iter__(self) -> Iterator[MappingEntry]:
+        for entry in self.source:
+            transformed = _check_entry(self.function(entry))
+            if transformed is not None:
+                yield transformed
+
+
+@dataclass(frozen=True, slots=True)
+class _AsyncTransformedEntries(AsyncIterable[MappingEntry]):
+    source: AsyncIterable[MappingEntry]
+    function: Callable[
+        [MappingEntry], MappingEntry | None | Awaitable[MappingEntry | None]
+    ]
+
+    async def __aiter__(self) -> AsyncIterator[MappingEntry]:
+        async for entry in self.source:
+            transformed = self.function(entry)
+            if inspect.isawaitable(transformed):
+                transformed = await transformed
+            transformed = _check_entry(transformed)
+            if transformed is not None:
+                yield transformed
+
+
+class Mapping(_ContextMapping, Iterable[MappingEntry]):
+    """Entries plus a local source base; transform returns another lazy mapping."""
+
+    def __init__(
+        self, entries: Iterable[MappingEntry], *,
+        cwd: PathArgument | None = None,
+        root: PathArgument | None = None,
+        follow_src: bool = False,
+    ) -> None:
+        super().__init__(cwd=cwd, root=root, follow_src=follow_src)
+        self._entries = entries
+
+    def __iter__(self) -> Iterator[MappingEntry]:
+        return iter(self._entries)
+
+    def transform(self, function: Callable[[MappingEntry], MappingEntry | None]) -> Mapping:
+        """Transform each entry; return None to omit it. Source context is kept."""
+        return Mapping(
+            _TransformedEntries(self, function),
+            cwd=None if self.root is not None else self.cwd,
+            root=self.root, follow_src=self.follow_src,
+        )
+
+
+class AsyncMapping(_ContextMapping, AsyncIterable[MappingEntry]):
+    """Async entries plus a local source base; transforms may be awaitable."""
+
+    def __init__(
+        self, entries: AsyncIterable[MappingEntry], *,
+        cwd: PathArgument | None = None,
+        root: PathArgument | None = None,
+        follow_src: bool = False,
+    ) -> None:
+        super().__init__(cwd=cwd, root=root, follow_src=follow_src)
+        self._entries = entries
+
+    def __aiter__(self) -> AsyncIterator[MappingEntry]:
+        return aiter(self._entries)
+
+    def transform(
+        self, function: Callable[[MappingEntry], MappingEntry | None | Awaitable[MappingEntry | None]],
+    ) -> AsyncMapping:
+        """Transform in stream order, awaiting callbacks; None omits an entry."""
+        return AsyncMapping(
+            _AsyncTransformedEntries(self, function),
+            cwd=None if self.root is not None else self.cwd,
+            root=self.root, follow_src=self.follow_src,
+        )
+
+
+def _source_options(
+    mapping: object, *, from_: str | None, cwd: PathArgument | None,
+    root: PathArgument | None, follow_src: bool,
+) -> tuple[PathArgument | None, PathArgument | None, bool]:
+    if not isinstance(mapping, _ContextMapping):
+        return cwd, root, follow_src
+    if from_ is not None or cwd is not None or root is not None:
+        raise SyqInvocationError("a context-carrying mapping cannot override from_, cwd, or root")
+    return (
+        None if mapping.root is not None else mapping.cwd,
+        mapping.root,
+        follow_src or mapping.follow_src,
+    )

--- a/sdk/python/src/syq/_paths.py
+++ b/sdk/python/src/syq/_paths.py
@@ -1,0 +1,52 @@
+"""Source-base spelling shared by mapping creation and map subprocesses."""
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+PathArgument = str | bytes | os.PathLike[str] | os.PathLike[bytes]
+
+
+def _native_path_spelling(
+    value: PathArgument, env: Mapping[str, str] | None
+) -> str:
+    """Apply native ``~`` expansion without normalizing path components."""
+
+    spelling = os.fsdecode(os.fspath(value))
+    if spelling == "~" or spelling.startswith("~/"):
+        home = (os.environ if env is None else env).get("HOME")
+        if home is not None:
+            suffix = spelling[2:] if len(spelling) > 2 else ""
+            return os.path.join(home, suffix) if suffix else home
+    return spelling
+
+
+def _join_path_spelling(base: str, path: str) -> str:
+    return path if os.path.isabs(path) else os.path.join(base, path)
+
+
+def _map_stream_cwd(
+    process_cwd: PathArgument | None,
+    env: Mapping[str, str] | None,
+    selected_base: PathArgument | None,
+    contents_selector: PathArgument | None,
+) -> Path:
+    """Derive the consumer base using the native component spelling."""
+
+    if process_cwd is None:
+        process_base = os.getcwd()
+    else:
+        process_spelling = os.fsdecode(os.fspath(process_cwd))
+        process_base = _join_path_spelling(os.getcwd(), process_spelling)
+    base_spelling = _native_path_spelling(
+        "." if selected_base is None else selected_base, env
+    )
+    effective = _join_path_spelling(process_base, base_spelling)
+    if contents_selector is not None:
+        effective = _join_path_spelling(
+            effective, _native_path_spelling(contents_selector, env)
+        )
+    # Path preserves `..` components. In particular, do not use abspath or
+    # resolve here: the native walker must encounter symlinks before `..`.
+    return Path(effective)
+

--- a/sdk/python/src/syq/async_client.py
+++ b/sdk/python/src/syq/async_client.py
@@ -20,6 +20,8 @@ from collections.abc import (
 from pathlib import Path
 from typing import BinaryIO, TypeVar
 
+from ._defaults import CLIENT_DEFAULT, Timeout, resolve_timeout
+from ._mapping import AsyncMapping, _source_options
 from .managed import managed_executable
 from .client import (
     Argument,
@@ -379,7 +381,7 @@ class _AsyncLineProcess:
             self._output_transport = None
 
 
-class AsyncMapStream(AsyncIterator[MappingEntry]):
+class AsyncMapStream(AsyncMapping):
     """A lazy, context-managed, streaming ``syq map`` result."""
 
     def __init__(
@@ -388,10 +390,17 @@ class AsyncMapStream(AsyncIterator[MappingEntry]):
         argv: list[Argument],
         cwd: Path,
         timeout: float | None,
+        *,
+        confined: bool = False,
+        follow_src: bool = False,
     ) -> None:
+        # This stream supplies its own iteration.
+        super().__init__(
+            self, cwd=None if confined else cwd,
+            root=cwd if confined else None, follow_src=follow_src,
+        )
         self._client = client
         self._argv = argv
-        self.cwd = cwd
         self._timeout = timeout
         self._process: _AsyncLineProcess | None = None
         self._start_lock = asyncio.Lock()
@@ -406,6 +415,8 @@ class AsyncMapStream(AsyncIterator[MappingEntry]):
         return self._process
 
     def __aiter__(self) -> AsyncMapStream:
+        if self._complete:
+            raise SyqInvocationError("mapping stream is closed or exhausted")
         return self
 
     async def __anext__(self) -> MappingEntry:
@@ -488,7 +499,7 @@ class AsyncClient:
         check: bool = True,
         cwd: PathArgument | None = None,
         env: Mapping[str, str] | None = None,
-        timeout: float | None = None,
+        timeout: Timeout = CLIENT_DEFAULT,
         input: bytes | None = None,
     ) -> Result:
         return await _run(
@@ -497,7 +508,7 @@ class AsyncClient:
             check=check,
             cwd=self.process_cwd if cwd is None else cwd,
             env=self.env if env is None else env,
-            timeout=self.timeout if timeout is None else timeout,
+            timeout=resolve_timeout(timeout, self.timeout),
             input=input,
         )
 
@@ -507,25 +518,25 @@ class AsyncClient:
         return _version_from_result(await self.run(["--version"]))
 
     async def _start_line(
-        self, argv: list[Argument], *, timeout: float | None
+        self, argv: list[Argument], *, timeout: Timeout
     ) -> _AsyncLineProcess:
         command = (await self._executable_value(), *argv)
         return await _AsyncLineProcess.start(
             command,
             cwd=self.process_cwd,
             env=self.env,
-            timeout=self.timeout if timeout is None else timeout,
+            timeout=resolve_timeout(timeout, self.timeout),
         )
 
     async def _start_results(
-        self, argv: list[Argument], *, timeout: float | None
+        self, argv: list[Argument], *, timeout: Timeout
     ) -> _AsyncLineProcess:
         command = (await self._executable_value(), *argv)
         return await _AsyncLineProcess.start_results(
             command,
             cwd=self.process_cwd,
             env=self.env,
-            timeout=self.timeout if timeout is None else timeout,
+            timeout=resolve_timeout(timeout, self.timeout),
         )
 
     async def _typed(
@@ -539,7 +550,7 @@ class AsyncClient:
         selectors_total: int | None,
         on_event: AsyncEventCallback | None,
         results: BinaryIO | None,
-        timeout: float | None,
+        timeout: Timeout,
         check: bool,
     ) -> OperationSummary:
         process = await self._start_results(argv, timeout=timeout)
@@ -649,7 +660,7 @@ class AsyncClient:
         min_size: str | int | None = None,
         max_delete: int | None = None,
         on_event: AsyncEventCallback | None = None,
-        timeout: float | None = None,
+        timeout: Timeout = CLIENT_DEFAULT,
         check: bool = True,
     ) -> CpResult:
         if (
@@ -664,6 +675,9 @@ class AsyncClient:
                 f"a remote-to-remote {'verification' if verify_only else 'dry run'} cannot produce the results "
                 "stream this surface relies on; pass coordinate_at='local'"
             )
+        cwd, root, follow_src = _source_options(
+            mapping, from_=from_, cwd=cwd, root=root, follow_src=follow_src,
+        )
         results = await _complete_task(
             asyncio.create_task(asyncio.to_thread(_prepare_results_file, results))
         )
@@ -821,7 +835,7 @@ class AsyncClient:
         no_bootstrap: bool = False,
         pscope: PathArgument | None = None,
         on_event: AsyncEventCallback | None = None,
-        timeout: float | None = None,
+        timeout: Timeout = CLIENT_DEFAULT,
         check: bool = True,
     ) -> RmResult:
         results = await _complete_task(
@@ -871,8 +885,18 @@ class AsyncClient:
         follow: bool = False,
         follow_src: bool = False,
         as_: PathArgument | None = None,
-        timeout: float | None = None,
+        timeout: Timeout = CLIENT_DEFAULT,
     ) -> AsyncMapStream:
+        # Keep lazy execution tied to the same cwd and environment used to
+        # derive the mapping's source context, even if the caller changes them.
+        environment = dict(os.environ if self.env is None else self.env)
+        producer = AsyncClient(
+            executable=self._executable,
+            cache_dir=self._cache_dir,
+            process_cwd=_map_stream_cwd(self.process_cwd, environment, None, None),
+            env=environment,
+            timeout=resolve_timeout(timeout, self.timeout),
+        )
         src_values = _values(src, label="--src")
         srcs_in_values = _values(srcs_in, label="--srcs-in")
         src_file_values = _values(src_file, label="--src-file")
@@ -929,9 +953,12 @@ class AsyncClient:
                 )
             contents_selector = srcs_in_values[0]
         effective_cwd = _map_stream_cwd(
-            self.process_cwd,
-            self.env,
+            producer.process_cwd,
+            producer.env,
             selected_base,
             contents_selector,
         )
-        return AsyncMapStream(self, argv, effective_cwd, timeout)
+        return AsyncMapStream(
+            producer, argv, effective_cwd, producer.timeout,
+            confined=root is not None, follow_src=follow or follow_src,
+        )

--- a/sdk/python/src/syq/async_client.py
+++ b/sdk/python/src/syq/async_client.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import BinaryIO, TypeVar
 
 from ._defaults import CLIENT_DEFAULT, Timeout, resolve_timeout
-from ._mapping import AsyncMapping, _source_options
+from ._mapping import AsyncMapping, _ContextMapping, _source_options
 from .managed import managed_executable
 from .client import (
     Argument,
@@ -394,8 +394,8 @@ class AsyncMapStream(AsyncMapping):
         confined: bool = False,
         follow_src: bool = False,
     ) -> None:
-        # This stream supplies its own iteration.
-        super().__init__(
+        # Initialize only source context: this stream supplies its own iterator.
+        _ContextMapping.__init__(
             self, cwd=None if confined else cwd,
             root=cwd if confined else None, follow_src=follow_src,
         )

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -16,6 +16,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO
 
+from ._defaults import CLIENT_DEFAULT, Timeout, resolve_timeout
+from ._mapping import Mapping as FileMapping, _source_options
+from ._paths import PathArgument, _map_stream_cwd
 from .managed import managed_executable
 from .errors import (
     SyqInvocationError,
@@ -37,7 +40,6 @@ from .models import (
 from .protocol import AutomationDecoder, parse_mapping_line
 
 
-PathArgument = str | bytes | os.PathLike[str] | os.PathLike[bytes]
 Argument = str | bytes
 Selector = PathArgument | Iterable[PathArgument]
 IgnoreSelector = str | IgnoreFrom | Iterable[str | IgnoreFrom]
@@ -72,50 +74,6 @@ def _argument(value: PathArgument, *, label: str) -> Argument:
     if contains_nul:
         raise ValueError(f"{label} may not contain NUL")
     return result
-
-
-def _native_path_spelling(
-    value: PathArgument, env: Mapping[str, str] | None
-) -> str:
-    """Apply native ``~`` expansion without normalizing path components."""
-
-    spelling = os.fsdecode(os.fspath(value))
-    if spelling == "~" or spelling.startswith("~/"):
-        home = (os.environ if env is None else env).get("HOME")
-        if home is not None:
-            suffix = spelling[2:] if len(spelling) > 2 else ""
-            return os.path.join(home, suffix) if suffix else home
-    return spelling
-
-
-def _join_path_spelling(base: str, path: str) -> str:
-    return path if os.path.isabs(path) else os.path.join(base, path)
-
-
-def _map_stream_cwd(
-    process_cwd: PathArgument | None,
-    env: Mapping[str, str] | None,
-    selected_base: PathArgument | None,
-    contents_selector: PathArgument | None,
-) -> Path:
-    """Derive the consumer base using the native component spelling."""
-
-    if process_cwd is None:
-        process_base = os.getcwd()
-    else:
-        process_spelling = os.fsdecode(os.fspath(process_cwd))
-        process_base = _join_path_spelling(os.getcwd(), process_spelling)
-    base_spelling = _native_path_spelling(
-        "." if selected_base is None else selected_base, env
-    )
-    effective = _join_path_spelling(process_base, base_spelling)
-    if contents_selector is not None:
-        effective = _join_path_spelling(
-            effective, _native_path_spelling(contents_selector, env)
-        )
-    # Path preserves `..` components. In particular, do not use abspath or
-    # resolve here: the native walker must encounter symlinks before `..`.
-    return Path(effective)
 
 
 def run(
@@ -852,15 +810,23 @@ def _write_mapping_manifest(
     manifest.flush()
 
 
-class MapStream(Iterable[MappingEntry]):
+class MapStream(FileMapping):
     """A context-managed, streaming ``syq map`` result."""
 
-    def __init__(self, process: _LineProcess, cwd: PathArgument) -> None:
+    def __init__(
+        self, process: _LineProcess, cwd: PathArgument, *,
+        confined: bool = False, follow_src: bool = False,
+    ) -> None:
+        super().__init__(
+            (), cwd=None if confined else cwd,
+            root=cwd if confined else None, follow_src=follow_src,
+        )
         self._process = process
-        self.cwd = cwd
         self._complete = False
 
     def __iter__(self) -> MapStream:
+        if self._complete:
+            raise SyqInvocationError("mapping stream is closed or exhausted")
         return self
 
     def __next__(self) -> MappingEntry:
@@ -941,7 +907,7 @@ class Client:
         check: bool = True,
         cwd: PathArgument | None = None,
         env: Mapping[str, str] | None = None,
-        timeout: float | None = None,
+        timeout: Timeout = CLIENT_DEFAULT,
         input: bytes | None = None,
     ) -> Result:
         return run(
@@ -950,7 +916,7 @@ class Client:
             check=check,
             cwd=self.process_cwd if cwd is None else cwd,
             env=self.env if env is None else env,
-            timeout=self.timeout if timeout is None else timeout,
+            timeout=resolve_timeout(timeout, self.timeout),
             input=input,
         )
 
@@ -970,7 +936,7 @@ class Client:
         selectors_total: int | None,
         on_event: Callable[[AutomationEvent], object] | None,
         results: BinaryIO | None,
-        timeout: float | None,
+        timeout: Timeout,
         check: bool,
     ) -> OperationSummary:
         command = (self._executable_value(), *argv)
@@ -978,7 +944,7 @@ class Client:
             command,
             cwd=self.process_cwd,
             env=self.env,
-            timeout=self.timeout if timeout is None else timeout,
+            timeout=resolve_timeout(timeout, self.timeout),
         )
         writer = _ResultsFileWriter(results)
         decoder = AutomationDecoder(
@@ -1070,7 +1036,7 @@ class Client:
         min_size: str | int | None = None,
         max_delete: int | None = None,
         on_event: Callable[[AutomationEvent], object] | None = None,
-        timeout: float | None = None,
+        timeout: Timeout = CLIENT_DEFAULT,
         check: bool = True,
     ) -> CpResult:
         if (
@@ -1085,6 +1051,9 @@ class Client:
                 f"a remote-to-remote {'verification' if verify_only else 'dry run'} cannot produce the results "
                 "stream this surface relies on; pass coordinate_at='local'"
             )
+        cwd, root, follow_src = _source_options(
+            mapping, from_=from_, cwd=cwd, root=root, follow_src=follow_src,
+        )
         results = _prepare_results_file(results)
         argv, source_count, source_end = _copy_arguments(
             "cp",
@@ -1222,7 +1191,7 @@ class Client:
         no_bootstrap: bool = False,
         pscope: PathArgument | None = None,
         on_event: Callable[[AutomationEvent], object] | None = None,
-        timeout: float | None = None,
+        timeout: Timeout = CLIENT_DEFAULT,
         check: bool = True,
     ) -> RmResult:
         results = _prepare_results_file(results)
@@ -1270,7 +1239,7 @@ class Client:
         follow: bool = False,
         follow_src: bool = False,
         as_: PathArgument | None = None,
-        timeout: float | None = None,
+        timeout: Timeout = CLIENT_DEFAULT,
     ) -> MapStream:
         # Materialize selectors once so generators are not consumed separately
         # while deriving the source base carried by MapStream.cwd.
@@ -1341,7 +1310,9 @@ class Client:
                 command,
                 cwd=self.process_cwd,
                 env=self.env,
-                timeout=self.timeout if timeout is None else timeout,
+                timeout=resolve_timeout(timeout, self.timeout),
             ),
             effective_cwd,
+            confined=root is not None,
+            follow_src=follow or follow_src,
         )

--- a/sdk/python/src/syq/errors.py
+++ b/sdk/python/src/syq/errors.py
@@ -9,11 +9,15 @@ if TYPE_CHECKING:
     from .models import OperationSummary
 
 
-class SyqInvocationError(ValueError):
+class SyqError(Exception):
+    """Base class for errors reported by the syq SDK."""
+
+
+class SyqInvocationError(SyqError, ValueError):
     """Python inputs cannot form a valid native syq invocation."""
 
 
-class SyqProcessError(RuntimeError):
+class SyqProcessError(SyqError, RuntimeError):
     """A raw syq process completed with a nonzero status."""
 
     def __init__(self, result: Result) -> None:
@@ -21,11 +25,11 @@ class SyqProcessError(RuntimeError):
         super().__init__(f"syq exited with status {result.returncode}")
 
 
-class SyqOutputError(ValueError):
+class SyqOutputError(SyqError, ValueError):
     """A raw syq helper returned output it cannot interpret."""
 
 
-class SyqProtocolError(ValueError):
+class SyqProtocolError(SyqError, ValueError):
     """A typed operation returned an invalid or incomplete automation stream."""
 
     def __init__(
@@ -40,7 +44,7 @@ class SyqProtocolError(ValueError):
         super().__init__(message)
 
 
-class SyqOperationError(RuntimeError):
+class SyqOperationError(SyqError, RuntimeError):
     """A valid automation result reports a non-successful operation."""
 
     def __init__(self, result: OperationSummary, *, stderr: bytes = b"") -> None:

--- a/sdk/python/src/syq/managed.py
+++ b/sdk/python/src/syq/managed.py
@@ -20,13 +20,15 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any, BinaryIO
 
+from .errors import SyqError
+
 
 _DOWNLOAD_TIMEOUT_SECONDS = 30
 _CHUNK_SIZE = 1024 * 1024
 _EXPECTED_REPOSITORY = "https://github.com/greaber/syq"
 
 
-class SyqInstallError(RuntimeError):
+class SyqInstallError(SyqError, RuntimeError):
     """The SDK could not install or validate its pinned syq executable."""
 
 

--- a/sdk/python/src/syq/models.py
+++ b/sdk/python/src/syq/models.py
@@ -251,10 +251,29 @@ class Endpoint:
 
 
 @dataclass(frozen=True, slots=True)
-class RunEvent:
+class ProtocolMetadata:
+    """Wire envelope shared by automation events and terminal results."""
+
     schema: str
     schema_version: int
     seq: int
+    type: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptSummary:
+    """Bookkeeping from a verified receiver receipt."""
+
+    status: ReceiptStatus
+    operations: int
+    final_states: int
+    records: int
+    provenance: str = "receiver_attested"
+
+
+@dataclass(frozen=True, slots=True)
+class RunEvent:
+    protocol: ProtocolMetadata
     run_id: str
     started_at: int
     syq_version: str
@@ -263,15 +282,12 @@ class RunEvent:
     mapping: bool | None
     dry_run: bool
     endpoints: tuple[Endpoint, ...]
-    type: str = "run"
     verify_only: bool = False
 
 
 @dataclass(frozen=True, slots=True)
 class ProgressEvent:
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     bytes_done: int
     bytes_total: int
     bytes_unchanged: int
@@ -282,28 +298,22 @@ class ProgressEvent:
     scanned: int
     scan_done: bool
     elapsed_ms: int
-    type: str = "progress"
 
 
 @dataclass(frozen=True, slots=True)
 class TraceEvent:
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     action: OperationAction
     dst: PathValue
     src: PathValue | None
     kind: EntryKind
     bytes: int | None
     reason: TraceReason
-    type: str = "trace"
 
 
 @dataclass(frozen=True, slots=True)
 class OperationResult:
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     action: OperationAction
     dst: PathValue
     src: PathValue | None
@@ -318,7 +328,6 @@ class OperationResult:
     provenance: str | None = None
     scope: int | None = None
     code: ReceiptCode | None = None
-    type: str = "operation_result"
 
     @property
     def is_retryable(self) -> bool:
@@ -342,33 +351,25 @@ class OperationResult:
 
 @dataclass(frozen=True, slots=True)
 class SelectionResult:
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     selector: int
     path: PathValue
     status: SelectionStatus
     kind: EntryKind | None
-    type: str = "selection_result"
 
 
 @dataclass(frozen=True, slots=True)
 class RemovalTrace:
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     selector: int
     path: PathValue
     kind: EntryKind
     disposition: RemovalDisposition
-    type: str = "removal_trace"
 
 
 @dataclass(frozen=True, slots=True)
 class RemovalResult:
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     selector: int
     path: PathValue
     kind: EntryKind | None
@@ -378,20 +379,16 @@ class RemovalResult:
     class_: ErrorClass | None
     os_kind: OsKind | None
     message: str | None
-    type: str = "removal_result"
 
 
 @dataclass(frozen=True, slots=True)
 class ErrorEvent:
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     message: str
     class_: ErrorClass | None
     os_kind: OsKind | None
     provenance: str | None = None
     code: ReceiptCode | None = None
-    type: str = "error"
 
 
 @dataclass(frozen=True, slots=True)
@@ -418,9 +415,7 @@ class AttestedDigest:
 class FinalStateEvent:
     """A receiver-attested closure-time observation of one touched path."""
 
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     provenance: str
     scope: int
     dst: PathValue
@@ -433,7 +428,6 @@ class FinalStateEvent:
     observation_error: str | None
     code: ReceiptCode | None
     message: str | None
-    type: str = "final_state"
 
 
 class OperationSummary:
@@ -441,9 +435,7 @@ class OperationSummary:
 
     __slots__ = ()
 
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     status: OperationStatus
     exit_code: int
     dry_run: bool
@@ -453,9 +445,7 @@ class OperationSummary:
 
 @dataclass(frozen=True, slots=True)
 class CpResult(OperationSummary):
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     status: OperationStatus
     exit_code: int
     dry_run: bool
@@ -472,19 +462,12 @@ class CpResult(OperationSummary):
     deletions_planned: int | None
     deletions_completed: int | None
     deletions_blocked: int | None
-    provenance: str | None = None
-    receipt_status: ReceiptStatus | None = None
-    operations: int | None = None
-    final_states: int | None = None
-    receipt_records: int | None = None
-    type: str = "result"
+    receipt: ReceiptSummary | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class RmResult(OperationSummary):
-    schema: str
-    schema_version: int
-    seq: int
+    protocol: ProtocolMetadata
     status: OperationStatus
     exit_code: int
     dry_run: bool
@@ -498,7 +481,6 @@ class RmResult(OperationSummary):
     errors: int
     elapsed_ms: int
     mode: str = "rm"
-    type: str = "result"
 
 
 AutomationEvent = (

--- a/sdk/python/src/syq/protocol.py
+++ b/sdk/python/src/syq/protocol.py
@@ -11,6 +11,8 @@ from .errors import SyqProtocolError
 from .models import (
     AutomationEvent,
     CpResult,
+    ProtocolMetadata,
+    ReceiptSummary,
     Disposition,
     Endpoint,
     EndpointKind,
@@ -262,7 +264,9 @@ class AutomationDecoder:
             )
         self._next_seq += 1
         record_type = _string(record, "type")
-        common = {"schema": SCHEMA, "schema_version": SCHEMA_VERSION, "seq": seq}
+        common = {
+            "protocol": ProtocolMetadata(SCHEMA, SCHEMA_VERSION, seq, record_type)
+        }
 
         if self.run is None:
             if record_type != "run":
@@ -841,16 +845,14 @@ class AutomationDecoder:
                 deletions_planned=deletion_values[0],
                 deletions_completed=deletion_values[1],
                 deletions_blocked=deletion_values[2],
-                provenance=provenance,
-                receipt_status=(
-                    _enum(record, "receipt_status", ReceiptStatus)
-                    if attested
-                    else None
-                ),
-                operations=_integer(record, "operations") if attested else None,
-                final_states=_integer(record, "final_states") if attested else None,
-                receipt_records=(
-                    _integer(record, "receipt_records") if attested else None
+                receipt=(
+                    ReceiptSummary(
+                        status=_enum(record, "receipt_status", ReceiptStatus),
+                        operations=_integer(record, "operations"),
+                        final_states=_integer(record, "final_states"),
+                        records=_integer(record, "receipt_records"),
+                    )
+                    if attested else None
                 ),
             )
             self.result = result

--- a/sdk/python/tests/test_api_design.py
+++ b/sdk/python/tests/test_api_design.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import tempfile
 import unittest
+import weakref
 from pathlib import Path
 
 import syq
@@ -41,8 +42,12 @@ class ErrorAndTimeoutTests(unittest.TestCase):
             with self.subTest(command=command):
                 with self.assertRaises(subprocess.TimeoutExpired):
                     self.call(client, command)
-                self.call(client, command, timeout=None)
-                self.call(client, command, timeout=5)
+                def forward(*, timeout: syq.Timeout = syq.CLIENT_DEFAULT):
+                    return self.call(client, command, timeout=timeout)
+                with self.assertRaises(subprocess.TimeoutExpired):
+                    forward()
+                forward(timeout=None)
+                forward(timeout=5)
                 self.assertEqual(client.timeout, 0)
 
     def test_common_error_base_preserves_specific_error_types(self):
@@ -99,6 +104,12 @@ class ErrorAndTimeoutTests(unittest.TestCase):
 
 
 class AsyncTimeoutTests(unittest.IsolatedAsyncioTestCase):
+    async def test_unstarted_stream_has_no_self_reference_cycle(self):
+        stream = syq.AsyncClient().map("source")
+        reference = weakref.ref(stream)
+        del stream
+        self.assertIsNone(reference())
+
     async def test_timeout_overrides_for_all_async_operations(self):
         with tempfile.TemporaryDirectory() as directory:
             executable = Path(directory) / "syq"
@@ -119,8 +130,12 @@ class AsyncTimeoutTests(unittest.IsolatedAsyncioTestCase):
                 with self.subTest(command=command):
                     with self.assertRaises(asyncio.TimeoutError):
                         await call(command)
-                    await call(command, timeout=None)
-                    await call(command, timeout=5)
+                    async def forward(*, timeout: syq.Timeout = syq.CLIENT_DEFAULT):
+                        return await call(command, timeout=timeout)
+                    with self.assertRaises(asyncio.TimeoutError):
+                        await forward()
+                    await forward(timeout=None)
+                    await forward(timeout=5)
                     self.assertEqual(client.timeout, 0)
 
 

--- a/sdk/python/tests/test_api_design.py
+++ b/sdk/python/tests/test_api_design.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import io
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import syq
+
+from test_native import FAKE_NATIVE
+
+
+class ErrorAndTimeoutTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.executable = self.root / "syq"
+        self.executable.write_text(FAKE_NATIVE)
+        self.executable.chmod(0o755)
+        self.env = {**os.environ, "SYQ_FAKE_PAUSE": "0.03"}
+
+    def call(self, client, command, **options):
+        if command == "map":
+            with client.map("source", **options) as mapping:
+                return list(mapping)
+        if command == "run":
+            return client.run(["map", "source"], **options)
+        if command == "cp":
+            return client.cp("source", into="destination", **options)
+        return client.rm("source", **options)
+
+    def test_omitted_timeout_inherits_none_disables_and_number_overrides(self):
+        client = syq.Client(executable=self.executable, env=self.env, timeout=0)
+        for command in ("cp", "rm", "map", "run"):
+            with self.subTest(command=command):
+                with self.assertRaises(subprocess.TimeoutExpired):
+                    self.call(client, command)
+                self.call(client, command, timeout=None)
+                self.call(client, command, timeout=5)
+                self.assertEqual(client.timeout, 0)
+
+    def test_common_error_base_preserves_specific_error_types(self):
+        for error_type in (syq.SyqInstallError, syq.SyqInvocationError,
+                           syq.SyqProcessError, syq.SyqOutputError,
+                           syq.SyqProtocolError, syq.SyqOperationError):
+            self.assertTrue(issubclass(error_type, syq.SyqError))
+        client = syq.Client(executable=self.executable)
+        with self.assertRaises(syq.SyqError) as caught:
+            client.cp("source", into="a", as_="b")
+        self.assertIsInstance(caught.exception, syq.SyqInvocationError)
+        client.env = {**os.environ, "SYQ_FAKE_STATUS": "partial"}
+        with self.assertRaises(syq.SyqError) as caught:
+            client.cp("source", into="a")
+        self.assertIsInstance(caught.exception, syq.SyqOperationError)
+        self.assertIs(caught.exception.result.status, syq.OperationStatus.PARTIAL)
+
+    def test_callback_exception_is_not_wrapped(self):
+        failure = LookupError("application error")
+        def callback(event):
+            raise failure
+        client = syq.Client(executable=self.executable)
+        with self.assertRaises(LookupError) as caught:
+            client.cp("source", into="destination", on_event=callback)
+        self.assertIs(caught.exception, failure)
+        self.assertNotIsInstance(caught.exception, syq.SyqError)
+
+    def test_grouped_metadata_keeps_saved_wire_records_unchanged(self):
+        client = syq.Client(executable=self.executable,
+                            env={**os.environ, "SYQ_FAKE_SHAPE": "attested"})
+        events = []
+        output = io.BytesIO()
+        result = client.cp("source", into="destination", results=output,
+                           on_event=events.append)
+        records = [json.loads(line) for line in output.getvalue().splitlines()]
+        self.assertEqual(len(records), len(events))
+        for event, record in zip(events, records):
+            self.assertEqual(dataclasses.asdict(event.protocol),
+                             {key: record[key] for key in ("schema", "schema_version", "seq", "type")})
+            self.assertNotIn("protocol", record)
+            self.assertFalse(hasattr(event, "seq"))
+        self.assertIs(result.receipt.status, syq.ReceiptStatus.CLEAN)
+        self.assertEqual(result.receipt.records, records[-1]["receipt_records"])
+        self.assertEqual(result.receipt.provenance, records[-1]["provenance"])
+        self.assertFalse(hasattr(result, "receipt_status"))
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            result.protocol.seq = 0
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            result.receipt.records = 0
+        final = next(event for event in events if isinstance(event, syq.FinalStateEvent))
+        # Filesystem metadata and protocol metadata remain distinct.
+        self.assertIsInstance(final.protocol, syq.ProtocolMetadata)
+        self.assertTrue(final.metadata is None or isinstance(final.metadata, syq.ObjectMetadata))
+
+
+class AsyncTimeoutTests(unittest.IsolatedAsyncioTestCase):
+    async def test_timeout_overrides_for_all_async_operations(self):
+        with tempfile.TemporaryDirectory() as directory:
+            executable = Path(directory) / "syq"
+            executable.write_text(FAKE_NATIVE)
+            executable.chmod(0o755)
+            client = syq.AsyncClient(executable=executable, timeout=0,
+                                    env={**os.environ, "SYQ_FAKE_PAUSE": "0.03"})
+            async def call(command, **options):
+                if command == "map":
+                    async with client.map("source", **options) as mapping:
+                        return [entry async for entry in mapping]
+                if command == "run":
+                    return await client.run(["map", "source"], **options)
+                if command == "cp":
+                    return await client.cp("source", into="destination", **options)
+                return await client.rm("source", **options)
+            for command in ("cp", "rm", "map", "run"):
+                with self.subTest(command=command):
+                    with self.assertRaises(asyncio.TimeoutError):
+                        await call(command)
+                    await call(command, timeout=None)
+                    await call(command, timeout=5)
+                    self.assertEqual(client.timeout, 0)
+
+
+EXECUTABLE = os.environ.get("SYQ_CANDIDATE_EXECUTABLE")
+
+
+@unittest.skipUnless(EXECUTABLE, "candidate binary required")
+class MappingContextTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.source = self.root / "source"
+        self.source.mkdir()
+        (self.source / "a").write_bytes(b"correct source")
+        (self.source / "b").write_bytes(b"omit this")
+        self.other = self.root / "other"
+        self.other.mkdir()
+        (self.other / "a").write_bytes(b"wrong source")
+        self.producer = syq.Client(executable=EXECUTABLE, process_cwd=self.root)
+        self.consumer = syq.Client(executable=EXECUTABLE, process_cwd=self.other)
+
+    def test_stream_transform_chain_preserves_context_and_filters(self):
+        calls = []
+        def select(entry):
+            calls.append(entry)
+            return entry if entry.src.text == "a" else None
+        with self.producer.map(srcs_in="source") as mapping:
+            transformed = mapping.transform(select).transform(
+                lambda entry: dataclasses.replace(entry, dst=syq.RelativePath("renamed")))
+            self.assertEqual(calls, [])
+            self.consumer.cp(mapping=transformed, into="destination")
+        self.assertEqual((self.other / "destination/renamed").read_bytes(), b"correct source")
+        self.assertEqual(len(calls), 2)
+        self.assertFalse((self.other / "destination/b").exists())
+        with self.assertRaisesRegex(syq.SyqInvocationError, "closed or exhausted"):
+            self.consumer.cp(mapping=transformed, into="repeat")
+        self.assertFalse((self.other / "repeat").exists())
+
+    def test_direct_mapping_and_custom_entries_capture_source_base(self):
+        with self.producer.map(srcs_in="source") as mapping:
+            self.consumer.cp(mapping=mapping, into="direct")
+        entries = syq.Mapping([syq.MappingEntry("a", "copied")], cwd=self.source)
+        self.consumer.cp(mapping=entries, into="custom")
+        self.assertEqual((self.other / "direct/a").read_bytes(), b"correct source")
+        self.assertEqual((self.other / "custom/copied").read_bytes(), b"correct source")
+        transformed = entries.transform(lambda entry: entry)
+        self.consumer.cp(mapping=transformed, into="repeat-one")
+        self.consumer.cp(mapping=transformed, into="repeat-two")
+        self.assertEqual((self.other / "repeat-two/copied").read_bytes(), b"correct source")
+
+    def test_explicit_source_overrides_are_rejected_before_copy(self):
+        with self.producer.map(srcs_in="source") as mapping:
+            for override in ({"cwd": mapping.cwd}, {"root": self.other}, {"from_": "server"}):
+                with self.subTest(override=override), self.assertRaises(syq.SyqInvocationError):
+                    self.consumer.cp(mapping=mapping, into="destination", **override)
+        self.assertFalse((self.other / "destination").exists())
+
+    def test_follow_policy_and_unresolved_components_survive_transformation(self):
+        (self.source / "nested").mkdir()
+        (self.root / "alias").symlink_to(self.source / "nested", target_is_directory=True)
+        with self.producer.map(srcs_in="alias/..", follow_src=True) as mapping:
+            transformed = mapping.transform(lambda entry: entry)
+            self.assertIn("alias/..", str(transformed.cwd))
+            self.assertTrue(transformed.follow_src)
+            self.consumer.cp(mapping=transformed, into="destination")
+        self.assertEqual((self.other / "destination/a").read_bytes(), b"correct source")
+
+    def test_root_context_remains_confined_during_copy(self):
+        with self.producer.map(srcs_in="source", root=self.root) as mapping:
+            transformed = mapping.transform(lambda entry: entry)
+            self.assertEqual(transformed.root, self.source)
+            self.consumer.cp(mapping=transformed, into="destination")
+        self.assertEqual((self.other / "destination/a").read_bytes(), b"correct source")
+        # A transformed source symlink cannot escape the carried root.
+        (self.source / "escape").symlink_to(self.other / "a")
+        with self.producer.map(src="a", root=self.source) as mapping:
+            transformed = mapping.transform(lambda entry: dataclasses.replace(entry, src=syq.RelativePath("escape")))
+            with self.assertRaises(syq.SyqError):
+                self.consumer.cp(mapping=transformed, into="escaped", follow_src=True)
+        self.assertFalse((self.other / "escaped/a").exists())
+
+    def test_closed_and_exhausted_streams_cannot_be_copied(self):
+        for consume in (False, True):
+            with self.producer.map(srcs_in="source") as mapping:
+                transformed = mapping.transform(lambda entry: entry)
+                if consume:
+                    list(mapping)
+            with self.assertRaisesRegex(syq.SyqInvocationError, "closed or exhausted"):
+                self.consumer.cp(mapping=transformed, into="destination")
+        self.assertFalse((self.other / "destination").exists())
+
+    def test_failed_transform_or_producer_never_starts_copy(self):
+        def fail(entry):
+            if entry.src.text == "b":
+                raise LookupError("transform failed")
+            return entry
+        with self.producer.map(srcs_in="source") as mapping:
+            with self.assertRaisesRegex(LookupError, "transform failed"):
+                self.consumer.cp(mapping=mapping.transform(fail), into="destination")
+        self.assertFalse((self.other / "destination").exists())
+        # The committed source fixtures already exercise protocol truncation;
+        # here use an actual producer failure after selecting a valid path.
+        with self.producer.map(src=["source/a", "missing"]) as mapping:
+            with self.assertRaises(syq.SyqError):
+                self.consumer.cp(mapping=mapping.transform(lambda entry: entry), into="destination")
+        self.assertFalse((self.other / "destination").exists())
+
+
+@unittest.skipUnless(EXECUTABLE, "candidate binary required")
+class AsyncMappingContextTests(unittest.IsolatedAsyncioTestCase):
+    async def test_async_transform_and_sync_mapping_cross_client(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "source").mkdir()
+            (root / "source/a").write_bytes(b"data")
+            (root / "other").mkdir()
+            producer = syq.AsyncClient(executable=EXECUTABLE, process_cwd=root)
+            consumer = syq.AsyncClient(executable=EXECUTABLE, process_cwd=root / "other")
+            async def rename(entry):
+                await asyncio.sleep(0)
+                return dataclasses.replace(entry, dst=syq.RelativePath("renamed"))
+            async with producer.map(srcs_in="source", root=root) as mapping:
+                transformed = mapping.transform(rename).transform(lambda entry: entry)
+                self.assertEqual(transformed.root, root / "source")
+                await consumer.cp(mapping=transformed, into="destination")
+            self.assertEqual((root / "other/destination/renamed").read_bytes(), b"data")
+            with self.assertRaisesRegex(syq.SyqInvocationError, "closed or exhausted"):
+                await consumer.cp(mapping=transformed, into="repeat")
+            self.assertFalse((root / "other/repeat").exists())
+            mapping = syq.Mapping([syq.MappingEntry("a", "a")], cwd=root / "source")
+            await consumer.cp(mapping=mapping, into="sync-input")
+            self.assertEqual((root / "other/sync-input/a").read_bytes(), b"data")
+
+    async def test_lazy_map_snapshots_producer_directory_and_environment(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for name in ("first", "second"):
+                (root / name).mkdir()
+                (root / name / "a").write_text(name)
+            env = {**os.environ, "HOME": str(root / "first")}
+            client = syq.AsyncClient(executable=EXECUTABLE, process_cwd=root / "first", env=env)
+            relative = client.map("a")
+            home = client.map(srcs_in="~/")
+            client.process_cwd = root / "second"
+            env["HOME"] = str(root / "second")
+            client.timeout = 0
+            async with relative:
+                await client.cp(mapping=relative, into=root / "relative", timeout=None)
+            async with home:
+                await client.cp(mapping=home, into=root / "home", timeout=None)
+            self.assertEqual((root / "relative/a").read_text(), "first")
+            self.assertEqual((root / "home/a").read_text(), "first")
+
+    async def test_async_mapping_constructor_and_closed_stream(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "source").mkdir()
+            (root / "source/a").write_bytes(b"data")
+            client = syq.AsyncClient(executable=EXECUTABLE, process_cwd=root)
+            async def entries():
+                yield syq.MappingEntry("a", "renamed")
+            mapping = syq.AsyncMapping(entries(), cwd=root / "source")
+            await client.cp(mapping=mapping, into="destination")
+            self.assertEqual((root / "destination/renamed").read_bytes(), b"data")
+            async with client.map(srcs_in="source") as stream:
+                transformed = stream.transform(lambda entry: entry)
+            with self.assertRaisesRegex(syq.SyqInvocationError, "closed or exhausted"):
+                await client.cp(mapping=transformed, into="closed")
+            self.assertFalse((root / "closed").exists())
+
+    async def test_async_failed_or_cancelled_transform_leaves_destination_untouched(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "a").write_bytes(b"data")
+            client = syq.AsyncClient(executable=EXECUTABLE, process_cwd=root)
+            async def fail(entry):
+                raise LookupError("transform failed")
+            async with client.map("a") as mapping:
+                with self.assertRaisesRegex(LookupError, "transform failed"):
+                    await client.cp(mapping=mapping.transform(fail), into="destination")
+            self.assertFalse((root / "destination").exists())
+            started = asyncio.Event()
+            async def wait(entry):
+                started.set()
+                await asyncio.Event().wait()
+                return entry
+            async with client.map("a") as mapping:
+                operation = asyncio.create_task(client.cp(mapping=mapping.transform(wait), into="destination"))
+                await asyncio.wait_for(started.wait(), timeout=5)
+                operation.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await operation
+            self.assertFalse((root / "destination").exists())

--- a/sdk/python/tests/test_async.py
+++ b/sdk/python/tests/test_async.py
@@ -174,7 +174,7 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
         records = [json.loads(line) for line in output.getvalue().splitlines()]
         self.assertEqual(records[-2]["type"], "final_state")
         self.assertEqual(records[-1]["provenance"], "receiver_attested")
-        self.assertEqual(result.receipt_status, syq.ReceiptStatus.CLEAN)
+        self.assertEqual(result.receipt.status, syq.ReceiptStatus.CLEAN)
 
     async def test_version_matches_synchronous_client(self) -> None:
         self.assertEqual(await self.client.version(), "9.8.7")
@@ -197,7 +197,7 @@ class AsyncClientTests(unittest.IsolatedAsyncioTestCase):
             self.assertIn("--follow-src", self.argv())
             self.assertIn("--root", self.argv())
             copied = await self.client.cp(
-                mapping=stream, cwd=stream.cwd, into="target"
+                mapping=stream, into="target"
             )
         self.assertEqual(copied.files_transferred, 1)
         self.assertEqual(stream.cwd, Path.cwd() / "source-root" / "source")

--- a/sdk/python/tests/test_candidate.py
+++ b/sdk/python/tests/test_candidate.py
@@ -124,7 +124,6 @@ class CandidateCompatibilityTests(unittest.TestCase):
             ) as component_mapping:
                 component_copy = client.cp(
                     mapping=component_mapping,
-                    cwd=component_mapping.cwd,
                     follow_src=True,
                     into="component-mapped",
                 )
@@ -349,7 +348,7 @@ class AsyncCandidateCompatibilityTests(unittest.IsolatedAsyncioTestCase):
                     side_effect=create_through_alias,
                 ):
                     copied = await client.cp(
-                        mapping=mapping, cwd=mapping.cwd, into="destination"
+                        mapping=mapping, into="destination"
                     )
             self.assertEqual(copied.files_transferred, 1)
             self.assertEqual((root / "destination" / "a").read_bytes(), b"async")

--- a/sdk/python/tests/test_native.py
+++ b/sdk/python/tests/test_native.py
@@ -497,7 +497,7 @@ class NativeClientTests(unittest.TestCase):
             ["run", "progress", "operation_result", "final_state", "result"],
         )
         self.assertEqual(records[-1]["provenance"], "receiver_attested")
-        self.assertEqual(result.receipt_status, syq.ReceiptStatus.CLEAN)
+        self.assertEqual(result.receipt.status, syq.ReceiptStatus.CLEAN)
         self.assertTrue(
             any(isinstance(event, syq.FinalStateEvent) for event in events)
         )
@@ -1073,8 +1073,8 @@ class ReceiverAttestedDecodingTests(unittest.TestCase):
 
         decoder = self._final_state_decoder()
         result = decoder.feed(self._terminal(**attested))
-        self.assertIs(result.receipt_status, syq.ReceiptStatus.CLEAN)
-        self.assertEqual(result.receipt_records, 1)
+        self.assertIs(result.receipt.status, syq.ReceiptStatus.CLEAN)
+        self.assertEqual(result.receipt.records, 1)
 
     def test_attested_records_decode_with_the_receiver_vocabulary(self) -> None:
         from syq.protocol import AutomationDecoder
@@ -1189,7 +1189,7 @@ class ReceiverAttestedDecodingTests(unittest.TestCase):
         self.assertIsNone(result.deletions_planned)
         self.assertIsNone(result.deletions_blocked)
         self.assertEqual(result.deletions_completed, 0)
-        self.assertEqual(result.receipt_status, "clean")
-        self.assertEqual(result.operations, 3)
-        self.assertEqual(result.final_states, 1)
-        self.assertEqual(result.receipt_records, 4)
+        self.assertEqual(result.receipt.status, "clean")
+        self.assertEqual(result.receipt.operations, 3)
+        self.assertEqual(result.receipt.final_states, 1)
+        self.assertEqual(result.receipt.records, 4)


### PR DESCRIPTION
Python callers had to repeat a map stream's source base when copying, could not disable an inherited timeout, and had no common SDK exception base. Result objects also mixed useful totals with protocol and receipt bookkeeping.

This revision implements the four agreed API improvements:
- `Mapping`/`AsyncMapping` carry the local source context; `map()` streams inherit those interfaces. `.transform()` preserves the context, supports omission with `None`, and awaits async callbacks. `cp(mapping=...)` uses that context and rejects conflicting source overrides. Lazy async maps capture producer cwd/environment/timeout. Closed or exhausted streams cannot be silently copied as empty mappings, including through transforms. Complete-input-before-copy behavior remains.
- `SyqError` groups all SDK-defined exceptions while preserving specific subclasses and leaving caller exceptions, standard Python errors, and cancellation untouched.
- Omitted timeouts inherit client configuration; explicit `None` disables it for that call. Public `syq.CLIENT_DEFAULT` and `syq.Timeout` let wrappers preserve inheritance without private imports.
- Every automation event/result has `protocol: ProtocolMetadata`; `CpResult.receipt` groups receiver-receipt details. Filesystem `FinalStateEvent.metadata` keeps its existing meaning.

The guide and exact type reference describe the new surface. `sdk/python/API_DESIGN.md` records rationale, migration examples, and the compatibility audit. This is an explicitly authorized pre-adoption Python API break; old flattened attributes and contextual `cwd=` calls have no compatibility aliases. That exception is scoped to this revision.

Native CLI/wire formats, signed state, receipt and mapping NDJSON, and caches are unchanged. The compatibility baseline is Python SDK 0.4.1 (release preparation merged at `2c80e73`) / syq `v0.4.1`, which still has the old flattened API. Master through `79a126a` is merged, including its managed 0.4.1 pin. All existing automation fixtures are byte-for-byte unchanged from `v0.4.1`, and the new SDK successfully runs against that released binary. Old packages continue to use their embedded pin and the same saved formats/cache.

The review follow-up also documents that relative `Mapping(cwd=...)` and `Mapping(root=...)` resolve against the Python process directory at construction, and removes the async map stream's self-reference.

Validation at `d4d30c9`:
- All 107 SDK tests passed on both Python 3.13 and Python 3.10.20 against managed syq 0.4.1, with no skips.
- Tests cover source context across clients, transformation chains/reuse, symlink policy and root confinement, producer/transform failure and cancellation before mutation, lazy async producer snapshots, timeout inheritance/disable/override and public-sentinel forwarding for all four methods, grouped immutable metadata, unchanged saved NDJSON, and unstarted async stream reclamation.
- Wheel and sdist build, mdBook 0.5.4, 19-file Markdown link checks, fixture identity against `v0.4.1`, and diff whitespace checks passed.
- Earlier validation at `8e6a503`: candidate cargo build, default three-container real OpenSSH suite, isolated Python 3.10 wheel smoke against managed 0.4.0, 84 rendered links, reference field/type coverage, and Python snippet syntax passed. These were not rerun for the small Python review follow-up.
- Full Rust unit/integration/clippy baselines and native macOS execution were not run; this PR changes no Rust sources.

Preview: https://chapter-tend-updating-paperbacks.trycloudflare.com/python-guide.html
