### PR TITLE
Dispatch generated SDK checks by merge commit

### DIFF
--- a/scripts/run-generated-sdk-post-merge-ci.sh
+++ b/scripts/run-generated-sdk-post-merge-ci.sh
@@ -39,7 +39,7 @@ for workflow in "${workflows[@]}"; do
   dispatch=$(gh api --method POST \
     -H 'X-GitHub-Api-Version: 2026-03-10' \
     "repos/$repository/actions/workflows/$workflow/dispatches" \
-    -f ref="$branch")
+    -f ref="$merge_sha")
   run_id=$(jq -er .workflow_run_id <<<"$dispatch")
   [[ "$run_id" =~ ^[0-9]+$ ]] || {
     echo "$workflow dispatch returned invalid workflow run ID: $run_id" >&2


### PR DESCRIPTION
Fixes Python release preparation when the automation branch push races a post-merge workflow dispatch. Dispatches CI by immutable merge SHA. Validation: scripts/test-release-orchestration.sh; ShellCheck.