### PR TITLE
Fix streaming bandwidth test fixture on macOS

### DIFF
--- a/tests/local.rs
+++ b/tests/local.rs
@@ -6087,6 +6087,9 @@ fn automatic_streaming_pull_preserves_average_bandwidth_pacing() {
     for tcp in [false, true] {
         let t = Tmp::new();
         let rsh = fake_rsh(&t);
+        // Require the SSH arrival address even where Linux interface discovery
+        // could otherwise hide an incomplete fake SSH session.
+        executable(&t.path("remote-bin/ip"), b"#!/bin/sh\nexit 1\n");
         let data = prng(1 << 20, 967);
         write(&t.path("source"), &data);
         let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
@@ -6115,6 +6118,9 @@ fn automatic_streaming_pull_preserves_average_bandwidth_pacing() {
             ])
             .env("SYQ_DEBUG", "1")
             .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+            .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env("FAKE_SSH_CONNECTION", "127.0.0.1 40000 127.0.0.1 22")
             .env("XDG_CONFIG_HOME", t.path("config"))
             .env("XDG_CACHE_HOME", t.path("cache"));
         if tcp {


### PR DESCRIPTION
The streaming bandwidth-pacing integration test fails its required TCP pull on macOS because its fake SSH session advertises no reachable address for `host`. Configure the fixture's loopback SSH arrival address and log path. Disable interface listing within this test so Linux also catches a missing arrival address. The existing TCP requirement, copy-content checks, streaming assertions, and minimum pacing duration remain exercised.

Validation at `8b572a7`:
- Reproduced the exact “no advertised data address is reachable” failure on Linux with interface listing disabled and the arrival address absent; adding the arrival address passed both SSH and TCP cases.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo test --bin syq`: 540 passed, 1 ignored.
- `cargo test --test local automatic_streaming_pull_preserves_average_bandwidth_pacing -- --exact` passed.
- [macOS validation](https://github.com/greaber/syq/actions/runs/34075258418) on this exact commit: Clippy and all native targets passed, including all 411 local integration tests and the repaired pacing test. The workflow subsequently failed in seven Python SDK mapping/process-cleanup tests (including `killpg` PermissionError); the same seven failures appear in the [earlier master run at `673981c`](https://github.com/greaber/syq/actions/runs/34067487032). Remaining SDK/tooling steps were skipped by the workflow. This PR is ready for review but does not have a green full macOS workflow.

This changes only one test fixture. No production or shared test infrastructure changes; Linux all-targets and real-SSH suites were not rerun.

Current branch-status output (exit 1 because master macOS is red at `6417c76`, with this same pacing fixture failure):

```text
Worktree: /home/grant/repos/syq/.worktrees/fix-streaming-pacing-fixture
Branch:   fix-streaming-pacing-fixture at 8b572a7 (clean)
Upstream: origin/fix-streaming-pacing-fixture (ahead 0, behind 0)
Master:   6417c76 from refs/heads/master (branch is ahead 1, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      6417c76  https://github.com/greaber/syq/actions/runs/34075099236
  rsync-compat.yml success      6417c76  https://github.com/greaber/syq/actions/runs/34075099422
  macos.yml        failure      6417c76  https://github.com/greaber/syq/actions/runs/34075099202

Pull request: #276 https://github.com/greaber/syq/pull/276
  base master, open, review none, merge state clean
  GitHub head 8b572a7: matches local 8b572a7
  checks: none registered yet

WARNING: master is red: macos.yml failure at 6417c76 https://github.com/greaber/syq/actions/runs/34075099202
```
