### PR TITLE
Avoid duplicate CI for generated Python SDK releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      scope_commit:
+        description: Commit whose diff determines the selected checks
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.run_id }}
@@ -36,6 +41,8 @@ jobs:
           persist-credentials: false
       - name: Classify changed paths
         id: changes
+        env:
+          SYQ_CI_SCOPE_COMMIT: ${{ inputs.scope_commit }}
         run: scripts/ci-scope.sh "$GITHUB_EVENT_PATH" >> "$GITHUB_OUTPUT"
 
   rust:

--- a/.github/workflows/prepare-python-sdk.yml
+++ b/.github/workflows/prepare-python-sdk.yml
@@ -115,7 +115,7 @@ jobs:
             "- sets the Python SDK version to match syq $SYQ_VERSION" \
             "- embeds the exact signed v$SYQ_VERSION release manifest" \
             "- updates the managed executable cache documentation" \
-            "The preparation workflow ran the pinned SDK release-tool and unit-test suites before opening this pull request. It will explicitly run and await the post-merge workflows on the exact merge commit. The release orchestrator will then sign sdk-python-v$PYTHON_VERSION, approve the protected pypi environment, and verify publication.")
+            "The preparation workflow ran the pinned SDK release-tool and unit-test suites before opening this pull request. It will explicitly run and await post-merge Python SDK validation on the exact merge commit. The release orchestrator will then sign sdk-python-v$PYTHON_VERSION, approve the protected pypi environment, and verify publication.")
           pr_url=$(gh pr create \
             --base master \
             --head "$branch" \
@@ -131,8 +131,8 @@ jobs:
           git merge-base --is-ancestor "$head_sha" "$merge_sha"
           git merge-base --is-ancestor "$merge_sha" origin/master
           git push origin "$merge_sha:refs/heads/$branch"
-          echo "Merged $pr_url at $merge_sha; running post-merge workflows"
+          echo "Merged $pr_url at $merge_sha; running post-merge Python SDK validation"
           scripts/run-generated-sdk-post-merge-ci.sh \
             "$GITHUB_REPOSITORY" "$branch" "$merge_sha"
           git push origin --delete "$branch"
-          echo "Post-merge workflows passed for $merge_sha"
+          echo "Post-merge Python SDK validation passed for $merge_sha"

--- a/scripts/ci-scope.sh
+++ b/scripts/ci-scope.sh
@@ -44,9 +44,26 @@ elif [ -n "$event_path" ] && [ -f "$event_path" ]; then
       diff_range="$base..$head"
       ;;
     workflow_dispatch)
-      run_everything
-      echo 'CI scope: manual run; running every check' >&2
-      exit 0
+      # A generated SDK follow-up uses a workflow dispatch because GitHub does
+      # not trigger push workflows for merges made with GITHUB_TOKEN. It passes
+      # the checked-out merge commit so this path has the same precise scope as
+      # a normal push. Other manual runs retain the full-suite default.
+      if [ -z "${SYQ_CI_SCOPE_COMMIT:-}" ]; then
+        run_everything
+        echo 'CI scope: manual run; running every check' >&2
+        exit 0
+      fi
+      [[ "$SYQ_CI_SCOPE_COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
+        echo "invalid CI scope commit: $SYQ_CI_SCOPE_COMMIT" >&2
+        exit 2
+      }
+      head=$(git rev-parse HEAD)
+      [ "$head" = "$SYQ_CI_SCOPE_COMMIT" ] || {
+        echo "CI scope commit $SYQ_CI_SCOPE_COMMIT is not checked out (found $head)" >&2
+        exit 1
+      }
+      base=$(git rev-parse "$head^")
+      diff_range="$base..$head"
       ;;
     *)
       echo "unsupported GitHub event in $event_path" >&2

--- a/scripts/run-generated-sdk-post-merge-ci.sh
+++ b/scripts/run-generated-sdk-post-merge-ci.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Dispatch and await the post-merge workflows on one generated SDK commit.
+# Dispatch and await Python SDK validation on one generated SDK commit.
 set -euo pipefail
 
 if [ "$#" -ne 3 ]; then
@@ -33,7 +33,7 @@ reference_sha=$(jq -er .object.sha <<<"$reference")
   exit 1
 }
 
-workflows=(ci.yml rsync-compat.yml macos.yml)
+workflows=(ci.yml)
 poll_attempts=${SYQ_POST_MERGE_POLL_ATTEMPTS:-30}
 [[ "$poll_attempts" =~ ^[1-9][0-9]*$ ]] || { echo "invalid poll attempt count" >&2; exit 2; }
 run_ids=()
@@ -41,7 +41,8 @@ for workflow in "${workflows[@]}"; do
   gh api --method POST \
     -H 'X-GitHub-Api-Version: 2026-03-10' \
     "repos/$repository/actions/workflows/$workflow/dispatches" \
-    -f ref="$branch" >/dev/null
+    -f ref="$branch" \
+    -f "inputs[scope_commit]=$merge_sha" >/dev/null
   run_id=
   for ((attempt = 1; attempt <= poll_attempts; attempt++)); do
     runs=$(gh api "repos/$repository/actions/workflows/$workflow/runs?event=workflow_dispatch&branch=$branch&per_page=100")
@@ -86,4 +87,4 @@ if [ "$sdk_count" -ne 1 ] || [ "$sdk_status" != completed ] || \
     exit 1
 fi
 
-echo "Post-merge workflows passed for $merge_sha"
+echo "Post-merge Python SDK validation passed for $merge_sha"

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -225,6 +225,27 @@ for key in "${scope_keys[@]}"; do
   assert_scope "$scope" "$key" true
 done
 
+# Generated Python SDK validation passes an exact checked-out commit, retaining
+# normal path selection instead of treating its workflow dispatch as a manual
+# full-suite request.
+mkdir -p "$scope_repo/sdk/python"
+printf 'release manifest\n' >"$scope_repo/sdk/python/syq-release-manifest.json"
+git -C "$scope_repo" add sdk/python/syq-release-manifest.json
+git -C "$scope_repo" commit -qm generated-python-sdk
+scoped_dispatch_head=$(git -C "$scope_repo" rev-parse HEAD)
+scope=$(cd "$scope_repo" && \
+  SYQ_CI_SCOPE_COMMIT="$scoped_dispatch_head" \
+  "$script_dir/ci-scope.sh" "$work/workflow-dispatch-event.json")
+assert_scope "$scope" native false
+assert_scope "$scope" sdks true
+assert_scope "$scope" python_sdk true
+for key in javascript_sdk go_sdk tooling shellcheck mapping_docs conformance macos linux_arm64 full_suite; do
+  assert_scope "$scope" "$key" false
+done
+expect_failure 'is not checked out' env \
+  SYQ_CI_SCOPE_COMMIT=0123456789abcdef0123456789abcdef01234567 \
+  bash -c "cd '$scope_repo' && '$script_dir/ci-scope.sh' '$work/workflow-dispatch-event.json'"
+
 # The generated SDK follow-up dispatches CI on a branch pinned to the exact
 # merge commit, binds the returned run to that commit, and requires its SDK job.
 post_merge_bin="$work/post-merge-bin"
@@ -241,13 +262,11 @@ case "$1:$2" in
           '{object:{sha:$sha}}'
         ;;
       *'/actions/workflows/ci.yml/dispatches '*)
+        case " $* " in
+          *" inputs[scope_commit]=$SYQ_TEST_MERGE_SHA "*) ;;
+          *) echo "scoped dispatch omitted merge commit: $*" >&2; exit 2 ;;
+        esac
         printf '{"workflow_run_id":501}\n'
-        ;;
-      *'/actions/workflows/rsync-compat.yml/dispatches '*)
-        printf '{"workflow_run_id":502}\n'
-        ;;
-      *'/actions/workflows/macos.yml/dispatches '*)
-        printf '{"workflow_run_id":503}\n'
         ;;
       *'/actions/workflows/ci.yml/runs?'*)
         jq -cn --arg sha "${SYQ_TEST_RUN_SHA:-$SYQ_TEST_MERGE_SHA}" \
@@ -285,7 +304,7 @@ SYQ_TEST_MERGE_SHA="$post_merge_sha" PATH="$post_merge_bin:$PATH" \
   "$script_dir/run-generated-sdk-post-merge-ci.sh" \
   greaber/syq automation/python-sdk-v0.1.9 "$post_merge_sha" \
   >"$work/post-merge.out"
-grep -F "Post-merge workflows passed for $post_merge_sha" \
+grep -F "Post-merge Python SDK validation passed for $post_merge_sha" \
   "$work/post-merge.out" >/dev/null
 expect_failure 'does not point to expected merge commit' env \
   SYQ_TEST_MERGE_SHA="$post_merge_sha" \

--- a/sdk/RELEASING.md
+++ b/sdk/RELEASING.md
@@ -138,9 +138,11 @@ immediately without starting pull-request CI.
 GitHub suppresses ordinary push-triggered workflows when a merge uses the
 repository's `GITHUB_TOKEN`. To preserve post-merge validation, the preparation
 workflow advances the automation branch to the exact merge commit and
-explicitly dispatches `ci.yml`, `rsync-compat.yml`, and `macos.yml` on that ref.
-It verifies that each returned run targets the merge commit, waits for all three
-runs, and requires the CI run's substantive `sdks` job to succeed before
+explicitly dispatches `ci.yml` with that commit as its scope. The CI selector
+then runs the substantive `sdks` job for the generated Python-only change and
+does not repeat the native, rsync, or macOS checks already certified for the
+immutable syq release. The workflow verifies that the returned run targets the
+merge commit, waits for it, and requires its `sdks` job to succeed before
 deleting the automation branch. A failure leaves the generated SDK changes
 merged and the branch available for diagnosis; it does not block unrelated
 merges. The repository keeps the default workflow token read only and grants


### PR DESCRIPTION
Generated Python SDK release follow-ups were explicitly dispatching `ci.yml`, `rsync-compat.yml`, and `macos.yml` after a release. Those checks repeated certification already completed on the immutable syq release, even though the generated merge changes only `sdk/python`.

This scopes the dispatched CI run to its exact checked-out merge commit and requires the `sdks` job to pass. Native, rsync, and macOS checks are not dispatched for that Python-only merge. Ordinary manual CI dispatches still select the complete suite, and the workflow verifies both the automation branch and returned run use the expected commit.

Validation:
- `scripts/test-release-orchestration.sh`
- `scripts/test-release-tools.sh`
- `scripts/check-workflows.sh`
- `shellcheck scripts/ci-scope.sh scripts/run-generated-sdk-post-merge-ci.sh scripts/test-release-orchestration.sh`
- `scripts/check-doc-links.py`
