### PR TITLE
Reduce SSH startup overhead for automatic copies

### DIFF
--- a/docs/server-tuning.md
+++ b/docs/server-tuning.md
@@ -81,7 +81,7 @@ bursts from unrelated clients, so choose limits that suit the server.
 
 `MaxSessions` is a different limit: channels sharing one SSH connection.
 Very low values can force extra logins when syq tries to reuse a connection.
-Syq can start one data worker through the copy's control connection; other
+Syq can start up to two data workers through the copy's control connection; other
 large-copy workers use independent connections. Raising this limit alone does
 not increase their capacity.
 

--- a/docs/server-tuning.md
+++ b/docs/server-tuning.md
@@ -81,8 +81,9 @@ bursts from unrelated clients, so choose limits that suit the server.
 
 `MaxSessions` is a different limit: channels sharing one SSH connection.
 Very low values can force extra logins when syq tries to reuse a connection.
-Syq's SSH data workers use independent connections, so raising this limit
-alone does not increase their capacity.
+Syq can start one data worker through the copy's control connection; other
+large-copy workers use independent connections. Raising this limit alone does
+not increase their capacity.
 
 Validate configuration changes with `sshd -t`, then reload SSH using your
 system's normal procedure. Keep an administrative session open while doing

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -4,10 +4,14 @@ Start with the defaults. Syq copies files in parallel, splits large files
 between workers, and adjusts connection count during the transfer. If a TCP
 data port is reachable, it sends data through separate encrypted connections.
 Otherwise, ordinary copies send their data over SSH. Small copies can stay
-on the SSH control connection to avoid extra setup. For larger copies, one
-worker can start on the copy's existing SSH connection while the others open
-independent connections for parallel throughput. This does not reuse a
-cross-run persistent connection or override a custom `--rsh` command.
+on the SSH control connection to avoid extra setup. Larger copies start up to
+two workers on the copy's existing SSH connection while the others open
+independent connections for parallel throughput. A fixed connection count
+reuses it for only one worker. This reuse does not apply to a cross-run
+persistent connection or a custom `--rsh` command. Automatic SSH copies into
+new or empty directories also limit their initial worker count to the available
+files and splittable ranges. Updates and resumed copies keep their usual count:
+one file can contain many separate changed regions.
 When pushing into an
 existing directory, syq pipelines destination setup checks to reduce network
 round trips. For eligible small-file trees in an empty destination, TCP workers

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -4,7 +4,11 @@ Start with the defaults. Syq copies files in parallel, splits large files
 between workers, and adjusts connection count during the transfer. If a TCP
 data port is reachable, it sends data through separate encrypted connections.
 Otherwise, ordinary copies send their data over SSH. Small copies can stay
-on the SSH control connection to avoid extra setup. When pushing into an
+on the SSH control connection to avoid extra setup. For larger copies, one
+worker can start on the copy's existing SSH connection while the others open
+independent connections for parallel throughput. This does not reuse a
+cross-run persistent connection or override a custom `--rsh` command.
+When pushing into an
 existing directory, syq pipelines destination setup checks to reduce network
 round trips. For eligible small-file trees in an empty destination, TCP workers
 connect while destination planning finishes. These overlap setup work without

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1469,7 +1469,7 @@ impl SshMultiplexer {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SshConnection {
     Independent,
     Control,
@@ -1671,14 +1671,16 @@ impl RemoteSpec {
         cmd
     }
 
-    fn ssh_connection(&self, limited: bool) -> SshConnection {
+    fn ssh_connection(&self, limited: bool, first_worker: bool) -> SshConnection {
+        // One bulk worker can start on this copy's authenticated transport.
+        // The others retain independent cipher processes and TCP streams.
+        // Do not share a persistent master: workers must keep the current
+        // invocation's environment and not compete with unrelated copies.
         if !limited {
             SshConnection::Control
-        } else if self
-            .ssh_multiplexer
-            .as_ref()
-            .is_some_and(|multiplexer| multiplexer.reuse_for_workers())
-        {
+        } else if self.ssh_multiplexer.as_ref().is_some_and(|multiplexer| {
+            (first_worker && !multiplexer.persistent) || multiplexer.reuse_for_workers()
+        }) {
             SshConnection::Worker
         } else {
             SshConnection::Independent
@@ -1784,7 +1786,7 @@ impl RemoteSpec {
         } else {
             ConnectionRole::Control
         };
-        self.connect_with_role(compress, limited, role)
+        self.connect_with_role(compress, limited, role, false)
     }
 
     /// One non-retrying control connection for speculative shell completion.
@@ -1819,13 +1821,14 @@ impl RemoteSpec {
         compress: bool,
         limited: bool,
         role: ConnectionRole,
+        first_worker: bool,
     ) -> Result<RemoteConn> {
         if matches!(role, ConnectionRole::Control) && compress {
             if let Some(conn) = self.take_pooled_control(compress) {
                 return Ok(conn);
             }
         }
-        let first = self.connect_retried(compress, limited, role.clone());
+        let first = self.connect_retried(compress, limited, role.clone(), first_worker);
         let Err(first_error) = first else {
             return first;
         };
@@ -1834,7 +1837,7 @@ impl RemoteSpec {
         }
 
         self.install_helper()?;
-        self.connect_retried(compress, limited, role)
+        self.connect_retried(compress, limited, role, first_worker)
             .with_context(|| {
                 format!(
                     "could not start the {} helper installed on {}",
@@ -1849,6 +1852,7 @@ impl RemoteSpec {
         compress: bool,
         limited: bool,
         role: ConnectionRole,
+        mut first_worker: bool,
     ) -> Result<RemoteConn> {
         let mut delay = std::time::Duration::from_millis(200);
         let mut last = None;
@@ -1858,7 +1862,7 @@ impl RemoteSpec {
         let attempts = if limited { 6 } else { 1 };
         for attempt in 0..attempts {
             let _slot = limited.then(connect_slot);
-            let ssh_connection = self.ssh_connection(limited);
+            let ssh_connection = self.ssh_connection(limited, first_worker);
             match self.connect_once(compress, ssh_connection, role.clone()) {
                 Ok(c) => return Ok(c),
                 Err(e)
@@ -1870,6 +1874,7 @@ impl RemoteSpec {
                     // independently authenticated SSH connection. Disable
                     // reuse for every later worker and retry immediately.
                     self.set_ssh_multiplexing(false);
+                    first_worker = false;
                     if crate::transfer::debug() {
                         crate::output::diagnostic!(
                             "syq: {}: multiplexed SSH worker rejected; using independent SSH connections",
@@ -3042,15 +3047,20 @@ impl Endpoint {
     }
 
     pub(crate) fn connect_control(&self, compress: bool) -> Result<Box<dyn Conn>> {
-        self.connect_with_role(compress, ConnectionRole::Control)
+        self.connect_with_role(compress, ConnectionRole::Control, false)
     }
 
     pub(crate) fn connect_with_sources(
         &self,
         compress: bool,
         roots: Vec<RegisteredSourceRoot>,
+        first_worker: bool,
     ) -> Result<Box<dyn Conn>> {
-        self.connect_with_role(compress, ConnectionRole::SourceWorker { roots })
+        self.connect_with_role(
+            compress,
+            ConnectionRole::SourceWorker { roots },
+            first_worker,
+        )
     }
 
     pub(crate) fn connect_with_copy_capabilities(
@@ -3058,6 +3068,7 @@ impl Endpoint {
         compress: bool,
         destination: Option<DestinationRoot>,
         copy_sources: Vec<RegisteredSourceRoot>,
+        first_worker: bool,
     ) -> Result<Box<dyn Conn>> {
         self.connect_with_role(
             compress,
@@ -3065,10 +3076,16 @@ impl Endpoint {
                 destination,
                 copy_sources,
             },
+            first_worker,
         )
     }
 
-    fn connect_with_role(&self, compress: bool, role: ConnectionRole) -> Result<Box<dyn Conn>> {
+    fn connect_with_role(
+        &self,
+        compress: bool,
+        role: ConnectionRole,
+        first_worker: bool,
+    ) -> Result<Box<dyn Conn>> {
         match self {
             Endpoint::Local { descriptor_session } => {
                 // Every connection clone for this logical local endpoint uses
@@ -3176,7 +3193,12 @@ impl Endpoint {
                     };
                     bail!("{}: {reason}", spec.label());
                 }
-                Ok(Box::new(spec.connect_with_role(compress, true, role)?))
+                Ok(Box::new(spec.connect_with_role(
+                    compress,
+                    true,
+                    role,
+                    first_worker,
+                )?))
             }
         }
     }
@@ -3394,9 +3416,11 @@ mod tests {
         // ticket with SCM_RIGHTS. The endpoint clone still succeeds because it
         // reaches the control connection's process-local registry instead.
         std::fs::remove_file(roots[0].ticket.broker_path()).unwrap();
-        endpoint.connect_with_sources(false, roots.clone()).unwrap();
+        endpoint
+            .connect_with_sources(false, roots.clone(), false)
+            .unwrap();
         let error = Endpoint::local()
-            .connect_with_sources(false, roots)
+            .connect_with_sources(false, roots, false)
             .err()
             .expect("a fresh local endpoint must not share another session");
         assert!(format!("{error:#}").contains("connect to descriptor broker"));
@@ -3428,7 +3452,7 @@ mod tests {
             panic!("unexpected source registration response: {response:?}")
         };
         let source_marker = roots[0].selection.join(b"marker").unwrap();
-        let mut source = endpoint.connect_with_sources(false, roots).unwrap();
+        let mut source = endpoint.connect_with_sources(false, roots, false).unwrap();
 
         let response = source
             .call(Request::ReadRange {
@@ -4371,7 +4395,11 @@ mod tests {
         };
         let endpoint = Endpoint::Remote(spec.clone());
         assert!(endpoint
-            .connect_with_role(false, ConnectionRole::SourceWorker { roots: Vec::new() })
+            .connect_with_role(
+                false,
+                ConnectionRole::SourceWorker { roots: Vec::new() },
+                false
+            )
             .is_err());
         assert!(marker.exists(), "worker never attempted SSH fallback");
         assert!(spec.tcp.lock().unwrap().as_ref().unwrap().failed);
@@ -4413,12 +4441,27 @@ mod tests {
             .any(|pair| pair[0] == "-S" && pair[1] == control_path));
         assert!(control.iter().any(|arg| arg == "ControlPersist=no"));
 
-        let worker = args(spec.ssh_connection(true));
+        let worker = args(spec.ssh_connection(true, false));
         assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
         assert!(worker.iter().any(|arg| arg == "ControlPath=none"));
 
+        let first = args(spec.ssh_connection(true, true));
+        assert!(first
+            .windows(2)
+            .any(|pair| pair[0] == "-S" && pair[1] == control_path));
+        assert!(!first.iter().any(|arg| arg == "ControlPath=none"));
+        assert_eq!(spec.ssh_connection(false, true), SshConnection::Control);
+        // The first worker's preference is per call, not an opt-in for peers.
+        assert_eq!(spec.ssh_connection(true, false), SshConnection::Independent);
+        let mut custom = spec.clone();
+        custom.ssh_multiplexer = None;
+        assert_eq!(
+            custom.ssh_connection(true, true),
+            SshConnection::Independent
+        );
+
         spec.set_ssh_multiplexing(true);
-        let worker = args(spec.ssh_connection(true));
+        let worker = args(spec.ssh_connection(true, false));
         assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
         assert!(worker
             .windows(2)
@@ -4427,6 +4470,37 @@ mod tests {
 
         let independent = args(SshConnection::Independent);
         assert!(independent.iter().any(|arg| arg == "ControlPath=none"));
+    }
+
+    #[test]
+    fn first_ssh_worker_retries_independently_after_mux_rejection() {
+        use std::os::unix::fs::PermissionsExt;
+        let temporary = crate::test_support::tempdir().unwrap();
+        let script = temporary.path().join("ssh");
+        let log = temporary.path().join("attempts");
+        std::fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\nfor arg do\n  if [ \"$arg\" = -S ]; then\n    echo shared >> {log}\n    exit 255\n  fi\ndone\necho independent >> {log}\nexit 127\n",
+                log = shell_words::quote(log.to_str().unwrap()),
+            ),
+        ).unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let mut spec = RemoteSpec::local_receiver(true);
+        spec.local_process = false;
+        spec.rsh = vec![script.to_string_lossy().into_owned()];
+        spec.ssh_multiplexer = Some(std::sync::Arc::new(SshMultiplexer::new().unwrap()));
+        let result = spec.connect_retried(
+            false,
+            true,
+            ConnectionRole::SourceWorker { roots: Vec::new() },
+            true,
+        );
+        assert!(result.is_err()); // The independent attempt reports a missing helper.
+        assert_eq!(
+            std::fs::read_to_string(log).unwrap(),
+            "shared\nindependent\n"
+        );
     }
 
     #[test]
@@ -4510,9 +4584,10 @@ mod tests {
         // Worker data channels never ride a cross-run master, even when the
         // small-file path asks for in-run multiplexing.
         spec.set_ssh_multiplexing(true);
-        let worker = args(spec.ssh_connection(true));
+        let worker = args(spec.ssh_connection(true, false));
         assert!(worker.iter().any(|arg| arg == "ControlMaster=no"));
         assert!(worker.iter().any(|arg| arg == "ControlPath=none"));
+        assert_eq!(spec.ssh_connection(true, true), SshConnection::Independent);
     }
 
     #[test]

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1672,7 +1672,7 @@ impl RemoteSpec {
     }
 
     fn ssh_connection(&self, limited: bool, first_worker: bool) -> SshConnection {
-        // One bulk worker can start on this copy's authenticated transport.
+        // Startup workers can begin on this copy's authenticated transport.
         // The others retain independent cipher processes and TCP streams.
         // Do not share a persistent master: workers must keep the current
         // invocation's environment and not compete with unrelated copies.

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -52,6 +52,24 @@ fn fast_batch_file_limit(
     }
 }
 
+/// Upper bound: each file needs one worker, and each simultaneous range must
+/// contain at least min_split bytes. Balanced/aligned splitting can use fewer.
+fn initial_range_workers(
+    limit: usize,
+    sizes: impl IntoIterator<Item = u64>,
+    min_split: u64,
+) -> usize {
+    assert!(min_split > 0);
+    let capacity = sizes.into_iter().fold(0u64, |total, size| {
+        total.saturating_add((size / min_split).max(1))
+    });
+    limit.min((capacity.min(usize::MAX as u64) as usize).max(1))
+}
+
+fn reuse_startup_ssh(id: usize, autotune: bool) -> bool {
+    id == 0 || (autotune && id == 1)
+}
+
 fn initial_fast_workers(
     max_connections: usize,
     file_jobs: usize,
@@ -491,7 +509,22 @@ fn print_transport_diagnostics(args: &Args, src: &Endpoint, dst: &Endpoint) {
     if !remote {
         crate::output::diagnostic!("syq: transport: local filesystem");
     }
-    if args.dry_run {
+    let automatic_ssh = args.connections_default
+        && [src, dst]
+            .into_iter()
+            .filter_map(real_remote_spec)
+            .any(|spec| spec.data_transport() == DataTransport::Ssh);
+    if automatic_ssh {
+        let dry = if args.dry_run {
+            "; dry-run starts no workers"
+        } else {
+            ""
+        };
+        crate::output::diagnostic!(
+            "syq: concurrency: target {} {unit} ({policy}); initial count limited by available work{dry}",
+            args.connections
+        );
+    } else if args.dry_run {
         crate::output::diagnostic!(
             "syq: concurrency: a real transfer would start with {} {unit} ({policy}); dry-run starts no workers",
             args.connections
@@ -1949,11 +1982,13 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         return Ok(());
                     }
                     let t0 = std::time::Instant::now();
-                    // Begin copying on one already-authenticated SSH transport
-                    // while the remaining workers open independent connections.
+                    // Automatic copies start two channels on the authenticated
+                    // SSH transport so file ranges can run in parallel before
+                    // the remaining independent connections finish logging in.
                     // TCP and custom remote shells keep their existing policy.
+                    let reuse_control = reuse_startup_ssh(id, autotune);
                     let conns = src_ep
-                        .connect_with_sources(compress, initial_sources.clone(), id == 0)
+                        .connect_with_sources(compress, initial_sources.clone(), reuse_control)
                         .and_then(|src| {
                             let copy_sources = if cfg!(target_os = "linux") && opts.same_host {
                                 initial_sources.clone()
@@ -1966,7 +2001,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                                     compress,
                                     initial_destination.clone(),
                                     copy_sources,
-                                    id == 0,
+                                    reuse_control,
                                 )?,
                             ))
                         });
@@ -2516,6 +2551,15 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     } else {
         None
     };
+    // Only a fresh container rules out both final-file and resumable partial
+    // bases. Either basis can produce many disjoint changed ranges even in a
+    // file too small for work stealing, so its size cannot bound concurrency.
+    let fresh_container = dst_is_dir
+        && (dst_root_entry.is_none()
+            || (dst_entry_is_dir
+                && initial_destination_filesystem
+                    .as_ref()
+                    .is_some_and(|info| info.empty == Some(true))));
     let fresh_capacity = initial_destination_filesystem.and_then(|info| {
         let fresh = dst_root_entry.is_none()
             || (dst_entry_is_dir && dst_root_entry.is_some() && info.empty == Some(true));
@@ -3183,6 +3227,27 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                     } else {
                         args.connections
                     };
+                    if autotune
+                        && fresh_container
+                        && !multiplex_small_files
+                        && !all_remote_endpoints_use_tcp
+                        && (src_ep.is_remote() || dst_ep.is_remote())
+                    {
+                        // A worker which cannot get a file or steal a range
+                        // still costs an SSH login, and joining its setup can
+                        // delay success after every byte has been copied.
+                        let jobs = sched.jobs.lock().unwrap();
+                        initial = initial_range_workers(
+                            initial,
+                            jobs.iter().map(|job| job.entry.size),
+                            sched.min_split,
+                        );
+                        if args.verbose >= 2 && initial < args.connections {
+                            crate::output::diagnostic!(
+                                "syq: SSH startup limited to {initial} workers by available files and ranges"
+                            );
+                        }
+                    }
                     if single_direct_candidate {
                         sched.arm_direct_fallback(args.connections);
                         initial = 1;
@@ -9296,6 +9361,25 @@ mod tests {
             fast_batch_file_limit(None, None, true),
             HIGH_RTT_FAST_BATCH_FILES
         );
+    }
+
+    #[test]
+    fn ssh_startup_workers_are_bounded_by_files_and_splittable_ranges() {
+        const MIB: u64 = 1 << 20;
+        for (bytes, expected) in [(0, 1), (32, 1), (63, 1), (64, 2), (128, 4), (512, 8)] {
+            assert_eq!(initial_range_workers(8, [bytes * MIB], 32 * MIB), expected);
+        }
+        assert_eq!(initial_range_workers(8, [40 * MIB, 40 * MIB], 32 * MIB), 2);
+        assert_eq!(initial_range_workers(8, [0, 0, 0, 0], 32 * MIB), 4);
+        assert_eq!(initial_range_workers(8, [64 * MIB], 16 * MIB), 4);
+        assert_eq!(initial_range_workers(8, [u64::MAX, u64::MAX], 1), 8);
+        assert_eq!(initial_range_workers(1, [u64::MAX], 1), 1);
+        assert_eq!(initial_range_workers(0, [u64::MAX], 1), 0);
+        assert_eq!(initial_range_workers(8, [], 1), 1);
+        for id in 0..crate::tune::MAX {
+            assert_eq!(reuse_startup_ssh(id, true), id < 2);
+            assert_eq!(reuse_startup_ssh(id, false), id == 0);
+        }
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1015,7 +1015,7 @@ fn attempt_small_copy(
     }
 
     // Read through the engine's source-worker path.
-    let Ok(mut reader) = src_ep.connect_with_sources(args.compress, roots.to_vec()) else {
+    let Ok(mut reader) = src_ep.connect_with_sources(args.compress, roots.to_vec(), true) else {
         return Ok(SmallCopy::Declined);
     };
     let reads: Vec<SmallRead> = srcs
@@ -1949,8 +1949,11 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         return Ok(());
                     }
                     let t0 = std::time::Instant::now();
+                    // Begin copying on one already-authenticated SSH transport
+                    // while the remaining workers open independent connections.
+                    // TCP and custom remote shells keep their existing policy.
                     let conns = src_ep
-                        .connect_with_sources(compress, initial_sources.clone())
+                        .connect_with_sources(compress, initial_sources.clone(), id == 0)
                         .and_then(|src| {
                             let copy_sources = if cfg!(target_os = "linux") && opts.same_host {
                                 initial_sources.clone()
@@ -1963,6 +1966,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                                     compress,
                                     initial_destination.clone(),
                                     copy_sources,
+                                    id == 0,
                                 )?,
                             ))
                         });

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -4712,7 +4712,7 @@ fn double_verbose_dry_run_reports_ssh_fallback_without_extra_connection() {
     );
     assert!(
         stderr.contains(
-            "a real transfer would start with 8 connections (auto-tuned); dry-run starts no workers"
+            "target 8 connections (auto-tuned); initial count limited by available work; dry-run starts no workers"
         ),
         "{stderr}"
     );
@@ -4904,6 +4904,55 @@ fn inplace_copy_to_missing_remote_destination_waits_for_planned_work() {
 
     assert_output_ok(&out);
     assert_eq!(read(&t.path("dst")), b"in-place over reachable TCP");
+}
+
+#[test]
+fn automatic_ssh_starts_only_workers_that_can_help_the_file() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    let content = prng(64 << 20, 3241);
+    write(&t.path("src"), &content);
+    for (label, fixed, nonempty) in [
+        ("auto", false, false),
+        ("fixed", true, false),
+        ("nonempty", false, true),
+    ] {
+        let directory = t.path(&format!("dst-{label}"));
+        fs::create_dir_all(&directory).unwrap();
+        if nonempty {
+            write(&directory.join("src"), b"old destination contents");
+        }
+        let destination = format!("host:{}/", directory.display());
+        let events = t.path(&format!("events-{label}"));
+        let mut command = compat_command();
+        command
+            .arg("-e")
+            .arg(&rsh)
+            .arg("--rsync-path")
+            .arg(env!("CARGO_BIN_EXE_syq"))
+            .args(["--syq-no-tcp", "-a", "--no-progress"])
+            .arg(t.s("src"))
+            .arg(destination)
+            .env("SYQ_TEST_WORKER_EVENTS", &events)
+            .env("XDG_CONFIG_HOME", t.path("config"))
+            .env("XDG_CACHE_HOME", t.path(label));
+        if fixed {
+            command.args(["--syq-connections", "8"]);
+        }
+        let out = command.run().unwrap();
+        assert_output_ok(&out);
+        assert_eq!(read(&directory.join("src")), content);
+        let connected = fs::read_to_string(events)
+            .unwrap()
+            .lines()
+            .filter(|line| line.starts_with("connected "))
+            .count();
+        assert_eq!(
+            connected,
+            if fixed || nonempty { 8 } else { 2 },
+            "{label}: {out:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Start up to two automatic SSH data workers on the copy's already-authenticated private control transport; with fixed concurrency, reuse it for one worker. Other workers retain independent SSH connections.
- For fresh directory copies, limit automatic initial SSH concurrency to the available files and splittable ranges, avoiding logins for workers that cannot help.
- Preserve independent retry after multiplexed-session rejection, persistent-master and custom-rsh transport policies, explicit worker counts, and update/resume concurrency. TCP is unchanged.
- Update user-facing diagnostics and documentation. No protocol, persistent-state, or CLI changes.

## Validation

Candidate: `49df92de9078e2a3fceaadfdaa221c62abefc297`; branch `ssh-download-tuning`, clean and pushed.

- Full Rust all-targets tests, Clippy all-targets/all-features, formatting, documentation-link and diff checks passed.
- Default and MaxSessions=1 real-SSH suites completed; owned lab cleanup verified.
- Optimized-build SSH measurements used fresh generated destinations, matching endpoint binaries, full SHA256 verification, and bounded end-to-end timing without a final disk flush. Private WAN downloads improve. Fast-network controls identify a small sub-second download regression, accepted for this change; longer-workload tuning remains separate. Mac performance has not been validated.

Before merge, the combined tree with current master `ca0c08a` also passed full Rust all-targets tests, Clippy all-targets/all-features, formatting, documentation-link and diff checks. Validation commit: `11a24b7`; tree: `711783891c05a1fb092e5bdded49221b4c2c987f`. This did not change the candidate branch. The real-SSH suites above were run on candidate `49df92d`, not rerun on this combined tree.

Master's earlier macOS `automatic_streaming_pull_preserves_average_bandwidth_pacing` failure predated this candidate. Its fixture fix landed separately in PR #276, included in `ca0c08a`; Linux and macOS CI for that master revision are still running, and rsync-compatibility CI passed. No claim of Mac performance validation.
