### PR TITLE
Enforce peer filters, confine source access, and bound decoding memory

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -240,7 +240,10 @@ Ignored directories are not scanned. To keep part of one, include the parent:
 syq cp --ignore 'logs/*' --ignore '!logs/keep/' --srcs-in project --into backup
 ```
 
-Ignored paths are also protected from pruning.
+Ignored paths are also protected from pruning. When pulling from another
+machine, syq independently checks the returned names and their ancestors.
+A source that returns an excluded path causes the copy to fail before that
+entry is planned.
 
 ## Resume an interrupted copy
 

--- a/docs/rsync-compat.md
+++ b/docs/rsync-compat.md
@@ -55,8 +55,9 @@ unsupported descendant-link options.
 
 `--files-from` cannot combine with syq ignore rules or deletion. A listed
 source whose parent is a symlink fails that entry with exit 23, without
-creating its implied destination parent. `--insecure-links` allows traversal
-on a local source only; remote sources always refuse it.
+creating its implied destination parent. `--insecure-links` only relaxes the
+ownership check on symlinks in typed local paths; it does not allow symlink
+traversal beneath a selected source, including entries from `--files-from`.
 
 Other parsing differences:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,7 +55,9 @@ without changing its owner. See the [rename rules](https://man7.org/linux/man-pa
 Native syq avoids that implicit trust decision. This is a stricter default
 for this case, not a claim that syq is more secure overall. `syq rsync`
 keeps the ownership-based policy for compatibility. Its local-only
-`--insecure-links` option relaxes source, destination, and control-path checks.
+`--insecure-links` option permits foreign-owned symlinks in typed local source,
+destination, and control paths. After opening a source root, scans and content
+reads still use its directory handles and refuse descendant symlink traversal.
 
 ## TCP data connections
 
@@ -66,6 +68,16 @@ when encryption is off. After Hello succeeds, it does not limit copy duration.
 Encrypted TCP rejects reused connection IDs and IDs outside its 24-bit nonce
 space. If a copying process exhausts those IDs, it reports an error; restart the
 copy to continue with a fresh session.
+
+Framed input has a separate memory allowance from the signed transfer's disk
+limits. Hello is limited to 1 MiB, ordinary metadata messages to 8 MiB, and
+bulk-data or hash messages to 65 MiB. Compression cannot bypass these limits;
+zstd windows are limited to 8 MiB. A shared 512 MiB budget conservatively
+accounts for frame bodies, decompression, decoded collections, and queued
+messages in each process. Exhaustion fails the connection visibly; reduce
+connections or pipeline depth before retrying. This is a decoding allowance,
+not a limit on transport buffers, application state, total process memory,
+or disk usage.
 
 ## A compromised source server
 
@@ -118,8 +130,9 @@ host resolution. A copy never switches routes after selecting its destination.
 
 - **Privileged copies need trusted destination directories.** Resume uses
   predictable partial-file names. Do not copy as root into a directory
-  writable by untrusted users: file checks cannot establish who created a
-  preexisting partial.
+  writable by untrusted users. Syq only reuses partials owned by its effective
+  user; foreign-owned leftovers are replaced without changing their contents
+  or permissions. This does not make a shared writable directory trusted.
 - **Copies are not snapshots or transactions.** Stop concurrent writers or
   use snapshots for consistent data. `--inplace` exposes incomplete updates.
   Syq does not `fsync` transfer data, so completion is not a power-loss
@@ -174,3 +187,6 @@ replayed automatically. Completed effects cannot be rolled back, and programs
 that create separate process sessions can outlive cancellation. See the
 [command reference](exec.md#output-completion-and-cancellation) for execution
 and interruption behavior.
+
+Human copy listings escape control characters in filenames. Diagnostics also
+escape terminal control sequences from peers; NDJSON keeps its JSON encoding.

--- a/docs/security.md
+++ b/docs/security.md
@@ -72,12 +72,17 @@ copy to continue with a fresh session.
 Framed input has a separate memory allowance from the signed transfer's disk
 limits. Hello is limited to 1 MiB, ordinary metadata messages to 8 MiB, and
 bulk-data or hash messages to 65 MiB. Compression cannot bypass these limits;
-zstd windows are limited to 8 MiB. A shared 512 MiB budget conservatively
-accounts for frame bodies, decompression, decoded collections, and queued
-messages in each process. Exhaustion fails the connection visibly; reduce
-connections or pipeline depth before retrying. This is a decoding allowance,
-not a limit on transport buffers, application state, total process memory,
-or disk usage.
+zstd windows are limited to 8 MiB. Both endpoints apply the smaller Hello
+limit before reading or decompressing its body.
+
+A shared 512 MiB allowance bounds decoded collection storage, including queued
+collections, because a short frame can advertise a very large collection.
+Exhaustion fails the connection visibly. Flat byte buffers, strings, and
+compression workspace use the frame-size limits and each connection's bounded
+queue instead of competing for that shared allowance. Their aggregate memory
+use grows with the connection count, request size, and pipeline depth; reduce
+those settings to use less memory. The collection allowance is not a limit on
+total process memory or disk usage.
 
 ## A compromised source server
 

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -619,6 +619,18 @@ fn spawn_reader(
     let (tx, rx) = std::sync::mpsc::sync_channel(read_ahead);
     let reader = std::thread::spawn(move || {
         let mut r = FrameReader::new(input);
+        r.set_limit(MAX_HANDSHAKE_FRAME);
+        let hello = r.read_budgeted::<Response>();
+        // Make the same acceptance check as receive_hello before allowing the
+        // background reader to allocate any ordinary data frame. This also
+        // covers pooled sessions, whose Hello was sent by another process.
+        let accepted = matches!(&hello, Ok(message)
+            if matches!(&message.value, Response::HelloOk { identity, .. }
+                if identity == crate::identity::build()));
+        if tx.send(hello).is_err() || !accepted {
+            return;
+        }
+        r.set_limit(MAX_FRAME);
         loop {
             let msg = r.read_budgeted::<Response>();
             let failed = msg.is_err();
@@ -2920,6 +2932,86 @@ mod tests {
     use std::ffi::OsStr;
     use std::os::unix::ffi::OsStrExt;
 
+    fn hello_ok() -> Response {
+        Response::HelloOk {
+            identity: crate::identity::build().into(),
+            platform: crate::identity::platform(),
+            supports_confined_socket_nodes: crate::identity::supports_confined_socket_nodes(),
+        }
+    }
+
+    #[test]
+    fn client_handshake_limit_applies_before_reading_the_body() {
+        let mut wire = Vec::new();
+        FrameWriter::new(&mut wire, false).write_preamble().unwrap();
+        wire.extend_from_slice(&((MAX_HANDSHAKE_FRAME + 1) as u32).to_le_bytes());
+        let (rx, thread) = spawn_reader(Box::new(std::io::Cursor::new(wire)), 4);
+        let error = rx.recv().unwrap().unwrap_err();
+        assert!(error.to_string().contains("bad frame length"));
+        assert!(rx.recv().is_err());
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn client_handshake_limit_also_bounds_compressed_output() {
+        let mut hello = hello_ok();
+        if let Response::HelloOk { platform, .. } = &mut hello {
+            *platform = "x".repeat(MAX_HANDSHAKE_FRAME + 1);
+        }
+        let payload = postcard::to_stdvec(&hello).unwrap();
+        let body = zstd::bulk::compress(&payload, 1).unwrap();
+        let mut wire = Vec::new();
+        FrameWriter::new(&mut wire, false).write_preamble().unwrap();
+        wire.extend_from_slice(&((body.len() + 1) as u32).to_le_bytes());
+        wire.push(1);
+        wire.extend_from_slice(&body);
+        let (rx, thread) = spawn_reader(Box::new(std::io::Cursor::new(wire)), 4);
+        assert!(rx
+            .recv()
+            .unwrap()
+            .unwrap_err()
+            .to_string()
+            .contains("decompressed frame exceeds limit"));
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn client_reader_requires_accepted_hello_before_large_data() {
+        for accepted in [false, true] {
+            let mut wire = Vec::new();
+            let mut writer = FrameWriter::new(&mut wire, false);
+            let mut hello = hello_ok();
+            if let Response::HelloOk { identity, .. } = &mut hello {
+                if !accepted {
+                    *identity = "wrong-build".into();
+                }
+            }
+            writer.write_msg(&hello).unwrap();
+            writer
+                .write_msg(&Response::Block {
+                    off: 0,
+                    hash: [0; 32],
+                    data: vec![7; 2 << 20],
+                })
+                .unwrap();
+            drop(writer);
+            let (rx, thread) = spawn_reader(Box::new(std::io::Cursor::new(wire)), 4);
+            assert!(matches!(
+                rx.recv().unwrap().unwrap().value,
+                Response::HelloOk { .. }
+            ));
+            if accepted {
+                assert!(
+                    matches!(rx.recv().unwrap().unwrap().value, Response::Block { data, .. } if data.len() == 2 << 20)
+                );
+            } else {
+                assert!(rx.recv().is_err());
+            }
+            drop(rx);
+            thread.join().unwrap();
+        }
+    }
+
     struct ExitObserved<R> {
         inner: R,
         dropped: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -3440,6 +3532,7 @@ mod tests {
         let server = std::thread::spawn(move || {
             let mut requests = FrameReader::new(helper.try_clone().unwrap());
             let mut responses = FrameWriter::new(helper, false);
+            responses.write_msg(&hello_ok()).unwrap();
             for _ in 0..depth {
                 let Request::ReadRange { off, len, .. } = requests.read_msg().unwrap() else {
                     panic!("expected a range request");
@@ -3454,6 +3547,10 @@ mod tests {
             }
         });
         let (responses, reader) = spawn_reader(Box::new(coordinator.try_clone().unwrap()), depth);
+        assert!(matches!(
+            responses.recv_timeout(timeout).unwrap().unwrap().value,
+            Response::HelloOk { .. }
+        ));
         let mut requests = FrameWriter::new(coordinator, false);
         // Both directions exceed socket buffering. A reader queue stuck at
         // four responses deadlocks against a sequential helper while the
@@ -3578,6 +3675,7 @@ mod tests {
         ] {
             let mut wire = Vec::new();
             let mut writer = FrameWriter::new(&mut wire, false);
+            writer.write_msg(&hello_ok()).unwrap();
             let mut root = entry(b"");
             root.kind = Kind::Dir;
             writer.write_msg(&Response::ScanBatch(vec![root])).unwrap();
@@ -3602,6 +3700,7 @@ mod tests {
                 multiplexed_ssh: false,
                 detached: false,
             };
+            remote = receive_hello(remote, false).unwrap();
             let mut planned = Vec::new();
             let result = remote.scan(
                 b"source",

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -594,7 +594,7 @@ pub struct RemoteConn {
     w: FrameWriter<Box<dyn Write + Send>>,
     /// Responses are parsed on a reader thread so the network keeps flowing
     /// while the caller processes the previous one.
-    rx: Option<std::sync::mpsc::Receiver<std::io::Result<Response>>>,
+    rx: Option<std::sync::mpsc::Receiver<std::io::Result<crate::wire_budget::Budgeted<Response>>>>,
     reader: Option<std::thread::JoinHandle<()>>,
     label: String,
     dead: bool,
@@ -613,14 +613,14 @@ fn spawn_reader(
     input: Box<dyn Read + Send>,
     read_ahead: usize,
 ) -> (
-    std::sync::mpsc::Receiver<std::io::Result<Response>>,
+    std::sync::mpsc::Receiver<std::io::Result<crate::wire_budget::Budgeted<Response>>>,
     std::thread::JoinHandle<()>,
 ) {
     let (tx, rx) = std::sync::mpsc::sync_channel(read_ahead);
     let reader = std::thread::spawn(move || {
         let mut r = FrameReader::new(input);
         loop {
-            let msg = r.read_msg::<Response>();
+            let msg = r.read_budgeted::<Response>();
             let failed = msg.is_err();
             if tx.send(msg).is_err() || failed {
                 break;
@@ -631,16 +631,23 @@ fn spawn_reader(
 }
 
 fn receive_transport_stats(
-    rx: &std::sync::mpsc::Receiver<std::io::Result<Response>>,
+    rx: &std::sync::mpsc::Receiver<std::io::Result<crate::wire_budget::Budgeted<Response>>>,
     timeout: std::time::Duration,
 ) -> Option<TcpSocketStats> {
-    match rx.recv_timeout(timeout) {
+    match rx
+        .recv_timeout(timeout)
+        .map(|result| result.map(crate::wire_budget::Budgeted::into_inner))
+    {
         Ok(Ok(Response::TransportStats(stats))) => stats,
         _ => None,
     }
 }
 
-fn validate_remote_scan_batch(batch: &[Entry], saw_root: &mut bool) -> Result<()> {
+fn validate_remote_scan_batch(
+    batch: &[Entry],
+    saw_root: &mut bool,
+    matcher: Option<&ignore::gitignore::Gitignore>,
+) -> Result<()> {
     for entry in batch {
         if !*saw_root {
             if !entry.path.is_empty() {
@@ -661,6 +668,14 @@ fn validate_remote_scan_batch(batch: &[Entry], saw_root: &mut bool) -> Result<()
         {
             bail!(
                 "scan response contained unsafe relative path {:?}",
+                String::from_utf8_lossy(&entry.path)
+            );
+        }
+        if matcher.is_some_and(|matcher| {
+            crate::scan::path_is_ignored(matcher, &entry.path, entry.kind == Kind::Dir)
+        }) {
+            bail!(
+                "scan response contained excluded path {:?}",
                 String::from_utf8_lossy(&entry.path)
             );
         }
@@ -787,7 +802,13 @@ impl Conn for RemoteConn {
         self.w.write_msg(&req).map_err(|e| self.io_err(e.into()))
     }
     fn recv(&mut self) -> Result<Response> {
-        match self.rx.as_ref().expect("reader receiver present").recv() {
+        match self
+            .rx
+            .as_ref()
+            .expect("reader receiver present")
+            .recv()
+            .map(|result| result.map(crate::wire_budget::Budgeted::into_inner))
+        {
             Ok(Ok(r)) => Ok(r),
             Ok(Err(e)) => Err(self.io_err(e.into())),
             Err(_) => Err(self.io_err(
@@ -826,11 +847,12 @@ impl Conn for RemoteConn {
             report_ignored,
             guard: None,
         })?;
+        let matcher = crate::scan::build_ignore(ignore)?;
         let mut saw_root = false;
         loop {
             match self.recv()? {
                 Response::ScanBatch(b) => {
-                    validate_remote_scan_batch(&b, &mut saw_root)
+                    validate_remote_scan_batch(&b, &mut saw_root, matcher.as_ref())
                         .with_context(|| format!("{}: unsafe remote scan", self.label))?;
                     sink(b)?;
                 }
@@ -3448,7 +3470,11 @@ mod tests {
                 .unwrap();
         }
         for i in 0..depth {
-            let response = responses.recv_timeout(timeout).unwrap().unwrap();
+            let response = responses
+                .recv_timeout(timeout)
+                .unwrap()
+                .unwrap()
+                .into_inner();
             assert!(matches!(response, Response::Block { off, data, .. }
                 if off == i as u64 * (64 << 10) && data == vec![7; 64 << 10]));
         }
@@ -3539,9 +3565,69 @@ mod tests {
     }
 
     #[test]
+    fn hostile_scan_cannot_deliver_excluded_entries_to_the_planner() {
+        for (path, patterns, allowed) in [
+            (b".env".as_slice(), vec![".env"], false),
+            (
+                b"ignored/keep/file",
+                vec!["ignored/", "!ignored/keep/file"],
+                false,
+            ),
+            (b"logs/keep/file", vec!["logs/*", "!logs/keep/"], true),
+            (b"nested/.env", vec!["/.env"], true),
+        ] {
+            let mut wire = Vec::new();
+            let mut writer = FrameWriter::new(&mut wire, false);
+            let mut root = entry(b"");
+            root.kind = Kind::Dir;
+            writer.write_msg(&Response::ScanBatch(vec![root])).unwrap();
+            // No excluded ancestor is sent. Filtering must not depend on the
+            // source's claimed tree order or on previous batches.
+            writer
+                .write_msg(&Response::ScanBatch(vec![entry(path)]))
+                .unwrap();
+            writer.write_msg(&Response::ScanDone).unwrap();
+            drop(writer);
+            let (rx, reader) = spawn_reader(Box::new(std::io::Cursor::new(wire)), 4);
+            let mut remote = RemoteConn {
+                child: None,
+                w: FrameWriter::new(Box::new(Vec::new()), false),
+                rx: Some(rx),
+                reader: Some(reader),
+                label: "hostile source".into(),
+                dead: false,
+                peer: None,
+                tcp_socket: None,
+                named_socket: None,
+                multiplexed_ssh: false,
+                detached: false,
+            };
+            let mut planned = Vec::new();
+            let result = remote.scan(
+                b"source",
+                None,
+                false,
+                &patterns.into_iter().map(String::from).collect::<Vec<_>>(),
+                false,
+                &mut |entries| {
+                    planned.extend(entries.into_iter().map(|e| e.path));
+                    Ok(())
+                },
+                &mut |_| Ok(()),
+                &mut |_| {},
+            );
+            assert_eq!(result.is_ok(), allowed, "{path:?}: {result:?}");
+            assert_eq!(planned.contains(&path.to_vec()), allowed);
+            if !allowed {
+                assert!(format!("{:#}", result.unwrap_err()).contains("excluded path"));
+            }
+        }
+    }
+
+    #[test]
     fn remote_scan_paths_are_rooted_and_normalized() {
         let mut saw_root = false;
-        validate_remote_scan_batch(&[entry(b""), entry(b"dir/file")], &mut saw_root).unwrap();
+        validate_remote_scan_batch(&[entry(b""), entry(b"dir/file")], &mut saw_root, None).unwrap();
         assert!(saw_root);
 
         for bad in [
@@ -3554,17 +3640,17 @@ mod tests {
             &b"nul\0byte"[..],
         ] {
             let mut saw_root = true;
-            assert!(validate_remote_scan_batch(&[entry(bad)], &mut saw_root).is_err());
+            assert!(validate_remote_scan_batch(&[entry(bad)], &mut saw_root, None).is_err());
         }
     }
 
     #[test]
     fn remote_scan_requires_exactly_one_leading_root() {
         let mut saw_root = false;
-        assert!(validate_remote_scan_batch(&[entry(b"file")], &mut saw_root).is_err());
+        assert!(validate_remote_scan_batch(&[entry(b"file")], &mut saw_root, None).is_err());
 
         let mut saw_root = true;
-        assert!(validate_remote_scan_batch(&[entry(b"")], &mut saw_root).is_err());
+        assert!(validate_remote_scan_batch(&[entry(b"")], &mut saw_root, None).is_err());
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -4482,7 +4482,7 @@ impl FsOps {
             let partial_size = target
                 .root
                 .metadata_optional(&relative)?
-                .filter(|metadata| is_safe_rooted_partial(*metadata))
+                .filter(|metadata| is_owned_rooted_partial(*metadata))
                 .map(|metadata| metadata.len);
             return Ok(Response::PartialSize(partial_size));
         }
@@ -4490,7 +4490,7 @@ impl FsOps {
         let pp = self.partial_path(&p, copy_id)?;
         let partial_size = match fs::symlink_metadata(&pp) {
             Err(error) if error.kind() == io::ErrorKind::NotFound => None,
-            Ok(metadata) if is_safe_partial(&metadata) => Some(metadata.len()),
+            Ok(metadata) if is_owned_partial(&metadata) => Some(metadata.len()),
             Ok(_) => None,
             Err(error) => return Err(error).with_context(|| format!("stat {}", pp.display())),
         };
@@ -4527,7 +4527,7 @@ impl FsOps {
         let mut repaired_permissions = false;
         for _ in 0..8 {
             match fs::symlink_metadata(pp) {
-                Ok(md) if is_safe_partial(&md) => {
+                Ok(md) if is_owned_partial(&md) => {
                     match OpenOptions::new()
                         .read(true)
                         .write(true)
@@ -4537,8 +4537,8 @@ impl FsOps {
                         Ok(file) => {
                             let fd_meta = file.metadata()?;
                             let path_meta = fs::symlink_metadata(pp)?;
-                            if !is_safe_partial(&fd_meta)
-                                || !is_safe_partial(&path_meta)
+                            if !is_owned_partial(&fd_meta)
+                                || !is_owned_partial(&path_meta)
                                 || fd_meta.dev() != path_meta.dev()
                                 || fd_meta.ino() != path_meta.ino()
                             {
@@ -4595,8 +4595,8 @@ impl FsOps {
                             };
                             let fd_meta = handle.metadata()?;
                             let path_meta = fs::symlink_metadata(pp)?;
-                            if !is_safe_partial(&fd_meta)
-                                || !is_safe_partial(&path_meta)
+                            if !is_owned_partial(&fd_meta)
+                                || !is_owned_partial(&path_meta)
                                 || fd_meta.dev() != md.dev()
                                 || fd_meta.ino() != md.ino()
                                 || fd_meta.dev() != path_meta.dev()
@@ -4679,13 +4679,13 @@ impl FsOps {
         }
         for _ in 0..8 {
             match root.metadata_optional(relative)? {
-                Some(metadata) if is_safe_rooted_partial(metadata) => {
+                Some(metadata) if is_owned_rooted_partial(metadata) => {
                     match root.open_regular_read_write(relative) {
                         Ok(file) => {
                             let opened = file.metadata()?;
                             let named = root.metadata(relative)?;
-                            if !is_safe_partial(&opened)
-                                || !is_safe_rooted_partial(named)
+                            if !is_owned_partial(&opened)
+                                || !is_owned_rooted_partial(named)
                                 || opened.dev() != named.dev
                                 || opened.ino() != named.ino
                             {
@@ -4758,6 +4758,9 @@ impl FsOps {
                                     continue;
                                 }
                             };
+                            if !is_owned_partial(&handle.metadata()?) {
+                                continue;
+                            }
                             require_rooted_metadata(&handle, metadata, label)?;
                             let repair = (|| -> Result<()> {
                                 fail_partial_chmod_for_test()?;
@@ -6515,6 +6518,16 @@ fn require_safe_partial(file: &File, target: &Path) -> Result<()> {
         );
     }
     Ok(())
+}
+
+// Ownership is required when adopting a leftover, before chmod or writes.
+// Publication checks deliberately allow metadata's requested final owner.
+fn is_owned_partial(metadata: &fs::Metadata) -> bool {
+    is_safe_partial(metadata) && metadata.uid() == unsafe { libc::geteuid() }
+}
+
+fn is_owned_rooted_partial(metadata: RootMetadata) -> bool {
+    is_safe_rooted_partial(metadata) && metadata.uid == unsafe { libc::geteuid() }
 }
 
 fn is_safe_partial(metadata: &fs::Metadata) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ mod transfer;
 mod transfer_tuning;
 mod tune;
 mod update;
+mod wire_budget;
 
 /// Keep multi-megabyte block buffers in the heap instead of mmap/munmap-ing
 /// each one: page faults and TLB shootdowns across many threads otherwise

--- a/src/output.rs
+++ b/src/output.rs
@@ -6,6 +6,22 @@ use std::io::{self, IsTerminal, Write};
 use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 use std::sync::Mutex;
 
+/// Escape text from names or peer diagnostics without allowing terminal control.
+/// Human messages may contain our own line breaks and tabs for layout.
+fn safe_message(args: Arguments<'_>) -> String {
+    let mut result = String::new();
+    for ch in args.to_string().chars() {
+        if (ch.is_control() && !matches!(ch, '\n' | '\t'))
+            || matches!(ch, '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}')
+        {
+            result.extend(ch.escape_default());
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
 /// One lock owns both the live row and writes that can disturb it. Diagnostic
 /// writers never take a Progress lock, so worker warnings cannot invert the
 /// ticker's lock order. Redirected stdout stays outside this lock.
@@ -37,7 +53,7 @@ impl Terminal {
     fn diagnostic(&mut self, out: &mut impl Write, args: Arguments<'_>) -> io::Result<()> {
         let line = self.line.clone();
         self.clear(out)?;
-        writeln!(out, "{args}")?;
+        writeln!(out, "{}", safe_message(args))?;
         if let Some(line) = line {
             self.draw(out, line)?;
         }
@@ -71,7 +87,7 @@ pub(crate) fn emit_diagnostic(args: Arguments<'_>) {
 }
 
 pub(crate) fn emit_human_stdout(args: Arguments<'_>) {
-    if let Err(error) = write_stdout(args) {
+    if let Err(error) = write_stdout(format_args!("{}", safe_message(args))) {
         warn_stdout(&error);
     }
 }
@@ -112,6 +128,23 @@ pub(crate) use human_stdout;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn peer_diagnostics_cannot_control_the_terminal() {
+        let mut output = Vec::new();
+        Terminal::default()
+            .diagnostic(
+                &mut output,
+                format_args!("name: \x1b]52;c;ZXZpbA==\x07\r\u{202e}"),
+            )
+            .unwrap();
+        let text = String::from_utf8(output).unwrap();
+        assert!(!text.contains('\x1b'));
+        assert!(!text.contains('\x07'));
+        assert!(!text.contains('\r'));
+        assert!(!text.contains('\u{202e}'));
+        assert!(text.contains("\\u{1b}]52"));
+    }
 
     #[test]
     fn diagnostics_get_a_clean_row_and_restore_the_bar() {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -12,7 +12,10 @@ use anyhow::{bail, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 
-pub const MAX_FRAME: usize = 256 * 1024 * 1024;
+// 64 MiB data/batch tuning remains supported, with room for its metadata.
+pub const MAX_FRAME: usize = 65 * 1024 * 1024;
+pub const MAX_HANDSHAKE_FRAME: usize = 1024 * 1024;
+const MAX_METADATA_FRAME: usize = 8 * 1024 * 1024;
 pub const MIN_HASH_BLOCK_BYTES: u64 = 64 * 1024;
 pub const MAX_HASH_BLOCK_BYTES: u64 = 64 * 1024 * 1024;
 const HASH_RESPONSE_BYTES_PER_ENTRY: u64 = 32;
@@ -1104,9 +1107,19 @@ pub struct DirectoryAnchor {
 /// Rough serialized size, so big blocks are encoded without reallocation.
 pub trait SizeHint {
     fn size_hint(&self) -> usize;
+    fn frame_limit(&self) -> usize;
 }
 
 impl SizeHint for Request {
+    fn frame_limit(&self) -> usize {
+        match self {
+            Request::Hello { .. } => MAX_HANDSHAKE_FRAME,
+            Request::WriteRange { .. } | Request::PutSmallBatch(_) | Request::CopySmallFiles(_) => {
+                MAX_FRAME
+            }
+            _ => MAX_METADATA_FRAME,
+        }
+    }
     fn size_hint(&self) -> usize {
         match self {
             Request::WriteRange { data, path, .. } => data.len() + path.len() + 64,
@@ -1159,6 +1172,16 @@ impl SizeHint for Request {
 }
 
 impl SizeHint for Response {
+    fn frame_limit(&self) -> usize {
+        match self {
+            Response::HelloOk { .. } => MAX_HANDSHAKE_FRAME,
+            Response::Block { .. }
+            | Response::SmallBlocks(_)
+            | Response::Hashes(_)
+            | Response::HeldHashes { .. } => MAX_FRAME,
+            _ => MAX_METADATA_FRAME,
+        }
+    }
     fn size_hint(&self) -> usize {
         match self {
             Response::Block { data, .. } => data.len() + 64,
@@ -1264,6 +1287,12 @@ impl<W: Write> FrameWriter<W> {
         self.write_preamble()?;
         let payload = postcard::to_extend(msg, Vec::with_capacity(msg.size_hint()))
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        if payload.len() >= msg.frame_limit() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "outgoing message exceeds its size limit",
+            ));
+        }
         let mut flag = 0u8;
         let mut body = payload;
         if self.compress && body.len() > COMPRESS_MIN {
@@ -1292,14 +1321,20 @@ impl<W: Write> FrameWriter<W> {
 pub struct FrameReader<R: Read> {
     r: BufReader<R>,
     preamble_read: bool,
+    limit: usize,
 }
 
 impl<R: Read> FrameReader<R> {
     pub fn new(r: R) -> Self {
         FrameReader {
-            r: BufReader::with_capacity(1 << 20, r),
+            r: BufReader::with_capacity(16 << 10, r),
             preamble_read: false,
+            limit: MAX_FRAME,
         }
+    }
+
+    pub(crate) fn set_limit(&mut self, limit: usize) {
+        self.limit = limit.min(MAX_FRAME);
     }
 
     fn read_preamble(&mut self) -> io::Result<()> {
@@ -1366,41 +1401,77 @@ impl<R: Read> FrameReader<R> {
         Ok(())
     }
 
-    pub fn read_msg<T: for<'de> Deserialize<'de>>(&mut self) -> io::Result<T> {
+    #[cfg(test)]
+    pub fn read_msg<T: for<'de> Deserialize<'de> + SizeHint>(&mut self) -> io::Result<T> {
+        self.read_budgeted()
+            .map(crate::wire_budget::Budgeted::into_inner)
+    }
+
+    pub(crate) fn read_budgeted<T: for<'de> Deserialize<'de> + SizeHint>(
+        &mut self,
+    ) -> io::Result<crate::wire_budget::Budgeted<T>> {
         self.read_preamble()?;
         let mut hdr = [0u8; 4];
         self.r.read_exact(&mut hdr)?;
         let len = u32::from_le_bytes(hdr) as usize;
-        if len == 0 || len > MAX_FRAME {
+        if len == 0 || len > self.limit {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("bad frame length {len}"),
+                format!("bad frame length {len}; limit {}", self.limit),
             ));
         }
         let mut flag = [0u8; 1];
         self.r.read_exact(&mut flag)?;
+        if flag[0] > 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unknown frame flags",
+            ));
+        }
+        // Reserve before allocating or reading, not after decoding has already
+        // consumed the memory. Failed/closed streams release both holds.
+        let mut input_hold = crate::wire_budget::Hold::new();
+        input_hold.grow(len - 1)?;
         let mut body = vec![0u8; len - 1];
         self.r.read_exact(&mut body)?;
-        let payload = if flag[0] & 1 != 0 {
-            {
-                use std::io::Read as _;
-                let mut dec = zstd::stream::read::Decoder::new(&body[..])?;
-                let mut out = Vec::new();
-                dec.by_ref()
-                    .take(MAX_FRAME as u64 + 1)
-                    .read_to_end(&mut out)?;
-                if out.len() > MAX_FRAME {
+        let payload = if flag[0] == 1 {
+            // Bound zstd's advertised window as well as its output. Level-1
+            // frames from the released writer use windows below this ceiling.
+            input_hold.grow(16 << 20)?;
+            let mut decoder = zstd::stream::read::Decoder::new(&body[..])?;
+            decoder.window_log_max(23)?;
+            let mut output = Vec::new();
+            let mut chunk = [0u8; 16 << 10];
+            loop {
+                let n = decoder.read(&mut chunk)?;
+                if n == 0 {
+                    break;
+                }
+                if output.len() + n >= self.limit {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "decompressed frame exceeds limit",
                     ));
                 }
-                out
+                // Vec growth is explicit so no uncharged geometric capacity
+                // appears while decompressing an attacker-controlled stream.
+                // Cover old and new allocations during a realloc too.
+                input_hold.grow(n * 2)?;
+                output.try_reserve_exact(n).map_err(io::Error::other)?;
+                output.extend_from_slice(&chunk[..n]);
             }
+            output
         } else {
             body
         };
-        postcard::from_bytes(&payload).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        let decoded = crate::wire_budget::decode::<T>(&payload)?;
+        if payload.len() >= decoded.value.frame_limit() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "incoming message exceeds its size limit",
+            ));
+        }
+        Ok(decoded)
     }
 }
 
@@ -1422,6 +1493,70 @@ mod tests {
             })
             .unwrap();
         frame
+    }
+
+    fn raw_frame(body: &[u8], flag: u8) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        FrameWriter::new(&mut bytes, false)
+            .write_preamble()
+            .unwrap();
+        bytes.extend_from_slice(&((body.len() + 1) as u32).to_le_bytes());
+        bytes.push(flag);
+        bytes.extend_from_slice(body);
+        bytes
+    }
+
+    #[test]
+    fn oversized_handshake_is_rejected_before_reading_its_body() {
+        let mut bytes = Vec::new();
+        FrameWriter::new(&mut bytes, false)
+            .write_preamble()
+            .unwrap();
+        bytes.extend_from_slice(&((MAX_HANDSHAKE_FRAME + 1) as u32).to_le_bytes());
+        let mut reader = FrameReader::new(bytes.as_slice());
+        reader.set_limit(MAX_HANDSHAKE_FRAME);
+        let error = reader.read_msg::<Request>().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("bad frame length"));
+    }
+
+    #[test]
+    fn compressed_handshake_cannot_expand_past_its_limit() {
+        let payload = postcard::to_stdvec(&Response::Err("x".repeat(4096))).unwrap();
+        let compressed = zstd::bulk::compress(&payload, 1).unwrap();
+        let bytes = raw_frame(&compressed, 1);
+        let mut reader = FrameReader::new(bytes.as_slice());
+        reader.set_limit(1024);
+        assert!(reader
+            .read_msg::<Response>()
+            .unwrap_err()
+            .to_string()
+            .contains("decompressed frame exceeds"));
+    }
+
+    #[test]
+    fn compressed_metadata_still_obeys_its_message_limit() {
+        let payload = postcard::to_stdvec(&Response::Err("x".repeat(MAX_METADATA_FRAME))).unwrap();
+        let compressed = zstd::bulk::compress(&payload, 1).unwrap();
+        let bytes = raw_frame(&compressed, 1);
+        let error = FrameReader::new(bytes.as_slice())
+            .read_msg::<Response>()
+            .unwrap_err();
+        assert!(error.to_string().contains("message exceeds its size limit"));
+    }
+
+    #[test]
+    fn bounded_decoder_preserves_released_completion_payloads() {
+        let request = include_bytes!("../tests/fixtures/completion/list-dir-v0.3.2.bin");
+        let response = include_bytes!("../tests/fixtures/completion/directory-entries-v0.3.2.bin");
+        let decoded = crate::wire_budget::decode::<Request>(request)
+            .unwrap()
+            .into_inner();
+        assert_eq!(postcard::to_stdvec(&decoded).unwrap(), request);
+        let decoded = crate::wire_budget::decode::<Response>(response)
+            .unwrap()
+            .into_inner();
+        assert_eq!(postcard::to_stdvec(&decoded).unwrap(), response);
     }
 
     #[test]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1428,16 +1428,13 @@ impl<R: Read> FrameReader<R> {
                 "unknown frame flags",
             ));
         }
-        // Reserve before allocating or reading, not after decoding has already
-        // consumed the memory. Failed/closed streams release both holds.
-        let mut input_hold = crate::wire_budget::Hold::new();
-        input_hold.grow(len - 1)?;
+        // Encoded bytes and decompression are bounded by this reader's frame
+        // limit. Their queue count is bounded by the connection's read-ahead.
         let mut body = vec![0u8; len - 1];
         self.r.read_exact(&mut body)?;
         let payload = if flag[0] == 1 {
             // Bound zstd's advertised window as well as its output. Level-1
             // frames from the released writer use windows below this ceiling.
-            input_hold.grow(16 << 20)?;
             let mut decoder = zstd::stream::read::Decoder::new(&body[..])?;
             decoder.window_log_max(23)?;
             let mut output = Vec::new();
@@ -1453,10 +1450,7 @@ impl<R: Read> FrameReader<R> {
                         "decompressed frame exceeds limit",
                     ));
                 }
-                // Vec growth is explicit so no uncharged geometric capacity
-                // appears while decompressing an attacker-controlled stream.
-                // Cover old and new allocations during a realloc too.
-                input_hold.grow(n * 2)?;
+                // Keep output capacity close to the bounded decoded length.
                 output.try_reserve_exact(n).map_err(io::Error::other)?;
                 output.extend_from_slice(&chunk[..n]);
             }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -51,6 +51,17 @@ pub fn build_ignore(lines: &[String]) -> Result<Option<Gitignore>> {
     Ok(Some(b.build()?))
 }
 
+/// Match the same pruned tree as a source walk, even when a peer omits or
+/// reorders excluded ancestors. A negation cannot reopen a pruned parent.
+pub(crate) fn path_is_ignored(matcher: &Gitignore, path: &[u8], is_dir: bool) -> bool {
+    let path = Path::new(std::ffi::OsStr::from_bytes(path));
+    !path.as_os_str().is_empty()
+        && (matcher.matched(path, is_dir).is_ignore()
+            || path.ancestors().skip(1).any(|ancestor| {
+                !ancestor.as_os_str().is_empty() && matcher.matched(ancestor, true).is_ignore()
+            }))
+}
+
 enum ScanEvent {
     Entry(Entry),
     Ignored(PathBytes),

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 struct RequestReader {
-    rx: Option<std::sync::mpsc::Receiver<io::Result<Request>>>,
+    rx: Option<std::sync::mpsc::Receiver<io::Result<crate::wire_budget::Budgeted<Request>>>>,
     thread: Option<std::thread::JoinHandle<()>>,
     tcp_socket: Option<TcpStream>,
     named_socket: Option<std::os::unix::net::UnixStream>,
@@ -27,7 +27,7 @@ impl RequestReader {
     ) -> Self {
         let (tx, rx) = std::sync::mpsc::sync_channel(4);
         let thread = std::thread::spawn(move || loop {
-            let msg = reader.read_msg::<Request>();
+            let msg = reader.read_budgeted::<Request>();
             let failed = msg.is_err();
             if tx.send(msg).is_err() || failed {
                 break;
@@ -41,7 +41,12 @@ impl RequestReader {
         }
     }
 
-    fn recv(&self) -> std::result::Result<io::Result<Request>, std::sync::mpsc::RecvError> {
+    fn recv(
+        &self,
+    ) -> std::result::Result<
+        io::Result<crate::wire_budget::Budgeted<Request>>,
+        std::sync::mpsc::RecvError,
+    > {
         self.rx.as_ref().expect("request receiver present").recv()
     }
 
@@ -257,6 +262,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
         descriptor_session,
     } = session;
     let mut r = FrameReader::new(r);
+    r.set_limit(MAX_HANDSHAKE_FRAME);
     let mut w = FrameWriter::new(w, false);
     // Send our build identity before waiting for the client's first postcard
     // frame. Both peers can therefore diagnose version skew even when their
@@ -268,7 +274,8 @@ fn serve<R: Read + Send + 'static, W: Write>(
     // Held for the life of the connection; dropping it releases the worker
     // permit even when a later request fails.
     let _permit: Option<ConnectionPermit>;
-    match r.read_msg::<Request>()? {
+    let (hello, _hello_hold) = r.read_budgeted::<Request>()?.into_parts();
+    match hello {
         Request::Hello {
             identity,
             compress,
@@ -408,18 +415,20 @@ fn serve<R: Read + Send + 'static, W: Write>(
     // Requests are parsed on a reader thread so incoming data keeps flowing
     // while a block is being hashed and written. TCP readers are shut down and
     // joined by the guard on every exit path.
+    r.set_limit(MAX_FRAME);
     let reader = RequestReader::spawn(r, tcp_socket, named_socket);
 
     let mut t = [0f64; 3];
     let (mut blocks, mut bytes) = (0u64, 0u64);
     loop {
         let t0 = std::time::Instant::now();
-        let mut req: Request = match reader.recv() {
+        let queued = match reader.recv() {
             Ok(Ok(req)) => req,
             Ok(Err(e)) if e.kind() == ErrorKind::UnexpectedEof => break,
             Ok(Err(e)) => return Err(e.into()),
             Err(_) => break,
         };
+        let (mut req, _request_hold) = queued.into_parts();
         t[0] += t0.elapsed().as_secs_f64();
         if !is_control
             && matches!(
@@ -1044,6 +1053,7 @@ fn accept_data_connections(
             }
             Err(_) => continue,
         };
+        let handshake_deadline = std::time::Instant::now() + Duration::from_secs(10);
         let id = next_id.fetch_add(1, Relaxed);
         // Reserve a slot atomically: both family listeners charge one bound.
         if live.fetch_add(1, Relaxed) >= max_live {
@@ -1074,7 +1084,7 @@ fn accept_data_connections(
                 &seen,
                 authority.clone(),
                 descriptor_session,
-                Duration::from_secs(10),
+                handshake_deadline,
             ) {
                 if debug {
                     crate::output::diagnostic!("syq server (tcp {id}): {e:#}");
@@ -1096,7 +1106,7 @@ fn serve_tcp(
     seen: &std::sync::Mutex<std::collections::HashSet<u32>>,
     authority: Option<Arc<crate::restricted::RestrictedAuthority>>,
     descriptor_session: DescriptorSessionSlot,
-    handshake_timeout: Duration,
+    handshake_deadline: std::time::Instant,
 ) -> Result<()> {
     // The listening socket is nonblocking so its owner can notice session
     // shutdown. Darwin propagates that status flag to accepted sockets, while
@@ -1104,13 +1114,17 @@ fn serve_tcp(
     stream.set_nonblocking(false)?;
     stream.set_nodelay(true)?;
     // Scanners and stray connections must not hold a thread forever.
+    let handshake_timeout = handshake_deadline
+        .checked_duration_since(std::time::Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .context("TCP Hello deadline expired before the handler started")?;
     stream.set_read_timeout(Some(handshake_timeout))?;
     stream.set_write_timeout(Some(handshake_timeout))?;
     let handshake_pending = Arc::new(std::sync::atomic::AtomicBool::new(true));
     let mut handshake_reader = TcpHandshakeReader {
         stream: stream.try_clone()?,
         pending: handshake_pending.clone(),
-        deadline: std::time::Instant::now() + handshake_timeout,
+        deadline: handshake_deadline,
     };
     // The client tells us its connection id first (plaintext), so both sides
     // derive the same nonces.
@@ -1676,7 +1690,7 @@ mod tests {
                 &seen,
                 Some(authority.clone()),
                 DescriptorSessionSlot::default(),
-                Duration::from_secs(1),
+                std::time::Instant::now() + Duration::from_secs(1),
             );
             if high != 0 {
                 assert!(result
@@ -1749,7 +1763,7 @@ mod tests {
                         &seen,
                         None,
                         DescriptorSessionSlot::default(),
-                        Duration::from_millis(100),
+                        std::time::Instant::now() + Duration::from_millis(100),
                     );
                     tx.send((result, seen.into_inner().unwrap())).unwrap();
                 });
@@ -1789,7 +1803,7 @@ mod tests {
                     &seen,
                     Some(authority),
                     DescriptorSessionSlot::default(),
-                    Duration::from_millis(100),
+                    std::time::Instant::now() + Duration::from_millis(100),
                 )
             });
             (&client).write_all(&44u32.to_be_bytes()).unwrap();

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -139,8 +139,7 @@ pub struct Opts {
     pub ignore_existing: bool,
     /// --existing: never create a destination path that doesn't exist.
     pub existing: bool,
-    /// Explicit rsync compatibility escape hatch for unconfined source
-    /// discovery through symlinked descendant components.
+    /// Record the local rsync operator-path opt-out in the resume identity.
     pub insecure_links: bool,
     /// Symlink policy for the operator-selected destination path.
     pub operator_symlink_policy: OperatorSymlinkPolicy,
@@ -1940,10 +1939,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                     let conns = src_ep
                         .connect_with_sources(compress, initial_sources.clone())
                         .and_then(|src| {
-                            let copy_sources = if cfg!(target_os = "linux")
-                                && opts.same_host
-                                && !opts.insecure_links
-                            {
+                            let copy_sources = if cfg!(target_os = "linux") && opts.same_host {
                                 initial_sources.clone()
                             } else {
                                 Vec::new()
@@ -2129,12 +2125,11 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     // source capabilities from the source endpoint's broker before reporting
     // ready. These are foreign-session claims even when both logical endpoints
     // are local to the coordinator process.
-    let copy_local_claim_workers =
-        if cfg!(target_os = "linux") && opts.same_host && !opts.insecure_links {
-            maximum_workers
-        } else {
-            0
-        };
+    let copy_local_claim_workers = if cfg!(target_os = "linux") && opts.same_host {
+        maximum_workers
+    } else {
+        0
+    };
     let source_independent_handoff_workers = source_independent_handoff_workers
         .checked_add(copy_local_claim_workers)
         .context("source worker count overflow")?;
@@ -3830,7 +3825,7 @@ fn register_source_roots(
             base,
             selections,
             symlink_policy: source_operator_symlink_policy(args, source_is_local),
-            allow_unconfined_paths: rsync_insecure_links(args, source_is_local),
+            allow_unconfined_paths: false,
             shared_workers,
             independent_handoff_workers,
         })?,
@@ -4149,7 +4144,7 @@ fn follow_container_symlink(
 }
 
 fn display(p: &[u8]) -> String {
-    String::from_utf8_lossy(p).into_owned()
+    crate::completion_details::display_bytes(p)
 }
 
 fn display_directory(p: &[u8]) -> String {
@@ -4850,11 +4845,7 @@ impl Planner<'_> {
             self,
             src,
             src_root,
-            if self.opts.insecure_links {
-                None
-            } else {
-                Some(&source)
-            },
+            Some(&source),
             follow_root,
             &ignore,
             |pl, batch| {
@@ -4925,9 +4916,8 @@ impl Planner<'_> {
 
     /// --files-from: instead of walking the source, stat each listed path (and
     /// the directories leading to it) and feed them to the planner as if a scan
-    /// had produced them. By default, implied parents are descriptor-relative
-    /// and never traversed through symlinks. `--insecure-links` selects the
-    /// legacy unconfined pathname behavior explicitly. Listed directories —
+    /// had produced them. Implied parents are descriptor-relative and never
+    /// traversed through symlinks, including with `--insecure-links`. Listed directories —
     /// only those, not implied parents — are walked with an explicit -r.
     fn scan_files_from(
         &mut self,
@@ -4944,16 +4934,12 @@ impl Planner<'_> {
             .context("registered source reference was not initialized")?;
         // Validate the root but never plan it: it isn't in the list, so an
         // existing destination is not stamped with source-root metadata.
-        let mut source_root_stat = if self.opts.insecure_links {
-            stat_many(src, vec![src_root.to_vec()], true)?
-        } else {
-            stat_many_registered(
-                src,
-                vec![src_root.to_vec()],
-                Some(vec![source_base.clone()]),
-                true,
-            )?
-        };
+        let mut source_root_stat = stat_many_registered(
+            src,
+            vec![src_root.to_vec()],
+            Some(vec![source_base.clone()]),
+            true,
+        )?;
         match source_root_stat.pop().flatten() {
             Some(e) if e.kind == Kind::Dir => {}
             Some(_) => bail!(
@@ -4966,8 +4952,7 @@ impl Planner<'_> {
 
         // Listed paths are lstat'ed (a listed symlink copies as a symlink).
         // Implied ancestors must be directories. Registered stats never follow
-        // descendant symlinks; only --insecure-links uses legacy followed
-        // pathname stats. Results are kept for the whole list, since a later
+        // descendant symlinks. Results are kept for the whole list, since a later
         // line may repeat a path or name one first seen as a parent.
         let mut leaves: HashMap<PathBytes, Option<Entry>> = HashMap::new();
         let mut parents: HashMap<PathBytes, Option<Entry>> = HashMap::new();
@@ -4983,9 +4968,6 @@ impl Planner<'_> {
         };
         let stat = |src: &mut dyn Conn, paths: Vec<PathBytes>, follow: bool| -> Result<_> {
             let legacy_paths = paths.iter().map(|r| join(src_root, r)).collect();
-            if self.opts.insecure_links {
-                return stat_many(src, legacy_paths, follow);
-            }
             let registered = paths
                 .iter()
                 .map(|relative| source_base.join(relative))
@@ -5324,11 +5306,7 @@ impl Planner<'_> {
             self,
             src,
             &join(src_root, rel),
-            if self.opts.insecure_links {
-                None
-            } else {
-                Some(&source)
-            },
+            Some(&source),
             false,
             &[],
             |pl, batch| {
@@ -7325,11 +7303,10 @@ struct BlockDiff {
 }
 
 impl Worker {
-    /// Confined source sessions carry the registered capability on every
-    /// content request. Only rsync's explicit --insecure-links compatibility
-    /// mode intentionally asks the endpoint to use its legacy pathname.
+    /// Every content request carries the source capability, including when
+    /// the operator allowed a foreign-owned symlink in the typed root path.
     fn source_reference(&self, job: &FileJob) -> Option<RegisteredPath> {
-        (!self.opts.insecure_links).then(|| job.source.clone())
+        Some(job.source.clone())
     }
 
     fn run(&mut self) -> Result<()> {
@@ -7660,12 +7637,8 @@ impl Worker {
         // Did any source change while we were at it?
         let paths: Vec<PathBytes> = jobs.iter().map(|j| j.src.clone()).collect();
         let phase = std::time::Instant::now();
-        let now = if self.opts.insecure_links {
-            stat_many(&mut *self.src, paths, false)?
-        } else {
-            let registered = jobs.iter().map(|job| job.source.clone()).collect();
-            stat_many_registered(&mut *self.src, paths, Some(registered), false)?
-        };
+        let registered = jobs.iter().map(|job| job.source.clone()).collect();
+        let now = stat_many_registered(&mut *self.src, paths, Some(registered), false)?;
         self.fast.restat += phase.elapsed().as_secs_f64();
         let phase = std::time::Instant::now();
         for ((idx, j), (res, now)) in batch
@@ -7838,7 +7811,6 @@ impl Worker {
         // uses the regular userspace path (also useful for mounted NFS paths).
         if self.opts.same_host
             && !self.opts.tuning.force_ranges()
-            && !self.opts.insecure_links
             && !self.opts.checksum
             && self.bwlimit.is_none()
             && job.entry.size > 0
@@ -8417,11 +8389,7 @@ impl Worker {
     /// the source changed during that work.
     fn complete_file(&mut self, idx: usize, job: FileJob, matched: bool) -> Result<()> {
         // Did the source change under us?
-        let now = if self.opts.insecure_links {
-            stat_one(&mut *self.src, &job.src, false)?
-        } else {
-            stat_one_registered(&mut *self.src, &job.src, &job.source, false)?
-        };
+        let now = stat_one_registered(&mut *self.src, &job.src, &job.source, false)?;
         let changed = match &now {
             Some(e) => {
                 e.kind != Kind::File

--- a/src/wire_budget.rs
+++ b/src/wire_budget.rs
@@ -1,0 +1,518 @@
+//! Conservative, process-wide accounting for framed input and owned decoded
+//! values. Reservations travel with queued messages and are released on drop.
+use serde::de::{self, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor};
+use serde::Deserialize;
+use std::fmt;
+use std::io;
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use std::sync::{Arc, OnceLock};
+
+pub(crate) const MEMORY_LIMIT: usize = 512 << 20;
+const RESERVATION_GRANULE: usize = 64 << 10;
+
+#[derive(Debug)]
+struct Budget {
+    used: AtomicUsize,
+    limit: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct Hold {
+    budget: Arc<Budget>,
+    used: usize,
+    reserved: usize,
+    exhausted: bool,
+}
+
+impl Hold {
+    pub(crate) fn new() -> Self {
+        static BUDGET: OnceLock<Arc<Budget>> = OnceLock::new();
+        Self {
+            budget: BUDGET
+                .get_or_init(|| {
+                    Arc::new(Budget {
+                        used: AtomicUsize::new(0),
+                        limit: MEMORY_LIMIT,
+                    })
+                })
+                .clone(),
+            used: 0,
+            reserved: 0,
+            exhausted: false,
+        }
+    }
+
+    pub(crate) fn grow(&mut self, bytes: usize) -> io::Result<()> {
+        let result = self.try_grow(bytes);
+        self.exhausted |= result.is_err();
+        result
+    }
+
+    fn try_grow(&mut self, bytes: usize) -> io::Result<()> {
+        let exhausted = || {
+            io::Error::other(
+                "framed input memory budget exhausted; reduce connections or pipeline depth",
+            )
+        };
+        let used = self.used.checked_add(bytes).ok_or_else(exhausted)?;
+        if used > self.reserved {
+            let wanted = used
+                .checked_add(RESERVATION_GRANULE - 1)
+                .ok_or_else(exhausted)?
+                / RESERVATION_GRANULE
+                * RESERVATION_GRANULE;
+            let extra = wanted - self.reserved;
+            self.budget
+                .used
+                .fetch_update(Relaxed, Relaxed, |current| {
+                    current
+                        .checked_add(extra)
+                        .filter(|total| *total <= self.budget.limit)
+                })
+                .map_err(|_| exhausted())?;
+            self.reserved = wanted;
+        }
+        self.used = used;
+        Ok(())
+    }
+
+    fn charge<E: de::Error>(&mut self, bytes: usize) -> Result<(), E> {
+        self.grow(bytes).map_err(E::custom)
+    }
+}
+
+impl Drop for Hold {
+    fn drop(&mut self) {
+        self.budget.used.fetch_sub(self.reserved, Relaxed);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Budgeted<T> {
+    pub(crate) value: T,
+    pub(crate) hold: Hold,
+}
+impl<T> Budgeted<T> {
+    pub(crate) fn into_inner(self) -> T {
+        self.value
+    }
+    pub(crate) fn into_parts(self) -> (T, Hold) {
+        (self.value, self.hold)
+    }
+}
+
+// Postcard's sequence length comes from the peer. Hide size hints to prevent
+// eager Vec/HashMap allocation, then charge conservative capacity before each
+// element. Eight times element size covers Vec growth (including its minimum
+// capacity) and map buckets; strings and byte buffers charge their own storage.
+// This is deliberately an upper bound, not an allocator/RSS measurement.
+struct Limited<'a, D> {
+    inner: D,
+    hold: &'a mut Hold,
+}
+struct LimitedVisitor<'a, V> {
+    inner: V,
+    hold: &'a mut Hold,
+}
+struct LimitedSeed<'a, S> {
+    inner: S,
+    hold: &'a mut Hold,
+}
+struct LimitedSeq<'a, S> {
+    inner: S,
+    hold: &'a mut Hold,
+}
+struct LimitedMap<'a, M> {
+    inner: M,
+    hold: &'a mut Hold,
+}
+struct LimitedEnum<'a, E> {
+    inner: E,
+    hold: &'a mut Hold,
+}
+struct LimitedVariant<'a, V> {
+    inner: V,
+    hold: &'a mut Hold,
+}
+
+impl<'de, S: DeserializeSeed<'de>> DeserializeSeed<'de> for LimitedSeed<'_, S> {
+    type Value = S::Value;
+    fn deserialize<D: de::Deserializer<'de>>(self, inner: D) -> Result<Self::Value, D::Error> {
+        self.inner.deserialize(Limited {
+            inner,
+            hold: self.hold,
+        })
+    }
+}
+impl<'de, S: SeqAccess<'de>> SeqAccess<'de> for LimitedSeq<'_, S> {
+    type Error = S::Error;
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, Self::Error> {
+        self.hold
+            .charge::<Self::Error>(std::mem::size_of::<T::Value>().max(1).saturating_mul(8))?;
+        self.inner.next_element_seed(LimitedSeed {
+            inner: seed,
+            hold: self.hold,
+        })
+    }
+    fn size_hint(&self) -> Option<usize> {
+        None
+    }
+}
+impl<'de, M: MapAccess<'de>> MapAccess<'de> for LimitedMap<'_, M> {
+    type Error = M::Error;
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, Self::Error> {
+        self.hold
+            .charge::<Self::Error>(std::mem::size_of::<K::Value>().max(1).saturating_mul(8))?;
+        self.inner.next_key_seed(LimitedSeed {
+            inner: seed,
+            hold: self.hold,
+        })
+    }
+    fn next_value_seed<V: DeserializeSeed<'de>>(
+        &mut self,
+        seed: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.hold
+            .charge::<Self::Error>(std::mem::size_of::<V::Value>().max(1).saturating_mul(8))?;
+        self.inner.next_value_seed(LimitedSeed {
+            inner: seed,
+            hold: self.hold,
+        })
+    }
+    fn size_hint(&self) -> Option<usize> {
+        None
+    }
+}
+impl<'a, 'de, E: EnumAccess<'de>> EnumAccess<'de> for LimitedEnum<'a, E> {
+    type Error = E::Error;
+    type Variant = LimitedVariant<'a, E::Variant>;
+    fn variant_seed<V: DeserializeSeed<'de>>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, Self::Variant), Self::Error> {
+        let (value, inner) = self.inner.variant_seed(LimitedSeed {
+            inner: seed,
+            hold: self.hold,
+        })?;
+        Ok((
+            value,
+            LimitedVariant {
+                inner,
+                hold: self.hold,
+            },
+        ))
+    }
+}
+impl<'de, V: VariantAccess<'de>> VariantAccess<'de> for LimitedVariant<'_, V> {
+    type Error = V::Error;
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        self.inner.unit_variant()
+    }
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(
+        self,
+        seed: T,
+    ) -> Result<T::Value, Self::Error> {
+        self.inner.newtype_variant_seed(LimitedSeed {
+            inner: seed,
+            hold: self.hold,
+        })
+    }
+    fn tuple_variant<T: Visitor<'de>>(
+        self,
+        len: usize,
+        visitor: T,
+    ) -> Result<T::Value, Self::Error> {
+        self.inner.tuple_variant(
+            len,
+            LimitedVisitor {
+                inner: visitor,
+                hold: self.hold,
+            },
+        )
+    }
+    fn struct_variant<T: Visitor<'de>>(
+        self,
+        fields: &'static [&'static str],
+        visitor: T,
+    ) -> Result<T::Value, Self::Error> {
+        self.inner.struct_variant(
+            fields,
+            LimitedVisitor {
+                inner: visitor,
+                hold: self.hold,
+            },
+        )
+    }
+}
+
+macro_rules! scalar_visits {
+    ($($method:ident: $ty:ty),* $(,)?) => {$(
+        fn $method<E: de::Error>(self, value: $ty) -> Result<Self::Value, E> { self.inner.$method(value) }
+    )*};
+}
+impl<'de, V: Visitor<'de>> Visitor<'de> for LimitedVisitor<'_, V> {
+    type Value = V::Value;
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.expecting(f)
+    }
+    scalar_visits! { visit_bool: bool, visit_i8: i8, visit_i16: i16, visit_i32: i32, visit_i64: i64,
+    visit_i128: i128, visit_u8: u8, visit_u16: u16, visit_u32: u32, visit_u64: u64,
+    visit_u128: u128, visit_f32: f32, visit_f64: f64, visit_char: char }
+    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.inner.visit_unit()
+    }
+    fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+        self.inner.visit_none()
+    }
+    fn visit_some<D: de::Deserializer<'de>>(self, inner: D) -> Result<Self::Value, D::Error> {
+        self.inner.visit_some(Limited {
+            inner,
+            hold: self.hold,
+        })
+    }
+    fn visit_newtype_struct<D: de::Deserializer<'de>>(
+        self,
+        inner: D,
+    ) -> Result<Self::Value, D::Error> {
+        self.inner.visit_newtype_struct(Limited {
+            inner,
+            hold: self.hold,
+        })
+    }
+    fn visit_seq<S: SeqAccess<'de>>(self, inner: S) -> Result<Self::Value, S::Error> {
+        self.inner.visit_seq(LimitedSeq {
+            inner,
+            hold: self.hold,
+        })
+    }
+    fn visit_map<M: MapAccess<'de>>(self, inner: M) -> Result<Self::Value, M::Error> {
+        self.inner.visit_map(LimitedMap {
+            inner,
+            hold: self.hold,
+        })
+    }
+    fn visit_enum<E: EnumAccess<'de>>(self, inner: E) -> Result<Self::Value, E::Error> {
+        self.inner.visit_enum(LimitedEnum {
+            inner,
+            hold: self.hold,
+        })
+    }
+    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        self.hold.charge::<E>(value.len())?;
+        self.inner.visit_str(value)
+    }
+    fn visit_borrowed_str<E: de::Error>(self, value: &'de str) -> Result<Self::Value, E> {
+        self.hold.charge::<E>(value.len())?;
+        self.inner.visit_borrowed_str(value)
+    }
+    fn visit_string<E: de::Error>(self, value: String) -> Result<Self::Value, E> {
+        self.hold.charge::<E>(value.len())?;
+        self.inner.visit_string(value)
+    }
+    fn visit_bytes<E: de::Error>(self, value: &[u8]) -> Result<Self::Value, E> {
+        self.hold.charge::<E>(value.len())?;
+        self.inner.visit_bytes(value)
+    }
+    fn visit_borrowed_bytes<E: de::Error>(self, value: &'de [u8]) -> Result<Self::Value, E> {
+        self.hold.charge::<E>(value.len())?;
+        self.inner.visit_borrowed_bytes(value)
+    }
+    fn visit_byte_buf<E: de::Error>(self, value: Vec<u8>) -> Result<Self::Value, E> {
+        self.hold.charge::<E>(value.len())?;
+        self.inner.visit_byte_buf(value)
+    }
+}
+
+macro_rules! forward_deserializers {
+    ($($method:ident),* $(,)?) => {$(
+        fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+            self.inner.$method(LimitedVisitor { inner: visitor, hold: self.hold })
+        }
+    )*};
+}
+impl<'de, D: de::Deserializer<'de>> de::Deserializer<'de> for Limited<'_, D> {
+    type Error = D::Error;
+    forward_deserializers! { deserialize_any, deserialize_bool, deserialize_i8, deserialize_i16,
+    deserialize_i32, deserialize_i64, deserialize_i128, deserialize_u8, deserialize_u16,
+    deserialize_u32, deserialize_u64, deserialize_u128, deserialize_f32, deserialize_f64,
+    deserialize_char, deserialize_str, deserialize_string, deserialize_bytes, deserialize_byte_buf,
+    deserialize_option, deserialize_unit, deserialize_seq, deserialize_map, deserialize_identifier,
+    deserialize_ignored_any }
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.inner.deserialize_unit_struct(
+            name,
+            LimitedVisitor {
+                inner: visitor,
+                hold: self.hold,
+            },
+        )
+    }
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.inner.deserialize_newtype_struct(
+            name,
+            LimitedVisitor {
+                inner: visitor,
+                hold: self.hold,
+            },
+        )
+    }
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.inner.deserialize_tuple(
+            len,
+            LimitedVisitor {
+                inner: visitor,
+                hold: self.hold,
+            },
+        )
+    }
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.inner.deserialize_tuple_struct(
+            name,
+            len,
+            LimitedVisitor {
+                inner: visitor,
+                hold: self.hold,
+            },
+        )
+    }
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.inner.deserialize_struct(
+            name,
+            fields,
+            LimitedVisitor {
+                inner: visitor,
+                hold: self.hold,
+            },
+        )
+    }
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.inner.deserialize_enum(
+            name,
+            variants,
+            LimitedVisitor {
+                inner: visitor,
+                hold: self.hold,
+            },
+        )
+    }
+    fn is_human_readable(&self) -> bool {
+        self.inner.is_human_readable()
+    }
+}
+
+pub(crate) fn decode<T: for<'de> Deserialize<'de>>(bytes: &[u8]) -> io::Result<Budgeted<T>> {
+    decode_with_hold(bytes, Hold::new())
+}
+
+fn decode_with_hold<T: for<'de> Deserialize<'de>>(
+    bytes: &[u8],
+    mut hold: Hold,
+) -> io::Result<Budgeted<T>> {
+    hold.grow(std::mem::size_of::<T>())?;
+    let mut decoder = postcard::Deserializer::from_bytes(bytes);
+    let value = T::deserialize(Limited {
+        inner: &mut decoder,
+        hold: &mut hold,
+    })
+    .map_err(|error| {
+        if hold.exhausted {
+            io::Error::other(
+                "framed input memory budget exhausted; reduce connections or pipeline depth",
+            )
+        } else {
+            io::Error::new(io::ErrorKind::InvalidData, error)
+        }
+    })?;
+    Ok(Budgeted { value, hold })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn hold(budget: &Arc<Budget>) -> Hold {
+        Hold {
+            budget: budget.clone(),
+            used: 0,
+            reserved: 0,
+            exhausted: false,
+        }
+    }
+    fn budget() -> Arc<Budget> {
+        Arc::new(Budget {
+            used: AtomicUsize::new(0),
+            limit: RESERVATION_GRANULE,
+        })
+    }
+
+    #[test]
+    fn queued_values_share_the_budget_and_release_it_on_drop() {
+        let shared = budget();
+        let bytes = postcard::to_stdvec(&vec!["payload".to_string(); 16]).unwrap();
+        let value = decode_with_hold::<Vec<String>>(&bytes, hold(&shared)).unwrap();
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        tx.send(value).unwrap();
+        assert!(decode_with_hold::<Vec<String>>(&bytes, hold(&shared)).is_err());
+        assert_eq!(shared.used.load(Relaxed), RESERVATION_GRANULE);
+        let (value, reservation) = rx.recv().unwrap().into_parts();
+        assert_eq!(value.len(), 16);
+        assert!(hold(&shared).grow(1).is_err());
+        drop(value);
+        drop(reservation);
+        assert_eq!(shared.used.load(Relaxed), 0);
+        assert!(decode_with_hold::<Vec<String>>(&bytes, hold(&shared)).is_ok());
+    }
+
+    #[test]
+    fn tiny_payload_cannot_expand_an_unbounded_collection() {
+        // Vec<()> has no element bytes in postcard. The hostile count must
+        // still consume budget, without trusting Vec's allocation hint.
+        let bytes = postcard::to_stdvec(&vec![(); 1_000_000]).unwrap();
+        assert!(bytes.len() < 8);
+        let shared = budget();
+        let error = decode_with_hold::<Vec<()>>(&bytes, hold(&shared)).unwrap_err();
+        assert!(error.to_string().contains("memory budget exhausted"));
+        assert_eq!(shared.used.load(Relaxed), 0);
+    }
+
+    #[test]
+    fn malformed_nested_values_release_their_reservations() {
+        let mut bytes = postcard::to_stdvec(&vec![vec!["abc".to_string(); 4]; 8]).unwrap();
+        bytes.pop();
+        let shared = budget();
+        assert!(decode_with_hold::<Vec<Vec<String>>>(&bytes, hold(&shared)).is_err());
+        assert_eq!(shared.used.load(Relaxed), 0);
+    }
+}

--- a/src/wire_budget.rs
+++ b/src/wire_budget.rs
@@ -1,5 +1,6 @@
-//! Conservative, process-wide accounting for framed input and owned decoded
-//! values. Reservations travel with queued messages and are released on drop.
+//! Shared accounting for decoded collection storage, whose size is not bounded
+//! by the encoded frame length alone. Reservations travel with queued messages.
+//! Flat byte buffers and strings are bounded separately by frame/queue limits.
 use serde::de::{self, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor};
 use serde::Deserialize;
 use std::fmt;
@@ -51,7 +52,7 @@ impl Hold {
     fn try_grow(&mut self, bytes: usize) -> io::Result<()> {
         let exhausted = || {
             io::Error::other(
-                "framed input memory budget exhausted; reduce connections or pipeline depth",
+                "decoded collection memory budget exhausted; reduce connections or pipeline depth",
             )
         };
         let used = self.used.checked_add(bytes).ok_or_else(exhausted)?;
@@ -104,7 +105,9 @@ impl<T> Budgeted<T> {
 // Postcard's sequence length comes from the peer. Hide size hints to prevent
 // eager Vec/HashMap allocation, then charge conservative capacity before each
 // element. Eight times element size covers Vec growth (including its minimum
-// capacity) and map buckets; strings and byte buffers charge their own storage.
+// capacity) and map buckets. Strings and byte buffers are already bounded by
+// their bytes in the frame; charging those globally made normal bulk transfers
+// compete for this allowance as concurrency increased.
 // This is deliberately an upper bound, not an allocator/RSS measurement.
 struct Limited<'a, D> {
     inner: D,
@@ -304,27 +307,21 @@ impl<'de, V: Visitor<'de>> Visitor<'de> for LimitedVisitor<'_, V> {
         })
     }
     fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
-        self.hold.charge::<E>(value.len())?;
         self.inner.visit_str(value)
     }
     fn visit_borrowed_str<E: de::Error>(self, value: &'de str) -> Result<Self::Value, E> {
-        self.hold.charge::<E>(value.len())?;
         self.inner.visit_borrowed_str(value)
     }
     fn visit_string<E: de::Error>(self, value: String) -> Result<Self::Value, E> {
-        self.hold.charge::<E>(value.len())?;
         self.inner.visit_string(value)
     }
     fn visit_bytes<E: de::Error>(self, value: &[u8]) -> Result<Self::Value, E> {
-        self.hold.charge::<E>(value.len())?;
         self.inner.visit_bytes(value)
     }
     fn visit_borrowed_bytes<E: de::Error>(self, value: &'de [u8]) -> Result<Self::Value, E> {
-        self.hold.charge::<E>(value.len())?;
         self.inner.visit_borrowed_bytes(value)
     }
     fn visit_byte_buf<E: de::Error>(self, value: Vec<u8>) -> Result<Self::Value, E> {
-        self.hold.charge::<E>(value.len())?;
         self.inner.visit_byte_buf(value)
     }
 }
@@ -450,7 +447,7 @@ fn decode_with_hold<T: for<'de> Deserialize<'de>>(
     .map_err(|error| {
         if hold.exhausted {
             io::Error::other(
-                "framed input memory budget exhausted; reduce connections or pipeline depth",
+                "decoded collection memory budget exhausted; reduce connections or pipeline depth",
             )
         } else {
             io::Error::new(io::ErrorKind::InvalidData, error)
@@ -505,6 +502,22 @@ mod tests {
         let error = decode_with_hold::<Vec<()>>(&bytes, hold(&shared)).unwrap_err();
         assert!(error.to_string().contains("memory budget exhausted"));
         assert_eq!(shared.used.load(Relaxed), 0);
+    }
+
+    #[test]
+    fn bounded_bulk_bytes_do_not_consume_collection_allowance() {
+        let shared = budget();
+        let response = crate::proto::Response::Block {
+            off: 0,
+            hash: [0; 32],
+            data: vec![7; 8 << 20],
+        };
+        let bytes = postcard::to_stdvec(&response).unwrap();
+        let decoded = decode_with_hold::<crate::proto::Response>(&bytes, hold(&shared)).unwrap();
+        assert!(
+            matches!(decoded.value, crate::proto::Response::Block { data, .. } if data.len() == 8 << 20)
+        );
+        assert_eq!(shared.used.load(Relaxed), RESERVATION_GRANULE);
     }
 
     #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -585,58 +585,61 @@ fn confinement_matrix_tcp_requirement_refuses_ssh_transport() {
 #[cfg(debug_assertions)]
 #[test]
 fn source_scan_uses_registered_root_after_operator_path_replacement() {
-    let t = Tmp::new();
-    write(&t.path("src/original"), b"original");
-    write(&t.path("outside/replacement"), b"replacement");
-    let ready = t.path("source-ready");
+    for insecure in [false, true] {
+        let t = Tmp::new();
+        write(&t.path("src/original"), b"original");
+        write(&t.path("outside/replacement"), b"replacement");
+        let ready = t.path("source-ready");
 
-    let mut child = compat_command()
-        .args([
-            "-anv",
-            "--syq-connections",
-            "1",
-            &t.s("src/"),
-            &t.s("dst/"),
-            "--no-progress",
-        ])
-        .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
-        .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .start()
-        .unwrap();
+        let mut child = compat_command()
+            .args(insecure.then_some("--insecure-links"))
+            .args([
+                "-anv",
+                "--syq-connections",
+                "1",
+                &t.s("src/"),
+                &t.s("dst/"),
+                "--no-progress",
+            ])
+            .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
+            .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .start()
+            .unwrap();
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    while !ready.exists() && std::time::Instant::now() < deadline {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !ready.exists() && std::time::Instant::now() < deadline {
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "syq exited before registering the source root"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
         assert!(
-            child.try_wait().unwrap().is_none(),
-            "syq exited before registering the source root"
+            ready.exists(),
+            "source root was not registered before timeout"
         );
-        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        fs::rename(t.path("src"), t.path("selected-and-moved")).unwrap();
+        std::os::unix::fs::symlink(t.path("outside"), t.path("src")).unwrap();
+
+        let output = child.wait_with_output().unwrap();
+        assert_output_ok(&output);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("/original (destination missing)"),
+            "{stdout}"
+        );
+        assert!(
+            !stdout.contains("/replacement (destination missing)"),
+            "{stdout}"
+        );
+        assert!(
+            !t.path("dst").exists(),
+            "dry run unexpectedly created output"
+        );
     }
-    assert!(
-        ready.exists(),
-        "source root was not registered before timeout"
-    );
-
-    fs::rename(t.path("src"), t.path("selected-and-moved")).unwrap();
-    std::os::unix::fs::symlink(t.path("outside"), t.path("src")).unwrap();
-
-    let output = child.wait_with_output().unwrap();
-    assert_output_ok(&output);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("/original (destination missing)"),
-        "{stdout}"
-    );
-    assert!(
-        !stdout.contains("/replacement (destination missing)"),
-        "{stdout}"
-    );
-    assert!(
-        !t.path("dst").exists(),
-        "dry run unexpectedly created output"
-    );
 }
 
 #[cfg(debug_assertions)]
@@ -825,53 +828,56 @@ fn exact_symlink_source_replacement_is_rejected_after_registration() {
 #[cfg(debug_assertions)]
 #[test]
 fn source_small_and_range_reads_use_registered_root_after_path_replacement() {
-    let t = Tmp::new();
-    let original_large = vec![b'o'; 5 << 20];
-    write(&t.path("src/small"), b"original");
-    write(&t.path("src/large"), &original_large);
-    write(&t.path("outside/small"), b"replaced");
-    write(&t.path("outside/large"), &vec![b'r'; 5 << 20]);
-    let ready = t.path("source-content-ready");
+    for insecure in [false, true] {
+        let t = Tmp::new();
+        let original_large = vec![b'o'; 5 << 20];
+        write(&t.path("src/small"), b"original");
+        write(&t.path("src/large"), &original_large);
+        write(&t.path("outside/small"), b"replaced");
+        write(&t.path("outside/large"), &vec![b'r'; 5 << 20]);
+        let ready = t.path("source-content-ready");
 
-    let mut child = compat_command()
-        .args([
-            "-a",
-            "--syq-connections",
-            "1",
-            &t.s("src/"),
-            &t.s("dst/"),
-            "--no-progress",
-        ])
-        // Keep the test on the ranged transport path instead of the excluded
-        // same-machine CopyLocal optimization.
-        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
-        .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
-        .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .start()
-        .unwrap();
+        let mut child = compat_command()
+            .args(insecure.then_some("--insecure-links"))
+            .args([
+                "-a",
+                "--syq-connections",
+                "1",
+                &t.s("src/"),
+                &t.s("dst/"),
+                "--no-progress",
+            ])
+            // Keep the test on the ranged transport path instead of the excluded
+            // same-machine CopyLocal optimization.
+            .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
+            .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .start()
+            .unwrap();
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    while !ready.exists() && std::time::Instant::now() < deadline {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !ready.exists() && std::time::Instant::now() < deadline {
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "syq exited before registering the source root"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
         assert!(
-            child.try_wait().unwrap().is_none(),
-            "syq exited before registering the source root"
+            ready.exists(),
+            "source root was not registered before timeout"
         );
-        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        fs::rename(t.path("src"), t.path("selected-and-moved")).unwrap();
+        std::os::unix::fs::symlink(t.path("outside"), t.path("src")).unwrap();
+
+        let output = child.wait_with_output().unwrap();
+        assert_output_ok(&output);
+        assert_eq!(read(&t.path("dst/small")), b"original");
+        assert_eq!(read(&t.path("dst/large")), original_large);
     }
-    assert!(
-        ready.exists(),
-        "source root was not registered before timeout"
-    );
-
-    fs::rename(t.path("src"), t.path("selected-and-moved")).unwrap();
-    std::os::unix::fs::symlink(t.path("outside"), t.path("src")).unwrap();
-
-    let output = child.wait_with_output().unwrap();
-    assert_output_ok(&output);
-    assert_eq!(read(&t.path("dst/small")), b"original");
-    assert_eq!(read(&t.path("dst/large")), original_large);
 }
 
 #[cfg(all(debug_assertions, target_os = "linux"))]
@@ -1044,9 +1050,23 @@ fn insecure_links_does_not_delegate_unconfined_names_to_copy_local() {
         .run()
         .unwrap();
 
-    assert_output_ok(&output);
+    assert_eq!(output.status.code(), Some(23));
     assert!(!copy_local_ready.exists());
-    assert_eq!(read(&t.path("dst/link/secret")), contents);
+    assert!(!t.path("dst/link/secret").exists());
+}
+
+#[test]
+fn verbose_copy_escapes_peer_filename_control_characters() {
+    let t = Tmp::new();
+    let name = "file\x1b]52;c;ZXZpbA==\x07\nline\r";
+    write(&t.path(&format!("src/{name}")), b"payload");
+    let out = syq(&["-av", &t.s("src/"), &t.s("dst/")]);
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path(&format!("dst/{name}"))), b"payload");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(!stdout.contains('\x1b'));
+    assert!(!stdout.contains('\x07'));
+    assert!(stdout.contains("\\nline\\r"), "{stdout}");
 }
 
 fn run_native_ok(args: &[&str]) -> String {
@@ -9520,9 +9540,7 @@ fn files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs() {
     assert_eq!(listing(&t.path("dst")), ["a", "a/listed"]);
     assert!(!t.path("dst/link/secret").exists());
 
-    // The compatibility escape hatch is explicit and unconfined. It restores
-    // the old followed-ancestor behavior; implied parents are materialized as
-    // real destination directories. `a` is still not recursively walked.
+    // The ownership opt-out keeps descendant traversal confined too.
     let out = syq(&[
         "-a",
         "-r",
@@ -9532,17 +9550,9 @@ fn files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs() {
         &t.s("src"),
         &t.s("dst-insecure"),
     ]);
-    assert!(out.status.success(), "{}", stderr_of(&out));
-    assert_eq!(
-        listing(&t.path("dst-insecure")),
-        ["a", "a/listed", "link", "link/secret"]
-    );
-    assert!(t
-        .path("dst-insecure/link")
-        .symlink_metadata()
-        .unwrap()
-        .is_dir());
-    assert_eq!(read(&t.path("dst-insecure/link/secret")), b"secret");
+    assert_eq!(out.status.code(), Some(23));
+    assert_eq!(listing(&t.path("dst-insecure")), ["a", "a/listed"]);
+    assert!(!t.path("dst-insecure/link/secret").exists());
 
     // An ancestor that resolves to a file, or dangles, is an error.
     std::os::unix::fs::symlink("a/listed", t.path("src/tofile")).unwrap();
@@ -9559,7 +9569,7 @@ fn files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs() {
     assert_eq!(out.status.code(), Some(23));
     let se = stderr_of(&out);
     assert!(
-        se.contains("tofile is not a directory") && se.contains("dangling/y: no such file"),
+        se.contains("tofile is not a directory") && se.contains("dangling is not a directory"),
         "{se}"
     );
     assert_eq!(listing(&t.path("dst2")), Vec::<String>::new());
@@ -9576,7 +9586,7 @@ fn files_from_rejects_symlinked_ancestors_and_recurses_only_listed_dirs() {
         &t.s("dst3"),
     ]);
     assert_eq!(out.status.code(), Some(23));
-    assert!(stderr_of(&out).contains("listed as a non-directory"));
+    assert!(stderr_of(&out).contains("link is not a directory"));
     assert!(t.path("dst3/link").symlink_metadata().unwrap().is_symlink());
     assert!(!t.path("outside/secret2").exists());
 }
@@ -9622,8 +9632,7 @@ fn insecure_links_never_reaches_a_remote_endpoint() {
     assert_eq!(listing(&t.path("dst")), ["a", "a/listed"]);
     assert!(!t.path("dst/link").exists());
 
-    // Local source, remote destination: the local opt-out still applies and
-    // the remote receiver is unaffected by it.
+    // Local source, remote destination: descendant traversal stays refused.
     let remote_dst = format!("fake:{}", t.s("dst-remote"));
     let out = remote_syq(
         &t,
@@ -9639,12 +9648,9 @@ fn insecure_links_never_reaches_a_remote_endpoint() {
             &remote_dst,
         ],
     );
-    assert!(out.status.success(), "{}", stderr_of(&out));
-    assert_eq!(
-        listing(&t.path("dst-remote")),
-        ["a", "a/listed", "link", "link/secret"]
-    );
-    assert_eq!(read(&t.path("dst-remote/link/secret")), b"secret");
+    assert_eq!(out.status.code(), Some(23), "{}", stderr_of(&out));
+    assert_eq!(listing(&t.path("dst-remote")), ["a", "a/listed"]);
+    assert!(!t.path("dst-remote/link/secret").exists());
 }
 
 #[test]

--- a/tests/real-ssh/Dockerfile
+++ b/tests/real-ssh/Dockerfile
@@ -55,4 +55,6 @@ COPY tests/real-ssh/test-forward-copy.py /usr/local/libexec/syq-test-forward-cop
 
 COPY tests/real-ssh/test-return-exec.py /usr/local/libexec/syq-test-return-exec.py
 
+COPY tests/real-ssh/test-root-security.py /usr/local/libexec/syq-test-root-security.py
+
 ENTRYPOINT ["/usr/local/libexec/syq-real-ssh-entrypoint"]

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -136,3 +136,8 @@ programs, sender interruption, receiving shutdown, process-group cleanup, and
 execution after reconnect. The D-Bus fixture also verifies separate command
 notification titles and Allow/Deny behavior. macOS UI rendering is not tested
 by this Linux container suite.
+
+The disposable runner also checks privileged copies before dropping to its
+normal test user: foreign-owned partials are replaced without modifying their
+inodes, requested final ownership still works, and `--insecure-links` permits
+foreign-owned symlinks in typed local paths. No host files are used.

--- a/tests/real-ssh/entrypoint.sh
+++ b/tests/real-ssh/entrypoint.sh
@@ -31,6 +31,7 @@ endpoint() {
 }
 
 runner() {
+    python3 /usr/local/libexec/syq-test-root-security.py
     test -r /run/lab/id_ed25519
     install -d -m 0700 -o syq -g syq /home/syq/.ssh
     install -m 0600 -o syq -g syq /run/lab/id_ed25519 /home/syq/.ssh/id_ed25519

--- a/tests/real-ssh/test-root-security.py
+++ b/tests/real-ssh/test-root-security.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Privileged-copy checks confined to the disposable OpenSSH runner container."""
+import ctypes
 import os
 from pathlib import Path
 import signal
@@ -18,15 +19,30 @@ def stop_group(process):
     except ProcessLookupError:
         pass
     process.wait(timeout=5)
-    try:
-        os.killpg(process.pid, 0)
-    except ProcessLookupError:
-        return
-    raise AssertionError("copy process group survived cancellation")
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        # The test is a subreaper, so helpers orphaned by the killed copier
+        # become our children. Reap them before checking group disappearance.
+        try:
+            while os.waitpid(-process.pid, os.WNOHANG)[0]:
+                pass
+        except ChildProcessError:
+            pass
+        try:
+            os.killpg(process.pid, 0)
+        except ProcessLookupError:
+            return
+        print(f"Waiting for killed copy process group {process.pid} to exit", flush=True)
+        time.sleep(0.1)
+    raise AssertionError(f"copy process group {process.pid} survived cancellation deadline")
 
 
 def main():
     assert os.geteuid() == 0, "run this check as root only inside the disposable lab"
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(36, 1, 0, 0, 0) != 0:  # PR_SET_CHILD_SUBREAPER, Linux lab only
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
     with tempfile.TemporaryDirectory(prefix="syq-root-security-") as temporary:
         root = Path(temporary)
         for interface in ["native", "native-owner", "rsync"]:

--- a/tests/real-ssh/test-root-security.py
+++ b/tests/real-ssh/test-root-security.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Privileged-copy checks confined to the disposable OpenSSH runner container."""
+import os
+from pathlib import Path
+import signal
+import subprocess
+import tempfile
+import time
+
+
+def run(args, **kwargs):
+    return subprocess.run(args, check=True, timeout=30, **kwargs)
+
+
+def stop_group(process):
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.wait(timeout=5)
+    try:
+        os.killpg(process.pid, 0)
+    except ProcessLookupError:
+        return
+    raise AssertionError("copy process group survived cancellation")
+
+
+def main():
+    assert os.geteuid() == 0, "run this check as root only inside the disposable lab"
+    with tempfile.TemporaryDirectory(prefix="syq-root-security-") as temporary:
+        root = Path(temporary)
+        for interface in ["native", "native-owner", "rsync"]:
+            source = root / f"source-{interface}"
+            destination = root / f"destination-{interface}"
+            source.write_bytes(b"payload\0" * (1 << 20))
+            os.chown(source, 1000, 1000)
+            if interface == "rsync":
+                args = ["syq", "rsync", "-a", "--syq-connections", "1", "--bwlimit", "1G", str(source), str(destination)]
+            else:
+                args = ["syq", "cp", "--connections", "1", "--tuning-options", "copy-path=ranges", str(source), "--as", str(destination)]
+                if interface == "native-owner":
+                    args.extend(["--preserve", "ownership,permissions"])
+            args.append("--no-progress")
+            process = subprocess.Popen(args, env={**os.environ, "SYQ_TEST_HOLD_PARTIAL_MS": "10000"}, start_new_session=True)
+            deadline = time.monotonic() + 10
+            partials = []
+            try:
+                while time.monotonic() < deadline:
+                    partials = list(root.glob(".*.syq-part.*"))
+                    if partials:
+                        break
+                    assert process.poll() is None, "copy exited before producing a partial"
+                    print(f"Waiting for {interface} partial: {partials}", flush=True)
+                    time.sleep(0.1)
+                assert len(partials) == 1, f"partial deadline expired: {partials}"
+            finally:
+                stop_group(process)
+            partial = partials[0]
+            partial.write_bytes(b"foreign inode must remain untouched")
+            os.chown(partial, 1000, 1000)
+            partial.chmod(0o666)
+            with partial.open("rb") as held:
+                old = os.fstat(held.fileno())
+                run(args)
+                published = destination.stat()
+                assert (published.st_dev, published.st_ino) != (old.st_dev, old.st_ino)
+                assert published.st_uid == (0 if interface == "native" else 1000)
+                assert destination.read_bytes() == source.read_bytes()
+                assert held.read() == b"foreign inode must remain untouched"
+                after = os.fstat(held.fileno())
+                assert after.st_uid == 1000 and after.st_mode & 0o777 == 0o666
+                assert not partial.exists()
+            print(f"Foreign-owned partial refused; requested ownership preserved: {interface}", flush=True)
+
+        selected = root / "typed-link"
+        destination = root / "typed-link-copy"
+        # The ownership opt-out permits a typed directory symlink while
+        # subsequent source discovery still uses its retained directory.
+        directory = root / "typed-directory"
+        directory.mkdir()
+        (directory / "file").write_bytes(b"selected")
+        selected.symlink_to(directory, target_is_directory=True)
+        os.lchown(selected, 1000, 1000)
+        refused = subprocess.run(["syq", "rsync", "-a", str(selected) + "/", str(destination)], timeout=10)
+        assert refused.returncode != 0
+        run(["syq", "rsync", "-a", "--insecure-links", str(selected) + "/", str(destination)])
+        assert (destination / "file").read_bytes() == b"selected"
+    print("Privileged copy security checks passed", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Remote sources could return entries excluded by the coordinator, and `rsync --insecure-links` disabled confinement of discovered source paths. Reject excluded scan entries (including descendants of excluded ancestors) before planning, and keep scans and reads anchored to registered descriptors while preserving the flag's typed-path ownership opt-out.

Also escape control characters in human filenames and diagnostics, refuse adoption or permission repair of foreign-owned partial inodes, and bound framed decoding. Both endpoints enforce the 1 MiB Hello limit before reading/decompressing its body; client readers enable ordinary frames only after accepting a matching HelloOk. Metadata frames are limited to 8 MiB, data/hash frames to 65 MiB, and zstd windows to 8 MiB. TCP's absolute Hello deadline starts at socket acceptance.

The shared 512 MiB allowance now covers decoded collection storage and queued collections. Flat bytes, strings, and compression workspace are bounded by frame sizes and per-connection queue depth instead of competing for that allowance. Their aggregate memory use scales with connection count, request size, and pipeline depth. This prevents ordinary bulk traffic from exhausting a fixed process-wide data allowance while retaining protection against collections whose decoded storage can greatly exceed their encoded frame. It is not a total RSS or signed disk-usage limit.

Stacked on #267 (`f9704b7`); current head `8656e53`. No merge requested.

Compatibility baseline: v0.4.1 (`13fc7d1`). Wire fields, signed authority/replay state, enrollment, receipts, resume identities, stored preferences, CLI/SDK spellings, and machine output remain unchanged. Released TCP and completion fixtures decode/re-encode identically. Existing exact-build checks reject mixed live helpers. Deliberate behavior changes are rejection of oversized frames and excluded source entries, replacement of foreign-owned partials, and confinement of descendants under `--insecure-links`. Same-owner resume and requested final ownership remain supported.

Validation:

- Formatting and all-target/all-feature Clippy passed. All-target tests at `91b09ac`: 947 passed, one existing opt-in ignored (four test threads). The Rust tree is identical at `8656e53`; its additional commit only fixes the Python SSH harness's cancellation wait/reaping. Tests include pre-body and compressed Hello limits, rejection of post-Hello data after a wrong build, valid large post-Hello frames, and independent bulk/collection accounting.
- Reproduced the `4b6e794` regression using a 4 GiB compressed TCP pull, 64 workers, 32 MiB requests, pipeline depth 4: repeated budget-related worker drops and exit 1. The repaired Rust tree completes the same workload with verified contents and no worker drops. A 512 MiB/16-worker baseline also passed.
- Documentation links: 20 files, no problems.
- Complete default three-container OpenSSH suite passed at `8656e53`. An earlier attempt at `91b09ac` exposed the root-test harness checking process-group disappearance immediately after SIGKILL; the final harness adopts/reaps killed descendants and waits with a bounded deadline. It passed the complete rerun.
- macOS and cross-platform suites were not run locally.

Branch status before review handoff:

```text
Worktree: /home/grant/repos/syq/.worktrees/security-review-fixes
Branch:   security-review-fixes at 8656e53 (clean)
Upstream: origin/security-review-fixes (ahead 0, behind 0)
Master:   f4fbd3f from refs/heads/master (branch is ahead 4, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      f4fbd3f  https://github.com/greaber/syq/actions/runs/34053852757
  rsync-compat.yml success      f4fbd3f  https://github.com/greaber/syq/actions/runs/34053852728
  macos.yml        success      f4fbd3f  https://github.com/greaber/syq/actions/runs/34053852735

Pull request: #269 https://github.com/greaber/syq/pull/269
  base tcp-auth-hardening, open, review none, merge state clean
  GitHub head 8656e53: matches local 8656e53
  checks: none registered yet
```
