### PR TITLE
Apply shared sidebar heading spacing over mdBook defaults

### DIFF
--- a/theme/README.md
+++ b/theme/README.md
@@ -9,6 +9,9 @@ The shared UI toolkit is inventoried in site-ui.json. Every mapped file must
 remain byte-for-byte identical to the syq-bench copy, including fonts/licenses.
 It owns branding, homepage buttons, sidebars, and Contents/Theme/Search controls.
 Both sidebars use 15px links, 16px headings, 24px left and 12px right padding.
+The shared heading selector matches mdBook's element specificity so native
+styles cannot override its 18px/4px top/bottom margins. Benchmark page links
+occupy separate block rows so those margins also affect their layout.
 
 Compare from either repo before review (arguments are toolkit directories):
 
@@ -16,6 +19,12 @@ Compare from either repo before review (arguments are toolkit directories):
 
 See site/BRANDING.md in syq-bench for the inventory and copy workflow.
 Each site builds independently from its committed toolkit.
+
+File equality alone does not catch renderer overrides. After building both
+sites, run syq-bench's scripts/check-sidebar-layout.cjs with target/book as its
+argument; it checks rendered heading spacing and rows across desktop/phone,
+light/dark, resizing and the no-JS iframe fallback. See the benchmark branding
+guide for the Node/Playwright prerequisites and command.
 
 docs.css and docs.js adapt mdBook. Native search and theme handlers remain
 behind the shared controls. Print/edit actions stay below the article. The

--- a/theme/sidebar.css
+++ b/theme/sidebar.css
@@ -17,8 +17,10 @@
 .chapter li a:hover,#benchmark-sidebar a:hover{color:var(--syq);text-decoration:underline}
 .chapter li a.active,.chapter a.current-header,
 #benchmark-sidebar a[aria-current]{color:var(--syq)}
-.chapter .part-title,#benchmark-sidebar .page-link{
+/* Match mdBook's element specificity so its native margins cannot win. */
+.chapter li.part-title,#benchmark-sidebar .page-link{
  font:700 16px/1.5 var(--display);margin:18px 0 4px;padding:0}
+#benchmark-sidebar .page-link{display:block}
 #benchmark-sidebar .page-link:first-child{margin-top:0}
 .chapter .section,#benchmark-sidebar .scenario-links{padding-left:16px}
 .chapter .on-this-page{


### PR DESCRIPTION
mdBook's native `.chapter li.part-title` selector overrides the shared sidebar heading margins, leaving docs and benchmarks with different spacing despite identical toolkit files. Match that specificity so the shared 18px/4px margins apply. The same shared CSS also gives benchmark page links block rows so their margins work and adjacent links do not run together.

Keep the stylesheet byte-identical to paired syq-bench PR https://github.com/greaber/syq-bench/pull/24 (`sidebar-style-fix` at `c1214f8`), and document the browser regression check maintained there. No article or runtime behavior changes.

Validation at `6ca9d92` (clean and pushed): mdBook 0.5.4 build, 20-file source link check and diff check passed. Paired Chromium tests passed on five generated pages at 320/390/620/760/820/1440px in light/dark with and without JavaScript, including the no-JS iframe and 240px resized sidebars. Checks reproduce the original margin and inline-row defects before the fix. Desktop/mobile screenshots inspected; all 20 shared toolkit files match. Rust, SDK runtime, SSH and performance tests were not run for this CSS/documentation change.

Pre-PR branch-status output:

```text
Worktree: /home/grant/repos/syq-bench/.worktrees/syq-sidebar-style-fix
Branch:   sidebar-style-fix at 6ca9d92 (clean)
Upstream: origin/sidebar-style-fix (ahead 0, behind 0)
Master:   79a126a from refs/heads/master (branch is ahead 13, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      d91b232  https://github.com/greaber/syq/actions/runs/34053084112
  rsync-compat.yml success      d91b232  https://github.com/greaber/syq/actions/runs/34053084138
  macos.yml        success      d91b232  https://github.com/greaber/syq/actions/runs/34053084099

Pull request: none for sidebar-style-fix
```

The coordination checkout remains on its existing master; this task branch starts from remote master `2f1d12e`.
