### PR TITLE
Fix TCP replay ID aliases and unauthenticated handshake timeouts

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -57,6 +57,16 @@ for this case, not a claim that syq is more secure overall. `syq rsync`
 keeps the ownership-based policy for compatibility. Its local-only
 `--insecure-links` option relaxes source, destination, and control-path checks.
 
+## TCP data connections
+
+TCP workers authenticate with a token delivered through the control connection.
+Their ten-second Hello deadline remains active across partial reads, including
+when encryption is off. After Hello succeeds, it does not limit copy duration.
+
+Encrypted TCP rejects reused connection IDs and IDs outside its 24-bit nonce
+space. If a copying process exhausts those IDs, it reports an error; restart the
+copy to continue with a fresh session.
+
 ## A compromised source server
 
 For a default direct remote-to-remote copy, the source gets permission for one

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2019,7 +2019,7 @@ impl RemoteSpec {
                 );
             }
             stream.set_nodelay(true)?;
-            let conn_id = TCP_CONN_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let conn_id = next_tcp_connection_id(&TCP_CONN_ID)?;
             (&stream).write_all(&conn_id.to_be_bytes())?;
             let (wc, rc) = match &info.key {
                 Some(k) => (
@@ -2152,6 +2152,15 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
 }
 
 static TCP_CONN_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(1);
+
+fn next_tcp_connection_id(next: &std::sync::atomic::AtomicU32) -> Result<u32> {
+    next.fetch_update(
+        std::sync::atomic::Ordering::Relaxed,
+        std::sync::atomic::Ordering::Relaxed,
+        |id| (id <= crate::tcp_records::CONNECTION_ID_MAX).then(|| id + 1),
+    )
+    .map_err(|_| anyhow!("TCP connection IDs exhausted; restart the copy"))
+}
 
 #[derive(Clone)]
 pub struct TcpInfo {
@@ -2872,6 +2881,19 @@ impl Endpoint {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn tcp_connection_ids_fail_at_nonce_space_exhaustion() {
+        let next = std::sync::atomic::AtomicU32::new(crate::tcp_records::CONNECTION_ID_MAX);
+        assert_eq!(super::next_tcp_connection_id(&next).unwrap(), 0x00ff_ffff);
+        for _ in 0..3 {
+            assert!(super::next_tcp_connection_id(&next)
+                .unwrap_err()
+                .to_string()
+                .contains("restart the copy"));
+        }
+        assert_eq!(next.load(std::sync::atomic::Ordering::Relaxed), 0x0100_0000);
+    }
+
     use super::*;
     use std::ffi::OsStr;
     use std::os::unix::ffi::OsStrExt;

--- a/src/server.rs
+++ b/src/server.rs
@@ -392,6 +392,10 @@ fn serve<R: Read + Send + 'static, W: Write>(
         supports_confined_socket_nodes: crate::identity::supports_confined_socket_nodes(),
     })?;
 
+    if let Some(socket) = &tcp_socket {
+        socket.set_read_timeout(None)?;
+        socket.set_write_timeout(None)?;
+    }
     if let Some(socket) = &named_socket {
         socket.set_read_timeout(None)?;
         socket.set_write_timeout(None)?;
@@ -1070,6 +1074,7 @@ fn accept_data_connections(
                 &seen,
                 authority.clone(),
                 descriptor_session,
+                Duration::from_secs(10),
             ) {
                 if debug {
                     crate::output::diagnostic!("syq server (tcp {id}): {e:#}");
@@ -1091,6 +1096,7 @@ fn serve_tcp(
     seen: &std::sync::Mutex<std::collections::HashSet<u32>>,
     authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
     descriptor_session: DescriptorSessionSlot,
+    handshake_timeout: Duration,
 ) -> Result<()> {
     // The listening socket is nonblocking so its owner can notice session
     // shutdown. Darwin propagates that status flag to accepted sockets, while
@@ -1098,13 +1104,24 @@ fn serve_tcp(
     stream.set_nonblocking(false)?;
     stream.set_nodelay(true)?;
     // Scanners and stray connections must not hold a thread forever.
-    stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+    stream.set_read_timeout(Some(handshake_timeout))?;
+    stream.set_write_timeout(Some(handshake_timeout))?;
+    let handshake_pending = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let mut handshake_reader = TcpHandshakeReader {
+        stream: stream.try_clone()?,
+        pending: handshake_pending.clone(),
+        deadline: std::time::Instant::now() + handshake_timeout,
+    };
     // The client tells us its connection id first (plaintext), so both sides
     // derive the same nonces.
     let mut idbuf = [0u8; 4];
-    (&stream).read_exact(&mut idbuf)?;
+    handshake_reader.read_exact(&mut idbuf)?;
     let conn_id = u32::from_be_bytes(idbuf);
     let _ = id;
+    // Reject aliases before reserving the ID or emitting encrypted records.
+    if conn_id > crate::tcp_records::CONNECTION_ID_MAX {
+        bail!("TCP connection id {conn_id} exceeds nonce space");
+    }
     // Each client connection id is single-use: a replayed record stream carries
     // the original id (it must, to decrypt) and is rejected here.
     if !seen.lock().unwrap().insert(conn_id) {
@@ -1117,7 +1134,7 @@ fn serve_tcp(
         ),
         None => (None, None),
     };
-    let reader = RecordReader::new(stream.try_clone()?, rc);
+    let reader = RecordReader::new(handshake_reader, rc);
     let writer = RecordWriter::new(stream.try_clone()?, wc);
     // Free the id only if the connection NEVER authenticated, so an
     // unauthenticated peer can't reserve ids. Once the token authenticated, the
@@ -1126,18 +1143,14 @@ fn serve_tcp(
     // then replay captured records under it.
     let authed = std::sync::atomic::AtomicBool::new(false);
     let res = serve(
-        TimeoutOnce {
-            inner: reader,
-            stream: stream.try_clone()?,
-            cleared: false,
-        },
+        reader,
         writer,
         false,
         Some(token),
         Some(&authed),
         Some(stream.try_clone()?),
         ServeSession {
-            handshake_pending: None,
+            handshake_pending: Some(handshake_pending),
             allow_tcp: true,
             named_socket: None,
             authority,
@@ -1188,21 +1201,25 @@ fn drop_after_handling_for_test(_request: &Request) -> bool {
     false
 }
 
-/// Clears the socket read timeout after the first successful read.
-struct TimeoutOnce<R: Read> {
-    inner: R,
+/// Bound every socket read, including partial IDs and records, by the same
+/// Hello deadline. `serve` clears the shared socket timeout after HelloOk.
+struct TcpHandshakeReader {
     stream: TcpStream,
-    cleared: bool,
+    pending: Arc<std::sync::atomic::AtomicBool>,
+    deadline: std::time::Instant,
 }
 
-impl<R: Read> Read for TimeoutOnce<R> {
+impl Read for TcpHandshakeReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n = self.inner.read(buf)?;
-        if !self.cleared {
-            self.cleared = true;
-            let _ = self.stream.set_read_timeout(None);
+        if self.pending.load(std::sync::atomic::Ordering::Acquire) {
+            let remaining = self
+                .deadline
+                .checked_duration_since(std::time::Instant::now())
+                .filter(|time| !time.is_zero())
+                .ok_or_else(|| io::Error::new(ErrorKind::TimedOut, "TCP Hello timed out"))?;
+            self.stream.set_read_timeout(Some(remaining))?;
         }
-        Ok(n)
+        self.stream.read(buf)
     }
 }
 
@@ -1596,6 +1613,233 @@ mod tests {
             Response::Err(error) if error.contains("initialize source worker")
         ));
         server.join().unwrap();
+    }
+
+    fn tcp_test_hello(token: &[u8]) -> Request {
+        Request::Hello {
+            identity: crate::identity::build().to_string(),
+            compress: true,
+            debug: false,
+            token: token.to_vec(),
+            role: ConnectionRole::DestinationWorker {
+                destination: None,
+                copy_sources: Vec::new(),
+            },
+        }
+    }
+
+    fn tcp_test_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        client
+            .set_read_timeout(Some(Duration::from_secs(3)))
+            .unwrap();
+        client
+            .set_write_timeout(Some(Duration::from_secs(3)))
+            .unwrap();
+        (client, listener.accept().unwrap().0)
+    }
+
+    #[test]
+    fn tcp_rejects_replayed_hello_with_high_connection_id_bits() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let authority = Arc::new(crate::restricted::tests::tcp_test_authority(
+            temporary.path(),
+        ));
+        let key = vec![7; crate::tcp_records::KEY_LEN];
+        let token = b"replay-test";
+        let conn_id = 42u32;
+        let mut capture = Vec::new();
+        FrameWriter::new(
+            RecordWriter::new(&mut capture, Some(Cipher::new(&key, conn_id, 1))),
+            false,
+        )
+        .write_msg(&tcp_test_hello(token))
+        .unwrap();
+        let seen = std::sync::Mutex::new(std::collections::HashSet::new());
+        // The original authenticates; changing only the high byte used to
+        // bypass the replay set while decrypting exactly the same records.
+        for (attempt, high) in [0u32, 1, 2, 128, 255, 0].into_iter().enumerate() {
+            let (mut client, server) = tcp_test_pair();
+            client
+                .write_all(&(conn_id | (high << 24)).to_be_bytes())
+                .unwrap();
+            client.write_all(&capture).unwrap();
+            client.shutdown(std::net::Shutdown::Write).unwrap();
+            let result = serve_tcp(
+                server,
+                0,
+                Some(key.clone()),
+                token.to_vec(),
+                false,
+                false,
+                &seen,
+                Some(authority.clone()),
+                DescriptorSessionSlot::default(),
+                Duration::from_secs(1),
+            );
+            if high != 0 {
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("exceeds nonce space"));
+                // Rejection must precede the server's encrypted preamble.
+                let mut response = Vec::new();
+                let _ = client.read_to_end(&mut response);
+                assert!(response.is_empty());
+            } else if attempt != 0 {
+                assert!(result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("duplicate connection id"));
+            } else {
+                result.unwrap();
+                assert!(seen.lock().unwrap().contains(&conn_id));
+            }
+            assert_eq!(
+                *seen.lock().unwrap(),
+                std::collections::HashSet::from([conn_id])
+            );
+        }
+    }
+
+    #[test]
+    fn tcp_partial_handshakes_time_out_without_reserving_ids() {
+        for encrypted in [false, true] {
+            // Stop inside the ID, after a complete preamble record, and
+            // inside the Hello record. None of these authenticates a peer.
+            for part in 0..3 {
+                let key = encrypted.then(|| vec![9; crate::tcp_records::KEY_LEN]);
+                let id = 43u32;
+                let mut preamble = Vec::new();
+                FrameWriter::new(
+                    RecordWriter::new(
+                        &mut preamble,
+                        key.as_ref().map(|key| Cipher::new(key, id, 1)),
+                    ),
+                    false,
+                )
+                .write_preamble()
+                .unwrap();
+                let mut hello = Vec::new();
+                FrameWriter::new(
+                    RecordWriter::new(&mut hello, key.as_ref().map(|key| Cipher::new(key, id, 1))),
+                    false,
+                )
+                .write_msg(&tcp_test_hello(b"timeout-test"))
+                .unwrap();
+                let mut bytes = id.to_be_bytes().to_vec();
+                match part {
+                    0 => bytes.truncate(1),
+                    1 => bytes.extend_from_slice(&preamble),
+                    _ => bytes.extend_from_slice(&hello[..hello.len() - 1]),
+                }
+                let (mut client, server) = tcp_test_pair();
+                client.write_all(&bytes).unwrap();
+                let (tx, rx) = std::sync::mpsc::channel();
+                let worker = std::thread::spawn(move || {
+                    let seen = std::sync::Mutex::new(std::collections::HashSet::new());
+                    let result = serve_tcp(
+                        server,
+                        0,
+                        key,
+                        b"timeout-test".to_vec(),
+                        false,
+                        false,
+                        &seen,
+                        None,
+                        DescriptorSessionSlot::default(),
+                        Duration::from_millis(100),
+                    );
+                    tx.send((result, seen.into_inner().unwrap())).unwrap();
+                });
+                let result = rx.recv_timeout(Duration::from_secs(3));
+                // Ensure a regression never leaves a blocked server thread.
+                client.shutdown(std::net::Shutdown::Both).ok();
+                worker.join().unwrap();
+                let (result, seen) =
+                    result.expect("partial TCP Hello held a worker past its deadline");
+                assert!(result.is_err());
+                assert!(seen.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn tcp_hello_clears_timeouts_only_after_authentication() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let authority = Arc::new(crate::restricted::tests::tcp_test_authority(
+            temporary.path(),
+        ));
+        for encrypted in [false, true] {
+            let key = encrypted.then(|| vec![8; crate::tcp_records::KEY_LEN]);
+            let server_key = key.clone();
+            let authority = authority.clone();
+            let (client, server) = tcp_test_pair();
+            let observer = server.try_clone().unwrap();
+            let worker = std::thread::spawn(move || {
+                let seen = std::sync::Mutex::new(std::collections::HashSet::new());
+                serve_tcp(
+                    server,
+                    0,
+                    server_key,
+                    b"valid-token".to_vec(),
+                    false,
+                    false,
+                    &seen,
+                    Some(authority),
+                    DescriptorSessionSlot::default(),
+                    Duration::from_millis(100),
+                )
+            });
+            (&client).write_all(&44u32.to_be_bytes()).unwrap();
+            let mut writer = FrameWriter::new(
+                RecordWriter::new(
+                    client.try_clone().unwrap(),
+                    key.as_ref().map(|key| Cipher::new(key, 44, 1)),
+                ),
+                false,
+            );
+            let mut reader = FrameReader::new(RecordReader::new(
+                client.try_clone().unwrap(),
+                key.as_ref().map(|key| Cipher::new(key, 44, 2)),
+            ));
+            writer.write_msg(&tcp_test_hello(b"valid-token")).unwrap();
+            assert!(matches!(
+                reader.read_msg::<Response>().unwrap(),
+                Response::HelloOk { .. }
+            ));
+            // Wait beyond the handshake deadline, then prove the worker is
+            // still alive and both shared socket timeouts have been cleared.
+            std::thread::sleep(Duration::from_millis(200));
+            assert_eq!(observer.read_timeout().unwrap(), None);
+            assert_eq!(observer.write_timeout().unwrap(), None);
+            assert!(!worker.is_finished());
+            client.shutdown(std::net::Shutdown::Both).unwrap();
+            worker.join().unwrap().unwrap();
+        }
+    }
+
+    #[test]
+    fn tcp_handshake_deadline_does_not_reset_after_partial_reads() {
+        let (mut client, server) = tcp_test_pair();
+        server
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut reader = TcpHandshakeReader {
+            stream: server,
+            pending: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            deadline: std::time::Instant::now() + Duration::from_millis(100),
+        };
+        client.write_all(b"a").unwrap();
+        reader.read_exact(&mut [0]).unwrap();
+        assert!(reader.stream.read_timeout().unwrap().is_some());
+        std::thread::sleep(Duration::from_millis(150));
+        client.write_all(b"b").unwrap();
+        assert_eq!(
+            reader.read(&mut [0]).unwrap_err().kind(),
+            ErrorKind::TimedOut
+        );
     }
 
     /// Connect to the data listener and complete a token-authenticated Hello

--- a/src/tcp_records.rs
+++ b/src/tcp_records.rs
@@ -9,6 +9,8 @@ use std::io::{self, Read, Write};
 
 pub const RECORD_MAX: usize = 256 * 1024;
 pub const KEY_LEN: usize = 32;
+/// The wire ID is four bytes, but only three bytes enter the nonce.
+pub const CONNECTION_ID_MAX: u32 = 0x00ff_ffff;
 
 pub struct Cipher {
     aead: Aes256Gcm,
@@ -19,6 +21,10 @@ pub struct Cipher {
 
 impl Cipher {
     pub fn new(key: &[u8], conn_id: u32, dir: u8) -> Cipher {
+        assert!(
+            conn_id <= CONNECTION_ID_MAX,
+            "TCP connection id exceeds nonce space"
+        );
         Cipher {
             aead: Aes256Gcm::new_from_slice(key).expect("key length"),
             conn_id,
@@ -171,6 +177,36 @@ pub fn random_bytes(n: usize) -> Vec<u8> {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    #[test]
+    fn encrypted_records_preserve_v041_wire_bytes() {
+        // Generated with the unchanged src/tcp_records.rs from tag v0.4.1:
+        // key [7; 32], ID 0x123456, direction 1, first record.
+        let fixture = [
+            35, 0, 0, 0, 198, 164, 119, 78, 242, 66, 129, 200, 51, 63, 3, 50, 75, 180, 63, 56, 117,
+            145, 62, 157, 157, 91, 122, 238, 3, 197, 253, 74, 74, 210, 26, 155, 127, 220, 156,
+        ];
+        let plain = b"released TCP record";
+        let mut reader = RecordReader::new(
+            Cursor::new(fixture),
+            Some(Cipher::new(&[7; KEY_LEN], 0x123456, 1)),
+        );
+        let mut decoded = [0; 19];
+        reader.read_exact(&mut decoded).unwrap();
+        assert_eq!(&decoded, plain);
+        let mut encoded = Vec::new();
+        let mut writer =
+            RecordWriter::new(&mut encoded, Some(Cipher::new(&[7; KEY_LEN], 0x123456, 1)));
+        writer.write_all(plain).unwrap();
+        writer.flush().unwrap();
+        assert_eq!(encoded, fixture);
+    }
+
+    #[test]
+    #[should_panic(expected = "TCP connection id exceeds nonce space")]
+    fn cipher_rejects_connection_id_aliases() {
+        Cipher::new(&[7; KEY_LEN], 0x0100_0001, 1);
+    }
 
     #[test]
     fn encrypted_records_round_trip_across_nonce_counters() {


### PR DESCRIPTION
A captured encrypted TCP Hello could be replayed by changing the high byte of its connection ID: the replay set used all 32 bits while the AES-GCM nonce used only 24. TCP also removed its read timeout after the first decoded read, allowing an incomplete unauthenticated Hello to hold a worker indefinitely.

Reject IDs above `0x00ff_ffff` before reserving an ID or writing the encrypted preamble, and stop client allocation at that boundary with an explicit restart error. Preserve the existing nonce layout. Apply one ten-second read deadline underneath the record layer, including partial connection IDs and records; clear the read/write timeouts only after an accepted Hello and HelloOk. Authenticated copies can still run indefinitely.

Compatibility: baseline v0.4.1 (`13fc7d1`). An unchanged record fixture generated using that tag's original Rust record layer verifies that the new reader accepts the old bytes and the new writer emits identical bytes. High-byte IDs now fail explicitly; restarting the copy supplies fresh session credentials and IDs. TCP IDs and replay tracking live only for the process/listener session. Helper framing and exact-build checks, enrollment, signed grants/redemptions, receipts, resume identities, persistence settings, tuning/completion caches, CLI/SDK and automation output, release/updater formats, and documentation URLs are unchanged. Existing saved state is read as before; old and new binaries retain their existing build-specific helper isolation and mixed-build rejection.

Validation:
- Passed formatting, all-target/all-feature Clippy with warnings denied, documentation links, and diff whitespace checks.
- Passed all 495 active unit tests with `--test-threads=1`; one pre-existing external v0.3.2 receiver test remains ignored.
- Passed all 12 `tests/local.rs` tests matching `tcp`, including encrypted/plaintext copies, confinement, fallback, and TCP/SSH range-transfer tuning.
- Passed the complete default three-container OpenSSH suite, including benchmark correctness and interruption cleanup. It ran the final production code from the uncommitted `f4fbd3f` worktree; subsequent edits only corrected unit-test fixtures before commit `f9704b7`.
- Regression coverage includes altered-ID replay, exhausted allocation, incomplete plaintext/encrypted handshakes, absolute deadlines, and authenticated connections remaining alive beyond the deadline.

The default parallel unit run twice failed the unchanged `destination::tests::pending_request_disconnect_and_trailing_data_are_detected_without_blocking` test at `src/destination.rs:1476`. It passed alone and in the full serial run. The immediate EOF assertion appears susceptible to concurrent child processes inheriting the peer socket; this PR does not change that test or its implementation.

Full `cargo test --all-targets` and local macOS tests were not run. This is ready for review of the transport fixes, with the parallel-unit failure disclosed separately; it has not been merged.

Branch status at review handoff:

```text
Worktree: /home/grant/repos/syq/.worktrees/tcp-auth-hardening
Branch:   tcp-auth-hardening at f9704b7 (clean)
Upstream: origin/tcp-auth-hardening (ahead 0, behind 0)
Master:   f4fbd3f from refs/heads/master (branch is ahead 1, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      f4fbd3f  https://github.com/greaber/syq/actions/runs/34053852757
  rsync-compat.yml success      f4fbd3f  https://github.com/greaber/syq/actions/runs/34053852728
  macos.yml        success      f4fbd3f  https://github.com/greaber/syq/actions/runs/34053852735

Pull request: #267 https://github.com/greaber/syq/pull/267
  base master, open, review none, merge state clean
  GitHub head f9704b7: matches local f9704b7
  checks: none registered yet
```
