### PR TITLE
Validate peer replies and bound TCP discovery resources

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -95,8 +95,10 @@ total process memory or disk usage.
 The coordinator rejects stat, apply, and partial-path replies whose entry
 counts differ from their requests. It also checks each source data block's
 offset and length against the outstanding read before forwarding it to the
-destination. These checks expose malformed replies; they cannot establish
-that a source's file listing or contents are truthful.
+destination. An offset or length mismatch fails the copy and closes that
+worker's connections without reusing them for another file. These checks expose
+malformed replies; they cannot establish that a source's file listing or contents
+are truthful.
 
 For a default direct remote-to-remote copy, the source gets permission for one
 transfer, not your SSH agent or a reusable destination credential. The

--- a/docs/security.md
+++ b/docs/security.md
@@ -64,6 +64,12 @@ reads still use its directory handles and refuse descendant symlink traversal.
 TCP workers authenticate with a token delivered through the control connection.
 Their ten-second Hello deadline remains active across partial reads, including
 when encryption is off. After Hello succeeds, it does not limit copy duration.
+There is no general coordinator I/O deadline: a stalled peer can leave a copy
+waiting until you cancel it.
+
+TCP discovery accepts at most 64 advertised addresses plus the SSH target,
+and at most 128 resolved socket addresses in total. Excessive replies fail
+TCP setup visibly; ordinary copies can still fall back to SSH data.
 
 Encrypted TCP rejects reused connection IDs and IDs outside its 24-bit nonce
 space. If a copying process exhausts those IDs, it reports an error; restart the
@@ -85,6 +91,12 @@ those settings to use less memory. The collection allowance is not a limit on
 total process memory or disk usage.
 
 ## A compromised source server
+
+The coordinator rejects stat, apply, and partial-path replies whose entry
+counts differ from their requests. It also checks each source data block's
+offset and length against the outstanding read before forwarding it to the
+destination. These checks expose malformed replies; they cannot establish
+that a source's file listing or contents are truthful.
 
 For a default direct remote-to-remote copy, the source gets permission for one
 transfer, not your SSH agent or a reusable destination credential. The

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -19,8 +19,29 @@ pub trait Conn: Send {
     fn send(&mut self, req: Request) -> Result<()>;
     fn recv(&mut self) -> Result<Response>;
     fn call(&mut self, req: Request) -> Result<Response> {
+        let expected = match &req {
+            Request::StatMany { paths, .. } => Some(("stat", paths.len())),
+            Request::Apply { ops, .. } => Some(("apply", ops.len())),
+            Request::PartialPaths { paths, .. } => Some(("partial paths", paths.len())),
+            _ => None,
+        };
         self.send(req)?;
-        self.recv()
+        let response = self.recv()?;
+        if let Some((operation, expected)) = expected {
+            let actual = match &response {
+                Response::Stats(values) => Some(values.len()),
+                Response::Applied(values) => Some(values.len()),
+                Response::PathResults(values) => Some(values.len()),
+                _ => None,
+            };
+            if actual.is_some_and(|actual| actual != expected) {
+                bail!(
+                    "{operation} reply count {} does not match request count {expected}",
+                    actual.unwrap()
+                );
+            }
+        }
+        Ok(response)
     }
     /// True once the transport has failed (remote process gone).
     fn is_dead(&self) -> bool {
@@ -1049,7 +1070,7 @@ pub(crate) struct PendingTcpSetup {
     token: Vec<u8>,
     congestion_control: Option<String>,
     remote_congestion_control: Option<String>,
-    probe: std::thread::JoinHandle<Vec<TcpCandidate>>,
+    probe: std::thread::JoinHandle<Result<Vec<TcpCandidate>>>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -1847,6 +1868,11 @@ impl RemoteSpec {
                 other => bail!("unexpected response {other:?}"),
             },
         };
+        if advertised.len() > MAX_ADVERTISED_TCP_ADDRESSES {
+            bail!(
+                "TCP listener advertised too many addresses (limit {MAX_ADVERTISED_TCP_ADDRESSES})"
+            );
+        }
         let mut candidates: Vec<TcpCandidate> = advertised
             .into_iter()
             .map(|(address, speed_mbps)| TcpCandidate {
@@ -1885,8 +1911,8 @@ impl RemoteSpec {
         // coordinator do destination preflight and plan payloads while every
         // candidate receives its complete bounded probe window.
         let probe = std::thread::spawn(move || {
-            probe_reachable(&mut candidates, port);
-            candidates
+            probe_reachable(&mut candidates, port)?;
+            Ok(candidates)
         });
         Ok(PendingTcpSetup {
             port,
@@ -1909,7 +1935,7 @@ impl RemoteSpec {
         } = pending;
         let mut candidates = probe
             .join()
-            .map_err(|_| anyhow!("TCP route probe thread panicked"))?;
+            .map_err(|_| anyhow!("TCP route probe thread panicked"))??;
         // Multipath only across comparable-speed NICs: keep those within 2x of
         // the fastest reachable one. Mixing a fast and a slow path (a rail and
         // Tailscale, say) would drag the transfer down, so we don't.
@@ -2101,7 +2127,14 @@ fn helper_needs_install(e: &anyhow::Error) -> bool {
 
 /// Concurrently probe which (addr, speed) entries accept a TCP connection on
 /// `port`, preserving the server's priority order. Used once per endpoint.
-fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
+const MAX_ADVERTISED_TCP_ADDRESSES: usize = 64;
+const MAX_RESOLVED_TCP_ADDRESSES: usize = 128;
+
+fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) -> Result<()> {
+    // One extra candidate is the coordinator's SSH target.
+    if candidates.len() > MAX_ADVERTISED_TCP_ADDRESSES + 1 {
+        bail!("too many TCP probe candidates");
+    }
     // Resolve candidate names in parallel. More importantly, probe every
     // resolved socket address in parallel too: a dual-stack name must not
     // spend the whole candidate budget timing out on IPv6 before trying IPv4.
@@ -2109,13 +2142,15 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
     for (i, candidate) in candidates.iter().enumerate() {
         let tx = resolved_tx.clone();
         let address = candidate.address.clone();
-        std::thread::spawn(move || {
-            let addrs = (address.as_str(), port)
-                .to_socket_addrs()
-                .map(|addresses| addresses.collect())
-                .unwrap_or_default();
-            let _ = tx.send((i, addrs));
-        });
+        std::thread::Builder::new()
+            .spawn(move || {
+                let addrs = (address.as_str(), port)
+                    .to_socket_addrs()
+                    .map(|addresses| addresses.take(MAX_RESOLVED_TCP_ADDRESSES + 1).collect())
+                    .unwrap_or_default();
+                let _ = tx.send((i, addrs));
+            })
+            .context("start TCP address resolver")?;
     }
     drop(resolved_tx);
     let mut resolved: Vec<Vec<SocketAddr>> = vec![Vec::new(); candidates.len()];
@@ -2124,6 +2159,9 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
             break;
         };
         resolved[i] = addrs;
+        if resolved.iter().map(Vec::len).sum::<usize>() > MAX_RESOLVED_TCP_ADDRESSES {
+            bail!("TCP candidates resolved to too many addresses (limit {MAX_RESOLVED_TCP_ADDRESSES})");
+        }
     }
 
     // Probe each distinct socket address once. An advertised literal and the
@@ -2154,9 +2192,11 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
     for (t, (addr, _)) in targets.iter().enumerate() {
         let tx = tx.clone();
         let addr = *addr;
-        std::thread::spawn(move || {
-            let _ = tx.send((t, TcpStream::connect_timeout(&addr, timeout).is_ok()));
-        });
+        std::thread::Builder::new()
+            .spawn(move || {
+                let _ = tx.send((t, TcpStream::connect_timeout(&addr, timeout).is_ok()));
+            })
+            .context("start TCP address probe")?;
     }
     drop(tx);
 
@@ -2183,6 +2223,7 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) {
             }
         }
     }
+    Ok(())
 }
 
 static TCP_CONN_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(1);
@@ -3010,6 +3051,85 @@ mod tests {
             drop(rx);
             thread.join().unwrap();
         }
+    }
+
+    #[test]
+    fn remote_vector_replies_must_match_request_counts() {
+        for count in [0, 1, 2] {
+            let cases = [
+                (
+                    Request::StatMany {
+                        paths: vec![b"file".to_vec()],
+                        sources: None,
+                        follow: false,
+                        guard: None,
+                    },
+                    Response::Stats(vec![None; count]),
+                ),
+                (
+                    Request::Apply {
+                        ops: vec![Op::Unlink {
+                            path: b"file".to_vec(),
+                        }],
+                        guard: None,
+                    },
+                    Response::Applied(vec![None; count]),
+                ),
+                (
+                    Request::PartialPaths {
+                        paths: vec![b"file".to_vec()],
+                        copy_id: [0; 16],
+                        guard: None,
+                    },
+                    Response::PathResults(vec![Ok(b"partial".to_vec()); count]),
+                ),
+            ];
+            for (request, response) in cases {
+                let mut bytes = Vec::new();
+                let mut writer = FrameWriter::new(&mut bytes, false);
+                writer.write_msg(&hello_ok()).unwrap();
+                writer.write_msg(&response).unwrap();
+                drop(writer);
+                let (rx, reader) = spawn_reader(Box::new(std::io::Cursor::new(bytes)), 4);
+                let mut conn = RemoteConn {
+                    child: None,
+                    w: FrameWriter::new(Box::new(std::io::sink()), false),
+                    rx: Some(rx),
+                    reader: Some(reader),
+                    label: "hostile vector reply".into(),
+                    dead: false,
+                    peer: None,
+                    tcp_socket: None,
+                    named_socket: None,
+                    multiplexed_ssh: false,
+                    detached: false,
+                };
+                conn = receive_hello(conn, false).unwrap();
+                let result = conn.call(request);
+                if count == 1 {
+                    assert!(result.is_ok());
+                } else {
+                    assert!(result.unwrap_err().to_string().contains("reply count"));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn excessive_probe_candidates_fail_before_resolution() {
+        let mut candidates: Vec<_> = (0..MAX_ADVERTISED_TCP_ADDRESSES + 2)
+            .map(|_| TcpCandidate {
+                address: "must-not-resolve.invalid".into(),
+                speed_mbps: 0,
+                source: DataAddressSource::RemoteInterface,
+                reachable: false,
+                selected: false,
+            })
+            .collect();
+        assert!(probe_reachable(&mut candidates, 1)
+            .unwrap_err()
+            .to_string()
+            .contains("too many"));
     }
 
     struct ExitObserved<R> {
@@ -4131,7 +4251,7 @@ mod tests {
             candidate("localhost"),
             candidate("127.0.0.1"),
         ];
-        probe_reachable(&mut candidates, port);
+        probe_reachable(&mut candidates, port).unwrap();
         assert!(candidates[0].reachable);
         assert!(candidates[2].reachable);
         assert_eq!(candidates[1].reachable, via_localhost);

--- a/src/enrollment.rs
+++ b/src/enrollment.rs
@@ -404,7 +404,9 @@ impl SshEndpoint {
             words.extend(["-p".to_owned(), port.to_string()]);
         }
         words.extend(["--".to_owned(), self.target.clone()]);
-        shell_words::join(words)
+        // OpenSSH expands percent tokens even inside shell quotes. Escape
+        // literal endpoint bytes before inserting them in ProxyCommand.
+        shell_words::join(words).replace('%', "%%")
     }
 }
 
@@ -678,6 +680,16 @@ mod tests {
                 .as_str(),
             "backup_user@host-b.example"
         );
+    }
+
+    #[test]
+    fn native_proxy_target_preserves_literal_percent_tokens() {
+        let endpoint = SshEndpoint::from_parts("user%h", "fe80::1%eth0", Some(2222)).unwrap();
+        assert_eq!(
+            endpoint.proxy_target(),
+            "-p 2222 -- 'user%%h@fe80::1%%eth0'"
+        );
+        assert_eq!(endpoint.as_str(), "user%h@fe80::1%eth0");
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -2013,11 +2013,14 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                     if let Some(benchmark) = &opts.benchmark {
                         benchmark.lock().unwrap().add(worker.benchmark);
                     }
-                    if collect_tcp_stats {
+                    let invalid_range = result
+                        .as_ref()
+                        .is_err_and(|error| error.is::<RangeReplyMismatch>());
+                    if collect_tcp_stats && !invalid_range {
                         let stats = worker.collect_transport_stats();
                         transport_stats.lock().unwrap().extend(stats);
                     }
-                    let dropped = result.is_err() && worker.transport_dead();
+                    let dropped = result.is_err() && !invalid_range && worker.transport_dead();
                     match result {
                         Ok(()) => {
                             gate.mark_absent(id);
@@ -3560,9 +3563,22 @@ fn stat_many(
     stat_many_registered(conn, paths, None, follow)
 }
 
+#[derive(Debug)]
+struct RangeReplyMismatch;
+
+impl std::fmt::Display for RangeReplyMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("source range reply violates the protocol")
+    }
+}
+
+impl std::error::Error for RangeReplyMismatch {}
+
 fn validate_range_reply(expected_off: u64, expected_len: u64, off: u64, len: usize) -> Result<()> {
     if off != expected_off || len as u64 != expected_len || off.checked_add(len as u64).is_none() {
-        bail!("source block range ({off}, {len}) does not match requested range ({expected_off}, {expected_len})");
+        return Err(anyhow::Error::new(RangeReplyMismatch).context(format!(
+            "source block range ({off}, {len}) does not match requested range ({expected_off}, {expected_len})"
+        )));
     }
     Ok(())
 }
@@ -7318,7 +7334,9 @@ impl Worker {
 
     fn run(&mut self) -> Result<()> {
         let r = self.run_inner();
-        if r.is_err() && !self.transport_dead() {
+        if r.as_ref()
+            .is_err_and(|error| error.is::<RangeReplyMismatch>() || !self.transport_dead())
+        {
             // Fatal local/protocol failures cannot be healed by reopening a
             // transport. Wake peers so the whole transfer unwinds.
             self.sched.abort();
@@ -7743,7 +7761,10 @@ impl Worker {
     }
 
     fn file_error(&mut self, idx: usize, e: anyhow::Error) -> Result<()> {
-        if self.src.is_dead() || self.dst.is_dead() {
+        // Range validation can leave pipelined source replies and destination
+        // acknowledgments unread. End this worker and abort the copy; neither
+        // connection may serve another job or enter transport recovery.
+        if e.is::<RangeReplyMismatch>() || self.transport_dead() {
             return Err(e);
         }
         if !self.sched.is_failed(idx) {
@@ -8538,6 +8559,200 @@ mod tests {
             assert!(validate_range_reply(4096, 1024, off, len).is_err());
         }
         assert!(validate_range_reply(u64::MAX, 1, u64::MAX, 1).is_err());
+    }
+
+    #[derive(Default)]
+    struct PipelineState {
+        requests: Vec<Request>,
+        replies: std::collections::VecDeque<Response>,
+        received: usize,
+    }
+
+    struct PipelineConn(Arc<Mutex<PipelineState>>);
+
+    impl Conn for PipelineConn {
+        fn send(&mut self, request: Request) -> Result<()> {
+            self.0.lock().unwrap().requests.push(request);
+            Ok(())
+        }
+        fn recv(&mut self) -> Result<Response> {
+            let mut state = self.0.lock().unwrap();
+            state.received += 1;
+            Ok(state.replies.pop_front().expect("unexpected receive"))
+        }
+        fn scan(
+            &mut self,
+            _: &[u8],
+            _: Option<&RegisteredPath>,
+            _: bool,
+            _: &[String],
+            _: bool,
+            _: &mut dyn FnMut(Vec<Entry>) -> Result<()>,
+            _: &mut dyn FnMut(Vec<PathBytes>) -> Result<()>,
+            _: &mut dyn FnMut(String),
+        ) -> Result<()> {
+            unreachable!()
+        }
+        fn native_remove(
+            &mut self,
+            _: Option<&[u8]>,
+            _: Option<&[u8]>,
+            _: &[NativeRemoveSelection],
+            _: bool,
+            _: bool,
+            _: usize,
+            _: &mut dyn FnMut(Vec<String>) -> Result<()>,
+            _: &mut dyn FnMut(Vec<NativeRemoveOutcome>) -> Result<()>,
+        ) -> Result<()> {
+            unreachable!()
+        }
+    }
+
+    #[test]
+    fn range_mismatch_aborts_worker_with_both_pipelines_outstanding() {
+        // Exercise both callers of transfer_range: initial file work and a
+        // queued range. Another file is ready when the malicious reply arrives.
+        for queued_range in [false, true] {
+            for wrong_length in [false, true] {
+                let directory = tempfile::tempdir().unwrap();
+                let path = directory.path().join("source");
+                std::fs::write(&path, vec![0; 4096]).unwrap();
+                let entry = crate::fsops::lstat_entry(Vec::new(), &path).unwrap();
+                let sched = Arc::new(Sched::new(512, 8192));
+                let job = FileJob {
+                    src: b"first".to_vec(),
+                    source: RegisteredPath {
+                        root: serde_json::from_str("0").unwrap(),
+                        relative: b"first".to_vec(),
+                    },
+                    dst: b"first-dst".to_vec(),
+                    rel: "first".into(),
+                    entry,
+                    dst_entry: None,
+                    target_condition: TargetCondition::Any,
+                    container_guard: None,
+                    attempt: 0,
+                    done: Arc::new(AtomicU64::new(0)),
+                    inplace: false,
+                    rel_bytes: b"first".to_vec(),
+                    src_rel: None,
+                };
+                sched.push_file(job.clone());
+                let mut next = job;
+                next.src = b"second".to_vec();
+                next.dst = b"second-dst".to_vec();
+                sched.push_file(next);
+                sched.scan_done();
+                if queued_range {
+                    assert!(matches!(sched.next(), Item::File(0)));
+                    let range = sched.ranges_ready(0, vec![(0, 4096)]).unwrap();
+                    sched.retry_range(&range, 0);
+                }
+                let src = Arc::new(Mutex::new(PipelineState::default()));
+                for i in 0..5 {
+                    let data = vec![0; if i == 1 && wrong_length { 511 } else { 512 }];
+                    src.lock().unwrap().replies.push_back(Response::Block {
+                        off: if i == 1 && !wrong_length {
+                            999
+                        } else {
+                            i * 512
+                        },
+                        hash: content_digest(&data),
+                        data,
+                    });
+                }
+                let dst = Arc::new(Mutex::new(PipelineState::default()));
+                if !queued_range {
+                    dst.lock()
+                        .unwrap()
+                        .replies
+                        .push_back(Response::PartialSize(None));
+                }
+                dst.lock().unwrap().replies.push_back(Response::Ok);
+                let opts = Arc::new(Opts {
+                    block: 512,
+                    tuning: crate::transfer_tuning::TransferTuning {
+                        copy_path: Some(crate::transfer_tuning::CopyPath::Ranges),
+                        pipeline_depth: Some(4),
+                        ..Default::default()
+                    },
+                    benchmark: None,
+                    flags: 0,
+                    recursive: true,
+                    links: false,
+                    perms: false,
+                    devices: false,
+                    checksum: false,
+                    verify_only: false,
+                    inplace: false,
+                    same_host: false,
+                    allow_sequential_nfs_fallback: false,
+                    dst_remote: true,
+                    restricted_receiver: false,
+                    dry_run: false,
+                    quiet: true,
+                    verbose: 0,
+                    umask: 0,
+                    copy_id: std::sync::OnceLock::from([0; 16]),
+                    ignore: Vec::new(),
+                    delete: false,
+                    delete_excluded: false,
+                    max_delete: None,
+                    update: false,
+                    ignore_existing: false,
+                    existing: false,
+                    insecure_links: false,
+                    operator_symlink_policy: OperatorSymlinkPolicy::Refuse,
+                    max_size: None,
+                    min_size: None,
+                });
+                let mut worker = Worker {
+                    id: 0,
+                    src: Box::new(PipelineConn(src.clone())),
+                    dst: Box::new(PipelineConn(dst.clone())),
+                    sched: sched.clone(),
+                    progress: Progress::new(false, false, None, false),
+                    opts,
+                    bwlimit: None,
+                    gate: Gate::new(1),
+                    t: [0.0; 4],
+                    fast: FastTiming::default(),
+                    benchmark: Default::default(),
+                    fast_batch_files: 1,
+                };
+                let error = worker.run().unwrap_err();
+                assert!(error.is::<RangeReplyMismatch>(), "{error:#}");
+                assert!(sched.is_aborted());
+                assert!(
+                    !worker.transport_dead(),
+                    "protocol failure, not a lost socket"
+                );
+                let source = src.lock().unwrap();
+                assert_eq!(source.received, 2);
+                assert_eq!(source.replies.len(), 3);
+                assert_eq!(source.requests.len(), 5);
+                assert!(source.requests.iter().all(|request| matches!(
+                    request, Request::ReadRange { path, .. } if path == b"first"
+                )));
+                let destination = dst.lock().unwrap();
+                assert_eq!(destination.received, usize::from(!queued_range));
+                assert_eq!(
+                    destination.replies.len(),
+                    1,
+                    "write ack remains outstanding"
+                );
+                let writes: Vec<_> = destination
+                    .requests
+                    .iter()
+                    .filter(|request| matches!(request, Request::WriteRange { .. }))
+                    .collect();
+                assert_eq!(writes.len(), 1);
+                assert!(
+                    matches!(writes[0], Request::WriteRange { off: 0, path, .. } if path == b"first-dst")
+                );
+                assert_eq!(destination.requests.len(), 1 + usize::from(!queued_range));
+            }
+        }
     }
 
     /// Enforce send-before-receive ordering while exercising the real local

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -3560,6 +3560,13 @@ fn stat_many(
     stat_many_registered(conn, paths, None, follow)
 }
 
+fn validate_range_reply(expected_off: u64, expected_len: u64, off: u64, len: usize) -> Result<()> {
+    if off != expected_off || len as u64 != expected_len || off.checked_add(len as u64).is_none() {
+        bail!("source block range ({off}, {len}) does not match requested range ({expected_off}, {expected_len})");
+    }
+    Ok(())
+}
+
 fn stat_many_registered(
     conn: &mut dyn Conn,
     paths: Vec<PathBytes>,
@@ -8193,7 +8200,7 @@ impl Worker {
             1
         };
         let inplace = job.inplace;
-        let mut reads_out = 0usize;
+        let mut pending_reads = std::collections::VecDeque::new();
         let mut writes_out = 0usize;
         loop {
             if !self.gate.allowed(self.id) {
@@ -8201,7 +8208,7 @@ impl Worker {
                 // worker picks it up; what's already requested still completes.
                 self.sched.release_rest(h);
             }
-            while reads_out < read_window {
+            while pending_reads.len() < read_window {
                 let (off, n) = {
                     let mut g = h.lock().unwrap();
                     if g.pos >= g.end {
@@ -8222,9 +8229,9 @@ impl Worker {
                 })?;
                 self.benchmark.range_requests += 1;
                 self.benchmark.max_request_bytes = self.benchmark.max_request_bytes.max(n);
-                reads_out += 1;
+                pending_reads.push_back((off, n));
             }
-            if reads_out == 0 {
+            if pending_reads.is_empty() {
                 break;
             }
             let t0 = std::time::Instant::now();
@@ -8233,7 +8240,8 @@ impl Worker {
                 other => bail!("unexpected response {other:?}"),
             };
             self.t[0] += t0.elapsed().as_secs_f64();
-            reads_out -= 1;
+            let (expected_off, expected_len) = pending_reads.pop_front().expect("pending read");
+            validate_range_reply(expected_off, expected_len, off, data.len())?;
             let n = data.len() as u64;
             let t0 = std::time::Instant::now();
             self.dst.send(Request::WriteRange {
@@ -8515,6 +8523,22 @@ impl Worker {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn source_block_must_match_the_requested_range() {
+        assert!(validate_range_reply(4096, 1024, 4096, 1024).is_ok());
+        for (off, len) in [
+            (0, 1024),
+            (8192, 1024),
+            (4096, 0),
+            (4096, 1023),
+            (4096, 1025),
+            (u64::MAX, 1024),
+        ] {
+            assert!(validate_range_reply(4096, 1024, off, len).is_err());
+        }
+        assert!(validate_range_reply(u64::MAX, 1, u64::MAX, 1).is_err());
+    }
 
     /// Enforce send-before-receive ordering while exercising the real local
     /// receiver. Inject response failures to check that every reply is drained.

--- a/src/tune.rs
+++ b/src/tune.rs
@@ -190,12 +190,20 @@ fn cache_path() -> Option<PathBuf> {
 
 fn lock_file(path: &Path, exclusive: bool) -> std::io::Result<std::fs::File> {
     let lock_path = path.with_extension("json.lock");
+    use std::os::unix::fs::OpenOptionsExt;
     let lock = std::fs::OpenOptions::new()
         .create(true)
         .truncate(false)
         .read(true)
         .write(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK)
+        .mode(0o600)
         .open(lock_path)?;
+    if !lock.metadata()?.is_file() {
+        return Err(std::io::Error::other(
+            "tuning cache lock is not a regular file",
+        ));
+    }
     let operation = if exclusive {
         libc::LOCK_EX
     } else {
@@ -1096,6 +1104,23 @@ pub fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_lock_refuses_symlinks_and_non_regular_files() {
+        let dir = crate::test_support::tempdir().unwrap();
+        let cache = dir.path().join("tuning.json");
+        let lock = cache.with_extension("json.lock");
+        let victim = dir.path().join("victim");
+        std::fs::write(&victim, b"untouched").unwrap();
+        std::os::unix::fs::symlink(&victim, &lock).unwrap();
+        assert!(lock_file(&cache, true).is_err());
+        assert_eq!(std::fs::read(&victim).unwrap(), b"untouched");
+        std::fs::remove_file(&lock).unwrap();
+        std::fs::create_dir(&lock).unwrap();
+        assert!(lock_file(&cache, false).is_err());
+        std::fs::remove_dir(&lock).unwrap();
+        assert!(lock_file(&cache, true).is_ok());
+    }
 
     #[test]
     fn local_start_reduces_only_for_one_or_two_cpus() {

--- a/src/update.rs
+++ b/src/update.rs
@@ -15,7 +15,7 @@ use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufReader, BufWriter, IsTerminal, Read, Write};
+use std::io::{BufReader, BufWriter, IsTerminal, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
@@ -271,7 +271,7 @@ pub(crate) fn verified_current_helper(helper: &TrustedCurrentHelper) -> Result<V
         helper.tag,
         helper.archive.name
     );
-    fetch(&url, archive.path(), FetchMode::Interactive)?;
+    fetch(&url, &archive, FetchMode::Interactive)?;
     verify_file_as(
         archive.path(),
         &helper.archive,
@@ -280,11 +280,7 @@ pub(crate) fn verified_current_helper(helper: &TrustedCurrentHelper) -> Result<V
 
     let input = File::open(archive.path()).context("open downloaded remote helper archive")?;
     let decoder = GzDecoder::new(BufReader::new(input));
-    let output = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .open(binary.path())
-        .context("open temporary remote helper")?;
+    let output = binary.writer()?;
     let mut output = BufWriter::new(output);
     std::io::copy(&mut decoder.take(helper.binary.size + 1), &mut output)
         .context("decompress the remote helper")?;
@@ -295,7 +291,7 @@ pub(crate) fn verified_current_helper(helper: &TrustedCurrentHelper) -> Result<V
         .context("sync the remote helper")?;
     drop(output);
     verify_file_as(binary.path(), &helper.binary, "downloaded remote helper")?;
-    set_executable(binary.path())?;
+    let binary = binary.seal_executable()?;
     fs::rename(binary.path(), &cache_path)
         .with_context(|| format!("cache verified remote helper at {}", cache_path.display()))?;
     sync_parent(parent)?;
@@ -316,11 +312,7 @@ fn fetch_verified(base_url: &str, mode: FetchMode) -> Result<VerifiedRelease> {
     let temp_dir = config_dir()?;
     create_private_dir(&temp_dir)?;
     let manifest_temp = TempFile::new(&temp_dir, ".json")?;
-    fetch(
-        &format!("{base_url}/{MANIFEST_NAME}"),
-        manifest_temp.path(),
-        mode,
-    )?;
+    fetch(&format!("{base_url}/{MANIFEST_NAME}"), &manifest_temp, mode)?;
     let manifest_bytes = fs::read(manifest_temp.path()).context("read release manifest")?;
     let manifest = verified_manifest(&manifest_bytes, key.as_ref())?;
     let version = validate_manifest(&manifest)?;
@@ -461,7 +453,7 @@ fn install_release(release: &VerifiedRelease, receipt: &mut InstallReceipt) -> R
         .parent()
         .ok_or_else(|| anyhow!("the syq executable has no parent directory"))?;
     let binary = download_artifact(release, artifact, parent)?;
-    set_executable(binary.path())?;
+    let binary = binary.seal_executable()?;
     verify_executable(binary.path(), release)?;
 
     fs::rename(binary.path(), &executable).with_context(|| {
@@ -529,7 +521,7 @@ fn download_artifact(
         release.manifest.tag,
         artifact.archive.name
     );
-    fetch(&url, archive.path(), FetchMode::Interactive)?;
+    fetch(&url, &archive, FetchMode::Interactive)?;
     verify_file_as(
         archive.path(),
         &artifact.archive,
@@ -538,11 +530,7 @@ fn download_artifact(
 
     let input = File::open(archive.path()).context("open downloaded release archive")?;
     let decoder = GzDecoder::new(BufReader::new(input));
-    let output = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .open(binary.path())
-        .context("open temporary release executable")?;
+    let output = binary.writer()?;
     let mut output = BufWriter::new(output);
     std::io::copy(&mut decoder.take(artifact.binary.size + 1), &mut output)
         .context("decompress the syq release executable")?;
@@ -618,7 +606,7 @@ fn verify_executable(path: &Path, release: &VerifiedRelease) -> Result<()> {
     Ok(())
 }
 
-fn fetch(url: &str, destination: &Path, mode: FetchMode) -> Result<()> {
+fn fetch(url: &str, destination: &TempFile, mode: FetchMode) -> Result<()> {
     #[cfg(debug_assertions)]
     if let Some(root) = std::env::var_os("SYQ_TEST_FIXTURES").filter(|value| !value.is_empty()) {
         let name = url
@@ -626,8 +614,11 @@ fn fetch(url: &str, destination: &Path, mode: FetchMode) -> Result<()> {
             .next()
             .filter(|name| !name.is_empty() && !matches!(*name, "." | ".."))
             .ok_or_else(|| anyhow!("test release URL has no fixture name"))?;
-        fs::copy(PathBuf::from(root).join(name), destination)
-            .with_context(|| format!("copy test release fixture {name}"))?;
+        std::io::copy(
+            &mut File::open(PathBuf::from(root).join(name))?,
+            &mut destination.writer()?,
+        )
+        .with_context(|| format!("copy test release fixture {name}"))?;
         return Ok(());
     }
 
@@ -650,16 +641,13 @@ fn fetch(url: &str, destination: &Path, mode: FetchMode) -> Result<()> {
                 .get(url)
                 .call()
                 .with_context(|| format!("request {url}"))?;
-            let file = OpenOptions::new()
-                .write(true)
-                .truncate(true)
-                .open(destination)
-                .with_context(|| format!("open {} for download", destination.display()))?;
+            let file = destination.writer()?;
             let mut file = BufWriter::new(file);
             std::io::copy(&mut response.body_mut().as_reader(), &mut file)
                 .with_context(|| format!("download {url}"))?;
-            file.flush()
-                .with_context(|| format!("flush downloaded file {}", destination.display()))?;
+            file.flush().with_context(|| {
+                format!("flush downloaded file {}", destination.path().display())
+            })?;
             Ok(())
         })();
         match result {
@@ -709,17 +697,13 @@ fn write_receipt(path: &Path, receipt: &InstallReceipt) -> Result<()> {
         .ok_or_else(|| anyhow!("install receipt has no parent directory"))?;
     create_private_dir(parent)?;
     let temporary = TempFile::new(parent, ".receipt")?;
-    let file = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .open(temporary.path())
-        .context("open temporary install receipt")?;
+    let file = temporary.writer()?;
     let mut file = BufWriter::new(file);
     serde_json::to_writer_pretty(&mut file, receipt).context("serialize install receipt")?;
     file.write_all(b"\n").context("write install receipt")?;
     file.flush().context("flush install receipt")?;
     file.get_ref().sync_all().context("sync install receipt")?;
-    set_private_file(temporary.path())?;
+    temporary.check_path()?;
     fs::rename(temporary.path(), path).context("replace install receipt")?;
     sync_parent(parent)
 }
@@ -814,16 +798,6 @@ fn set_private_file(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn set_executable(path: &Path) -> Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o755))
-            .with_context(|| format!("make {} executable", path.display()))?;
-    }
-    Ok(())
-}
-
 fn sync_parent(parent: &Path) -> Result<()> {
     File::open(parent)
         .and_then(|directory| directory.sync_all())
@@ -832,6 +806,7 @@ fn sync_parent(parent: &Path) -> Result<()> {
 
 struct TempFile {
     path: PathBuf,
+    file: File,
 }
 
 impl TempFile {
@@ -842,11 +817,15 @@ impl TempFile {
                 .map_err(|e| anyhow!("generate a temporary file name: {e}"))?;
             let token: String = random.iter().map(|byte| format!("{byte:02x}")).collect();
             let path = parent.join(format!(".syq-{}-{token}{suffix}", std::process::id()));
-            match OpenOptions::new().write(true).create_new(true).open(&path) {
-                Ok(_) => {
-                    set_private_file(&path)?;
-                    return Ok(Self { path });
-                }
+            use std::os::unix::fs::OpenOptionsExt;
+            match OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&path)
+            {
+                Ok(file) => return Ok(Self { path, file }),
                 Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
                 Err(e) => {
                     return Err(e)
@@ -863,11 +842,51 @@ impl TempFile {
     fn path(&self) -> &Path {
         &self.path
     }
+
+    fn check_path(&self) -> Result<()> {
+        use std::os::unix::fs::MetadataExt;
+        let current = fs::symlink_metadata(&self.path)?;
+        let held = self.file.metadata()?;
+        if !current.is_file() || current.dev() != held.dev() || current.ino() != held.ino() {
+            bail!("temporary update file was replaced");
+        }
+        Ok(())
+    }
+
+    fn writer(&self) -> Result<File> {
+        self.check_path()?;
+        let mut file = self.file.try_clone()?;
+        file.set_len(0)?;
+        file.rewind()?;
+        Ok(file)
+    }
+
+    fn seal_executable(mut self) -> Result<Self> {
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+        self.check_path()?;
+        self.file
+            .set_permissions(fs::Permissions::from_mode(0o755))?;
+        // Linux refuses to execute an inode while a writable handle is open.
+        // Reopen only for reading, verify identity, then close our writer.
+        let read_only = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&self.path)?;
+        let held = self.file.metadata()?;
+        let reopened = read_only.metadata()?;
+        if held.dev() != reopened.dev() || held.ino() != reopened.ino() {
+            bail!("temporary update file was replaced");
+        }
+        self.file = read_only;
+        Ok(self)
+    }
 }
 
 impl Drop for TempFile {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        if self.check_path().is_ok() {
+            let _ = fs::remove_file(&self.path);
+        }
     }
 }
 
@@ -974,12 +993,28 @@ mod tests {
     }
 
     #[test]
+    fn replaced_update_temp_cannot_truncate_or_remove_another_file() {
+        let dir = crate::test_support::tempdir().unwrap();
+        let temporary = TempFile::new(dir.path(), ".bin").unwrap();
+        temporary.writer().unwrap().write_all(b"original").unwrap();
+        let victim = dir.path().join("victim");
+        fs::write(&victim, b"untouched").unwrap();
+        fs::remove_file(temporary.path()).unwrap();
+        std::os::unix::fs::symlink(&victim, temporary.path()).unwrap();
+        let path = temporary.path().to_owned();
+        assert!(temporary.writer().is_err());
+        drop(temporary);
+        assert!(path.is_symlink());
+        assert_eq!(fs::read(victim).unwrap(), b"untouched");
+    }
+
+    #[test]
     fn release_fetches_reject_plain_http() {
         let parent = crate::test_support::temp_dir();
         let destination = TempFile::new(&parent, ".http-test").unwrap();
         let error = fetch(
             "http://127.0.0.1:1/release",
-            destination.path(),
+            &destination,
             FetchMode::BackgroundCheck,
         )
         .unwrap_err();


### PR DESCRIPTION
Malformed stat, apply, and partial-path replies could silently drop work through zipped vectors, and source range replies could choose an offset or length outside the coordinator's request. Validate reply counts and retain each outstanding read's offset and length, rejecting each mismatch before forwarding that block to the destination. A range mismatch terminates the worker and aborts the copy, skips follow-up transport statistics, and never reopens or reuses the affected connections. Outstanding pipelined replies therefore cannot reach another job.

Also bound TCP discovery to 64 advertised addresses plus the SSH target and 128 resolved addresses in total, using fallible resolver/probe thread creation. Harden the smaller local boundaries: tuning locks refuse symlinks and non-regular files; downloaded/update/receipt temporary files retain their exclusive write handles and verify pathname identity (executable temporaries switch to a checked read-only handle before execution); literal percent signs in enrollment jump targets are escaped for OpenSSH before ProxyCommand expansion.

Triage: these are worthwhile protocol-validation and local hardening fixes. They do not prove that a source supplied an honest or complete file list. General coordinator I/O deadlines are deferred: a blanket timeout would also cover slow scans, storage, and bandwidth-limited copies. The documented current behavior is that a stalled peer can wait until cancellation. Temporary-file hardening does not make an untrusted installation directory safe.

Targets `master` after #267 and #269 merged. Current follow-up: `e71a297`. This PR remains open for review.

Compatibility baseline: v0.4.1 (`13fc7d1`). No wire fields, endpoint/CLI spellings, cache filenames or serialized state, enrollment records, signed grants, replay protection, receipts, or resume identities change. Conforming old replies keep their interpretation; oversized discovery and malformed replies now fail visibly. Existing exact-build helper checks continue to reject mixed live builds. Literal percent characters remain literal instead of being interpreted as OpenSSH tokens. No migration, cache reset, or release action is required.

Validation at `e71a297`:

- Formatting, all-target/all-feature Clippy, and documentation links passed (20 files, no problems).
- New worker regression passed for wrong offsets and lengths, through both the initial-file and queued-range paths. Each case has unread source replies, an outstanding destination acknowledgment, and another queued file; the worker returns the protocol error and aborts without any further requests.
- All-target tests passed: 954 active tests, one existing opt-in test ignored (four test threads). The complete default three-container OpenSSH suite passed, including privileged security checks, every routing mode, resume/recovery, benchmark correctness, and cancellation cleanup.
- macOS and cross-platform checks have not run on this follow-up. Merged `master` at `0278e5d` passed `ci.yml` and `rsync-compat.yml`, but `macos.yml` failed in Python SDK mapping/cleanup tests after its Rust native suite passed. Similar Python failures already occurred after #267 at `bfd3ad9`. A disposable Linux reproduction of the mapping scenario at `e71a297` fails with a symlink in the temporary-directory path and succeeds with that path resolved; this supports a fixture-path issue. The process-group permission errors remain separately unresolved. No macOS check is claimed as passing.

Branch status before review handoff (exit 1 because master macOS is red):

```text
Worktree: /home/grant/repos/syq/.worktrees/security-peer-validation
Branch:   security-peer-validation at e71a297 (clean)
Upstream: origin/security-peer-validation (ahead 0, behind 0)
Master:   f4fbd3f from refs/heads/master (branch is ahead 6, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      0278e5d  https://github.com/greaber/syq/actions/runs/34065507507
  rsync-compat.yml success      0278e5d  https://github.com/greaber/syq/actions/runs/34065507400
  macos.yml        failure      0278e5d  https://github.com/greaber/syq/actions/runs/34065507420

Pull request: #270 https://github.com/greaber/syq/pull/270
  base master, open, review none, merge state clean
  GitHub head e71a297: matches local e71a297
  checks: none registered yet

WARNING: master is red: macos.yml failure at 0278e5d https://github.com/greaber/syq/actions/runs/34065507420
```
