### PR TITLE
Validate receiver inputs and preserve JSON progress encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ dependencies = [
  "socket2",
  "ssh-agent-lib",
  "ssh-key",
+ "subtle",
  "tempfile",
  "ureq",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ ssh-agent-lib = { version = "0.6", default-features = false }
 ssh-key = { version = "0.6.7", features = ["ed25519", "p256", "p384", "p521", "rsa"] }
 tempfile = "3"
 signature = "2"
+subtle = "2.6.1"
 signal-hook = "0.4.4"
 
 [build-dependencies]

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -111,6 +111,8 @@ out of the discovered total; while syq is still scanning, the percentage is
 unknown. Wider terminals also show elapsed time, speed, ETA, and file counts.
 Use `--progress` to force the display or `--no-progress` to hide it. `--quiet`
 hides it too. `--progress-json` selects JSON progress instead of the bar.
+JSON progress and warning records preserve their original string values,
+including Unicode characters; terminal escaping applies only to human output.
 
 The bar advances when syq processes a block or completes a file. On a slow
 link, or during a local server-side copy, it can stay at the same position

--- a/docs/remote-reference.md
+++ b/docs/remote-reference.md
@@ -48,6 +48,11 @@ finish within seven days of authorization.
 | `--detach` | Unsupported; the local broker must remain attached |
 | Native `rm` | Unsupported; use a normal SSH login |
 
+TCP listeners must advertise a port in the requested range. An invalid port
+fails TCP setup before any address is probed. Special-file creation accepts
+only FIFO, socket, and device types; permission bits follow the grant's
+permission-preservation setting.
+
 ## Signed results
 
 The destination signs a receipt and your machine verifies it before reporting

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -2100,6 +2100,7 @@ impl RemoteSpec {
                 other => bail!("unexpected response {other:?}"),
             },
         };
+        validate_advertised_tcp_port(port, ports)?;
         if advertised.len() > MAX_ADVERTISED_TCP_ADDRESSES {
             bail!(
                 "TCP listener advertised too many addresses (limit {MAX_ADVERTISED_TCP_ADDRESSES})"
@@ -2455,6 +2456,18 @@ fn probe_reachable(candidates: &mut [TcpCandidate], port: u16) -> Result<()> {
                 undetermined -= 1;
             }
         }
+    }
+    Ok(())
+}
+
+fn validate_advertised_tcp_port(port: u16, requested: (u16, u16)) -> Result<()> {
+    // (0, 0) asks the operating system to allocate an ephemeral port.
+    if port == 0 || (requested != (0, 0) && !(requested.0..=requested.1).contains(&port)) {
+        bail!(
+            "TCP listener advertised port {port} outside requested range {}-{}",
+            requested.0,
+            requested.1
+        );
     }
     Ok(())
 }
@@ -3305,6 +3318,23 @@ impl Endpoint {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn advertised_tcp_port_must_match_requested_range() {
+        for port in [47_600, 47_650, 47_699] {
+            super::validate_advertised_tcp_port(port, (47_600, 47_699)).unwrap();
+        }
+        for port in [0, 22, 47_599, 47_700, u16::MAX] {
+            assert!(super::validate_advertised_tcp_port(port, (47_600, 47_699)).is_err());
+        }
+        super::validate_advertised_tcp_port(12345, (12345, 12345)).unwrap();
+        assert!(super::validate_advertised_tcp_port(12346, (12345, 12345)).is_err());
+        // Existing test and local listener callers use (0, 0) for OS allocation.
+        for port in [1, 47_650, u16::MAX] {
+            super::validate_advertised_tcp_port(port, (0, 0)).unwrap();
+        }
+        assert!(super::validate_advertised_tcp_port(0, (0, 0)).is_err());
+    }
+
     #[test]
     fn tcp_connection_ids_fail_at_nonce_space_exhaustion() {
         let next = std::sync::atomic::AtomicU32::new(crate::tcp_records::CONNECTION_ID_MAX);

--- a/src/output.rs
+++ b/src/output.rs
@@ -51,9 +51,13 @@ impl Terminal {
     }
 
     fn diagnostic(&mut self, out: &mut impl Write, args: Arguments<'_>) -> io::Result<()> {
+        self.write_line(out, format_args!("{}", safe_message(args)))
+    }
+
+    fn write_line(&mut self, out: &mut impl Write, args: Arguments<'_>) -> io::Result<()> {
         let line = self.line.clone();
         self.clear(out)?;
-        writeln!(out, "{}", safe_message(args))?;
+        writeln!(out, "{args}")?;
         if let Some(line) = line {
             self.draw(out, line)?;
         }
@@ -84,6 +88,14 @@ pub(crate) fn emit_diagnostic(args: Arguments<'_>) {
         .lock()
         .unwrap()
         .diagnostic(&mut io::stderr().lock(), args);
+}
+
+/// Already serialized JSON must retain its encoding, including Unicode values.
+pub(crate) fn emit_json_stderr(args: Arguments<'_>) {
+    let _ = TERMINAL
+        .lock()
+        .unwrap()
+        .write_line(&mut io::stderr().lock(), args);
 }
 
 pub(crate) fn emit_human_stdout(args: Arguments<'_>) {
@@ -128,6 +140,20 @@ pub(crate) use human_stdout;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn json_output_preserves_unicode_and_json_escapes() {
+        let message = "quote \" slash \\ newline\n control \u{1b} separators \u{2028}\u{2029} bidi \u{061c}\u{202e}";
+        let warning = serde_json::json!({"type": "warning", "message": message});
+        let mut output = Vec::new();
+        Terminal::default()
+            .write_line(&mut output, format_args!("{warning}"))
+            .unwrap();
+        let decoded: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(decoded["message"], message);
+        assert_eq!(output.iter().filter(|&&byte| byte == b'\n').count(), 1);
+        assert!(!output.contains(&0x1b));
+    }
 
     #[test]
     fn peer_diagnostics_cannot_control_the_terminal() {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -192,7 +192,7 @@ impl Progress {
 
     pub fn warning(&self, code: &str, count: u64, message: &str) {
         if self.json {
-            crate::output::diagnostic!(
+            crate::output::emit_json_stderr(format_args!(
                 "{}",
                 serde_json::json!({
                     "type": "warning",
@@ -200,7 +200,7 @@ impl Progress {
                     "count": count,
                     "message": message,
                 })
-            );
+            ));
         } else {
             crate::output::diagnostic!("syq: warning: {message}");
         }
@@ -280,7 +280,7 @@ impl Progress {
                 .is_none_or(|l| now - l >= Duration::from_secs(1))
             {
                 t.last_json = Some(now);
-                crate::output::diagnostic!(
+                crate::output::emit_json_stderr(format_args!(
                     "{{\"bytes_done\":{done},\"bytes_total\":{total},\"bytes_unchanged\":{skipped},\"files_done\":{fdone},\"files_total\":{ftotal},\"files_unchanged\":{},\"files_excluded\":{},\"scanned\":{},\"scan_done\":{scan_done},\"rate\":{:.0},\"eta\":{},\"elapsed\":{:.1}}}",
                     self.files_unchanged.load(Relaxed),
                     self.files_excluded.load(Relaxed),
@@ -288,7 +288,7 @@ impl Progress {
                     rate,
                     eta.map_or("null".to_string(), |e| format!("{e:.0}")),
                     self.start.elapsed().as_secs_f64()
-                );
+                ));
             }
         }
         if !self.enabled {

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -1911,13 +1911,23 @@ impl RestrictedAuthority {
                 ..
             } => {
                 let kind = kind_from_mode(*mode);
+                if !matches!(
+                    kind,
+                    proto::Kind::Fifo
+                        | proto::Kind::Socket
+                        | proto::Kind::CharDev
+                        | proto::Kind::BlockDev
+                ) {
+                    bail!("special-file creation requires a FIFO, socket, or device mode");
+                }
+                #[cfg(target_os = "linux")]
+                let file_type = *mode & libc::S_IFMT;
+                #[cfg(not(target_os = "linux"))]
+                let file_type = *mode & libc::S_IFMT as u32;
+                *mode = file_type | (*mode & 0o7777);
                 self.constrain_creation(path, condition, false, index, pending)?;
                 if !self.copy.options.preserve_permissions {
                     self.remember_receiver_creation(path, false)?;
-                    #[cfg(target_os = "linux")]
-                    let file_type = *mode & libc::S_IFMT;
-                    #[cfg(not(target_os = "linux"))]
-                    let file_type = *mode & libc::S_IFMT as u32;
                     *mode = file_type | 0o600;
                 }
                 outcomes.push(PendingOutcome::Logical {
@@ -5532,6 +5542,65 @@ pub(crate) mod tests {
             flags: 0,
             condition: proto::TargetCondition::Any,
         }
+    }
+
+    #[test]
+    fn special_file_creation_checks_kind_and_masks_mode() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let root = temporary.path();
+        fs::create_dir(root.join("target")).unwrap();
+        for preserve_permissions in [false, true] {
+            for kind in [
+                libc::S_IFREG,
+                libc::S_IFDIR,
+                libc::S_IFLNK,
+                0,
+                libc::S_IFIFO,
+                libc::S_IFSOCK,
+                libc::S_IFCHR,
+                libc::S_IFBLK,
+            ] {
+                let mut authority = test_authority(root, DeletionPolicy::Forbid, 1024);
+                authority.copy.options.preserve_devices = true;
+                authority.copy.options.preserve_permissions = preserve_permissions;
+                #[allow(clippy::unnecessary_cast)]
+                let kind = kind as u32;
+                let mut request = apply(Op::Mknod {
+                    path: path_bytes(&root.join("target/node")),
+                    mode: kind | 0x8000_0000 | 0o6754,
+                    rdev: 0,
+                    condition: proto::TargetCondition::Any,
+                });
+                let allowed = matches!(
+                    kind_from_mode(kind),
+                    proto::Kind::Fifo
+                        | proto::Kind::Socket
+                        | proto::Kind::CharDev
+                        | proto::Kind::BlockDev
+                );
+                let result = authority.authorize(&mut request, false);
+                if !allowed {
+                    assert!(result
+                        .err()
+                        .unwrap()
+                        .to_string()
+                        .contains("special-file creation requires"));
+                    continue;
+                }
+                result.unwrap();
+                let Request::Apply { ops, .. } = request else {
+                    unreachable!()
+                };
+                let Op::Mknod { mode, .. } = ops[0] else {
+                    unreachable!()
+                };
+                assert_eq!(
+                    mode,
+                    kind | if preserve_permissions { 0o6754 } else { 0o600 }
+                );
+            }
+        }
+        assert!(!root.join("target/node").exists());
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
 use std::sync::Arc;
 use std::time::Duration;
+use subtle::ConstantTimeEq;
 
 struct RequestReader {
     rx: Option<std::sync::mpsc::Receiver<io::Result<crate::wire_budget::Budgeted<Request>>>>,
@@ -315,7 +316,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
         } => {
             debug = d;
             if let Some(t) = &expect_token {
-                if &token != t {
+                if !bool::from(token.ct_eq(t)) {
                     bail!("bad token on data connection");
                 }
             }


### PR DESCRIPTION
Restricted receivers now reject regular-file, directory, symlink, and unknown modes in special-file creation requests, and discard mode bits outside the file type and permissions. Valid FIFO, socket, and device creation keeps the grant's permission policy (L3).

JSON progress and warning records bypass human terminal escaping, preserving valid JSON and original Unicode values (L7). TCP setup rejects an advertised port outside the requested range before probing addresses, while preserving `(0, 0)` requests for OS-assigned ports (L10). Worker tokens use `subtle::ConstantTimeEq`; `subtle` was already locked transitively, so no package versions change (L11).

Compatibility baseline: released v0.4.1 (`13fc7d1`). No helper wire fields, signed grants, enrollment/replay records, receipts, resume identities, persistence state, CLI/SDK names, or documentation URLs change. The unchanged v0.4.1 encrypted-record fixture still decodes and re-encodes identically; live helpers retain exact-build checks. Existing state is read the same way by old and new binaries, and shared-host state needs no migration. The intentional behavior changes reject malformed receiver inputs and correct JSON encoding; valid special-file modes and the existing ephemeral-port convention remain supported.

Validation at `ef6ea17`:

- Rust formatting and all-target/all-feature Clippy with warnings denied passed.
- `cargo test --all-targets`: 1,003 passed, one pre-existing ignored test. This includes 546 unit tests, 434 local integration tests, released wire fixtures, JSON progress, TCP/SSH transfers, special files, and output failure handling.
- Complete default three-container OpenSSH suite passed, including restricted receiver transfers, TCP/SSH paths, and benchmark interruption cleanup. It ran against the unchanged source tree committed as `ef6ea17`.
- Documentation links: 20 files, no problems.
- macOS and the Python SDK suite were not run locally.

Hard-link policy, running-copy revocation, aggregate receiver memory limits, TCP connection-ID/nonce changes, macOS runtime paths, and SDK manifest signature verification are separate follow-ups requiring policy or implementation work beyond these input and output corrections.

Branch status at handoff: `ef6ea17` is clean, pushed, and matches the PR head; no PR checks are registered. Independent master `2499d7c` has successful Linux CI and rsync compatibility runs, but its [macOS run failed](https://github.com/greaber/syq/actions/runs/34135292235). This branch predates that master update and a merge-tree check reports no conflicts. No merge performed.
