### PR TITLE
Stop active restricted receivers when enrollment is revoked

### DIFF
--- a/docs/remote-reference.md
+++ b/docs/remote-reference.md
@@ -23,7 +23,9 @@ SSH configuration, programs, or enrollment state. Manage that state with
 
 Repeating `enroll` updates the receiver to match your local build. A pending
 enrollment can be retried or revoked. Revoke and enroll again to rotate its
-receipt key.
+receipt key. Revocation stops active receivers for that enrollment before
+removing its state; see [revocation and upgrades](remote-to-remote.md#first-copy-and-access-management)
+for interruption, retry, and older-receiver behavior.
 
 Enrollment uploads the executable running on your machine, which must also run
 on the destination. It does not use `--syq-path` or fetch a release for another

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -122,9 +122,24 @@ syq receiver list
 syq receiver revoke ID
 ```
 
-Use the ID from `list`. Revocation blocks new sessions; an ongoing copy may
-finish. If your machine reaches hostB through hostA, add `--via hostA` to
-`enroll` or `revoke`.
+Use the ID from `list`. Revocation stops all active restricted receivers for
+that enrollment and blocks new sessions. It waits for their shutdown before
+reporting success, then removes the enrollment from both machines. Other
+enrollments keep running. Revocation does not undo completed writes; interrupted
+copies fail and can leave partial files. Enroll again to authorize a new copy
+that can resume them.
+
+If receivers have not stopped within ten seconds, revocation reports failure
+and keeps the enrollment marked revoked. Retry `receiver revoke` to finish
+cleanup; an enrollment with unfinished revocation cannot be refreshed.
+
+Before upgrading from released v0.4.1 or an older binary, stop its active copies:
+those running processes have no shutdown watcher. Updating the installed
+executable does not add revocation support to a process already running it.
+The seven-day finish window is unchanged.
+
+If your machine reaches hostB through hostA, add `--via hostA` to `enroll` or
+`revoke`.
 
 ## Mirror a directory
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -152,6 +152,10 @@ host resolution. A copy never switches routes after selecting its destination.
   writable by untrusted users. Syq only reuses partials owned by its effective
   user; foreign-owned leftovers are replaced without changing their contents
   or permissions. This does not make a shared writable directory trusted.
+- **Hard links share contents and metadata.** In-place writes and metadata
+  changes through a destination hard link affect every name for that file,
+  including names outside the selected destination or a restricted grant's
+  path scope.
 - **Copies are not snapshots or transactions.** Stop concurrent writers or
   use snapshots for consistent data. `--inplace` exposes incomplete updates.
   Syq does not `fsync` transfer data, so completion is not a power-loss

--- a/src/help.rs
+++ b/src/help.rs
@@ -204,7 +204,7 @@ pub(crate) fn receiver() -> Command {
             .subcommand(Command::new("list").about("List local active and pending enrollments"))
             .subcommand(
                 Command::new("revoke")
-                    .about("Remove the forced key and per-enrollment state from both machines")
+                    .about("Stop active receivers and remove their enrollment from both machines")
                     .arg(
                         Arg::new("id")
                             .required(true)

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -1,5 +1,7 @@
 //! End-to-end enrollment and signed restricted-transfer integration.
 
+mod active;
+
 use crate::cli::{Args, Existence, Location, Placement};
 use crate::delegation::{
     self, CopyLimits, CopyOperation, CopyOptions, CopyPolicy, DeletionPolicy, DestinationPlacement,
@@ -3126,6 +3128,7 @@ pub(crate) fn remote_install() -> Result<()> {
     // cannot leave a usable key, and a later state-write failure leaves only
     // inert private state that an idempotent retry can complete.
     let (state, _allowed_signers, _replay) = install_state_paths(&home, request.id)?;
+    active::require_not_revoked(&state)?;
     atomic_write(
         &state,
         "allowed-signers",
@@ -3214,6 +3217,10 @@ fn revoke_for_account(request: &RevokeRequest, account: &str, home: &Path) -> Re
     if account != request.target_login {
         bail!("revocation target login does not match the remote account");
     }
+    // Serialize revocation with both enrollment updates and receiver admission.
+    let ssh = ensure_directory_chain(home, &[".ssh"])?;
+    let directory = open_directory(&ssh)?;
+    lock_directory(&directory)?;
     let state_base = home.join(".local/share/syq/restricted");
     let state = state_base.join(request.id.to_string());
     let (receiver_path, remove_state) = match fs::symlink_metadata(&state) {
@@ -3241,15 +3248,17 @@ fn revoke_for_account(request: &RevokeRequest, account: &str, home: &Path) -> Re
     // Validate the shared state chain before removing the credential. The
     // second check below determines whether the now-updated state is empty.
     let _ = directory_is_empty(&state_base)?;
-    let ssh = ensure_directory_chain(home, &[".ssh"])?;
-    let directory = open_directory(&ssh)?;
-    lock_directory(&directory)?;
+    let leases = remove_state
+        .as_deref()
+        .map(active::open_leases)
+        .transpose()?;
     let original =
         read_leaf(&directory, "authorized_keys", MAX_AUTHORIZED_KEYS, false)?.unwrap_or_default();
     let normalized = normalize_managed_authorized_keys(&original, &entry.marker());
     let (updated, _) = enrollment::revoke_authorized_key(&normalized, &entry)?;
     atomic_write_locked(&directory, "authorized_keys", &updated, 0o600, false)?;
     if let Some(state) = remove_state {
+        active::revoke(&state, leases.as_ref().expect("enrollment lease file"))?;
         fs::remove_dir_all(&state)
             .with_context(|| format!("remove revoked receiver state {}", state.display()))?;
     }
@@ -4301,6 +4310,8 @@ pub(crate) fn run_receiver(enrollment: &str) -> Result<()> {
         .context("restricted receiver requires SSH_ORIGINAL_COMMAND from sshd")?;
     let envelope = decode_receiver_command(&original)?;
     let (config, allowed_signers, replay_path) = receiver_config(enrollment)?;
+    let state = replay_path.parent().context("receiver state directory")?;
+    let observed_state = fs::symlink_metadata(state).context("inspect receiver enrollment")?;
     let (_, home) = current_account()?;
     let canonical_home = fs::canonicalize(&home)
         .with_context(|| format!("resolve receiver home {}", home.display()))?;
@@ -4350,6 +4361,14 @@ pub(crate) fn run_receiver(enrollment: &str) -> Result<()> {
         deadline,
         &protected,
     )?);
+    // Verification does not hold the lifecycle lock or permit mutations. A
+    // revoke during verification is caught when this receiver tries to enter.
+    active::watch(
+        &home,
+        state,
+        (observed_state.dev(), observed_state.ino()),
+        deadline,
+    )?;
     crate::server::run_restricted(authority)
 }
 
@@ -4515,6 +4534,20 @@ pub(crate) mod tests {
     use super::*;
     use clap::Parser;
     use std::os::unix::fs::{symlink, PermissionsExt};
+
+    #[test]
+    fn receiver_configuration_preserves_released_v041_bytes() {
+        // Unmodified output of the checksum-verified released v0.4.1
+        // --restricted-install, produced in a disposable account/container.
+        let encoded = include_bytes!("../tests/fixtures/restricted-enrollment-v0.4.1.json");
+        let config: ReceiverEnrollment = serde_json::from_slice(encoded).unwrap();
+        assert_eq!(config.version, CONFIG_VERSION);
+        assert_eq!(
+            config.id,
+            EnrollmentId::parse("00112233445546778899aabbccddeeff").unwrap()
+        );
+        assert_eq!(serde_json::to_vec(&config).unwrap(), encoded);
+    }
 
     #[test]
     fn enrollment_ssh_failures_distinguish_transport_from_remote_rejection() {

--- a/src/restricted/active.rs
+++ b/src/restricted/active.rs
@@ -1,0 +1,404 @@
+//! Active receiver shutdown. The grant holder cannot modify enrollment state.
+//!
+//! Receivers hold shared leases and terminate themselves on revocation. The
+//! revoker waits for an exclusive lease, so successful revocation confirms that
+//! their processes have stopped without identifying or signalling a numeric PID.
+
+use super::{atomic_write, lock_directory, open_directory};
+use anyhow::{bail, Context, Result};
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+const CHECK_INTERVAL: Duration = Duration::from_millis(100);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(super) fn require_not_revoked(state: &Path) -> Result<()> {
+    match fs::symlink_metadata(state.join("revoked")) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).context("inspect receiver revocation state"),
+        Ok(_) => {
+            bail!("receiver enrollment is revoked; finish receiver revoke before enrolling again")
+        }
+    }
+}
+
+pub(super) fn open_leases(state: &Path) -> Result<File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC)
+        .open(state.join("active-receivers"))
+        .context("open active receiver leases")?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file()
+        || metadata.nlink() != 1
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.mode() & 0o7777 != 0o600
+    {
+        bail!("active receiver leases must be a private, singly linked regular file");
+    }
+    Ok(file)
+}
+
+fn try_lock(file: &File, operation: libc::c_int) -> Result<bool> {
+    loop {
+        if unsafe { libc::flock(file.as_raw_fd(), operation | libc::LOCK_NB) } == 0 {
+            return Ok(true);
+        }
+        let error = io::Error::last_os_error();
+        match error.kind() {
+            io::ErrorKind::Interrupted => continue,
+            io::ErrorKind::WouldBlock => return Ok(false),
+            _ => return Err(error).context("lock active receiver leases"),
+        }
+    }
+}
+
+/// Start the standalone receiver's watcher. Its lease lives in the watcher
+/// thread until process exit, including while the main thread reports a server
+/// error or any admitted worker finishes. Dropping it when `serve` returns
+/// would let revocation report success while worker threads could still write.
+pub(super) fn watch(
+    home: &Path,
+    state: &Path,
+    expected: (u64, u64),
+    deadline: Instant,
+) -> Result<()> {
+    let lifecycle = open_directory(&home.join(".ssh"))?;
+    lock_directory(&lifecycle)?;
+    crate::delegation::validate_private_directory_path(state)?;
+    let directory = open_directory(state)?;
+    let metadata = directory.metadata()?;
+    if (metadata.dev(), metadata.ino()) != expected {
+        bail!("receiver enrollment changed during grant verification");
+    }
+    require_not_revoked(state)?;
+    let lease = open_leases(state)?;
+    if !try_lock(&lease, libc::LOCK_SH)? {
+        bail!("receiver enrollment is being revoked");
+    }
+    // Include any helper child (such as interface discovery) in shutdown,
+    // without sharing a process group with sshd or another receiver.
+    if unsafe { libc::getpgrp() } != unsafe { libc::getpid() }
+        && unsafe { libc::setpgid(0, 0) } != 0
+    {
+        return Err(io::Error::last_os_error()).context("isolate receiver process group");
+    }
+    let state = state.to_path_buf();
+    std::thread::Builder::new()
+        .name("receiver-revocation".into())
+        .spawn(move || {
+            let _lease = lease;
+            // Pin the enrollment inode even if an older revoke removes it.
+            let _directory = directory;
+            loop {
+                // Also notice an older revoke command removing the enrollment.
+                let unchanged = fs::symlink_metadata(&state)
+                    .is_ok_and(|metadata| (metadata.dev(), metadata.ino()) == expected);
+                if !unchanged || require_not_revoked(&state).is_err() || Instant::now() >= deadline
+                {
+                    // Do not write to peer-controlled output before stopping: a
+                    // full SSH pipe must not prevent revocation. This process
+                    // only runs the restricted receiver and its worker threads.
+                    unsafe {
+                        libc::kill(0, libc::SIGKILL);
+                        libc::_exit(1);
+                    }
+                }
+                std::thread::sleep(
+                    CHECK_INTERVAL.min(deadline.saturating_duration_since(Instant::now())),
+                );
+            }
+        })
+        .context("start receiver revocation watcher")?;
+    Ok(())
+}
+
+/// Caller holds the SSH directory lifecycle lock until state removal finishes.
+/// Leave the marker and credentials' local bookkeeping intact on failure so a
+/// retry can finish revocation; never reopen admission after a partial failure.
+pub(super) fn revoke(state: &Path, leases: &File) -> Result<()> {
+    atomic_write(state, "revoked", b"revoked\n", 0o600)?;
+    wait_for_receivers(leases, SHUTDOWN_TIMEOUT)
+}
+
+fn wait_for_receivers(leases: &File, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut next_progress = Instant::now() + Duration::from_secs(1);
+    loop {
+        if try_lock(leases, libc::LOCK_EX)? {
+            return Ok(());
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            bail!("receiver enrollment is revoked but active receivers have not stopped; retry receiver revoke (last state: active receiver leases are still held)");
+        }
+        if now >= next_progress {
+            crate::output::diagnostic!("syq: waiting for revoked receivers to stop");
+            next_progress = now + Duration::from_secs(1);
+        }
+        std::thread::sleep(CHECK_INTERVAL.min(deadline - now));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::process::CommandExt;
+    use std::process::{Child, Command, ExitStatus, Stdio};
+
+    struct Worker(Child);
+    impl Drop for Worker {
+        fn drop(&mut self) {
+            if self.0.try_wait().ok().flatten().is_none() {
+                unsafe {
+                    libc::kill(-(self.0.id() as i32), libc::SIGKILL);
+                }
+                let _ = self.0.wait();
+            }
+        }
+    }
+
+    fn private_dir(path: &Path) {
+        fs::create_dir(path).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700)).unwrap();
+    }
+
+    fn identity(path: &Path) -> (u64, u64) {
+        let metadata = fs::metadata(path).unwrap();
+        (metadata.dev(), metadata.ino())
+    }
+
+    fn wait_until(label: &str, mut ready: impl FnMut() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut progress = Instant::now();
+        while !ready() {
+            assert!(
+                Instant::now() < deadline,
+                "{label}: deadline expired; condition still false"
+            );
+            if Instant::now() >= progress {
+                eprintln!("waiting for {label}");
+                progress = Instant::now() + Duration::from_secs(1);
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn worker(home: &Path, state: &Path, name: &str, mode: &str) -> Worker {
+        let ready = home.join(format!("ready-{name}"));
+        let child = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "restricted::active::tests::receiver_process",
+                "--nocapture",
+            ])
+            .env("SYQ_TEST_ACTIVE_HOME", home)
+            .env("SYQ_TEST_ACTIVE_STATE", state)
+            .env("SYQ_TEST_ACTIVE_READY", &ready)
+            .env("SYQ_TEST_ACTIVE_MODE", mode)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .process_group(0)
+            .spawn()
+            .unwrap();
+        let mut child = Worker(child);
+        wait_until("receiver readiness", || {
+            assert!(
+                child.0.try_wait().unwrap().is_none(),
+                "receiver exited before readiness"
+            );
+            ready.exists()
+        });
+        child
+    }
+
+    fn exited(child: &mut Worker) -> ExitStatus {
+        let mut status = None;
+        wait_until("receiver exit", || {
+            status = child.0.try_wait().unwrap();
+            status.is_some()
+        });
+        status.unwrap()
+    }
+
+    #[test]
+    fn receiver_process() {
+        let Some(home) = std::env::var_os("SYQ_TEST_ACTIVE_HOME") else {
+            return;
+        };
+        let home = Path::new(&home);
+        let state = std::env::var_os("SYQ_TEST_ACTIVE_STATE").unwrap();
+        let state = Path::new(&state);
+        let ready = std::env::var_os("SYQ_TEST_ACTIVE_READY").unwrap();
+        let mode = std::env::var("SYQ_TEST_ACTIVE_MODE").unwrap();
+        let expected = identity(state);
+        if mode == "verification" {
+            fs::write(&ready, b"verifying").unwrap();
+            std::io::stdin().read_exact(&mut [0]).unwrap();
+        }
+        let result = watch(
+            home,
+            state,
+            expected,
+            Instant::now() + Duration::from_secs(30),
+        );
+        if mode == "verification" {
+            assert!(result.is_err(), "revoked verification admitted a receiver");
+            return;
+        }
+        result.unwrap();
+        fs::write(&ready, b"ready").unwrap();
+        if mode == "normal" {
+            return;
+        }
+        // The revocation watcher must stop the entire process even when its
+        // main thread is blocked on a source that will not read its output.
+        std::io::stdout()
+            .write_all(&vec![b'x'; 2 * 1024 * 1024])
+            .unwrap();
+        panic!("test output pipe unexpectedly accepted all bytes");
+    }
+
+    #[test]
+    fn revoke_stops_all_receivers_of_only_that_enrollment() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let home = temporary.path();
+        private_dir(&home.join(".ssh"));
+        let state = home.join("enrollment");
+        let other = home.join("other-enrollment");
+        private_dir(&state);
+        private_dir(&other);
+        let mut first = worker(home, &state, "first", "blocked");
+        let mut second = worker(home, &state, "second", "blocked");
+        let mut unrelated = worker(home, &other, "unrelated", "blocked");
+        let leases = open_leases(&state).unwrap();
+        assert!(!try_lock(&leases, libc::LOCK_EX).unwrap());
+        revoke(&state, &leases).unwrap();
+        assert!(!exited(&mut first).success());
+        assert!(!exited(&mut second).success());
+        assert!(unrelated.0.try_wait().unwrap().is_none());
+        assert!(watch(
+            home,
+            &state,
+            identity(&state),
+            Instant::now() + Duration::from_secs(30)
+        )
+        .is_err());
+        let other_leases = open_leases(&other).unwrap();
+        revoke(&other, &other_leases).unwrap();
+        assert!(!exited(&mut unrelated).success());
+    }
+
+    #[test]
+    fn revocation_during_verification_prevents_admission() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let home = temporary.path();
+        private_dir(&home.join(".ssh"));
+        let state = home.join("enrollment");
+        private_dir(&state);
+        let mut child = worker(home, &state, "verifying", "verification");
+        let leases = open_leases(&state).unwrap();
+        revoke(&state, &leases).unwrap();
+        child.0.stdin.as_mut().unwrap().write_all(b"x").unwrap();
+        assert!(exited(&mut child).success());
+    }
+
+    #[test]
+    fn enrollment_replacement_prevents_admission() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let home = temporary.path();
+        private_dir(&home.join(".ssh"));
+        let state = home.join("enrollment");
+        private_dir(&state);
+        let mut child = worker(home, &state, "verifying", "verification");
+        fs::rename(&state, home.join("old-enrollment")).unwrap();
+        private_dir(&state);
+        child.0.stdin.as_mut().unwrap().write_all(b"x").unwrap();
+        assert!(exited(&mut child).success());
+    }
+
+    #[test]
+    fn older_revoke_removing_state_also_stops_new_receivers() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let home = temporary.path();
+        private_dir(&home.join(".ssh"));
+        let state = home.join("enrollment");
+        private_dir(&state);
+        let mut child = worker(home, &state, "old-revoke", "blocked");
+        fs::remove_dir_all(&state).unwrap();
+        private_dir(&state);
+        assert!(!exited(&mut child).success());
+    }
+
+    #[test]
+    fn normal_receiver_exit_releases_its_lease() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let home = temporary.path();
+        private_dir(&home.join(".ssh"));
+        let state = home.join("enrollment");
+        private_dir(&state);
+        // No readiness poll: this receiver can finish before the parent runs.
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "restricted::active::tests::receiver_process",
+                "--nocapture",
+            ])
+            .env("SYQ_TEST_ACTIVE_HOME", home)
+            .env("SYQ_TEST_ACTIVE_STATE", &state)
+            .env("SYQ_TEST_ACTIVE_READY", home.join("ready-normal"))
+            .env("SYQ_TEST_ACTIVE_MODE", "normal")
+            .process_group(0)
+            .spawn()
+            .map(Worker)
+            .unwrap();
+        assert!(exited(&mut child).success());
+        revoke(&state, &open_leases(&state).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn shutdown_timeout_keeps_admission_closed_and_allows_retry() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let state_path = temporary.path().join("enrollment");
+        private_dir(&state_path);
+        let state = state_path.as_path();
+        let held = open_leases(state).unwrap();
+        assert!(try_lock(&held, libc::LOCK_SH).unwrap());
+        let leases = open_leases(state).unwrap();
+        atomic_write(state, "revoked", b"revoked\n", 0o600).unwrap();
+        let error = wait_for_receivers(&leases, Duration::from_millis(20)).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("active receiver leases are still held"));
+        assert!(require_not_revoked(state).is_err());
+        drop(held);
+        revoke(state, &leases).unwrap();
+    }
+
+    #[test]
+    fn lease_file_rejects_symlinks_and_hardlinks() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let state = temporary.path();
+        let outside = state.join("outside");
+        fs::write(&outside, b"sentinel").unwrap();
+        fs::set_permissions(&outside, fs::Permissions::from_mode(0o600)).unwrap();
+        let leases = state.join("active-receivers");
+        std::os::unix::fs::symlink(&outside, &leases).unwrap();
+        assert!(open_leases(state).is_err());
+        fs::remove_file(&leases).unwrap();
+        fs::hard_link(&outside, &leases).unwrap();
+        assert!(open_leases(state).is_err());
+        assert_eq!(fs::read(&outside).unwrap(), b"sentinel");
+    }
+}

--- a/tests/fixtures/restricted-enrollment-v0.4.1.json
+++ b/tests/fixtures/restricted-enrollment-v0.4.1.json
@@ -1,0 +1,1 @@
+{"version":3,"id":[0,17,34,51,68,85,70,119,136,153,170,187,204,221,238,255],"target_login":"syq","signer":"syq-enrollment-00112233445546778899aabbccddeeff","root":"/tmp/revoke-legacy-fixture","root_dev":63,"root_ino":8388682,"ssh_keygen":"/usr/bin/ssh-keygen","receiver_path":"/home/syq/.local/libexec/syq-receiver"}

--- a/tests/real-ssh/Dockerfile
+++ b/tests/real-ssh/Dockerfile
@@ -66,4 +66,6 @@ COPY tests/real-ssh/test-return-handoff.py /usr/local/libexec/syq-test-return-ha
 
 COPY tests/real-ssh/test-root-security.py /usr/local/libexec/syq-test-root-security.py
 
+COPY tests/real-ssh/test-receiver-revoke.py /usr/local/libexec/syq-test-receiver-revoke.py
+
 ENTRYPOINT ["/usr/local/libexec/syq-real-ssh-entrypoint"]

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -171,3 +171,7 @@ and check that it respects disabled receiving. An ephemeral connect establishes
 forward SSH without creating a return service or enabling durable persistence.
 Network interruption and heartbeat
 expiry cases verify automatic recovery and successful subsequent copies.
+
+The suite also revokes an enrollment while two restricted copies are writing,
+checks that both fail without publishing their files, and verifies that a fresh
+enrollment can resume their partials.

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -662,6 +662,9 @@ ssh destination '
     test ! -e ~/.local/libexec/syq-receiver
 '
 
+printf 'case: enrollment revocation stops active restricted receivers\n'
+python3 /usr/local/libexec/syq-test-receiver-revoke.py
+
 printf 'case: source coordinator with constrained agent and restricted destination\n'
 make_tree source /tmp/syq-real-ssh/direct-source direct
 syq cp --no-progress -j 2 --preserve=permissions \

--- a/tests/real-ssh/test-receiver-revoke.py
+++ b/tests/real-ssh/test-receiver-revoke.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Revoke two active restricted copies in the disposable OpenSSH lab."""
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import signal
+import subprocess
+import tempfile
+import time
+import uuid
+
+
+def run(*args, **kwargs):
+    return subprocess.run(args, check=True, timeout=45, **kwargs)
+
+
+def remote(command):
+    return run("ssh", "destination", command, stdout=subprocess.PIPE, text=True).stdout.strip()
+
+
+def enrollment(parent):
+    records = [json.loads(path.read_bytes()) for path in
+               (Path.home() / ".local/state/syq/restricted").glob("*/metadata.json")]
+    matches = [record for record in records if record["requested_parent"] == parent]
+    assert len(matches) == 1, matches
+    return matches[0]
+
+
+def wait_for(label, probe, seconds=25):
+    deadline = time.monotonic() + seconds
+    progress = 0
+    last = None
+    while time.monotonic() < deadline:
+        done, last = probe()
+        if done:
+            return last
+        if time.monotonic() >= progress:
+            print(f"Waiting for {label}: {last}", flush=True)
+            progress = time.monotonic() + 2
+        time.sleep(.1)
+    raise AssertionError(f"{label} timed out; last state: {last}")
+
+
+def stop(process):
+    if process.poll() is None:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait(timeout=10)
+
+
+def main():
+    root = "/tmp/syq-real-ssh/revoke-active-" + uuid.uuid4().hex
+    source = "/tmp/syq-real-ssh/revoke-source"
+    remote("mkdir -p " + shlex.quote(root))
+    run("ssh", "source", "python3 -c " + shlex.quote(
+        f"from pathlib import Path; Path({source!r}).write_bytes(b'x' * (32 << 20))"))
+    run("syq", "receiver", "enroll", f"destination:{root}/one")
+    before = enrollment(root)
+    # EnrollmentId is serialized as bytes in the private JSON state.
+    identifier = bytes(before["id"]).hex()
+    state = before["remote_home"] + "/.local/share/syq/restricted/" + identifier
+    processes = []
+    outputs = []
+    try:
+        for name in ("one", "two"):
+            output = tempfile.TemporaryFile()
+            outputs.append(output)
+            process = subprocess.Popen([
+                "syq", "cp", "--from", "source", source, "--to", "destination",
+                "--as", f"{root}/{name}", "--connections", "1", "--bwlimit", "1M", "--no-progress",
+            ], stdout=output, stderr=output, start_new_session=True)
+            processes.append(process)
+        probe = "python3 -c " + shlex.quote(f"""
+import json
+from pathlib import Path
+root = Path({root!r})
+print(json.dumps([any(p.open('rb').read(4 << 20) == b'x' * (4 << 20) for p in root.glob('.' + name + '.syq-part.*')) for name in ('one', 'two')]))
+""")
+        def started():
+            assert all(process.poll() is None for process in processes), "copy exited before revocation"
+            observed = json.loads(remote(probe))
+            return all(observed), observed
+        wait_for("two admitted, writing receivers", started)
+        run("syq", "receiver", "revoke", identifier)
+        remote("test ! -e " + shlex.quote(state))
+        for process in processes:
+            status = process.wait(timeout=25)
+            assert status != 0, "revoked transfer reported success"
+        for output in outputs:
+            output.seek(0)
+            print(output.read().decode(errors="replace"), end="", flush=True)
+        remote("test ! -e " + shlex.quote(root + "/one") + " && test ! -e " + shlex.quote(root + "/two"))
+        # Copies under a fresh enrollment can resume their partials normally.
+        run("syq", "receiver", "enroll", f"destination:{root}/one")
+        after = enrollment(root)
+        assert after["id"] != before["id"], "revocation reused the old enrollment identity"
+        assert after["receipt_public_key"] != before["receipt_public_key"]
+        for name in ("one", "two"):
+            with tempfile.TemporaryDirectory(prefix="revoke-resume-results-") as temporary:
+                results = Path(temporary) / "results.ndjson"
+                run("syq", "cp", "--from", "source", source, "--to", "destination",
+                    "--as", f"{root}/{name}", "--connections", "2", "--no-progress", "--results", str(results))
+                terminal = [json.loads(line) for line in results.read_text().splitlines()][-1]
+                assert terminal["type"] == "result" and terminal["status"] == "success", terminal
+                assert 0 < terminal["bytes_transferred"] <= 28 << 20, terminal
+            actual = remote("sha256sum " + shlex.quote(root + "/" + name)).split()[0]
+            assert actual == hashlib.sha256(b'x' * (32 << 20)).hexdigest()
+        run("syq", "receiver", "revoke", bytes(after["id"]).hex())
+        print("Active receiver revocation and fresh-enrollment resume passed", flush=True)
+    finally:
+        for process in processes:
+            stop(process)
+        for output in outputs:
+            output.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`syq receiver revoke` previously removed authorization while already-admitted restricted receivers could keep writing until their grant's finish deadline. Revocation now closes admission, stops every running receiver for that enrollment, and waits for shutdown before removing its state and reporting success. Other enrollments continue running; interrupted copies fail visibly and their partial data can be resumed under a fresh enrollment.

Receivers hold shared file locks for their process lifetime and watch a private revocation marker. Each receiver isolates its process group so shutdown also stops its helper children without signalling a stored, potentially recycled PID. Admission and enrollment updates share the revoker's lifecycle lock. A ten-second shutdown timeout leaves the enrollment revoked and retryable. The seven-day grant finish window is unchanged.

Hard-link behavior is unchanged; the security documentation now explicitly describes how in-place writes and metadata changes can affect names outside a destination or grant scope.

Compatibility: tested the checksum-verified released v0.4.1 Linux binary in a disposable container. The new installer preserves its configuration bytes, receipt key, and replay records; the old installer accepts the additive lease file; the new revoker removes an old-created enrollment. An unchanged v0.4.1 configuration fixture is included. There is no wire or signed-grant format change. Copies already running an older binary must be stopped once before upgrading, as documented: replacing an executable cannot retrofit their shutdown watcher. Older revoke commands also cause updated receivers to stop when they remove enrollment state, but do not wait for that shutdown.

Validation:
- Rust formatting and all-target/all-feature Clippy passed.
- All-target Rust tests passed; the subsequently added unchanged v0.4.1 fixture test also passed.
- Full default three-container real-SSH suite passed, including concurrent receiver revocation and fresh-enrollment resume. A strengthened focused rerun additionally verified reuse of at least 4 MiB per interrupted copy using machine-readable transfer results.
- Documentation links, ShellCheck for the changed scenario runner, Python syntax, and whitespace checks passed.
- macOS and the Python SDK suite were not run locally.

Branch is based on 2499d7c. A merge-tree check against remote master 166eef3 found no conflicts; no synchronization or merge was performed. Latest master Linux and rsync workflows passed; its macOS workflow failed: https://github.com/greaber/syq/actions/runs/34142184217.
