### PR TITLE
docs: combine shell completion examples

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -79,9 +79,7 @@ eval "$(syq completion bash)"
 
 # Zsh (~/.zshrc), after autoload -Uz compinit && compinit
 source <(syq completion zsh)
-```
 
-```fish
 # fish (~/.config/fish/config.fish)
 syq completion fish | source
 ```


### PR DESCRIPTION
## Summary

Combine the Bash, zsh, and Fish shell completion examples into one preformatted block in the installation guide.

## Validation

- Documentation links: 19 files, 0 problems
- mdBook 0.5.4 build passed
- cargo fmt passed
- cargo clippy passed
- cargo test --bin syq: one unrelated intermittent failure in destination::tests::pending_request_disconnect_and_trailing_data_are_detected_without_blocking

The latest master macOS workflow was already failing at b2277ae.