### PR TITLE
Bound remote-supplied input before allocating or writing it

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2604,18 +2604,23 @@ impl RemoteSpec {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        let out = cmd
-            .output()
+        let out = run_captured(&mut cmd, None)
             .with_context(|| format!("probe platform on {}", self.label()))?;
         if !out.status.success() {
             bail!(
                 "could not detect the platform on {} ({}){}",
                 self.label(),
                 out.status,
-                output_suffix(&out.stderr)
+                output_suffix(&out.stderr.bytes)
             );
         }
-        let text = String::from_utf8_lossy(&out.stdout);
+        if out.stdout.truncated {
+            bail!(
+                "{}: platform probe printed more than {MAX_BOOTSTRAP_OUTPUT_BYTES} bytes",
+                self.label()
+            );
+        }
+        let text = String::from_utf8_lossy(&out.stdout.bytes);
         let value = text
             .lines()
             .find_map(|line| line.strip_prefix("syq-helper-target:"))
@@ -2734,15 +2739,11 @@ impl RemoteSpec {
             .stdout
             .take()
             .ok_or_else(|| anyhow!("remote helper download stdout was not piped"))?;
-        let mut stderr = child
+        let stderr = child
             .stderr
             .take()
             .ok_or_else(|| anyhow!("remote helper download stderr was not piped"))?;
-        let stderr_reader = std::thread::spawn(move || {
-            let mut bytes = Vec::new();
-            let _ = stderr.read_to_end(&mut bytes);
-            bytes
-        });
+        let stderr_reader = capture_stream(stderr);
 
         let report = read_remote_download_report(&mut BufReader::new(stdout));
         let mut helper = None;
@@ -2798,7 +2799,9 @@ impl RemoteSpec {
             .with_context(|| format!("wait for helper download on {}", self.label()))?;
         let stderr = stderr_reader
             .join()
-            .map_err(|_| anyhow!("remote helper stderr reader panicked"))?;
+            .map_err(|_| anyhow!("remote helper stderr reader panicked"))?
+            .map(|captured| captured.bytes)
+            .unwrap_or_default();
         let detail = output_message(&stderr);
         if status.success() {
             write_result.context("authorize the verified remote helper")?;
@@ -2847,26 +2850,19 @@ impl RemoteSpec {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        let mut child = cmd
-            .spawn()
-            .with_context(|| format!("start helper upload to {}", self.label()))?;
-        let mut stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| anyhow!("helper upload stdin was not piped"))?;
-        let write_result = stdin.write_all(binary);
-        drop(stdin);
-        let out = child
-            .wait_with_output()
-            .with_context(|| format!("wait for helper upload to {}", self.label()))?;
+        let out = run_captured(&mut cmd, Some(binary))
+            .with_context(|| format!("run helper upload to {}", self.label()))?;
         if !out.status.success() {
             bail!(
                 "remote helper upload exited {}{}",
                 out.status,
-                output_suffix(&out.stderr)
+                output_suffix(&out.stderr.bytes)
             );
         }
-        write_result.with_context(|| format!("upload helper to {}", self.label()))
+        match out.input_error {
+            Some(error) => Err(error).with_context(|| format!("upload helper to {}", self.label())),
+            None => Ok(()),
+        }
     }
 }
 
@@ -2894,12 +2890,118 @@ struct RemoteDownloadReport {
     sha256: String,
 }
 
+/// Bound on each captured stream of a bootstrap command: the platform probe,
+/// the remote download report's stderr, and the helper upload. Legitimate
+/// output is a few lines; the bound keeps a faulty or hostile remote from
+/// growing local memory without limit. Streams are drained past the bound so
+/// the child never blocks on a full pipe.
+const MAX_BOOTSTRAP_OUTPUT_BYTES: usize = 1024 * 1024;
+/// Largest remote release manifest accepted from the download report.
+const MAX_MANIFEST_SIZE: usize = 1024 * 1024;
+/// Longest report line buffered before it is checked. A manifest data line may
+/// carry the whole manifest after its framing prefix.
+const MAX_REPORT_LINE_BYTES: usize = MAX_MANIFEST_SIZE + 1024;
+
+struct CapturedStream {
+    bytes: Vec<u8>,
+    /// The stream produced more than the retained bytes; the rest was discarded.
+    truncated: bool,
+}
+
+/// Read a stream keeping at most `limit` bytes, then drain and discard the
+/// remainder so a child process writing to it never blocks.
+fn read_capped(mut reader: impl Read, limit: usize) -> std::io::Result<CapturedStream> {
+    let mut bytes = Vec::new();
+    reader.by_ref().take(limit as u64).read_to_end(&mut bytes)?;
+    let discarded = std::io::copy(&mut reader, &mut std::io::sink())?;
+    Ok(CapturedStream {
+        bytes,
+        truncated: discarded > 0,
+    })
+}
+
+fn capture_stream(
+    reader: impl Read + Send + 'static,
+) -> std::thread::JoinHandle<std::io::Result<CapturedStream>> {
+    std::thread::spawn(move || read_capped(reader, MAX_BOOTSTRAP_OUTPUT_BYTES))
+}
+
+struct CapturedOutput {
+    status: std::process::ExitStatus,
+    stdout: CapturedStream,
+    stderr: CapturedStream,
+    /// Writing `input` to the child's stdin failed. Reported after the exit
+    /// status, which usually explains why the child stopped reading.
+    input_error: Option<std::io::Error>,
+}
+
+/// Run a bootstrap command, feeding it `input` when given, with both output
+/// streams captured under `MAX_BOOTSTRAP_OUTPUT_BYTES`. The command must have
+/// piped stdout and stderr; stdin is piped when there is input.
+fn run_captured(cmd: &mut Command, input: Option<&[u8]>) -> Result<CapturedOutput> {
+    if input.is_some() {
+        cmd.stdin(Stdio::piped());
+    }
+    let mut child = cmd.spawn().context("start command")?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("command stdout was not piped"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("command stderr was not piped"))?;
+    let stdout_reader = capture_stream(stdout);
+    let stderr_reader = capture_stream(stderr);
+    let input_error = match input {
+        Some(bytes) => {
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| anyhow!("command stdin was not piped"))?;
+            stdin.write_all(bytes).err()
+        }
+        None => None,
+    };
+    let status = child.wait().context("wait for command")?;
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| anyhow!("stdout reader panicked"))?
+        .context("read command stdout")?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| anyhow!("stderr reader panicked"))?
+        .context("read command stderr")?;
+    Ok(CapturedOutput {
+        status,
+        stdout,
+        stderr,
+        input_error,
+    })
+}
+
+/// Read one report line into `line`, refusing lines longer than
+/// `MAX_REPORT_LINE_BYTES` before they are buffered in full.
+fn read_report_line(reader: &mut impl BufRead, line: &mut Vec<u8>) -> std::io::Result<usize> {
+    line.clear();
+    let read = reader
+        .by_ref()
+        .take(MAX_REPORT_LINE_BYTES as u64 + 1)
+        .read_until(b'\n', line)?;
+    if read > MAX_REPORT_LINE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "remote helper report line exceeded the size limit",
+        ));
+    }
+    Ok(read)
+}
+
 fn read_remote_download_report(
     reader: &mut impl BufRead,
 ) -> std::io::Result<Option<RemoteDownloadReport>> {
-    const MAX_MANIFEST_SIZE: usize = 1024 * 1024;
     let mut line = Vec::new();
-    if reader.read_until(b'\n', &mut line)? == 0 {
+    if read_report_line(reader, &mut line)? == 0 {
         return Ok(None);
     }
     if protocol_line(&line) != b"syq-helper-manifest-begin" {
@@ -2908,8 +3010,7 @@ fn read_remote_download_report(
 
     let mut manifest = Vec::new();
     loop {
-        line.clear();
-        if reader.read_until(b'\n', &mut line)? == 0 {
+        if read_report_line(reader, &mut line)? == 0 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "remote manifest was not terminated",
@@ -2937,8 +3038,7 @@ fn read_remote_download_report(
         manifest.push(b'\n');
     }
 
-    line.clear();
-    if reader.read_until(b'\n', &mut line)? == 0 {
+    if read_report_line(reader, &mut line)? == 0 {
         return Err(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "remote helper digest was missing",
@@ -2953,8 +3053,7 @@ fn read_remote_download_report(
             )
         })?;
     let sha256 = String::from_utf8_lossy(digest).into_owned();
-    line.clear();
-    if reader.read_until(b'\n', &mut line)? == 0 {
+    if read_report_line(reader, &mut line)? == 0 {
         return Err(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "remote helper report was not terminated",
@@ -4232,6 +4331,41 @@ mod tests {
 
         let mut saw_root = true;
         assert!(validate_remote_scan_batch(&[entry(b"")], &mut saw_root, None).is_err());
+    }
+
+    #[test]
+    fn remote_download_report_rejects_an_oversized_line() {
+        let mut input = b"syq-helper-manifest-begin\nsyq-helper-manifest-data:".to_vec();
+        input.resize(input.len() + MAX_REPORT_LINE_BYTES + 16, b'x');
+        let error = read_remote_download_report(&mut input.as_slice()).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("line exceeded"), "{error}");
+    }
+
+    #[test]
+    fn capped_reads_keep_the_prefix_and_drain_the_rest() {
+        let captured = read_capped(std::io::repeat(b'x').take(5000), 100).unwrap();
+        assert_eq!(captured.bytes.len(), 100);
+        assert!(captured.truncated);
+        let captured = read_capped(&b"short"[..], 100).unwrap();
+        assert_eq!(captured.bytes, b"short");
+        assert!(!captured.truncated);
+    }
+
+    #[test]
+    fn captured_commands_bound_both_streams_and_feed_input() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("cat >/dev/null; head -c 3000000 /dev/zero; echo boom >&2; exit 3")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let out = run_captured(&mut cmd, Some(b"input")).unwrap();
+        assert_eq!(out.status.code(), Some(3));
+        assert_eq!(out.stdout.bytes.len(), MAX_BOOTSTRAP_OUTPUT_BYTES);
+        assert!(out.stdout.truncated);
+        assert_eq!(out.stderr.bytes, b"boom\n");
+        assert!(!out.stderr.truncated);
+        assert!(out.input_error.is_none());
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -5726,6 +5726,9 @@ impl FsOps {
         {
             bail!("test read-range failure");
         }
+        if u64::from(len) > MAX_READ_BYTES {
+            bail!("read length {len} exceeds the {MAX_READ_BYTES}-byte protocol limit");
+        }
         let target = self.source_content_target(source)?;
         let p = resolve(path);
         let f = if let Some((root_id, target)) = target {
@@ -6264,24 +6267,37 @@ impl FsOps {
                 len,
                 ..
             } => self.read_range(path, source.as_ref(), *attempt, *off, *len),
-            Request::ReadSmallBatch(reads) => Ok(Response::SmallBlocks(
-                reads
-                    .iter()
-                    .map(|read| {
-                        match self.read_range(
-                            &read.path,
-                            read.source.as_ref(),
-                            read.attempt,
-                            0,
-                            read.len,
-                        ) {
-                            Ok(Response::Block { data, hash, .. }) => Ok(SmallBlock { data, hash }),
-                            Ok(other) => Err(format!("unexpected response {other:?}")),
-                            Err(error) => Err(errstr(&error)),
-                        }
-                    })
-                    .collect(),
-            )),
+            Request::ReadSmallBatch(reads) => {
+                // Every block is collected before the batch is answered, so
+                // bound the whole batch, not just each read.
+                let total: u64 = reads.iter().map(|read| u64::from(read.len)).sum();
+                if total > MAX_READ_BYTES {
+                    Err(anyhow!(
+                        "small-file batch requests {total} bytes, exceeding the {MAX_READ_BYTES}-byte protocol limit"
+                    ))
+                } else {
+                    Ok(Response::SmallBlocks(
+                        reads
+                            .iter()
+                            .map(|read| {
+                                match self.read_range(
+                                    &read.path,
+                                    read.source.as_ref(),
+                                    read.attempt,
+                                    0,
+                                    read.len,
+                                ) {
+                                    Ok(Response::Block { data, hash, .. }) => {
+                                        Ok(SmallBlock { data, hash })
+                                    }
+                                    Ok(other) => Err(format!("unexpected response {other:?}")),
+                                    Err(error) => Err(errstr(&error)),
+                                }
+                            })
+                            .collect(),
+                    ))
+                }
+            }
             Request::WriteRange {
                 path,
                 inplace,
@@ -6944,6 +6960,53 @@ mod tests {
         // Return the control endpoint so tests retain the complete session
         // lifecycle in addition to each worker's own root and leaf clones.
         (worker, selections, control)
+    }
+
+    #[test]
+    fn oversized_reads_are_rejected_before_allocation() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let selected = temporary.path().join("selected");
+        fs::create_dir(&selected).unwrap();
+        fs::write(selected.join("marker"), b"original").unwrap();
+        let (mut worker, selections, _control) = registered_source_worker(&[&selected], false);
+        let marker = selections[0].join(b"marker").unwrap();
+        let path = selected.join("marker").as_os_str().as_bytes().to_vec();
+
+        let response = worker.handle(&Request::ReadRange {
+            path: path.clone(),
+            source: Some(marker.clone()),
+            attempt: 0,
+            off: 0,
+            len: u32::MAX,
+        });
+        assert!(
+            matches!(&response, Response::EndpointError(error) if error.message.contains("exceed")),
+            "{response:?}"
+        );
+
+        // Each read stays under the limit; together they exceed it.
+        let half = u32::try_from(MAX_READ_BYTES / 2 + 1).unwrap();
+        let read = SmallRead {
+            path: path.clone(),
+            source: Some(marker.clone()),
+            attempt: 0,
+            len: half,
+        };
+        let response = worker.handle(&Request::ReadSmallBatch(vec![read.clone(), read]));
+        assert!(
+            matches!(&response, Response::EndpointError(error) if error.message.contains("exceed")),
+            "{response:?}"
+        );
+
+        // A read within the limit still reaches the file.
+        let response = worker.handle(&Request::ReadRange {
+            path,
+            source: Some(marker),
+            attempt: 0,
+            off: 0,
+            len: 8,
+        });
+        assert!(matches!(response, Response::Block { data, .. } if data == b"original"));
     }
 
     #[test]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -14,6 +14,10 @@ use std::io::{self, BufReader, BufWriter, Read, Write};
 
 // 64 MiB data/batch tuning remains supported, with room for its metadata.
 pub const MAX_FRAME: usize = 65 * 1024 * 1024;
+/// Largest single `ReadRange` length and largest total `ReadSmallBatch`
+/// payload a server accepts. A longer read could never fit in a `MAX_FRAME`
+/// response, so it is rejected before the server allocates anything.
+pub const MAX_READ_BYTES: u64 = 64 * 1024 * 1024;
 pub const MAX_HANDSHAKE_FRAME: usize = 1024 * 1024;
 const MAX_METADATA_FRAME: usize = 8 * 1024 * 1024;
 pub const MIN_HASH_BLOCK_BYTES: u64 = 64 * 1024;

--- a/src/update.rs
+++ b/src/update.rs
@@ -28,6 +28,10 @@ const RECEIPT_SCHEMA: u32 = 1;
 const MANIFEST_SCHEMA: u32 = 1;
 const MANIFEST_SIGNATURE_SCHEME: &str = "ed25519-jcs-v1";
 const MAX_SAFE_JSON_INTEGER: u64 = (1 << 53) - 1;
+/// Ceiling for a release manifest download. Signed manifests are a few
+/// kilobytes; this bounds what an unverified response can write before its
+/// signature is checked.
+const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
 const CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const RELEASE_PUBLIC_KEY: Option<&str> = option_env!("SYQ_RELEASE_PUBLIC_KEY");
 
@@ -271,7 +275,7 @@ pub(crate) fn verified_current_helper(helper: &TrustedCurrentHelper) -> Result<V
         helper.tag,
         helper.archive.name
     );
-    fetch(&url, &archive, FetchMode::Interactive)?;
+    fetch(&url, &archive, FetchMode::Interactive, helper.archive.size)?;
     verify_file_as(
         archive.path(),
         &helper.archive,
@@ -312,7 +316,12 @@ fn fetch_verified(base_url: &str, mode: FetchMode) -> Result<VerifiedRelease> {
     let temp_dir = config_dir()?;
     create_private_dir(&temp_dir)?;
     let manifest_temp = TempFile::new(&temp_dir, ".json")?;
-    fetch(&format!("{base_url}/{MANIFEST_NAME}"), &manifest_temp, mode)?;
+    fetch(
+        &format!("{base_url}/{MANIFEST_NAME}"),
+        &manifest_temp,
+        mode,
+        MAX_MANIFEST_BYTES,
+    )?;
     let manifest_bytes = fs::read(manifest_temp.path()).context("read release manifest")?;
     let manifest = verified_manifest(&manifest_bytes, key.as_ref())?;
     let version = validate_manifest(&manifest)?;
@@ -521,7 +530,12 @@ fn download_artifact(
         release.manifest.tag,
         artifact.archive.name
     );
-    fetch(&url, &archive, FetchMode::Interactive)?;
+    fetch(
+        &url,
+        &archive,
+        FetchMode::Interactive,
+        artifact.archive.size,
+    )?;
     verify_file_as(
         archive.path(),
         &artifact.archive,
@@ -606,7 +620,35 @@ fn verify_executable(path: &Path, release: &VerifiedRelease) -> Result<()> {
     Ok(())
 }
 
-fn fetch(url: &str, destination: &TempFile, mode: FetchMode) -> Result<()> {
+/// A response body exceeded the caller's byte ceiling. Retrying cannot help.
+#[derive(Debug)]
+struct DownloadTooLarge {
+    limit: u64,
+}
+
+impl std::fmt::Display for DownloadTooLarge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "response exceeds the expected {} bytes", self.limit)
+    }
+}
+
+impl std::error::Error for DownloadTooLarge {}
+
+/// Copy at most `limit` bytes; a longer source fails instead of being
+/// truncated to something that might still look complete.
+fn copy_bounded(source: &mut impl Read, destination: &mut impl Write, limit: u64) -> Result<u64> {
+    let copied = std::io::copy(&mut source.take(limit.saturating_add(1)), destination)?;
+    if copied > limit {
+        bail!(DownloadTooLarge { limit });
+    }
+    Ok(copied)
+}
+
+/// Download `url` into `destination`, writing at most `limit` bytes. The
+/// caller passes the signed size for an archive and a fixed ceiling for a
+/// manifest, so an unverified response cannot fill the disk before its
+/// signature or digest is checked.
+fn fetch(url: &str, destination: &TempFile, mode: FetchMode, limit: u64) -> Result<()> {
     #[cfg(debug_assertions)]
     if let Some(root) = std::env::var_os("SYQ_TEST_FIXTURES").filter(|value| !value.is_empty()) {
         let name = url
@@ -614,9 +656,10 @@ fn fetch(url: &str, destination: &TempFile, mode: FetchMode) -> Result<()> {
             .next()
             .filter(|name| !name.is_empty() && !matches!(*name, "." | ".."))
             .ok_or_else(|| anyhow!("test release URL has no fixture name"))?;
-        std::io::copy(
+        copy_bounded(
             &mut File::open(PathBuf::from(root).join(name))?,
             &mut destination.writer()?,
+            limit,
         )
         .with_context(|| format!("copy test release fixture {name}"))?;
         return Ok(());
@@ -643,7 +686,7 @@ fn fetch(url: &str, destination: &TempFile, mode: FetchMode) -> Result<()> {
                 .with_context(|| format!("request {url}"))?;
             let file = destination.writer()?;
             let mut file = BufWriter::new(file);
-            std::io::copy(&mut response.body_mut().as_reader(), &mut file)
+            copy_bounded(&mut response.body_mut().as_reader(), &mut file, limit)
                 .with_context(|| format!("download {url}"))?;
             file.flush().with_context(|| {
                 format!("flush downloaded file {}", destination.path().display())
@@ -653,11 +696,12 @@ fn fetch(url: &str, destination: &TempFile, mode: FetchMode) -> Result<()> {
         match result {
             Ok(()) => return Ok(()),
             Err(error) => {
-                let retryable = !matches!(
-                    error.downcast_ref::<ureq::Error>(),
-                    Some(ureq::Error::StatusCode(code))
-                        if *code < 500 && !matches!(*code, 408 | 429)
-                );
+                let retryable = error.downcast_ref::<DownloadTooLarge>().is_none()
+                    && !matches!(
+                        error.downcast_ref::<ureq::Error>(),
+                        Some(ureq::Error::StatusCode(code))
+                            if *code < 500 && !matches!(*code, 408 | 429)
+                    );
                 last_error = Some(error);
                 if !retryable || attempt + 1 == attempts {
                     break;
@@ -1009,6 +1053,20 @@ mod tests {
     }
 
     #[test]
+    fn bounded_copies_fail_instead_of_truncating() {
+        let mut output = Vec::new();
+        assert_eq!(
+            copy_bounded(&mut &b"abcdef"[..], &mut output, 6).unwrap(),
+            6
+        );
+        let error = copy_bounded(&mut &b"abcdef"[..], &mut Vec::new(), 5).unwrap_err();
+        assert!(
+            error.downcast_ref::<DownloadTooLarge>().is_some(),
+            "{error}"
+        );
+    }
+
+    #[test]
     fn release_fetches_reject_plain_http() {
         let parent = crate::test_support::temp_dir();
         let destination = TempFile::new(&parent, ".http-test").unwrap();
@@ -1016,6 +1074,7 @@ mod tests {
             "http://127.0.0.1:1/release",
             &destination,
             FetchMode::BackgroundCheck,
+            MAX_MANIFEST_BYTES,
         )
         .unwrap_err();
         assert!(matches!(

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -260,7 +260,7 @@ fn self_update_rejects_a_tampered_archive_without_changing_install() {
         .unwrap();
 
     let update = fixture.command("--self-update");
-    assert_failure_contains(&update, "downloaded release archive has size");
+    assert_failure_contains(&update, "response exceeds the expected");
     fixture.assert_original_unchanged();
 }
 


### PR DESCRIPTION
## What changes

Three places accepted a size from a remote peer, host, or release origin and only checked it afterward. Each now enforces its bound before allocating memory or writing to disk.

- **Source worker reads.** `ReadRange` longer than 64 MiB, or a `ReadSmallBatch` whose lengths sum past 64 MiB, is rejected before the buffer is allocated. Such a response could never fit in a 65 MiB frame, so no legitimate client sends one; the client's request cap is already 64 MiB. This mirrors the existing `HashBlocks` pre-validation. The peer on a TCP data connection is authenticated by the transfer token only, so in a remote-to-remote copy this is another host with no shell on the source. Restricted receivers already reject these requests.
- **Release downloads.** The archive download stops at the manifest's signed size plus one byte and the manifest download at a fixed 1 MiB, instead of streaming whatever the origin sends and checking the size after. An oversized response fails immediately and is not retried. The size and SHA-256 verification after download is unchanged.
- **Remote helper bootstrap.** The platform probe, download report, and helper upload capture stdout and stderr through a 1 MiB cap per stream and drain the rest so the child never blocks on a full pipe. Report lines are bounded before they are buffered, so a single long line cannot bypass the existing 1 MiB manifest limit. A truncated probe fails rather than parsing a partial result; truncated stderr is diagnostic text and keeps its prefix.

No wire format, state, or documented behavior changes. Client and helper are always the same build, so the new server-side read limit has no cross-version exposure. The 1 MiB manifest ceiling is a forward commitment for future release manifests; today's manifest is a few kilobytes.

Deadlines were deliberately left out. A hostile SSH host or release origin can already stall the ordinary connection path, so a bootstrap-only or download-only deadline would be an availability change with tradeoffs on slow links, not a security boundary.

## Checks

- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`: pass
- `cargo test --bin syq`: 539 passed, 1 ignored (pre-existing), including new unit tests for oversized reads and batches, capped stream capture, bounded report lines, and bounded copies
- `cargo test --test local` filtered to the remote helper bootstrap tests (`managed_remote_helper`, `remote_helper_integrity`, `remote_manifest*`, `helper_install_and_upload`, `remote_corrupted_local_helper`, `development_build_uploads`, `no_bootstrap_uses`) and the small-file batch tests (`small_files_atomic`, `small_file_failure`): 10 passed
- `cargo test --test update`: 7 passed. The tampered-archive test now expects the download-time size failure, since the appended bytes stop the download at the signed size before the post-download size check runs
- `scripts/test-real-ssh.sh` (default profile): passed for the build at 172389b; the later commit changed only a test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015n5fjdQKq6zZtg6TfVTLUT

