### PR TITLE
Harden SDK source arguments, terminal output, and release tag signatures

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -121,6 +121,10 @@ ssh-add -l -E sha256 | grep -F 'SHA256:y3++huNJminuTLAOkyb635Vohfph9TfrzbtmVzM0d
 gh auth status
 ```
 
+Release CI also verifies tag signatures against this key in
+`scripts/release-tag-signers`; GitHub verification by another signer is not
+sufficient. A tag-key rotation must update that public allowlist.
+
 Configure each fresh clone once to use the public half of that forwarded key:
 
 ```sh

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -91,6 +91,7 @@ syq cp --from server project     # fetch project into your current directory
 ```
 
 Endpoints use `[USER@]HOST[:PORT]`, for example `alice@server:2222`.
+Host names cannot start with a dash, including when using an `--rsh` wrapper.
 Enclose IPv6 addresses in brackets: `alice@[2001:db8::1]:2222`.
 A colon in a native path is simply part of the path.
 
@@ -103,6 +104,10 @@ for ordering, supported options, and approval behavior. `--via @laptop` remains
 an alias for the explicit receiving-machine selection.
 
 ## Progress
+
+Human output, including `persist status` and `persist receive status`, escapes
+terminal control characters, Unicode line separators, and directional marks
+in names and peer diagnostics. JSON status output keeps the original values.
 
 When stderr is a terminal, syq shows one progress bar for the whole copy.
 The bar stays in place as files and workers change. It shows bytes processed

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -105,10 +105,6 @@ an alias for the explicit receiving-machine selection.
 
 ## Progress
 
-Human output, including `persist status` and `persist receive status`, escapes
-terminal control characters, Unicode line separators, and directional marks
-in names and peer diagnostics. JSON status output keeps the original values.
-
 When stderr is a terminal, syq shows one progress bar for the whole copy.
 The bar stays in place as files and workers change. It shows bytes processed
 out of the discovered total; while syq is still scanning, the percentage is
@@ -358,6 +354,12 @@ Sources must be relative to that root. A selection such as `../private` is
 refused; even with `--follow-src`, symlinks cannot lead outside the root.
 Unlike `-C`, this is a boundary, not just a starting directory. It does not
 constrain the destination.
+
+## Output and diagnostics
+
+Human output, including `persist status` and `persist receive status`, escapes
+terminal control characters, Unicode line separators, and directional marks
+in names and peer diagnostics. JSON status output keeps the original values.
 
 ## More options
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -165,8 +165,11 @@ host resolution. A copy never switches routes after selecting its destination.
 
 ## Code and transport integrity
 
-File data is encrypted and authenticated by default. `--tcp-plain` gives up
-that protection. Downloaded code for remote operations and explicit
+File data is encrypted and authenticated by default. `--tcp-plain` sends
+file contents, protocol messages, and the worker authentication token in
+plaintext. An observer can steal the token and connect as a worker while the
+transfer is active; a network attacker can also alter traffic. Use it only on
+a network you trust. Downloaded code for remote operations and explicit
 self-updates is verified against a signed release manifest before use.
 That verification cannot protect a machine whose trusted account or programs
 have already been compromised.

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -94,7 +94,11 @@ signing_identity=$(awk '{print $1 " " $2}' <<<"$signing_key")
 [[ "$signing_identity" == ssh-*' '* ]] || die 'user.signingkey is not an inline SSH public key'
 signing_fingerprint=$(ssh-keygen -lf /dev/stdin <<<"$signing_identity" | awk '{print $2}') \
   || die 'cannot fingerprint user.signingkey'
-pinned_signing_identity=$(awk '$1 == "syq-release" {print $3 " " $4}' "$script_dir/release-tag-signers")
+pinned_signing_identity=$(awk '$1 == "syq-release" {
+  for (i = 2; i < NF; i++) {
+    if ($i ~ /^ssh-/) {print $i " " $(i + 1); break}
+  }
+}' "$script_dir/release-tag-signers")
 [ "$signing_identity" = "$pinned_signing_identity" ] \
   || die "tag signing key $signing_fingerprint is not the pinned maintainer key"
 github_login=$(gh api user --jq .login)

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -94,6 +94,9 @@ signing_identity=$(awk '{print $1 " " $2}' <<<"$signing_key")
 [[ "$signing_identity" == ssh-*' '* ]] || die 'user.signingkey is not an inline SSH public key'
 signing_fingerprint=$(ssh-keygen -lf /dev/stdin <<<"$signing_identity" | awk '{print $2}') \
   || die 'cannot fingerprint user.signingkey'
+pinned_signing_identity=$(awk '$1 == "syq-release" {print $3 " " $4}' "$script_dir/release-tag-signers")
+[ "$signing_identity" = "$pinned_signing_identity" ] \
+  || die "tag signing key $signing_fingerprint is not the pinned maintainer key"
 github_login=$(gh api user --jq .login)
 github_signing_keys=$(gh api "users/$github_login/ssh_signing_keys?per_page=100")
 jq -e --arg key "$signing_identity" '

--- a/scripts/release-tag-signers
+++ b/scripts/release-tag-signers
@@ -1,0 +1,1 @@
+syq-release namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIISayu4yojryfTmgi9qKUTlNkWkwNfVmA0GyVjbhHCQK

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -366,7 +366,11 @@ jq -n --arg commit "$preflight_head" --arg tree "$preflight_tree" \
   '{schema:1,commit:$commit,tree:$tree,profile:"default",result:"success"}' \
   >"$preflight_repo/.git/syq-release/real-ssh/$preflight_tree.json"
 git -C "$preflight_repo" update-ref refs/remotes/origin/master "$preflight_head"
-signing_key=$(awk '$1 == "syq-release" {print $3 " " $4}' "$script_dir/release-tag-signers")
+signing_key=$(awk '$1 == "syq-release" {
+  for (i = 2; i < NF; i++) {
+    if ($i ~ /^ssh-/) {print $i " " $(i + 1); break}
+  }
+}' "$script_dir/release-tag-signers")
 git -C "$preflight_repo" config gpg.format ssh
 git -C "$preflight_repo" config user.signingkey "key::$signing_key"
 git -C "$preflight_repo" config tag.gpgsign true
@@ -437,6 +441,18 @@ preflight_env=(
 (cd "$preflight_repo" && env "${preflight_env[@]}" \
   "$script_dir/release-preflight.sh" v9.9.9) >"$work/preflight.out"
 grep -F "Release preflight passed for v9.9.9 at $preflight_head" "$work/preflight.out" >/dev/null
+# Exercise preflight with allowlist options whose quoted whitespace changes
+# awk field positions. Keep the repository's real allowlist untouched.
+option_scripts="$work/tag-option-scripts"
+mkdir "$option_scripts"
+cp "$script_dir/release-preflight.sh" "$option_scripts/"
+ln -s "$script_dir/release-readiness.py" "$option_scripts/release-readiness.py"
+ln -s "$script_dir/verify-release-ci.sh" "$option_scripts/verify-release-ci.sh"
+for options in '' 'namespaces="git"' 'namespaces="git, file",valid-before="20990101"'; do
+  printf 'syq-release %s %s\n' "$options" "$signing_key" >"$option_scripts/release-tag-signers"
+  (cd "$preflight_repo" && env "${preflight_env[@]}" \
+    "$option_scripts/release-preflight.sh" v9.9.9) >"$work/preflight-options.out"
+done
 ssh-keygen -q -t ed25519 -N '' -f "$work/other-preflight-key"
 other_signing_key=$(awk '{print $1 " " $2}' "$work/other-preflight-key.pub")
 git -C "$preflight_repo" config user.signingkey "key::$other_signing_key"

--- a/scripts/test-release-orchestration.sh
+++ b/scripts/test-release-orchestration.sh
@@ -366,8 +366,7 @@ jq -n --arg commit "$preflight_head" --arg tree "$preflight_tree" \
   '{schema:1,commit:$commit,tree:$tree,profile:"default",result:"success"}' \
   >"$preflight_repo/.git/syq-release/real-ssh/$preflight_tree.json"
 git -C "$preflight_repo" update-ref refs/remotes/origin/master "$preflight_head"
-ssh-keygen -q -t ed25519 -N '' -f "$work/tag-signing-key"
-signing_key=$(awk '{print $1 " " $2}' "$work/tag-signing-key.pub")
+signing_key=$(awk '$1 == "syq-release" {print $3 " " $4}' "$script_dir/release-tag-signers")
 git -C "$preflight_repo" config gpg.format ssh
 git -C "$preflight_repo" config user.signingkey "key::$signing_key"
 git -C "$preflight_repo" config tag.gpgsign true
@@ -438,6 +437,17 @@ preflight_env=(
 (cd "$preflight_repo" && env "${preflight_env[@]}" \
   "$script_dir/release-preflight.sh" v9.9.9) >"$work/preflight.out"
 grep -F "Release preflight passed for v9.9.9 at $preflight_head" "$work/preflight.out" >/dev/null
+ssh-keygen -q -t ed25519 -N '' -f "$work/other-preflight-key"
+other_signing_key=$(awk '{print $1 " " $2}' "$work/other-preflight-key.pub")
+git -C "$preflight_repo" config user.signingkey "key::$other_signing_key"
+if (cd "$preflight_repo" && env "${preflight_env[@]}" \
+  SYQ_TEST_SIGNING_KEY="$other_signing_key" \
+  "$script_dir/release-preflight.sh" v9.9.9) >"$work/failure.out" 2>&1; then
+  echo 'preflight unexpectedly accepted another GitHub-registered signing key' >&2
+  exit 1
+fi
+grep -F 'not the pinned maintainer key' "$work/failure.out" >/dev/null
+git -C "$preflight_repo" config user.signingkey "key::$signing_key"
 checks_without_conformance=$(jq -cn '{check_runs:["rust","sdks","macos","linux-arm64"] | map({name:.,conclusion:"success"})}')
 if (cd "$preflight_repo" && env "${preflight_env[@]}" \
   SYQ_TEST_CHECKS_JSON="$checks_without_conformance" \

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -207,12 +207,11 @@ case "$1:$2" in
 esac
 EOF
 chmod 755 "$fakebin/gh"
-commit=0123456789abcdef0123456789abcdef01234567
+commit=13fc7d1093b28aadd212e1a7ffabcfa277ba3b20
 tag_sha=89abcdef0123456789abcdef0123456789abcdef
 ref_json=$(jq -cn --arg sha "$tag_sha" '{object:{type:"tag",sha:$sha}}')
-tag_json=$(jq -cn --arg commit "$commit" '
-  {tag:"v0.1.0",object:{type:"commit",sha:$commit},
-   verification:{verified:true,reason:"valid"}}')
+# Unchanged published tag: verification must accept the existing maintainer key.
+tag_json=$(cat "$repo_dir/tests/fixtures/release-tag-v0.4.1.json")
 compare_json=$(jq -cn --arg commit "$commit" \
   '{base_commit:{sha:$commit},merge_base_commit:{sha:$commit}}')
 checks_json=$(jq -cn '{check_runs:[
@@ -227,7 +226,7 @@ workflow_runs_json=$(jq -cn --arg commit "$commit" '{workflow_runs:[{
 SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
   SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$checks_json" \
   PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos >/dev/null
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos >/dev/null
 
 SYQ_TEST_WORKFLOW_RUNS_JSON="$workflow_runs_json" PATH="$fakebin:$PATH" \
   "$script_dir/verify-release-ci.sh" greaber/syq "$commit" >/dev/null
@@ -298,23 +297,23 @@ expect_failure 'macos.yml has no push or workflow_dispatch run' env \
 lightweight=$(jq -cn --arg sha "$commit" '{object:{type:"commit",sha:$sha}}')
 expect_failure 'is lightweight' env \
   SYQ_TEST_REF_JSON="$lightweight" SYQ_TEST_TAG_JSON="$tag_json" PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos
 unsigned=$(jq -cn --arg commit "$commit" '
-  {tag:"v0.1.0",object:{type:"commit",sha:$commit},
+  {tag:"v0.4.1",object:{type:"commit",sha:$commit},
    verification:{verified:false,reason:"unsigned"}}')
 expect_failure 'reason: unsigned' env \
   SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$unsigned" PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos
 expect_failure 'not workflow commit' env \
   SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 \
   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa master rust,macos
 unmerged_compare=$(jq -cn --arg commit "$commit" \
   '{base_commit:{sha:$commit},merge_base_commit:{sha:("b"*40)}}')
 expect_failure 'not reachable from protected branch master' env \
   SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
   SYQ_TEST_COMPARE_JSON="$unmerged_compare" PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos
 # A red, pending, or absent required check on the tagged commit blocks the
 # release even when the tag itself is valid and merged.
 failed_checks=$(jq -cn '{check_runs:[
@@ -324,7 +323,7 @@ expect_failure 'required check rust is failure' env \
   SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
   SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$failed_checks" \
   PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos
 pending_checks=$(jq -cn '{check_runs:[
   {name:"rust",status:"in_progress",conclusion:null},
   {name:"macos",status:"completed",conclusion:"success"}]}')
@@ -332,12 +331,27 @@ expect_failure 'required check rust is pending' env \
   SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
   SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$pending_checks" \
   PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos
 expect_failure 'required check linux-arm64 is missing' env \
   SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tag_json" \
   SYQ_TEST_COMPARE_JSON="$compare_json" SYQ_TEST_CHECKS_JSON="$checks_json" \
   PATH="$fakebin:$PATH" \
-  "$script_dir/verify-release-tag.sh" greaber/syq v0.1.0 "$commit" master rust,macos,linux-arm64
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos,linux-arm64
+
+# A valid signature by another key is not release authority, even when GitHub
+# reports it as verified. Use an ephemeral test key, never a maintainer secret.
+ssh-keygen -q -t ed25519 -N '' -f "$work/other-tag-key"
+jq -j '.verification.payload' <<<"$tag_json" >"$work/other-tag-payload"
+ssh-keygen -Y sign -f "$work/other-tag-key" -n git "$work/other-tag-payload"
+other_signer=$(jq --rawfile signature "$work/other-tag-payload.sig" \
+  '.verification.signature = $signature' <<<"$tag_json")
+expect_failure 'not signed by the pinned maintainer key' env \
+  SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$other_signer" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos
+tampered=$(jq '.verification.payload += "tampered"' <<<"$tag_json")
+expect_failure 'not signed by the pinned maintainer key' env \
+  SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$tampered" PATH="$fakebin:$PATH" \
+  "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos
 
 # Published-release reruns compare content, not just asset names.
 local_assets="$work/local-assets"

--- a/scripts/test-release-tools.sh
+++ b/scripts/test-release-tools.sh
@@ -338,6 +338,21 @@ expect_failure 'required check linux-arm64 is missing' env \
   PATH="$fakebin:$PATH" \
   "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos,linux-arm64
 
+# Missing and malformed API fields must fail with a useful diagnostic.
+for field in signature payload; do
+  for value in missing null '""' 123; do
+    if [ "$value" = missing ]; then
+      invalid=$(jq --arg field "$field" 'del(.verification[$field])' <<<"$tag_json")
+    else
+      invalid=$(jq --arg field "$field" --argjson value "$value" \
+        '.verification[$field] = $value' <<<"$tag_json")
+    fi
+    expect_failure "missing, empty, or invalid verification $field" env \
+      SYQ_TEST_REF_JSON="$ref_json" SYQ_TEST_TAG_JSON="$invalid" PATH="$fakebin:$PATH" \
+      "$script_dir/verify-release-tag.sh" greaber/syq v0.4.1 "$commit" master rust,macos
+  done
+done
+
 # A valid signature by another key is not release authority, even when GitHub
 # reports it as verified. Use an ephemeral test key, never a maintainer secret.
 ssh-keygen -q -t ed25519 -N '' -f "$work/other-tag-key"

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Require a GitHub-verified annotated tag that directly names the commit being
-# built by this release workflow, is reachable from the protected branch, and
+# Require a maintainer-signed, GitHub-verified annotated tag that directly names
+# the workflow commit, is reachable from the protected branch, and
 # has every named CI check concluded successfully. Pull requests do not run CI;
 # the tagged commit's own post-merge or manual check runs are what prove it.
 set -euo pipefail
@@ -62,6 +62,22 @@ test "$target_commit" = "$expected_commit" || {
 }
 if [ "$verified" != true ] || [ "$reason" != valid ]; then
   echo "GitHub did not verify the signature on release tag $tag (reason: $reason)" >&2
+  exit 1
+fi
+
+# GitHub's verified flag establishes signature validity, not release authority.
+# Verify the signed payload against the public maintainer identity as well.
+command -v ssh-keygen >/dev/null || { echo 'tag verification needs ssh-keygen' >&2; exit 1; }
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+verification_dir=$(mktemp -d "${TMPDIR:-/tmp}/syq-tag-verification.XXXXXXXX")
+trap 'rm -rf "$verification_dir"' EXIT
+jq -ej '.verification.signature | select(type == "string" and length > 0)' \
+  <<<"$tag_object" >"$verification_dir/signature"
+jq -ej '.verification.payload | select(type == "string" and length > 0)' \
+  <<<"$tag_object" >"$verification_dir/payload"
+if ! ssh-keygen -Y verify -f "$script_dir/release-tag-signers" -I syq-release \
+  -n git -s "$verification_dir/signature" <"$verification_dir/payload"; then
+  echo "release tag $tag was not signed by the pinned maintainer key" >&2
   exit 1
 fi
 

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -71,10 +71,14 @@ command -v ssh-keygen >/dev/null || { echo 'tag verification needs ssh-keygen' >
 script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 verification_dir=$(mktemp -d "${TMPDIR:-/tmp}/syq-tag-verification.XXXXXXXX")
 trap 'rm -rf "$verification_dir"' EXIT
-jq -ej '.verification.signature | select(type == "string" and length > 0)' \
-  <<<"$tag_object" >"$verification_dir/signature"
-jq -ej '.verification.payload | select(type == "string" and length > 0)' \
-  <<<"$tag_object" >"$verification_dir/payload"
+for field in signature payload; do
+  if ! jq -ej --arg field "$field" \
+    '.verification[$field] | select(type == "string" and length > 0)' \
+    <<<"$tag_object" >"$verification_dir/$field"; then
+    echo "release tag $tag has a missing, empty, or invalid verification $field" >&2
+    exit 1
+  fi
+done
 if ! ssh-keygen -Y verify -f "$script_dir/release-tag-signers" -I syq-release \
   -n git -s "$verification_dir/signature" <"$verification_dir/payload"; then
   echo "release tag $tag was not signed by the pinned maintainer key" >&2

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -589,7 +589,8 @@ def _copy_arguments(
     source_count = 0
     contents_count = 0
     for index, source in enumerate(sources):
-        argv.append(_argument(source, label=f"sources[{index}]"))
+        value = _argument(source, label=f"sources[{index}]")
+        argv.append(b"--src=" + value if isinstance(value, bytes) else f"--src={value}")
         source_count += 1
     for option, value in (
         ("--src", src),
@@ -742,7 +743,8 @@ def _rm_arguments(
     argv: list[Argument] = ["rm"]
     source_count = 0
     for index, source in enumerate(sources):
-        argv.append(_argument(source, label=f"sources[{index}]"))
+        value = _argument(source, label=f"sources[{index}]")
+        argv.append(b"--src=" + value if isinstance(value, bytes) else f"--src={value}")
         source_count += 1
     for option, value in (
         ("--src", src),

--- a/sdk/python/tests/test_candidate.py
+++ b/sdk/python/tests/test_candidate.py
@@ -28,6 +28,18 @@ def resolved_temporary_directory() -> tempfile.TemporaryDirectory[str]:
     "candidate compatibility requires SYQ_CANDIDATE_EXECUTABLE and version",
 )
 class CandidateCompatibilityTests(unittest.TestCase):
+    def test_positional_option_names_are_copied_and_removed_as_files(self) -> None:
+        with resolved_temporary_directory() as temporary_directory:
+            root = Path(temporary_directory)
+            client = syq.Client(executable=EXECUTABLE, process_cwd=root)
+            for index, name in enumerate(("--rsh=evil", "--prune", "--srcs-in=.")):
+                (root / name).write_bytes(b"literal filename")
+                destination = f"out-{index}"
+                client.cp(name, as_new=destination)
+                self.assertEqual((root / destination).read_bytes(), b"literal filename")
+                client.rm(name)
+                self.assertFalse((root / name).exists())
+
     def test_candidate_version_and_typed_native_surface(self) -> None:
         assert EXECUTABLE is not None
         assert EXPECTED_VERSION is not None

--- a/sdk/python/tests/test_native.py
+++ b/sdk/python/tests/test_native.py
@@ -346,6 +346,18 @@ class NativeClientTests(unittest.TestCase):
         self.assertNotIn("-base", argv)
         self.assertNotIn("-destination", argv)
 
+    def test_positional_sources_cannot_inject_options(self) -> None:
+        for source in ("--rsh=/tmp/evil", b"--rsh=/tmp/evil", Path("--prune"), "ordinary"):
+            for command in ("cp", "rm"):
+                with self.subTest(source=source, command=command):
+                    if command == "cp":
+                        self.client.cp(source, into="target")
+                    else:
+                        self.client.rm(source)
+                    argv = self.argv()
+                    self.assertIn("--src=" + os.fsdecode(source), argv)
+                    self.assertNotIn(os.fsdecode(source), argv)
+
     def test_mapping_precedes_the_destination(self) -> None:
         self.client.cp(mapping="manifest", into="target")
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1889,8 +1889,8 @@ fn apply_internal_native_direct(args: &mut Args) -> Result<()> {
     };
     args.restricted_grant = utf8("SYQ_INTERNAL_NATIVE_RESTRICTED_GRANT")?;
     args.plan_source_host = utf8("SYQ_INTERNAL_NATIVE_PLAN_SOURCE_HOST")?;
-    if let Some(rsh) = utf8("SYQ_INTERNAL_NATIVE_RSH")? {
-        args.rsh = Some(rsh);
+    if args.rsh.is_none() {
+        args.rsh = utf8("SYQ_INTERNAL_NATIVE_RSH")?;
     }
     if let Some(width) = utf8("SYQ_INTERNAL_NATIVE_PROGRESS_WIDTH")? {
         args.width = Some(
@@ -1998,6 +1998,9 @@ pub(crate) fn parse_native_endpoint(spec: Option<&str>) -> Result<Option<NativeE
     };
     if host.is_empty() {
         bail!("empty host in endpoint {spec:?}");
+    }
+    if host.starts_with('-') {
+        bail!("host in endpoint {spec:?} must not start with a dash");
     }
     if host
         .bytes()
@@ -2630,6 +2633,13 @@ mod tests {
                 port: Some(2200),
             })
         );
+        for host in ["-oProxyCommand=evil", "user@-oProxyCommand=evil", "[-evil]"] {
+            assert!(parse_native_endpoint(Some(host)).is_err(), "{host}");
+            assert!(
+                super::Location::parse(&format!("{host}:path")).is_err(),
+                "{host}"
+            );
+        }
         assert!(parse_native_endpoint(Some("host:path")).is_err());
         assert!(parse_native_endpoint(Some("2001:db8::1")).is_err());
         assert!(parse_native_endpoint(Some("host:0")).is_err());
@@ -2800,6 +2810,9 @@ impl Location {
             .to_string();
         if host.is_empty() {
             bail!("empty host in {s:?}");
+        }
+        if host.starts_with('-') {
+            bail!("host in {s:?} must not start with a dash");
         }
         let path = if path.is_empty() {
             b".".to_vec()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1889,9 +1889,6 @@ fn apply_internal_native_direct(args: &mut Args) -> Result<()> {
     };
     args.restricted_grant = utf8("SYQ_INTERNAL_NATIVE_RESTRICTED_GRANT")?;
     args.plan_source_host = utf8("SYQ_INTERNAL_NATIVE_PLAN_SOURCE_HOST")?;
-    if args.rsh.is_none() {
-        args.rsh = utf8("SYQ_INTERNAL_NATIVE_RSH")?;
-    }
     if let Some(width) = utf8("SYQ_INTERNAL_NATIVE_PROGRESS_WIDTH")? {
         args.width = Some(
             width

--- a/src/output.rs
+++ b/src/output.rs
@@ -12,7 +12,7 @@ fn safe_message(args: Arguments<'_>) -> String {
     let mut result = String::new();
     for ch in args.to_string().chars() {
         if (ch.is_control() && !matches!(ch, '\n' | '\t'))
-            || matches!(ch, '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}')
+            || matches!(ch, '\u{061c}' | '\u{200e}'..='\u{200f}' | '\u{2028}'..='\u{202e}' | '\u{2066}'..='\u{2069}')
         {
             result.extend(ch.escape_default());
         } else {
@@ -144,6 +144,14 @@ mod tests {
         assert!(!text.contains('\r'));
         assert!(!text.contains('\u{202e}'));
         assert!(text.contains("\\u{1b}]52"));
+    }
+
+    #[test]
+    fn human_messages_escape_unicode_separators_and_directional_marks() {
+        let text = safe_message(format_args!(
+            "a\u{061c}\u{200e}\u{200f}\u{2028}\u{2029}z\n\t"
+        ));
+        assert_eq!(text, "a\\u{61c}\\u{200e}\\u{200f}\\u{2028}\\u{2029}z\n\t");
     }
 
     #[test]

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -146,8 +146,8 @@ pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
         PersistAction::On { ephemeral: false } => {
             let scope = ensure_global_scope()?;
             write_global_config(true)?;
-            println!("SSH connection persistence is on");
-            println!("scope: {}", scope.display());
+            crate::output::human_stdout!("SSH connection persistence is on");
+            crate::output::human_stdout!("scope: {}", scope.display());
         }
         PersistAction::Off {
             pscope: Some(scope),
@@ -158,7 +158,7 @@ pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
                 );
             }
             close_scope(&scope)?;
-            println!("persistence scope closed: {}", scope.display());
+            crate::output::human_stdout!("persistence scope closed: {}", scope.display());
         }
         PersistAction::Off { pscope: None } => {
             // Disable first so a later command cannot intentionally join the
@@ -173,14 +173,14 @@ pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
                         .with_context(|| format!("inspect global scope {}", scope.display()));
                 }
             }
-            println!("SSH connection persistence is off");
+            crate::output::human_stdout!("SSH connection persistence is off");
         }
         PersistAction::Status {
             pscope: Some(scope),
         } => print_scope_status(&scope, Some("ephemeral"))?,
         PersistAction::Status { pscope: None } => {
             let enabled = global_enabled()?;
-            println!(
+            crate::output::human_stdout!(
                 "SSH connection persistence is {}",
                 if enabled { "on" } else { "off" }
             );
@@ -188,7 +188,7 @@ pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
             match scope.symlink_metadata() {
                 Ok(_) => print_scope_status(&scope, Some("global"))?,
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                    println!("connections: 0");
+                    crate::output::human_stdout!("connections: 0");
                 }
                 Err(error) => {
                     return Err(error)
@@ -674,11 +674,11 @@ fn socket_is_live(path: &Path) -> bool {
 fn print_scope_status(scope: &Path, kind: Option<&str>) -> Result<()> {
     let records = scope_records(scope)?;
     if let Some(kind) = kind {
-        println!("scope ({kind}): {}", scope.display());
+        crate::output::human_stdout!("scope ({kind}): {}", scope.display());
     } else {
-        println!("scope: {}", scope.display());
+        crate::output::human_stdout!("scope: {}", scope.display());
     }
-    println!("connections: {}", records.len());
+    crate::output::human_stdout!("connections: {}", records.len());
     for (key, record) in records {
         let control = scope.join(&key);
         let state = if socket_is_live(&control) {
@@ -692,7 +692,7 @@ fn print_scope_status(scope: &Path, kind: Option<&str>) -> Result<()> {
             ""
         };
         let receiving = crate::receive_service::summary(&control);
-        println!("  {}  {state}{pool}{receiving}", record.label());
+        crate::output::human_stdout!("  {}  {state}{pool}{receiving}", record.label());
     }
     Ok(())
 }

--- a/src/receive_service.rs
+++ b/src/receive_service.rs
@@ -741,12 +741,12 @@ fn configure(options: Configure) -> Result<()> {
             spawn(&control)?;
         }
     }
-    println!("Receiving is on: {} ({})", config.name, config.approval);
-    println!("cwd: {}", config.cwd.display());
+    crate::output::human_stdout!("Receiving is on: {} ({})", config.name, config.approval);
+    crate::output::human_stdout!("cwd: {}", config.cwd.display());
     if let Some(root) = config.root {
-        println!("root: {}", root.display());
+        crate::output::human_stdout!("root: {}", root.display());
     }
-    println!(
+    crate::output::human_stdout!(
         "Applies to persistent syq SSH connections; use syq persist on to enable persistence."
     );
     Ok(())
@@ -766,10 +766,10 @@ fn pending(json: bool, wait: bool, timeout: u64) -> Result<()> {
             if json {
                 println!("{}", serde_json::to_string(&requests)?);
             } else if requests.is_empty() {
-                println!("No requests awaiting approval");
+                crate::output::human_stdout!("No requests awaiting approval");
             } else {
                 for request in requests {
-                    println!(
+                    crate::output::human_stdout!(
                         "{}\n{}\nNotification: {}\n",
                         request.id,
                         request.description(),
@@ -810,7 +810,7 @@ fn decide(id: &str, allow: bool) -> Result<()> {
             if let Some(error) = response.decision_error {
                 bail!("{error}");
             }
-            println!("{} {id}", if allow { "Approved" } else { "Denied" });
+            crate::output::human_stdout!("{} {id}", if allow { "Approved" } else { "Denied" });
             return Ok(());
         }
     }
@@ -848,7 +848,7 @@ pub(crate) fn run_command(command: ReceiveCommand) -> Result<i32> {
             for control in all_controls()? {
                 stop_inner(&control, false)?;
             }
-            println!("Receiving is off; ordinary SSH persistence is unchanged");
+            crate::output::human_stdout!("Receiving is off; ordinary SSH persistence is unchanged");
         }
         Action::Status { json } => {
             let config = settings()?;
@@ -861,18 +861,18 @@ pub(crate) fn run_command(command: ReceiveCommand) -> Result<i32> {
                     )?
                 );
             } else {
-                println!(
+                crate::output::human_stdout!(
                     "Receiving is {}: {} ({})",
                     if config.enabled { "on" } else { "off" },
                     config.name,
                     config.approval
                 );
-                println!("cwd: {}", config.cwd.display());
+                crate::output::human_stdout!("cwd: {}", config.cwd.display());
                 if let Some(root) = config.root {
-                    println!("root: {}", root.display());
+                    crate::output::human_stdout!("root: {}", root.display());
                 }
                 for state in connections {
-                    println!(
+                    crate::output::human_stdout!(
                         "  {}: {} ({}, {} pending){}",
                         state.endpoint,
                         state.connection.phase,

--- a/tests/fixtures/release-tag-v0.4.1.json
+++ b/tests/fixtures/release-tag-v0.4.1.json
@@ -1,0 +1,13 @@
+{
+  "tag": "v0.4.1",
+  "object": {
+    "type": "commit",
+    "sha": "13fc7d1093b28aadd212e1a7ffabcfa277ba3b20"
+  },
+  "verification": {
+    "verified": true,
+    "reason": "valid",
+    "payload": "object 13fc7d1093b28aadd212e1a7ffabcfa277ba3b20\ntype commit\ntag v0.4.1\ntagger Grant Reaber <grant.reaber@gmail.com> 1788717858 +0200\n\nsyq 0.4.1\n",
+    "signature": "-----BEGIN SSH SIGNATURE-----\nU1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAghJrK7jKiOvJ9OaCL2opROU2RaT\nA19WYDQbJWNuEcJAoAAAADZ2l0AAAAAAAAAAZzaGE1MTIAAABTAAAAC3NzaC1lZDI1NTE5\nAAAAQKXBo9j6eD7ITDm5x4RWSiE6xoo1pgSHKmyy7IKHBakNkgWSbcmAiegAC5MZFpsR4+\nUTbC3VxEzi9UytO0yNJgI=\n-----END SSH SIGNATURE-----\n"
+  }
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -18886,3 +18886,118 @@ fn return_exec_completion_and_offline_selection_never_contact_ssh() {
     assert!(output.stdout.is_empty());
     assert!(!t.path("home/ssh-used").exists());
 }
+
+#[test]
+fn persistence_status_escapes_peer_errors_but_json_preserves_them() {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::UnixListener;
+    let t = Tmp::new();
+    let command = |args: &[&str]| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+        command
+            .args(args)
+            .env("XDG_RUNTIME_DIR", &t.0)
+            .env("XDG_CONFIG_HOME", t.path("config"));
+        command
+    };
+    let output = command(&["persist", "on", "--ephemeral"]).run().unwrap();
+    assert_output_ok(&output);
+    let scope = PathBuf::from(String::from_utf8(output.stdout).unwrap().trim());
+    let digest = Sha256::digest(b"@example");
+    let key = format!(
+        "cm-{}",
+        digest[..8]
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>()
+    );
+    write(
+        &scope.join(format!("{key}.json")),
+        br#"{"user":null,"host":"example","port":null}"#,
+    );
+    let listener = UnixListener::bind(scope.join(format!("{key}.recv"))).unwrap();
+    let error = "peer: \x1b]52;c;bad\x07\r\u{2028}\u{200f}";
+    let response = serde_json::to_vec(&serde_json::json!({
+        "version": 2, "identity": "old-daemon-fixture", "pid": 1,
+        "endpoint": "example", "name": "laptop",
+        "connection": {"phase": "failed", "error": error, "ssh_pid": null}
+    }))
+    .unwrap();
+    let server = std::thread::spawn(move || {
+        for _ in 0..3 {
+            let mut ready = libc::pollfd {
+                fd: listener.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            assert_eq!(
+                unsafe { libc::poll(&mut ready, 1, 5000) },
+                1,
+                "status client did not connect within five seconds"
+            );
+            let (mut socket, _) = listener.accept().unwrap();
+            socket
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            let mut length = [0; 4];
+            socket.read_exact(&mut length).unwrap();
+            let mut request = vec![0; u32::from_be_bytes(length) as usize];
+            socket.read_exact(&mut request).unwrap();
+            socket
+                .write_all(&(response.len() as u32).to_be_bytes())
+                .unwrap();
+            socket.write_all(&response).unwrap();
+        }
+    });
+    for args in [
+        vec!["persist", "status", "--pscope", scope.to_str().unwrap()],
+        vec!["persist", "receive", "status"],
+    ] {
+        let output = command(&args).run().unwrap();
+        assert_output_ok(&output);
+        let text = String::from_utf8(output.stdout).unwrap();
+        assert!(
+            text.contains("peer: \\u{1b}]52;c;bad\\u{7}\\r\\u{2028}\\u{200f}"),
+            "{text}"
+        );
+    }
+    let output = command(&["persist", "receive", "status", "--json"])
+        .run()
+        .unwrap();
+    assert_output_ok(&output);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["connections"][0]["connection"]["error"], error);
+    server.join().unwrap();
+}
+
+#[test]
+fn native_explicit_rsh_overrides_internal_environment() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    fs::create_dir_all(t.path("remote-bin")).unwrap();
+    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+    write(&t.path("source"), b"data");
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--from",
+            "example",
+            "--src",
+            &t.s("source"),
+            "--as",
+            &t.s("dest"),
+            "--rsh",
+            rsh.to_str().unwrap(),
+            "--syq-path",
+            "syq",
+            "--no-tcp",
+        ])
+        .env("SYQ_INTERNAL_NATIVE_RSH", "/missing-internal-rsh")
+        .env("FAKE_REMOTE_HOME", &t.0)
+        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+        .env("FAKE_RSH_LOG", t.path("rsh.log"))
+        .run()
+        .unwrap();
+    assert_output_ok(&output);
+    assert_eq!(read(&t.path("dest")), b"data");
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -18971,14 +18971,16 @@ fn persistence_status_escapes_peer_errors_but_json_preserves_them() {
 }
 
 #[test]
-fn native_explicit_rsh_overrides_internal_environment() {
-    let t = Tmp::new();
-    let rsh = fake_rsh(&t);
-    fs::create_dir_all(t.path("remote-bin")).unwrap();
-    std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
-    write(&t.path("source"), b"data");
-    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
-        .args([
+fn native_ignores_internal_rsh_environment() {
+    for explicit_rsh in [false, true] {
+        let t = Tmp::new();
+        let ssh = fake_ssh(&t);
+        let rsh = fake_rsh(&t);
+        fs::create_dir_all(t.path("remote-bin")).unwrap();
+        std::os::unix::fs::symlink(env!("CARGO_BIN_EXE_syq"), t.path("remote-bin/syq")).unwrap();
+        write(&t.path("source"), b"data");
+        let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+        command.args([
             "cp",
             "--from",
             "example",
@@ -18986,18 +18988,25 @@ fn native_explicit_rsh_overrides_internal_environment() {
             &t.s("source"),
             "--as",
             &t.s("dest"),
-            "--rsh",
-            rsh.to_str().unwrap(),
             "--syq-path",
             "syq",
             "--no-tcp",
-        ])
-        .env("SYQ_INTERNAL_NATIVE_RSH", "/missing-internal-rsh")
-        .env("FAKE_REMOTE_HOME", &t.0)
-        .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
-        .env("FAKE_RSH_LOG", t.path("rsh.log"))
-        .run()
-        .unwrap();
-    assert_output_ok(&output);
-    assert_eq!(read(&t.path("dest")), b"data");
+        ]);
+        if explicit_rsh {
+            command.arg("--rsh").arg(&rsh);
+        }
+        let output = command
+            .env("SYQ_INTERNAL_NATIVE_RSH", "/missing-internal-rsh")
+            .env(
+                "PATH",
+                format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+            )
+            .env("FAKE_REMOTE_HOME", &t.0)
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .run()
+            .unwrap();
+        assert_output_ok(&output);
+        assert_eq!(read(&t.path("dest")), b"data");
+    }
 }


### PR DESCRIPTION
The Python SDK now attaches positional source values to `--src=` for copy and removal, so a filename such as `--rsh=evil` cannot become an option (H1). Both endpoint parsers reject dash-prefixed hosts before invoking an SSH wrapper (M4), and the unused `SYQ_INTERNAL_NATIVE_RSH` environment override is ignored, both with default SSH and an explicit `--rsh`.

Persistence and receiving human output now uses terminal escaping, including Unicode separators and directional marks (M3). JSON status retains original values. Release CI and local preflight require the documented maintainer SSH signing key, in addition to GitHub signature verification (M5). Missing or malformed signature/payload fields produce an explicit diagnostic, and preflight finds the pinned SSH key independently of allowlist option positions. The security documentation also explains that `--tcp-plain` exposes the worker token.

Compatibility: the copy/removal injection regression passes with the downloaded, checksum-verified released v0.4.1 binary. The unchanged published v0.4.1 tag signature passes the new verifier; a different valid signer and tampered payload fail. A version-2 daemon status fixture verifies both human escaping and unchanged JSON values. No helper protocol, grant, redemption, receipt, or persistent-state format changes.

Validation:
- Follow-up at ff44631: Rust formatting, all-target/all-feature Clippy, all 535 active unit tests (one existing ignored), default/explicit-SSH environment regression, release-tool and orchestration tests, ShellCheck, and documentation links passed. The new release tests cover missing/empty/invalid signature and payload fields and allowlists with varying option positions.
- Rust formatting and all-target/all-feature Clippy with warnings denied passed.
- At 04570f8, all Rust targets exercised: 991 tests passed, one existing ignored test. The first broad run hit transient `ETXTBSY` in an existing SSH-wrapper test; the retry passed it. Two new fixture mistakes were corrected, and all 433 local integration tests then passed.
- At 04570f8, all 109 Python SDK tests passed against the candidate; expanded copy/removal injection tests also passed against candidate and released v0.4.1.
- Default three-container real-SSH suite passed for the runtime code committed at ff44631, including benchmark cleanup.
- Release tooling, release orchestration, ShellCheck, documentation links, and Python API inventory checks passed.

Scope: hard-link write policy (M1), TCP admission/ID reservation (M2), cancellation/revocation semantics, receiver memory budgets, and plaintext authentication changes await discussion and are not fixed by this PR.
