### PR TITLE
Keep persistence status test sockets within macOS path limits

### DIFF
--- a/tests/local.rs
+++ b/tests/local.rs
@@ -18947,11 +18947,12 @@ fn persistence_status_escapes_peer_errors_but_json_preserves_them() {
     use std::os::fd::AsRawFd;
     use std::os::unix::net::UnixListener;
     let t = Tmp::new();
+    fs::create_dir(t.runtime()).unwrap();
     let command = |args: &[&str]| {
         let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
         command
             .args(args)
-            .env("XDG_RUNTIME_DIR", &t.0)
+            .env("XDG_RUNTIME_DIR", t.runtime())
             .env("XDG_CONFIG_HOME", t.path("config"));
         command
     };


### PR DESCRIPTION
The persistence status escaping test introduced in #273 used the full test directory for `XDG_RUNTIME_DIR`. macOS places temporary files under a long `/private/var/folders/...` path, so the test failed before reaching its assertions because the SSH control socket exceeded the platform limit.

Use and create the existing `Tmp::runtime()` directory, which keeps Unix socket paths short and is cleaned up with the fixture. Production behavior is unchanged.

Validation at 177a365:
- Reproduced the original failure on Linux using a long `TMPDIR`; the same focused test passes after the fix.
- `cargo fmt --all -- --check`, all-target/all-feature Clippy with warnings denied, and all 543 active unit tests passed (one existing ignored test).
- macOS workflow [34080181663](https://github.com/greaber/syq/actions/runs/34080181663) passed Clippy and all native tests on this exact commit, including the repaired status regression. The workflow then failed in seven Python SDK mapping/cleanup tests; the same seven failures and cleanup PermissionError occur in pre-existing master run [34067487032](https://github.com/greaber/syq/actions/runs/34067487032), before #273. Subsequent SDK and release-shell stages were skipped. The complete macOS workflow is not green.
