### PR TITLE
Wait for generated SDK workflow dispatches

### DIFF
--- a/scripts/run-generated-sdk-post-merge-ci.sh
+++ b/scripts/run-generated-sdk-post-merge-ci.sh
@@ -34,26 +34,26 @@ reference_sha=$(jq -er .object.sha <<<"$reference")
 }
 
 workflows=(ci.yml rsync-compat.yml macos.yml)
+poll_attempts=${SYQ_POST_MERGE_POLL_ATTEMPTS:-30}
+[[ "$poll_attempts" =~ ^[1-9][0-9]*$ ]] || { echo "invalid poll attempt count" >&2; exit 2; }
 run_ids=()
 for workflow in "${workflows[@]}"; do
-  dispatch=$(gh api --method POST \
+  gh api --method POST \
     -H 'X-GitHub-Api-Version: 2026-03-10' \
     "repos/$repository/actions/workflows/$workflow/dispatches" \
-    -f ref="$merge_sha")
-  run_id=$(jq -er .workflow_run_id <<<"$dispatch")
+    -f ref="$branch" >/dev/null
+  run_id=
+  for ((attempt = 1; attempt <= poll_attempts; attempt++)); do
+    runs=$(gh api "repos/$repository/actions/workflows/$workflow/runs?event=workflow_dispatch&branch=$branch&per_page=100")
+    run_id=$(jq -r --arg sha "$merge_sha" '
+      [.workflow_runs[] | select(.event == "workflow_dispatch" and .head_sha == $sha)]
+      | sort_by(.created_at) | last | .id // empty
+    ' <<<"$runs")
+    [[ "$run_id" =~ ^[0-9]+$ ]] && break
+    sleep 1
+  done
   [[ "$run_id" =~ ^[0-9]+$ ]] || {
-    echo "$workflow dispatch returned invalid workflow run ID: $run_id" >&2
-    exit 1
-  }
-  run=$(gh api "repos/$repository/actions/runs/$run_id")
-  run_event=$(jq -er .event <<<"$run")
-  run_sha=$(jq -er .head_sha <<<"$run")
-  [ "$run_event" = workflow_dispatch ] || {
-    echo "$workflow run $run_id has event $run_event, expected workflow_dispatch" >&2
-    exit 1
-  }
-  [ "$run_sha" = "$merge_sha" ] || {
-    echo "$workflow run $run_id targets $run_sha, expected $merge_sha" >&2
+    echo "$workflow dispatch did not create a workflow_dispatch run for $merge_sha within $poll_attempts seconds" >&2
     exit 1
   }
   run_ids+=("$run_id")

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -249,6 +249,18 @@ case "$1:$2" in
       *'/actions/workflows/macos.yml/dispatches '*)
         printf '{"workflow_run_id":503}\n'
         ;;
+      *'/actions/workflows/ci.yml/runs?'*)
+        jq -cn --arg sha "${SYQ_TEST_RUN_SHA:-$SYQ_TEST_MERGE_SHA}" \
+          '{workflow_runs:[{id:501,event:"workflow_dispatch",head_sha:$sha,created_at:"2026-01-01T00:00:00Z"}]}'
+        ;;
+      *'/actions/workflows/rsync-compat.yml/runs?'*)
+        jq -cn --arg sha "${SYQ_TEST_RUN_SHA:-$SYQ_TEST_MERGE_SHA}" \
+          '{workflow_runs:[{id:502,event:"workflow_dispatch",head_sha:$sha,created_at:"2026-01-01T00:00:00Z"}]}'
+        ;;
+      *'/actions/workflows/macos.yml/runs?'*)
+        jq -cn --arg sha "${SYQ_TEST_RUN_SHA:-$SYQ_TEST_MERGE_SHA}" \
+          '{workflow_runs:[{id:503,event:"workflow_dispatch",head_sha:$sha,created_at:"2026-01-01T00:00:00Z"}]}'
+        ;;
       *'/actions/runs/501/jobs?per_page=100 '*)
         jq -cn --arg conclusion "${SYQ_TEST_SDK_CONCLUSION:-success}" \
           '{jobs:[{name:"sdks",status:"completed",conclusion:$conclusion}]}'
@@ -281,9 +293,10 @@ expect_failure 'does not point to expected merge commit' env \
   PATH="$post_merge_bin:$PATH" \
   "$script_dir/run-generated-sdk-post-merge-ci.sh" \
   greaber/syq automation/python-sdk-v0.1.9 "$post_merge_sha"
-expect_failure 'ci.yml run 501 targets' env \
+expect_failure 'ci.yml dispatch did not create' env \
   SYQ_TEST_MERGE_SHA="$post_merge_sha" \
   SYQ_TEST_RUN_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  SYQ_POST_MERGE_POLL_ATTEMPTS=1 \
   PATH="$post_merge_bin:$PATH" \
   "$script_dir/run-generated-sdk-post-merge-ci.sh" \
   greaber/syq automation/python-sdk-v0.1.9 "$post_merge_sha"


### PR DESCRIPTION
Fixes post-merge SDK workflow dispatch selection by polling for the exact workflow_dispatch run on the immutable merge commit. Validation: ShellCheck and scripts/test-release-orchestration.sh.