### PR TITLE
Fix macOS Python cleanup and persistence test races

### DIFF
--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -589,8 +589,10 @@ are re-raised unchanged. Async cancellation remains `asyncio.CancelledError`.
 These exceptions are not wrapped in `SyqError`.
 
 Timeout, cancellation, early mapping exit, and streaming failures terminate and
-reap the local process group, including SSH children. Filesystem changes already
-completed are not rolled back.
+reap the local process group, including SSH children. Closing a mapping whose
+producer has already exited still cleans up its children; the exited producer
+alone does not cause a cleanup permission error on macOS. Filesystem changes
+already completed are not rolled back.
 
 <a id="deliberate-exclusions"></a>
 

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -244,7 +244,15 @@ class _ResultsFileWriter:
 
 def _kill_process_group(process: subprocess.Popen[bytes]) -> None:
     try:
-        os.killpg(process.pid, signal.SIGKILL)
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except PermissionError:
+            # Darwin can report EPERM for a group containing only zombies.
+            # Reap our exited leader, then retry so surviving descendants still
+            # receive the signal and genuine permission failures remain visible.
+            if process.poll() is None:
+                raise
+            os.killpg(process.pid, signal.SIGKILL)
     except ProcessLookupError:
         pass
 

--- a/sdk/python/src/syq/client.py
+++ b/sdk/python/src/syq/client.py
@@ -315,6 +315,7 @@ class _LineProcess:
         self.returncode: int | None = None
         self.stderr = b""
         self._closed = False
+        self._aborted = False
 
     @classmethod
     def start_results(
@@ -393,11 +394,12 @@ class _LineProcess:
         return self.returncode
 
     def abort(self) -> None:
-        if self._closed:
+        if self._aborted:
             return
         # Kill the owned group even if the leader just exited: a malformed
         # producer or callback failure must not leave an SSH/helper descendant.
         _kill_process_group(self._process)
+        self._aborted = True
         self.returncode = self._process.wait()
         self._capture_stderr()
         self._close_files()

--- a/sdk/python/tests/test_api_design.py
+++ b/sdk/python/tests/test_api_design.py
@@ -147,7 +147,9 @@ class MappingContextTests(unittest.TestCase):
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
-        self.root = Path(self.temporary.name)
+        # macOS TMPDIR passes through /var, a symlink to /private/var.
+        # These fixtures test mappings, so give the native walker a real path.
+        self.root = Path(self.temporary.name).resolve()
         self.source = self.root / "source"
         self.source.mkdir()
         (self.source / "a").write_bytes(b"correct source")
@@ -249,7 +251,7 @@ class MappingContextTests(unittest.TestCase):
 class AsyncMappingContextTests(unittest.IsolatedAsyncioTestCase):
     async def test_async_transform_and_sync_mapping_cross_client(self):
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             (root / "source").mkdir()
             (root / "source/a").write_bytes(b"data")
             (root / "other").mkdir()
@@ -272,7 +274,7 @@ class AsyncMappingContextTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_lazy_map_snapshots_producer_directory_and_environment(self):
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             for name in ("first", "second"):
                 (root / name).mkdir()
                 (root / name / "a").write_text(name)
@@ -292,7 +294,7 @@ class AsyncMappingContextTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_async_mapping_constructor_and_closed_stream(self):
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             (root / "source").mkdir()
             (root / "source/a").write_bytes(b"data")
             client = syq.AsyncClient(executable=EXECUTABLE, process_cwd=root)
@@ -309,7 +311,7 @@ class AsyncMappingContextTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_async_failed_or_cancelled_transform_leaves_destination_untouched(self):
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             (root / "a").write_bytes(b"data")
             client = syq.AsyncClient(executable=EXECUTABLE, process_cwd=root)
             async def fail(entry):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -13,6 +13,51 @@ from unittest import mock
 import syq
 
 
+class ProcessGroupCleanupTests(unittest.TestCase):
+    def test_exited_mapping_process_can_be_closed_without_consuming_output(self):
+        from syq.client import _LineProcess
+
+        # Leave the exited leader unreaped, as an abandoned mapping can do.
+        # On Darwin, signalling its zombie-only group may return EPERM.
+        for _ in range(10):
+            process = _LineProcess(
+                (sys.executable, "-c", "print('unconsumed mapping')"),
+                cwd=None, env=None, timeout=5,
+            )
+            try:
+                process._stderr_thread.join(timeout=5)
+                self.assertFalse(process._stderr_thread.is_alive())
+            finally:
+                process.abort()
+            self.assertIsNotNone(process.returncode)
+            self.assertTrue(process._closed)
+
+    def test_permission_error_reaps_exited_leader_and_retries_group(self):
+        from syq.client import _kill_process_group
+
+        process = mock.Mock(pid=123, poll=mock.Mock(return_value=0))
+        for retry in (None, ProcessLookupError()):
+            with self.subTest(retry=retry), mock.patch(
+                "syq.client.os.killpg", side_effect=[PermissionError(), retry]
+            ) as kill:
+                _kill_process_group(process)
+                self.assertEqual(kill.call_args_list, [
+                    mock.call(123, signal.SIGKILL), mock.call(123, signal.SIGKILL),
+                ])
+
+    def test_permission_errors_for_live_or_remaining_group_are_visible(self):
+        from syq.client import _kill_process_group
+
+        for returncode, attempts in ((None, 1), (0, 2)):
+            with self.subTest(returncode=returncode), mock.patch(
+                "syq.client.os.killpg", side_effect=PermissionError("denied")
+            ) as kill:
+                process = mock.Mock(pid=123, poll=mock.Mock(return_value=returncode))
+                with self.assertRaisesRegex(PermissionError, "denied"):
+                    _kill_process_group(process)
+                self.assertEqual(kill.call_count, attempts)
+
+
 FAKE_SYQ = """#!/bin/sh
 case "$1" in
   --version)

--- a/sdk/python/tests/test_native.py
+++ b/sdk/python/tests/test_native.py
@@ -805,6 +805,27 @@ class NativeClientTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "NUL"):
             syq.RelativePath(b"nul\0path")
 
+    def test_protocol_failure_kills_descendants_after_the_leader_exits(self) -> None:
+        from syq.client import _kill_process_group
+
+        marker = self.root / "post-exit-descendant"
+        client = syq.Client(
+            executable=self.executable,
+            env={**self.env, "SYQ_FAKE_DESCENDANT": os.fspath(marker),
+                 "SYQ_FAKE_SHAPE": "truncated"},
+        )
+
+        def kill_after_exit(process):
+            process.wait(timeout=5)
+            _kill_process_group(process)
+
+        with mock.patch("syq.client._kill_process_group", side_effect=kill_after_exit):
+            with self.assertRaisesRegex(syq.SyqProtocolError, "terminal result"):
+                client.cp("source", into="target")
+        self.assertTrue(marker.with_suffix(".ready").exists())
+        time.sleep(0.8)
+        self.assertFalse(marker.exists())
+
     def test_callback_failure_kills_the_owned_process_group(self) -> None:
         marker = self.root / "descendant"
         client = syq.Client(

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -17136,14 +17136,14 @@ fn persist_connect_scopes_skip_receiving_and_setup_errors_are_reported_once() {
     let t = Tmp::new();
     fs::create_dir(t.runtime()).unwrap();
     let ssh = fake_ssh(&t);
-    let connect = |scope: Option<&Path>| {
+    let connect = |scope: Option<&Path>, log: &str| {
         let mut cmd = persistence_command(&t, &["connect", "test-server", "--timeout", "1"]);
         cmd.args(["--syq-path", env!("CARGO_BIN_EXE_syq")])
             .env_remove("HOME")
             .env("XDG_CACHE_HOME", t.path("cache"))
             .env("FAKE_REMOTE_HOME", t.path("remote-home"))
             .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
-            .env("FAKE_RSH_LOG", t.path("rsh.log"))
+            .env("FAKE_RSH_LOG", t.path(log))
             .env(
                 "PATH",
                 format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
@@ -17158,7 +17158,7 @@ fn persist_connect_scopes_skip_receiving_and_setup_errors_are_reported_once() {
     write(&receive, b"not json");
     fs::set_permissions(&receive, fs::Permissions::from_mode(0o600)).unwrap();
     let scope = ephemeral_scope(&t);
-    let output = connect(Some(&scope));
+    let output = connect(Some(&scope), "rsh.log");
     assert_output_ok(&output);
     assert!(String::from_utf8_lossy(&output.stdout)
         .contains("ready; ephemeral scopes do not support receiving"));
@@ -17198,7 +17198,7 @@ fn persist_connect_scopes_skip_receiving_and_setup_errors_are_reported_once() {
 
     // Successful forward setup followed by invalid receiving settings reports
     // one error, with no best-effort setup attempt before the explicit one.
-    let output = connect(None);
+    let output = connect(None, "rsh.log");
     assert!(!output.status.success());
     let error = stderr_of(&output);
     assert_eq!(error.matches("expected ident").count(), 1, "{error}");
@@ -17213,11 +17213,15 @@ fn persist_connect_scopes_skip_receiving_and_setup_errors_are_reported_once() {
         &t.path("config/syq/persistence.json"),
         b"{\"enabled\":false}\n",
     );
-    fs::remove_file(t.path("rsh.log")).unwrap();
-    let rejected = connect(Some(global));
+    // Earlier connections leave a pool that can still write to rsh.log.
+    // Only this invocation can write to the rejection log.
+    let rejected = connect(Some(global), "rejected-rsh.log");
     assert!(!rejected.status.success());
     assert!(stderr_of(&rejected).contains("without --pscope"));
-    assert!(!t.path("rsh.log").exists(), "invalid scope reached SSH");
+    assert!(
+        !t.path("rejected-rsh.log").exists(),
+        "invalid scope reached SSH"
+    );
     assert_output_ok(&persistence_command(&t, &["off"]).run().unwrap());
 }
 


### PR DESCRIPTION
The post-merge persistence test could mistake background pool SSH checks for activity from a rejected command. Give that invocation a separate log. Python mapping fixtures now canonicalize their temporary directories so macOS's `/var` symlink does not trigger the native path-confinement checks.

Fix synchronous Python cleanup when Darwin reports `EPERM` for a zombie-only process group: reap an exited leader and retry the group signal once, preserving actual permission errors. Also keep abort cleanup independent of stream closure, so a truncated result discovered after the producer exits still terminates its descendants. Regression tests cover exited producers, permission failures, and surviving descendants. [Darwin's group-signal implementation](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/kern_sig.c) excludes zombies and can return EPERM when it finds no signalable members.

Validation at `993e95d`:
- Rust formatting, all-target/all-feature Clippy with warnings denied, 543 unit tests (one existing ignored), and all three `persist_connect_` integration tests passed. The first unit run hit an unrelated OpenSSH fixture `Text file busy` error; the complete unit retry passed.
- All 113 Python SDK tests passed against the candidate binary, including unchanged automation fixtures. All 11 mapping-context tests also passed with a symlinked temporary directory.
- Documentation links (20 files) and Python API inventory passed.
- Full macOS workflow [34142135935](https://github.com/greaber/syq/actions/runs/34142135935) passed on this exact commit: all native tests, Python/JavaScript/Go SDK tests and packaging, benchmark tests, and release-shell suites.
- No local full Rust all-targets or real-SSH container run: native production code and remote transports are unchanged; the macOS workflow exercises all native targets.

Compatibility: the cleanup helper also exists in release `v0.4.1`; this repairs its lifecycle handling without changing SDK signatures, command arguments, wire formats, persistent state, or path-following policy. No migration or support-baseline change is needed.

Merged into master as `10e05dc`. All post-merge workflows passed on that exact commit: [ci](https://github.com/greaber/syq/actions/runs/34143063664), [rsync compatibility](https://github.com/greaber/syq/actions/runs/34143063692), and [macOS](https://github.com/greaber/syq/actions/runs/34143063652).

Final branch status (exit 0):

```text
Worktree: /home/grant/repos/syq/.worktrees/investigate-macos-postmerge
Branch:   fix-macos-followups at 993e95d (clean)
Upstream: origin/fix-macos-followups (ahead 0, behind 0)
Master:   2499d7c from refs/heads/master (branch is ahead 4, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           in_progress  a912399  https://github.com/greaber/syq/actions/runs/34143643825
  rsync-compat.yml success      a912399  https://github.com/greaber/syq/actions/runs/34143643913
  macos.yml        in_progress  a912399  https://github.com/greaber/syq/actions/runs/34143643773

Pull request: none for fix-macos-followups
```
