### PR TITLE
Improve SSH startup and initial range scheduling

### DIFF
--- a/docs/speed.md
+++ b/docs/speed.md
@@ -354,7 +354,8 @@ a mixture of old and new contents while the copy runs. If interrupted, that
 incomplete version stays at the final filename until you finish the copy.
 
 `--no-compress` saves CPU at the cost of potentially sending more bytes; it
-does not affect file contents or integrity checks.
+does not affect file contents or integrity checks. Compression applies across
+the network, not between syq and its receiver process on the same machine.
 
 Examples use native options. In rsync mode, syq-specific options have a
 `--syq-` prefix, such as `--syq-connections` and `--syq-no-tcp`.

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -9,9 +9,11 @@ two workers on the copy's existing SSH connection while the others open
 independent connections for parallel throughput. A fixed connection count
 reuses it for only one worker. This reuse does not apply to a cross-run
 persistent connection or a custom `--rsh` command. Automatic SSH copies into
-new or empty directories also limit their initial worker count to the available
-files and splittable ranges. Updates and resumed copies keep their usual count:
-one file can contain many separate changed regions.
+new or empty directories, or to missing single-file destinations, also limit
+their initial worker count to the available files and splittable ranges.
+Updates keep their usual count. If a missing file has a resumable partial,
+syq restores that count when it discovers the partial: one file can contain
+many separate changed regions.
 When pushing into an
 existing directory, syq pipelines destination setup checks to reduce network
 round trips. For eligible small-file trees in an empty destination, TCP workers

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -14,6 +14,10 @@ their initial worker count to the available files and splittable ranges.
 Updates keep their usual count. If a missing file has a resumable partial,
 syq restores that count when it discovers the partial: one file can contain
 many separate changed regions.
+With automatic concurrency, syq divides a single large fresh file over SSH
+before copying starts, so workers that connect later can help without waiting for a large enough
+remaining range to split. Earlier workers can keep taking work while those
+connections start.
 When pushing into an
 existing directory, syq pipelines destination setup checks to reduce network
 round trips. For eligible small-file trees in an empty destination, TCP workers

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1324,6 +1324,7 @@ pub(crate) struct SshMultiplexer {
     /// handshake.
     persistent: bool,
     reuse_for_workers: AtomicBool,
+    workers_rejected: AtomicBool,
 }
 
 /// How long a persistent control master lingers after its last client, in
@@ -1437,6 +1438,7 @@ impl SshMultiplexer {
             path,
             persistent: false,
             reuse_for_workers: AtomicBool::new(false),
+            workers_rejected: AtomicBool::new(false),
         })
     }
 
@@ -1452,6 +1454,7 @@ impl SshMultiplexer {
             path,
             persistent: true,
             reuse_for_workers: AtomicBool::new(false),
+            workers_rejected: AtomicBool::new(false),
         })
     }
 
@@ -1679,7 +1682,8 @@ impl RemoteSpec {
         if !limited {
             SshConnection::Control
         } else if self.ssh_multiplexer.as_ref().is_some_and(|multiplexer| {
-            (first_worker && !multiplexer.persistent) || multiplexer.reuse_for_workers()
+            !multiplexer.workers_rejected.load(Ordering::Relaxed)
+                && ((first_worker && !multiplexer.persistent) || multiplexer.reuse_for_workers())
         }) {
             SshConnection::Worker
         } else {
@@ -1874,6 +1878,9 @@ impl RemoteSpec {
                     // independently authenticated SSH connection. Disable
                     // reuse for every later worker and retry immediately.
                     self.set_ssh_multiplexing(false);
+                    if let Some(multiplexer) = &self.ssh_multiplexer {
+                        multiplexer.workers_rejected.store(true, Ordering::Relaxed);
+                    }
                     first_worker = false;
                     if crate::transfer::debug() {
                         crate::output::diagnostic!(
@@ -4683,9 +4690,16 @@ mod tests {
         );
         assert!(result.is_err()); // The independent attempt reports a missing helper.
         assert_eq!(
-            std::fs::read_to_string(log).unwrap(),
+            std::fs::read_to_string(&log).unwrap(),
             "shared\nindependent\n"
         );
+        // Another startup worker's per-call preference must not override a
+        // rejection already observed by a peer sharing this control session.
+        let peer = spec.clone();
+        peer.set_ssh_multiplexing(true);
+        assert_eq!(peer.ssh_connection(true, true), SshConnection::Independent);
+        assert_eq!(peer.ssh_connection(true, false), SshConnection::Independent);
+        assert_eq!(peer.ssh_connection(false, true), SshConnection::Control);
     }
 
     #[test]
@@ -4794,6 +4808,7 @@ mod tests {
             path: PathBuf::from("/tmp/syq-test-socket"),
             persistent: true,
             reuse_for_workers: AtomicBool::new(false),
+            workers_rejected: AtomicBool::new(false),
         }));
         assert!(!verbose(&spec, true));
         assert!(!spec
@@ -4814,6 +4829,7 @@ mod tests {
             path,
             persistent: true,
             reuse_for_workers: AtomicBool::new(false),
+            workers_rejected: AtomicBool::new(false),
         };
         let spec = RemoteSpec {
             local_process: false,

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1920,6 +1920,9 @@ impl RemoteSpec {
         ssh_connection: SshConnection,
         role: ConnectionRole,
     ) -> Result<RemoteConn> {
+        // The receiver child is on this machine, not across the network.
+        // Recompressing forwarded blocks here adds CPU work to downloads.
+        let compress = compress && !self.local_process;
         let return_stream = if let Some(approved) = &self.forwarded {
             if !matches!(role, ConnectionRole::Control) {
                 bail!("copies via a return connection require encrypted TCP workers");
@@ -2258,6 +2261,8 @@ impl RemoteSpec {
         compress: bool,
         role: ConnectionRole,
     ) -> Result<RemoteConn> {
+        // Keep network compression, but not on the local receiver's data hop.
+        let compress = compress && !self.local_process;
         let n = info.addrs.len();
         let start = info.next.fetch_add(1, std::sync::atomic::Ordering::Relaxed) % n;
         let mut last = anyhow!("no data address");
@@ -3941,6 +3946,52 @@ mod tests {
             tcp_congestion_fallback_note(Some("reno")),
             "; requested congestion control reno is not used by the SSH fallback"
         );
+    }
+
+    #[test]
+    fn only_the_local_receiver_disables_requested_tcp_compression() {
+        for local_process in [false, true] {
+            for requested in [false, true] {
+                let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+                let port = listener.local_addr().unwrap().port();
+                let server = std::thread::spawn(move || {
+                    let (mut socket, _) = listener.accept().unwrap();
+                    socket
+                        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                        .unwrap();
+                    let mut id = [0; 4];
+                    socket.read_exact(&mut id).unwrap();
+                    let mut reader =
+                        FrameReader::new(RecordReader::new(socket.try_clone().unwrap(), None));
+                    let Request::Hello { compress, .. } = reader.read_msg().unwrap() else {
+                        panic!("expected Hello");
+                    };
+                    let mut writer = FrameWriter::new(RecordWriter::new(socket, None), false);
+                    writer.write_msg(&hello_ok()).unwrap();
+                    compress
+                });
+                let mut spec = RemoteSpec::local_receiver(false);
+                // Even an explicit SSH endpoint on loopback is not the
+                // in-process receiver and keeps the requested compression.
+                spec.local_process = local_process;
+                let info = TcpInfo {
+                    addrs: vec!["127.0.0.1".into()],
+                    port,
+                    key: None,
+                    token: Vec::new(),
+                    congestion_control: None,
+                    failed: false,
+                    failure: None,
+                    next: Default::default(),
+                };
+                let conn = spec
+                    .connect_tcp(&info, requested, ConnectionRole::Control)
+                    .unwrap();
+                let expected = requested && !local_process;
+                assert_eq!(conn.w.compress, expected);
+                assert_eq!(server.join().unwrap(), expected);
+            }
+        }
     }
 
     #[test]

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -87,6 +87,7 @@ pub struct Sched {
     cv: Condvar,
     tune_cv: Condvar,
     direct_fallback_workers: AtomicUsize,
+    initial_range_workers: AtomicUsize,
     tune_request: AtomicUsize,
     pub jobs: Mutex<Vec<FileJob>>,
     pub block: u64,
@@ -113,6 +114,7 @@ impl Sched {
             cv: Condvar::new(),
             tune_cv: Condvar::new(),
             direct_fallback_workers: AtomicUsize::new(0),
+            initial_range_workers: AtomicUsize::new(0),
             tune_request: AtomicUsize::new(0),
             jobs: Mutex::new(Vec::new()),
             block,
@@ -158,6 +160,12 @@ impl Sched {
 
     pub fn arm_direct_fallback(&self, workers: usize) {
         self.direct_fallback_workers.store(workers, Relaxed);
+    }
+
+    pub fn reserve_initial_ranges(&self, workers: usize) {
+        // Reserve runnable work, not workers: an early connection can take
+        // another queued range if its peers are still connecting.
+        self.initial_range_workers.store(workers, Relaxed);
     }
 
     pub fn request_direct_fallback(&self) {
@@ -419,9 +427,35 @@ impl Sched {
 
     /// After probing a file: register its ranges. Returns the handle for the
     /// first range (already marked in flight) or None if nothing to transfer.
-    pub fn ranges_ready(&self, idx: usize, ranges: Vec<(u64, u64)>) -> Option<RangeHandle> {
+    pub fn ranges_ready(&self, idx: usize, mut ranges: Vec<(u64, u64)>) -> Option<RangeHandle> {
         let mut g = self.inner.lock().unwrap();
         g.probing -= 1;
+        let workers = self.initial_range_workers.swap(0, Relaxed) as u64;
+        // Preserve the split floor while exposing the initial parallelism
+        // before any worker's progress makes balanced stealing impossible.
+        if workers > 1 && g.files.is_empty() && ranges.len() == 1 {
+            let (start, end) = ranges[0];
+            if start.is_multiple_of(self.block) {
+                let blocks = (end - start) / self.block;
+                let parts = workers
+                    .min(blocks / self.min_split.div_ceil(self.block))
+                    .max(1);
+                if parts > 1 {
+                    ranges.clear();
+                    let mut off = start;
+                    for part in 0..parts {
+                        let n = blocks / parts + u64::from(part < blocks % parts);
+                        let limit = if part + 1 == parts {
+                            end
+                        } else {
+                            off + n * self.block
+                        };
+                        ranges.push((off, limit));
+                        off = limit;
+                    }
+                }
+            }
+        }
         if !ranges.is_empty() {
             g.outstanding.insert(idx, ranges.len() as u32);
         }
@@ -487,6 +521,88 @@ impl Sched {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn initial_ranges_preserve_coverage_alignment_and_split_floor() {
+        for size in [
+            1,
+            31 << 20,
+            32 << 20,
+            63 << 20,
+            64 << 20,
+            256 << 20,
+            (257 << 20) + 7,
+        ] {
+            for workers in [0, 1, 2, 8, 16] {
+                let sched = Sched::new(4 << 20, 32 << 20);
+                sched.inner.lock().unwrap().probing = 1;
+                sched.reserve_initial_ranges(workers);
+                let first = sched.ranges_ready(0, vec![(0, size)]).unwrap();
+                let mut spans = {
+                    let r = first.lock().unwrap();
+                    vec![(r.pos, r.end)]
+                };
+                let inner = sched.inner.lock().unwrap();
+                spans.extend(inner.ranges.iter().map(|(_, off, end)| (*off, *end)));
+                spans.sort_unstable();
+                let count = workers.min((size / sched.min_split) as usize).max(1);
+                assert_eq!(spans.len(), count);
+                assert_eq!(inner.outstanding[&0] as usize, count);
+                let mut end = 0;
+                for (off, limit) in spans {
+                    assert_eq!(off, end);
+                    assert_eq!(off % sched.block, 0);
+                    assert!(count == 1 || limit - off >= sched.min_split);
+                    end = limit;
+                }
+                assert_eq!(end, size);
+            }
+        }
+    }
+
+    #[test]
+    fn initial_ranges_remain_available_after_the_first_worker_advances() {
+        let sched = Sched::new(4 << 20, 32 << 20);
+        sched.inner.lock().unwrap().probing = 1;
+        sched.reserve_initial_ranges(8);
+        let first = sched.ranges_ready(0, vec![(0, 256 << 20)]).unwrap();
+        first.lock().unwrap().pos += 4 << 20;
+        sched.scan_done();
+        for _ in 1..8 {
+            let Item::Range(range) = sched.next() else {
+                panic!("missing reserved range")
+            };
+            assert!(!sched.range_done(&range));
+        }
+        assert!(sched.range_done(&first));
+        assert!(matches!(sched.next(), Item::Exit));
+    }
+
+    #[test]
+    fn initial_ranges_leave_diff_ranges_and_other_files_alone() {
+        for queued_file in [false, true] {
+            let sched = Sched::new(4 << 20, 32 << 20);
+            {
+                let mut inner = sched.inner.lock().unwrap();
+                inner.probing = 1;
+                if queued_file {
+                    inner.files.push((64 << 20, Reverse(1)));
+                }
+            }
+            sched.reserve_initial_ranges(8);
+            let spans = if queued_file {
+                vec![(0, 256 << 20)]
+            } else {
+                vec![(0, 64 << 20), (128 << 20, 256 << 20)]
+            };
+            let first = sched.ranges_ready(0, spans.clone()).unwrap();
+            let range = first.lock().unwrap();
+            assert_eq!((range.pos, range.end), spans[0]);
+            let inner = sched.inner.lock().unwrap();
+            assert_eq!(inner.outstanding[&0] as usize, spans.len());
+            assert_eq!(sched.initial_range_workers.load(Relaxed), 0);
+        }
+    }
 
     #[test]
     fn tuning_split_threshold_controls_when_idle_workers_can_help() {

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -146,8 +146,8 @@ impl Sched {
         inner.failed = HashSet::new();
     }
 
-    /// Wake the tuner when a speculative direct local copy discovers that it
-    /// needs the ordinary parallel userspace path after all.
+    /// Wake the tuner when a speculative low-concurrency start discovers
+    /// more parallel work (a local-copy fallback or a resumable basis).
     pub fn request_worker_count(&self, workers: usize) {
         // Share the scheduler mutex with the tuning wait predicate so a
         // request cannot land between the driver's check and its sleep.

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -521,7 +521,7 @@ fn print_transport_diagnostics(args: &Args, src: &Endpoint, dst: &Endpoint) {
             ""
         };
         crate::output::diagnostic!(
-            "syq: concurrency: target {} {unit} ({policy}); initial count limited by available work{dry}",
+            "syq: concurrency: target {} {unit} ({policy}){dry}",
             args.connections
         );
     } else if args.dry_run {
@@ -2551,19 +2551,16 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     } else {
         None
     };
-    // Only a fresh container rules out both final-file and resumable partial
-    // bases. Either basis can produce many disjoint changed ranges even in a
-    // file too small for work stealing, so its size cannot bound concurrency.
-    let fresh_container = dst_is_dir
-        && (dst_root_entry.is_none()
-            || (dst_entry_is_dir
-                && initial_destination_filesystem
-                    .as_ref()
-                    .is_some_and(|info| info.empty == Some(true))));
+    // A missing single-file target may still have a resumable sidecar. Bound
+    // its initial SSH workers speculatively, then restore concurrency if the
+    // worker discovers a basis with potentially disjoint changed ranges.
+    let fresh_destination = dst_root_entry.is_none()
+        || (dst_entry_is_dir
+            && initial_destination_filesystem
+                .as_ref()
+                .is_some_and(|info| info.empty == Some(true)));
     let fresh_capacity = initial_destination_filesystem.and_then(|info| {
-        let fresh = dst_root_entry.is_none()
-            || (dst_entry_is_dir && dst_root_entry.is_some() && info.empty == Some(true));
-        fresh.then_some(FreshCapacityPlan {
+        fresh_destination.then_some(FreshCapacityPlan {
             device: info.device,
             target: exact_capacity_target,
             root_existed: dst_root_entry.is_some(),
@@ -3228,7 +3225,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         args.connections
                     };
                     if autotune
-                        && fresh_container
+                        && fresh_destination
                         && !multiplex_small_files
                         && !all_remote_endpoints_use_tcp
                         && (src_ep.is_remote() || dst_ep.is_remote())
@@ -3242,6 +3239,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                             jobs.iter().map(|job| job.entry.size),
                             sched.min_split,
                         );
+                        if initial < args.connections {
+                            sched.arm_direct_fallback(args.connections);
+                        }
                         if args.verbose >= 2 && initial < args.connections {
                             crate::output::diagnostic!(
                                 "syq: SSH startup limited to {initial} workers by available files and ranges"
@@ -7987,6 +7987,9 @@ impl Worker {
                 other => bail!("unexpected response {other:?}"),
             };
 
+            if partial_size.is_some() || final_is_file {
+                self.sched.request_direct_fallback();
+            }
             if inplace {
                 if final_is_file && size > 0 {
                     return Ok((self.diff_blocks(&job, Which::Final)?, true));

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -3242,6 +3242,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                         if initial < args.connections {
                             sched.arm_direct_fallback(args.connections);
                         }
+                        if jobs.len() == 1 {
+                            sched.reserve_initial_ranges(initial);
+                        }
                         if args.verbose >= 2 && initial < args.connections {
                             crate::output::diagnostic!(
                                 "syq: SSH startup limited to {initial} workers by available files and ranges"

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -11681,13 +11681,14 @@ fn changed_source_retry_uses_published_file_as_block_basis() {
         .stderr(Stdio::piped())
         .start()
         .unwrap();
-    for _ in 0..200 {
-        if t.path("dst/file").exists() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
-    assert!(t.path("dst/file").exists(), "first attempt never finalized");
+    // This includes copying the fixture in a debug build. Uncompressed local
+    // receiver traffic can take more than two seconds; wait for publication,
+    // not a throughput target, before changing the source during the hold.
+    wait_for(
+        "first attempt to finalize",
+        std::time::Duration::from_secs(10),
+        || t.path("dst/file").exists(),
+    );
     write(&t.path("replacement"), &changed);
     set_mtime(&t.path("replacement"), 1_600_000_001);
     fs::rename(t.path("replacement"), t.path("src/file")).unwrap();
@@ -11724,13 +11725,11 @@ fn changed_source_retry_still_uses_copy_file_range() {
         .stderr(Stdio::piped())
         .start()
         .unwrap();
-    for _ in 0..200 {
-        if t.path("dst/file").exists() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(10));
-    }
-    assert!(t.path("dst/file").exists(), "first attempt never finalized");
+    wait_for(
+        "first attempt to finalize",
+        std::time::Duration::from_secs(10),
+        || t.path("dst/file").exists(),
+    );
     write(&t.path("replacement"), &changed);
     set_mtime(&t.path("replacement"), 1_600_000_001);
     fs::rename(t.path("replacement"), t.path("src/file")).unwrap();

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -4711,9 +4711,7 @@ fn double_verbose_dry_run_reports_ssh_fallback_without_extra_connection() {
         "{stderr}"
     );
     assert!(
-        stderr.contains(
-            "target 8 connections (auto-tuned); initial count limited by available work; dry-run starts no workers"
-        ),
+        stderr.contains("target 8 connections (auto-tuned); dry-run starts no workers"),
         "{stderr}"
     );
     assert_eq!(
@@ -4912,17 +4910,24 @@ fn automatic_ssh_starts_only_workers_that_can_help_the_file() {
     let rsh = fake_rsh(&t);
     let content = prng(64 << 20, 3241);
     write(&t.path("src"), &content);
-    for (label, fixed, nonempty) in [
-        ("auto", false, false),
-        ("fixed", true, false),
-        ("nonempty", false, true),
+    for (label, fixed, nonempty, single_file) in [
+        ("auto", false, false, false),
+        ("fixed", true, false, false),
+        ("nonempty", false, true, false),
+        ("single", false, false, true),
+        ("single-fixed", true, false, true),
+        ("single-update", false, true, true),
     ] {
         let directory = t.path(&format!("dst-{label}"));
         fs::create_dir_all(&directory).unwrap();
         if nonempty {
             write(&directory.join("src"), b"old destination contents");
         }
-        let destination = format!("host:{}/", directory.display());
+        let destination = if single_file {
+            format!("host:{}/src", directory.display())
+        } else {
+            format!("host:{}/", directory.display())
+        };
         let events = t.path(&format!("events-{label}"));
         let mut command = compat_command();
         command
@@ -4930,7 +4935,7 @@ fn automatic_ssh_starts_only_workers_that_can_help_the_file() {
             .arg(&rsh)
             .arg("--rsync-path")
             .arg(env!("CARGO_BIN_EXE_syq"))
-            .args(["--syq-no-tcp", "-a", "--no-progress"])
+            .args(["--syq-no-tcp", "-a", "-vv", "--no-progress"])
             .arg(t.s("src"))
             .arg(destination)
             .env("SYQ_TEST_WORKER_EVENTS", &events)
@@ -4941,6 +4946,12 @@ fn automatic_ssh_starts_only_workers_that_can_help_the_file() {
         }
         let out = command.run().unwrap();
         assert_output_ok(&out);
+        assert_eq!(
+            stderr_of(&out).contains("SSH startup limited to 2 workers"),
+            !fixed && !nonempty,
+            "{label}: {out:?}"
+        );
+        assert!(!stderr_of(&out).contains("initial count limited by available work"));
         assert_eq!(read(&directory.join("src")), content);
         let connected = fs::read_to_string(events)
             .unwrap()
@@ -4953,6 +4964,67 @@ fn automatic_ssh_starts_only_workers_that_can_help_the_file() {
             "{label}: {out:?}"
         );
     }
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn automatic_ssh_restores_workers_for_a_single_file_partial() {
+    let t = Tmp::new();
+    let rsh = fake_rsh(&t);
+    let content = prng(64 << 20, 3242);
+    write(&t.path("src"), &content);
+    fs::create_dir_all(t.path("dest")).unwrap();
+    let destination = format!("host:{}/file", t.path("dest").display());
+    let source = t.s("src");
+    let args = [
+        "-e",
+        rsh.to_str().unwrap(),
+        "--rsync-path",
+        env!("CARGO_BIN_EXE_syq"),
+        "--syq-no-tcp",
+        "-a",
+        "-vv",
+        source.as_str(),
+        destination.as_str(),
+    ];
+    let failed = compat_command()
+        .args(args)
+        .env("SYQ_TEST_FAIL_READ_RANGE", "1")
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_CACHE_HOME", t.path("failed-cache"))
+        .run()
+        .unwrap();
+    assert_eq!(failed.status.code(), Some(23), "{failed:?}");
+    assert!(!t.path("dest/file").exists());
+    let partials = partial_files(&t.path("dest"));
+    assert_eq!(partials.len(), 1, "{failed:?}");
+    let partial = partials[0].clone();
+    // Eight disjoint missing blocks: size-based startup alone would leave
+    // only two workers, even though every missing block is independent work.
+    let mut resumed = content.clone();
+    for block in (0..16).step_by(2) {
+        resumed[block * (4 << 20)..(block + 1) * (4 << 20)].fill(0);
+    }
+    write(&partial, &resumed);
+    let events = t.path("events");
+    let out = compat_command()
+        .args(args)
+        .arg("--no-progress")
+        .env("SYQ_TEST_WORKER_EVENTS", &events)
+        .env("XDG_CONFIG_HOME", t.path("config"))
+        .env("XDG_CACHE_HOME", t.path("cache"))
+        .run()
+        .unwrap();
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dest/file")), content);
+    assert!(!partial.exists());
+    let connected = fs::read_to_string(events)
+        .unwrap()
+        .lines()
+        .filter(|line| line.starts_with("connected "))
+        .count();
+    assert_eq!(connected, 8, "{out:?}");
+    assert!(stderr_of(&out).contains("SSH startup limited to 2 workers"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Improve automatic SSH transfers without adding tuning knobs or changing the wire format:

- Skip redundant compression between the coordinator and its local receiver child. Compression over the network is unchanged; this is not compressed pass-through.
- Extend bounded SSH startup to missing single-file destinations. Restore the full worker target when preparation discovers resumable data; preserve explicit connection counts and existing-file updates.
- Queue initial ranges for a fresh single-file SSH copy before early workers can consume the split opportunity. Keep the existing 32 MiB split floor and two shared startup workers. Workers can continue taking queued ranges without waiting for their peers to connect.
- Remember rejected shared SSH channels across startup workers and make concurrency diagnostics accurately describe when the startup cap applies.

## Performance evidence and limits

Paired diagnostic measurements used incompressible generated data, matching optimized endpoint binaries, forced SSH, fresh destinations, and full SHA256 verification outside the timer. Timings include startup/cleanup and buffered writes, with no final disk flush. Source-page eviction was advisory, not guaranteed cold cache; ambient conditions were uncontrolled.

- Exact head `7bf7238`, 256 MiB WAN: downloads **12.84 vs 11.68 MiB/s (+9.9%)**; uploads **12.80 vs 11.77 MiB/s (+8.7%)**, two pairs per direction against `cac5154`. All eight copies passed full SHA256 verification and cleanup. This isolates startup/range-scheduling changes from the earlier local-compression change; it is not the whole PR versus master.
- The pre-commit range-reservation prototype's sub-second 256 MiB fast-link control was approximately **3% slower**. The 64 MiB missing-file WAN test showed no material throughput gain, although the startup cap avoids six unnecessary worker connections.
- Exact head `7bf7238`, 4 GiB fast-link control: **971.4 vs 977.1 MiB/s** against `cac5154`, within 1%, two pairs. This control used an isolated same-host Docker bridge and four disjoint physical cores per endpoint, without CPU quotas or bandwidth shaping.

The exact-head WAN recheck completed after SSH agent forwarding recovered. No Mac measurements were run. This does not claim a universal speedup.

## Validation

Passed on `7bf7238`:

- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 scripts/check-doc-links.py`
- `cargo clippy --all-targets --all-features -j 8 -- -D warnings`
- `cargo test --all-targets -j 8 -- --test-threads=4`
- `scripts/test-real-ssh.sh`
- `scripts/test-real-ssh.sh --profile max-sessions-1`
- `cargo build --locked --release -j 8` (pre-existing release-only `unused_mut` warning in `session_pool.rs`)

Tests cover compression negotiation, single-file startup and explicit counts, resume restoration, remembered channel rejection, and initial-range coverage/alignment/split boundaries. Real-SSH suite timings use debug builds and are correctness evidence only. All owned benchmark infrastructure and scratch data were cleaned up.

At PR creation, master `2499d7c` has passing Linux and rsync-compat workflows, but [the latest macOS workflow is failing](https://github.com/greaber/syq/actions/runs/34135292235). This is a pre-existing master status, not a passing check for this branch.
