### PR TITLE
Speed up cross-filesystem local tree copies without tuning

### DIFF
--- a/docs/speed.md
+++ b/docs/speed.md
@@ -342,11 +342,12 @@ copy authorization.
 ## Local copies and NFS
 
 Same-machine Linux copies first try kernel or NFS server-side copying. If
-that is unavailable between ext4, XFS, or tmpfs filesystems, syq copies eligible
-large files directly through their open source and destination files. It runs
+that is unavailable between ext4, XFS, or tmpfs filesystems during a multi-file
+copy, syq copies eligible large files directly through their open source and destination files. It runs
 these file copies in parallel without sending their contents through local TCP
 connections. Small files still use batches. This happens automatically, without
-tuning options.
+tuning options. Single-file copies retain parallel range copying when offload
+is unavailable.
 
 Syq also uses a sequential destination writer for eligible local-disk to
 asynchronous-NFS copies. NFS sources, synchronous destinations, and other

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -342,10 +342,11 @@ copy authorization.
 ## Local copies and NFS
 
 Same-machine Linux copies first try kernel or NFS server-side copying. If
-that is unavailable between ext4, XFS, or tmpfs filesystems, syq copies each
-file directly through its open source and destination files. It runs file
-copies in parallel without sending their contents through local TCP connections.
-This happens automatically, without tuning options.
+that is unavailable between ext4, XFS, or tmpfs filesystems, syq copies eligible
+large files directly through their open source and destination files. It runs
+these file copies in parallel without sending their contents through local TCP
+connections. Small files still use batches. This happens automatically, without
+tuning options.
 
 Syq also uses a sequential destination writer for eligible local-disk to
 asynchronous-NFS copies. NFS sources, synchronous destinations, and other

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -341,10 +341,17 @@ copy authorization.
 
 ## Local copies and NFS
 
-Same-machine Linux copies can use kernel or NFS server-side copying. When
-that is unavailable, syq can still benefit from parallel file operations.
-It automatically uses a sequential destination writer for eligible local-disk
-to asynchronous-NFS copies; you usually need no special flags.
+Same-machine Linux copies first try kernel or NFS server-side copying. If
+that is unavailable between ext4, XFS, or tmpfs filesystems, syq copies each
+file directly through its open source and destination files. It runs file
+copies in parallel without sending their contents through local TCP connections.
+This happens automatically, without tuning options.
+
+Syq also uses a sequential destination writer for eligible local-disk to
+asynchronous-NFS copies. NFS sources, synchronous destinations, and other
+filesystems retain parallel range copying when offload is unavailable.
+Checksum comparisons, resumed data, and bandwidth limits keep their usual
+range-based behavior.
 
 ```sh
 syq cp /raid/data --into /mnt/nfs/backup

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -124,6 +124,7 @@ enum FileSystemKey {
 struct CopyLocalPolicy {
     inplace: bool,
     allow_sequential_nfs_fallback: bool,
+    allow_sequential_local_fallback: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -5176,6 +5177,7 @@ impl FsOps {
         let CopyLocalPolicy {
             inplace,
             allow_sequential_nfs_fallback,
+            allow_sequential_local_fallback,
         } = policy;
         let source_target = self
             .registered_source_target(source)
@@ -5325,7 +5327,8 @@ impl FsOps {
         // Local files keep parallelism across files without paying transport
         // and per-range hashing costs. Do not widen the NFS exception above.
         let use_userspace_fallback = use_sequential_nfs_fallback
-            || (source_fs.local_userspace_copy
+            || (allow_sequential_local_fallback
+                && source_fs.local_userspace_copy
                 && destination_fs.local_userspace_copy
                 && !source_fs.is_nfs
                 && !destination_fs.is_nfs
@@ -6249,6 +6252,7 @@ impl FsOps {
                 dst,
                 inplace,
                 allow_sequential_nfs_fallback,
+                allow_sequential_local_fallback,
                 copy_id,
                 size,
                 mode,
@@ -6259,6 +6263,7 @@ impl FsOps {
                     CopyLocalPolicy {
                         inplace: *inplace,
                         allow_sequential_nfs_fallback: *allow_sequential_nfs_fallback,
+                        allow_sequential_local_fallback: *allow_sequential_local_fallback,
                     },
                     copy_id,
                     *size,

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -107,6 +107,7 @@ struct FileSystemTraits {
     is_nfs: bool,
     synchronous: bool,
     measured_local_source: bool,
+    local_userspace_copy: bool,
 }
 
 #[cfg(target_os = "linux")]
@@ -192,10 +193,15 @@ fn inspect_file_system(file: &File) -> FileSystemTraits {
         FileSystemTraits {
             is_nfs: file_system_type == libc::NFS_SUPER_MAGIC as u32,
             synchronous,
-            // Keep the automatic optimization confined to the source
-            // filesystems actually exercised by the ext-family and XFS NFS
-            // benchmarks. Unknown or network-backed sources retain adaptive
-            // range reads until measured independently.
+            // Keep unknown and network-backed filesystems on adaptive ranges.
+            // tmpfs also provides a real cross-filesystem control for this path.
+            local_userspace_copy: matches!(
+                file_system_type,
+                t if t == libc::EXT4_SUPER_MAGIC as u32
+                    || t == libc::XFS_SUPER_MAGIC as u32
+                    || t == libc::TMPFS_MAGIC as u32
+            ),
+            // Preserve the independently measured ext-family/XFS -> NFS scope.
             measured_local_source: matches!(
                 file_system_type,
                 t if t == libc::EXT4_SUPER_MAGIC as u32
@@ -243,12 +249,6 @@ fn file_system_traits(file: &File, key: FileSystemKey) -> FileSystemTraits {
 fn unsupported_copy_pairs() -> &'static Mutex<HashSet<(FileSystemKey, FileSystemKey)>> {
     static PAIRS: OnceLock<Mutex<HashSet<(FileSystemKey, FileSystemKey)>>> = OnceLock::new();
     PAIRS.get_or_init(|| Mutex::new(HashSet::new()))
-}
-
-#[cfg(target_os = "linux")]
-fn copy_destination_mounts() -> &'static Mutex<HashMap<PathBuf, FileSystemKey>> {
-    static MOUNTS: OnceLock<Mutex<HashMap<PathBuf, FileSystemKey>>> = OnceLock::new();
-    MOUNTS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 #[cfg(target_os = "linux")]
@@ -5159,10 +5159,10 @@ impl FsOps {
     }
 
     /// Copy a whole same-machine file without routing its bytes through the
-    /// transport. Prefer copy_file_range; when a cross-mount copy into NFS
-    /// cannot be offloaded, use one sequential userspace writer instead. Other
-    /// unsupported filesystems return `CopyLocalOutcome::Unsupported` for the
-    /// parallel streaming path.
+    /// transport. Prefer copy_file_range; eligible local filesystems and the
+    /// measured asynchronous NFS destination case use a sequential userspace
+    /// writer when offload is unsupported. File workers still run in parallel;
+    /// other filesystem pairs retain the adaptive range path.
     #[cfg(target_os = "linux")]
     fn copy_local(
         &mut self,
@@ -5197,11 +5197,6 @@ impl FsOps {
         let dp = PathBuf::from(OsStr::from_bytes(dst));
         let destination_relative = RelativePath::new(dst)?;
         let destination_label = self.logical_destination_path(&dp);
-        let destination_parent = destination_label
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-            .unwrap_or_else(|| Path::new("."))
-            .to_path_buf();
         #[cfg(debug_assertions)]
         hold_copy_local_before_destination_open_for_test()?;
         let source_metadata = s.metadata()?;
@@ -5223,21 +5218,6 @@ impl FsOps {
             );
         }
         let source_key = file_system_key(&s, source_metadata.dev());
-        if !allow_sequential_nfs_fallback {
-            let known_destination = copy_destination_mounts()
-                .lock()
-                .unwrap()
-                .get(&destination_parent)
-                .copied();
-            if known_destination.is_some_and(|destination_key| {
-                unsupported_copy_pairs()
-                    .lock()
-                    .unwrap()
-                    .contains(&(source_key, destination_key))
-            }) {
-                return Ok(CopyLocalOutcome::Unsupported);
-            }
-        }
         self.uncache_rooted(&destination_root, &destination_relative);
         let (target_relative, target_label) = if inplace {
             (destination_relative, destination_label)
@@ -5316,10 +5296,6 @@ impl FsOps {
         let destination_metadata = d.metadata()?;
         let destination_dev = destination_metadata.dev();
         let destination_key = file_system_key(&d, destination_dev);
-        copy_destination_mounts()
-            .lock()
-            .unwrap()
-            .insert(destination_parent, destination_key);
         let source_fs = file_system_traits(&s, source_key);
         let destination_fs = file_system_traits(&d, destination_key);
         #[cfg(debug_assertions)]
@@ -5346,13 +5322,21 @@ impl FsOps {
             && source_fs.measured_local_source
             && destination_fs.is_nfs
             && !destination_fs.synchronous;
+        // Local files keep parallelism across files without paying transport
+        // and per-range hashing costs. Do not widen the NFS exception above.
+        let use_userspace_fallback = use_sequential_nfs_fallback
+            || (source_fs.local_userspace_copy
+                && destination_fs.local_userspace_copy
+                && !source_fs.is_nfs
+                && !destination_fs.is_nfs
+                && !destination_fs.synchronous);
         let copy_pair = (source_key, destination_key);
         let copy_pair_unsupported = unsupported_copy_pairs()
             .lock()
             .unwrap()
             .contains(&copy_pair);
-        let mut userspace_fallback = copy_pair_unsupported && use_sequential_nfs_fallback;
-        if copy_pair_unsupported && !use_sequential_nfs_fallback {
+        let mut userspace_fallback = copy_pair_unsupported && use_userspace_fallback;
+        if copy_pair_unsupported && !use_userspace_fallback {
             let partial_metadata = d.metadata()?;
             drop(d);
             if !inplace {
@@ -5368,7 +5352,8 @@ impl FsOps {
         }
         #[cfg(debug_assertions)]
         if std::env::var_os("SYQ_TEST_COPY_LOCAL_EXDEV").is_some() {
-            if use_sequential_nfs_fallback {
+            unsupported_copy_pairs().lock().unwrap().insert(copy_pair);
+            if use_userspace_fallback {
                 userspace_fallback = true;
             } else {
                 let partial_metadata = d.metadata()?;
@@ -5414,7 +5399,7 @@ impl FsOps {
                     if matches!(raw, libc::EXDEV | libc::ENOSYS | libc::EOPNOTSUPP) {
                         unsupported_copy_pairs().lock().unwrap().insert(copy_pair);
                     }
-                    if use_sequential_nfs_fallback {
+                    if use_userspace_fallback {
                         userspace_fallback = true;
                         continue;
                     }
@@ -5468,6 +5453,19 @@ impl FsOps {
                 destination
                     .write_all(&buffer[..n])
                     .with_context(|| format!("write {}", target_label.display()))?;
+                #[cfg(debug_assertions)]
+                if remaining == size {
+                    test_race_barrier(
+                        "SYQ_TEST_COPY_LOCAL_WRITTEN_FILE",
+                        "SYQ_TEST_COPY_LOCAL_CONTINUE_FILE",
+                        "SYQ_TEST_HOLD_COPY_LOCAL_WRITTEN_MS",
+                        "local-copy first write",
+                    )?;
+                    if std::env::var_os("SYQ_TEST_FAIL_COPY_LOCAL_AFTER_WRITE").is_some() {
+                        return Err(io::Error::from_raw_os_error(libc::ENOSPC))
+                            .context("test local-copy write failure");
+                    }
+                }
                 remaining -= n as u64;
             }
             d.set_len(size)?;

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -5300,6 +5300,23 @@ impl FsOps {
         let destination_key = file_system_key(&d, destination_dev);
         let source_fs = file_system_traits(&s, source_key);
         let destination_fs = file_system_traits(&d, destination_key);
+        // Exercise fallback policy independently of the filesystem hosting the
+        // integration tests. Apply before the NFS/synchronous overrides so those
+        // exclusions can still be tested with otherwise eligible local traits.
+        #[cfg(debug_assertions)]
+        let (source_fs, destination_fs) = match std::env::var("SYQ_TEST_COPY_LOCAL_FS").as_deref() {
+            Ok("local") => {
+                let local = FileSystemTraits {
+                    measured_local_source: true,
+                    local_userspace_copy: true,
+                    ..FileSystemTraits::default()
+                };
+                (local, local)
+            }
+            Ok("unsupported") => (FileSystemTraits::default(), FileSystemTraits::default()),
+            Ok(value) => panic!("unknown SYQ_TEST_COPY_LOCAL_FS value: {value}"),
+            Err(_) => (source_fs, destination_fs),
+        };
         #[cfg(debug_assertions)]
         let source_fs = FileSystemTraits {
             is_nfs: source_fs.is_nfs

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -747,14 +747,17 @@ pub enum Request {
         guard: Option<ContainerGuard>,
     },
     /// Receiver-side copy of a same-machine file (copy_file_range when
-    /// possible, optionally a sequential userspace fallback for a local
-    /// source and asynchronous NFS destination). `CopyLocalUnsupported`
+    /// possible, otherwise an eligible sequential userspace fallback).
+    /// Local and NFS fallback policies are independent. `CopyLocalUnsupported`
     /// tells the caller to use the normal streaming path.
     CopyLocal {
         source: RegisteredPath,
         dst: PathBytes,
         inplace: bool,
         allow_sequential_nfs_fallback: bool,
+        /// The planner has multiple files, so whole-file writers can run in
+        /// parallel. A single local file retains adaptive range copying.
+        allow_sequential_local_fallback: bool,
         copy_id: CopyId,
         size: u64,
         mode: u32,
@@ -1085,7 +1088,7 @@ pub enum Response {
     /// and authorization protocol failures continue to use Err(String).
     EndpointError(WireError),
     Err(String),
-    /// `CopyLocal` could not use the receiver-side kernel-copy path. This is
+    /// `CopyLocal` could not use the receiver-side direct-copy path. This is
     /// deliberately distinct from `Err`: filenames and other diagnostics are
     /// untrusted text and must never select a recovery path.
     CopyLocalUnsupported,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -3199,8 +3199,8 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 if !workers_started {
                     // A same-machine file normally completes wholly inside one
                     // small-file or receiver-side copy request (copy_file_range,
-                    // or an eligible sequential userspace fallback). Starting 32 loopback
-                    // connections cannot help that request. If a larger file
+                    // or an eligible sequential userspace fallback). Starting
+                    // 32 loopback connections cannot help that request. If a larger file
                     // instead discovers a partial or an unsupported offload,
                     // the first worker wakes the tuner to restore the ordinary
                     // local starting count immediately.
@@ -8132,11 +8132,15 @@ impl Worker {
             && job.container_guard.is_none();
         self.set_inplace(idx, inplace);
         let mode = self.create_mode(job);
+        // Keep range parallelism for a single-file copy. Read the planned
+        // file count before the RPC so no scheduler lock spans the copy.
+        let allow_sequential_local_fallback = self.sched.jobs.lock().unwrap().len() > 1;
         let resp = self.dst.call(Request::CopyLocal {
             source: job.source.clone(),
             dst: job.dst.clone(),
             inplace,
             allow_sequential_nfs_fallback: self.opts.allow_sequential_nfs_fallback,
+            allow_sequential_local_fallback,
             copy_id: self.copy_id(),
             size: job.entry.size,
             mode,

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -3199,7 +3199,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 if !workers_started {
                     // A same-machine file normally completes wholly inside one
                     // small-file or receiver-side copy request (copy_file_range,
-                    // or the sequential NFS fallback). Starting 32 loopback
+                    // or an eligible sequential userspace fallback). Starting 32 loopback
                     // connections cannot help that request. If a larger file
                     // instead discovers a partial or an unsupported offload,
                     // the first worker wakes the tuner to restore the ordinary
@@ -7933,7 +7933,7 @@ impl Worker {
             && job.target_condition == TargetCondition::Any
             && job.container_guard.is_none();
         // Same-machine copy: let the receiver move the bytes directly (kernel
-        // offload, or one sequential writer for cross-mount NFS) instead of
+        // offload, or an eligible sequential userspace writer) instead of
         // framing, hashing and scheduling them through the transport.
         // copy_file_range cannot be paced, so a limited same-machine transfer
         // uses the regular userspace path (also useful for mounted NFS paths).

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -850,6 +850,7 @@ fn source_small_and_range_reads_use_registered_root_after_path_replacement() {
             // Keep the test on the ranged transport path instead of the excluded
             // same-machine CopyLocal optimization.
             .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .env("SYQ_TEST_COPY_LOCAL_SOURCE_NFS", "1")
             .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
             .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
             .stdout(Stdio::piped())
@@ -883,145 +884,154 @@ fn source_small_and_range_reads_use_registered_root_after_path_replacement() {
 #[cfg(all(debug_assertions, target_os = "linux"))]
 #[test]
 fn copy_local_uses_registered_source_after_path_replacement() {
-    let t = Tmp::new();
-    let original = vec![b'o'; 8 << 20];
-    write(&t.path("src/file"), &original);
-    write(&t.path("outside/file"), &vec![b'r'; original.len()]);
-    let ready = t.path("source-capability-ready");
+    for userspace in [false, true] {
+        let t = Tmp::new();
+        let original = vec![b'o'; 8 << 20];
+        write(&t.path("src/file"), &original);
+        write(&t.path("outside/file"), &vec![b'r'; original.len()]);
+        let ready = t.path("source-capability-ready");
 
-    let mut child = compat_command()
-        .args([
-            "-a",
-            "--syq-connections",
-            "1",
-            &t.s("src/"),
-            &t.s("dst/"),
-            "--no-progress",
-        ])
-        .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
-        .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
-        // A pathname fallback would read through the replacement below. A
-        // streaming fallback fails instead of hiding that CopyLocal was not
-        // exercised.
-        .env("SYQ_TEST_FAIL_READ_RANGE", "1")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .start()
-        .unwrap();
+        let mut child = compat_command()
+            .args([
+                "-a",
+                "--syq-connections",
+                "1",
+                &t.s("src/"),
+                &t.s("dst/"),
+                "--no-progress",
+            ])
+            .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
+            .env("SYQ_TEST_HOLD_SOURCE_ROOTS_MS", "750")
+            // A pathname fallback would read through the replacement below. A
+            // streaming fallback fails instead of hiding that CopyLocal was not
+            // exercised.
+            .env("SYQ_TEST_FAIL_READ_RANGE", "1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .envs(userspace.then_some(("SYQ_TEST_COPY_LOCAL_EXDEV", "1")))
+            .start()
+            .unwrap();
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    while !ready.exists() && std::time::Instant::now() < deadline {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !ready.exists() && std::time::Instant::now() < deadline {
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "syq exited before registering the source root"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
         assert!(
-            child.try_wait().unwrap().is_none(),
-            "syq exited before registering the source root"
+            ready.exists(),
+            "source root was not registered before timeout"
         );
-        std::thread::sleep(std::time::Duration::from_millis(10));
+
+        fs::rename(t.path("src"), t.path("selected-and-moved")).unwrap();
+        std::os::unix::fs::symlink(t.path("outside"), t.path("src")).unwrap();
+
+        let output = child.wait_with_output().unwrap();
+        assert_output_ok(&output);
+        assert_eq!(read(&t.path("dst/file")), original);
     }
-    assert!(
-        ready.exists(),
-        "source root was not registered before timeout"
-    );
-
-    fs::rename(t.path("src"), t.path("selected-and-moved")).unwrap();
-    std::os::unix::fs::symlink(t.path("outside"), t.path("src")).unwrap();
-
-    let output = child.wait_with_output().unwrap();
-    assert_output_ok(&output);
-    assert_eq!(read(&t.path("dst/file")), original);
 }
 
 #[cfg(all(debug_assertions, target_os = "linux"))]
 #[test]
 fn copy_local_refuses_a_replaced_destination_parent() {
-    let t = Tmp::new();
-    write(&t.path("src/tree/file"), &vec![b's'; 8 << 20]);
-    fs::create_dir_all(t.path("dst/tree")).unwrap();
-    write(&t.path("outside/sentinel"), b"unchanged");
-    let ready = t.path("copy-local-ready");
+    for userspace in [false, true] {
+        let t = Tmp::new();
+        write(&t.path("src/tree/file"), &vec![b's'; 8 << 20]);
+        fs::create_dir_all(t.path("dst/tree")).unwrap();
+        write(&t.path("outside/sentinel"), b"unchanged");
+        let ready = t.path("copy-local-ready");
 
-    let mut child = compat_command()
-        .args([
-            "-a",
-            "--syq-connections",
-            "1",
-            &t.s("src/"),
-            &t.s("dst/"),
-            "--no-progress",
-        ])
-        .env("SYQ_TEST_COPY_LOCAL_READY_FILE", &ready)
-        .env("SYQ_TEST_HOLD_COPY_LOCAL_MS", "750")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .start()
-        .unwrap();
+        let mut child = compat_command()
+            .args([
+                "-a",
+                "--syq-connections",
+                "1",
+                &t.s("src/"),
+                &t.s("dst/"),
+                "--no-progress",
+            ])
+            .env("SYQ_TEST_COPY_LOCAL_READY_FILE", &ready)
+            .env("SYQ_TEST_HOLD_COPY_LOCAL_MS", "750")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .envs(userspace.then_some(("SYQ_TEST_COPY_LOCAL_EXDEV", "1")))
+            .start()
+            .unwrap();
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    while !ready.exists() && std::time::Instant::now() < deadline {
-        assert!(
-            child.try_wait().unwrap().is_none(),
-            "syq exited before reaching the local-copy destination open"
-        );
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !ready.exists() && std::time::Instant::now() < deadline {
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "syq exited before reaching the local-copy destination open"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(ready.exists(), "local copy did not reach the test hook");
+
+        fs::rename(t.path("dst/tree"), t.path("dst/tree-original")).unwrap();
+        std::os::unix::fs::symlink(t.path("outside"), t.path("dst/tree")).unwrap();
+
+        let output = child.wait_with_output().unwrap();
+        assert!(!output.status.success(), "unexpected success: {output:?}");
+        assert_eq!(read(&t.path("outside/sentinel")), b"unchanged");
+        assert!(!t.path("outside/file").exists());
     }
-    assert!(ready.exists(), "local copy did not reach the test hook");
-
-    fs::rename(t.path("dst/tree"), t.path("dst/tree-original")).unwrap();
-    std::os::unix::fs::symlink(t.path("outside"), t.path("dst/tree")).unwrap();
-
-    let output = child.wait_with_output().unwrap();
-    assert!(!output.status.success(), "unexpected success: {output:?}");
-    assert_eq!(read(&t.path("outside/sentinel")), b"unchanged");
-    assert!(!t.path("outside/file").exists());
 }
 
 #[cfg(all(debug_assertions, target_os = "linux"))]
 #[test]
 fn inplace_copy_local_replaces_a_raced_destination_symlink() {
-    let t = Tmp::new();
-    let contents = vec![b's'; 8 << 20];
-    write(&t.path("src"), &contents);
-    write(&t.path("dst"), &vec![b'd'; contents.len()]);
-    write(&t.path("outside"), b"unchanged");
-    set_mtime(&t.path("src"), 1_700_000_000);
-    set_mtime(&t.path("dst"), 1_600_000_000);
-    let ready = t.path("copy-local-ready");
+    for userspace in [false, true] {
+        let t = Tmp::new();
+        let contents = vec![b's'; 8 << 20];
+        write(&t.path("src"), &contents);
+        write(&t.path("dst"), &vec![b'd'; contents.len()]);
+        write(&t.path("outside"), b"unchanged");
+        set_mtime(&t.path("src"), 1_700_000_000);
+        set_mtime(&t.path("dst"), 1_600_000_000);
+        let ready = t.path("copy-local-ready");
 
-    let mut child = compat_command()
-        .args([
-            "-a",
-            "--inplace",
-            "--syq-connections",
-            "1",
-            &t.s("src"),
-            &t.s("dst"),
-            "--no-progress",
-        ])
-        .env("SYQ_TEST_COPY_LOCAL_READY_FILE", &ready)
-        .env("SYQ_TEST_HOLD_COPY_LOCAL_MS", "750")
-        .env("SYQ_TEST_FAIL_READ_RANGE", "1")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .start()
-        .unwrap();
+        let mut child = compat_command()
+            .args([
+                "-a",
+                "--inplace",
+                "--syq-connections",
+                "1",
+                &t.s("src"),
+                &t.s("dst"),
+                "--no-progress",
+            ])
+            .env("SYQ_TEST_COPY_LOCAL_READY_FILE", &ready)
+            .env("SYQ_TEST_HOLD_COPY_LOCAL_MS", "750")
+            .env("SYQ_TEST_FAIL_READ_RANGE", "1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .envs(userspace.then_some(("SYQ_TEST_COPY_LOCAL_EXDEV", "1")))
+            .start()
+            .unwrap();
 
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    while !ready.exists() && std::time::Instant::now() < deadline {
-        assert!(
-            child.try_wait().unwrap().is_none(),
-            "syq exited before reaching the local-copy destination open"
-        );
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !ready.exists() && std::time::Instant::now() < deadline {
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "syq exited before reaching the local-copy destination open"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(ready.exists(), "local copy did not reach the test hook");
+
+        fs::remove_file(t.path("dst")).unwrap();
+        std::os::unix::fs::symlink("outside", t.path("dst")).unwrap();
+
+        let output = child.wait_with_output().unwrap();
+        assert_output_ok(&output);
+        assert_eq!(read(&t.path("outside")), b"unchanged");
+        assert!(fs::symlink_metadata(t.path("dst")).unwrap().is_file());
+        assert_eq!(read(&t.path("dst")), contents);
     }
-    assert!(ready.exists(), "local copy did not reach the test hook");
-
-    fs::remove_file(t.path("dst")).unwrap();
-    std::os::unix::fs::symlink("outside", t.path("dst")).unwrap();
-
-    let output = child.wait_with_output().unwrap();
-    assert_output_ok(&output);
-    assert_eq!(read(&t.path("outside")), b"unchanged");
-    assert!(fs::symlink_metadata(t.path("dst")).unwrap().is_file());
-    assert_eq!(read(&t.path("dst")), contents);
 }
 
 #[cfg(all(debug_assertions, target_os = "linux"))]
@@ -11456,6 +11466,7 @@ fn copy_local_exdev_auto_fallback_restores_parallel_workers() {
     let out = compat_command()
         .args(["-a", "--stats", "--no-progress", &t.s("src"), &t.s("dst")])
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_SOURCE_NFS", "1")
         .run()
         .unwrap();
     assert_output_ok(&out);
@@ -11502,6 +11513,135 @@ fn native_inplace_exdev_fallback_preserves_hardlink_aliases() {
     assert_eq!(fs::metadata(t.path("dst")).unwrap().ino(), original_inode);
     assert_eq!(fs::metadata(t.path("alias")).unwrap().ino(), original_inode);
     assert!(partial_files(&t.0).is_empty());
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_disk_exdev_uses_parallel_whole_file_workers() {
+    for connections in [None, Some("2")] {
+        let t = Tmp::new();
+        for index in 0..4 {
+            write(&t.path(&format!("src/file{index}")), &prng(5 << 20, index));
+        }
+        write(&t.path("src/small"), b"small file batch");
+        let mut command = compat_command();
+        command.args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")]);
+        if let Some(connections) = connections {
+            command.args(["--syq-connections", connections]);
+        }
+        let out = command
+            .env("SYQ_DEBUG", "1")
+            .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .run()
+            .unwrap();
+        assert_output_ok(&out);
+        assert_same_tree(&t.path("src"), &t.path("dst"));
+        let observed = tuning_observed(&out);
+        assert_eq!(observed["local_whole_files"], 4);
+        assert_eq!(observed["range_requests"], 0);
+        assert!(observed["small_batches"].as_u64().unwrap() > 0);
+        assert!(partial_files(&t.0).is_empty());
+    }
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_disk_exdev_preserves_range_controls() {
+    for (args, synchronous) in [
+        (vec!["--checksum"], false),
+        (vec!["--bwlimit", "1G"], false),
+        (vec![], true),
+    ] {
+        let t = Tmp::new();
+        write(&t.path("src"), &prng(5 << 20, 455));
+        let out = compat_command()
+            .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+            .args(args)
+            .env("SYQ_DEBUG", "1")
+            .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .envs(synchronous.then_some(("SYQ_TEST_COPY_LOCAL_NFS_SYNC", "1")))
+            .run()
+            .unwrap();
+        assert_output_ok(&out);
+        assert_eq!(read(&t.path("src")), read(&t.path("dst")));
+        let observed = tuning_observed(&out);
+        assert_eq!(observed["local_whole_files"], 0);
+        assert!(observed["range_requests"].as_u64().unwrap() > 0);
+    }
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_disk_write_failure_keeps_old_destination_and_resumes_changed_source() {
+    let t = Tmp::new();
+    let original = prng(8 << 20, 456);
+    write(&t.path("src"), &original);
+    write(&t.path("dst"), b"old destination");
+    let out = compat_command()
+        .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+        .env("SYQ_DEBUG", "1")
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_FAIL_COPY_LOCAL_AFTER_WRITE", "1")
+        .run()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1), "{out:?}");
+    assert!(stderr_of(&out).contains("test local-copy write failure"));
+    assert_eq!(read(&t.path("dst")), b"old destination");
+    let partials = partial_files(&t.0);
+    assert_eq!(partials.len(), 1);
+    assert_eq!(fs::metadata(&partials[0]).unwrap().len(), 1 << 20);
+    let observed = tuning_observed(&out);
+    assert_eq!(observed["local_whole_files"], 0);
+    assert_eq!(observed["range_requests"], 0);
+
+    // The failed userspace write is a resumable basis, not authority to skip
+    // checking bytes that changed in the source before the retry.
+    let mut changed = original;
+    changed[..1 << 20].fill(b'c');
+    write(&t.path("src"), &changed);
+    let out = compat_command()
+        .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+        .env("SYQ_DEBUG", "1")
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .run()
+        .unwrap();
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst")), changed);
+    let observed = tuning_observed(&out);
+    assert_eq!(observed["local_whole_files"], 0);
+    assert!(observed["range_requests"].as_u64().unwrap() > 0);
+    assert!(partial_files(&t.0).is_empty());
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_disk_source_shrink_is_not_published() {
+    let t = Tmp::new();
+    write(&t.path("src"), &prng(8 << 20, 457));
+    let ready = t.path("written");
+    let resume = t.path("continue");
+    let mut child = compat_command()
+        .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_WRITTEN_FILE", &ready)
+        .env("SYQ_TEST_COPY_LOCAL_CONTINUE_FILE", &resume)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !ready.exists() && std::time::Instant::now() < deadline {
+        assert!(child.try_wait().unwrap().is_none());
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(ready.exists(), "copy did not reach the first-write barrier");
+    File::create(t.path("src")).unwrap();
+    write(&resume, b"continue");
+    let out = child.wait_with_output().unwrap();
+    assert_eq!(out.status.code(), Some(23), "{out:?}");
+    assert!(stderr_of(&out).contains("source shortened while copying"));
+    assert!(!t.path("dst").exists());
+    assert_eq!(partial_files(&t.0).len(), 1);
 }
 
 #[cfg(all(debug_assertions, target_os = "linux"))]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -910,6 +910,7 @@ fn copy_local_uses_registered_source_after_path_replacement() {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .envs(userspace.then_some(("SYQ_TEST_COPY_LOCAL_EXDEV", "1")))
+            .envs(userspace.then_some(("SYQ_TEST_COPY_LOCAL_FS", "local")))
             .start()
             .unwrap();
 
@@ -960,6 +961,7 @@ fn copy_local_refuses_a_replaced_destination_parent() {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .envs(userspace.then_some(("SYQ_TEST_COPY_LOCAL_EXDEV", "1")))
+            .envs(userspace.then_some(("SYQ_TEST_COPY_LOCAL_FS", "local")))
             .start()
             .unwrap();
 
@@ -1013,6 +1015,7 @@ fn inplace_copy_local_replaces_a_raced_destination_symlink() {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .envs(userspace.then_some(("SYQ_TEST_COPY_LOCAL_EXDEV", "1")))
+            .envs(userspace.then_some(("SYQ_TEST_COPY_LOCAL_FS", "local")))
             .start()
             .unwrap();
 
@@ -11535,6 +11538,7 @@ fn copy_local_disk_exdev_uses_parallel_whole_file_workers() {
         let out = command
             .env("SYQ_DEBUG", "1")
             .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .env("SYQ_TEST_COPY_LOCAL_FS", "local")
             .run()
             .unwrap();
         assert_output_ok(&out);
@@ -11545,6 +11549,27 @@ fn copy_local_disk_exdev_uses_parallel_whole_file_workers() {
         assert!(observed["small_batches"].as_u64().unwrap() > 0);
         assert!(partial_files(&t.0).is_empty());
     }
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_unsupported_filesystems_retain_ranges() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), &prng(5 << 20, 460));
+    write(&t.path("src/other"), &prng(5 << 20, 461));
+    let out = compat_command()
+        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
+        .env("SYQ_DEBUG", "1")
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_FS", "unsupported")
+        .run()
+        .unwrap();
+    assert_output_ok(&out);
+    assert_same_tree(&t.path("src"), &t.path("dst"));
+    let observed = tuning_observed(&out);
+    assert_eq!(observed["local_whole_files"], 0);
+    assert!(observed["range_requests"].as_u64().unwrap() > 0);
+    assert!(partial_files(&t.0).is_empty());
 }
 
 #[cfg(all(debug_assertions, target_os = "linux"))]
@@ -11566,6 +11591,7 @@ fn copy_local_disk_whole_files_write_concurrently() {
         ])
         .env("SYQ_DEBUG", "1")
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_FS", "local")
         .env("SYQ_TEST_COPY_LOCAL_WRITTEN_FILE", t.path("ready"))
         .env("SYQ_TEST_COPY_LOCAL_CONTINUE_FILE", &continuation)
         .stdout(Stdio::piped())
@@ -11615,6 +11641,7 @@ fn copy_local_disk_single_file_retains_parallel_ranges() {
         let out = command
             .env("SYQ_DEBUG", "1")
             .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .env("SYQ_TEST_COPY_LOCAL_FS", "local")
             .run()
             .unwrap();
         assert_output_ok(&out);
@@ -11651,6 +11678,7 @@ fn copy_local_disk_exdev_preserves_range_controls() {
             .args(args)
             .env("SYQ_DEBUG", "1")
             .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .env("SYQ_TEST_COPY_LOCAL_FS", "local")
             .envs(synchronous.then_some(("SYQ_TEST_COPY_LOCAL_NFS_SYNC", "1")))
             .run()
             .unwrap();
@@ -11674,6 +11702,7 @@ fn copy_local_disk_write_failure_keeps_old_destination_and_resumes_changed_sourc
         .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
         .env("SYQ_DEBUG", "1")
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_FS", "local")
         .env("SYQ_TEST_FAIL_COPY_LOCAL_AFTER_WRITE", "1")
         .run()
         .unwrap();
@@ -11696,6 +11725,7 @@ fn copy_local_disk_write_failure_keeps_old_destination_and_resumes_changed_sourc
         .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
         .env("SYQ_DEBUG", "1")
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_FS", "local")
         .run()
         .unwrap();
     assert_output_ok(&out);
@@ -11717,6 +11747,7 @@ fn copy_local_disk_source_shrink_is_not_published() {
     let mut child = compat_command()
         .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_FS", "local")
         .env("SYQ_TEST_COPY_LOCAL_WRITTEN_FILE", &ready)
         .env("SYQ_TEST_COPY_LOCAL_CONTINUE_FILE", &resume)
         .stdout(Stdio::piped())

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -888,6 +888,7 @@ fn copy_local_uses_registered_source_after_path_replacement() {
         let t = Tmp::new();
         let original = vec![b'o'; 8 << 20];
         write(&t.path("src/file"), &original);
+        write(&t.path("src/other"), &vec![b'o'; 5 << 20]);
         write(&t.path("outside/file"), &vec![b'r'; original.len()]);
         let ready = t.path("source-capability-ready");
 
@@ -940,6 +941,7 @@ fn copy_local_refuses_a_replaced_destination_parent() {
     for userspace in [false, true] {
         let t = Tmp::new();
         write(&t.path("src/tree/file"), &vec![b's'; 8 << 20]);
+        write(&t.path("src/tree/other"), &vec![b'o'; 5 << 20]);
         fs::create_dir_all(t.path("dst/tree")).unwrap();
         write(&t.path("outside/sentinel"), b"unchanged");
         let ready = t.path("copy-local-ready");
@@ -987,11 +989,12 @@ fn inplace_copy_local_replaces_a_raced_destination_symlink() {
     for userspace in [false, true] {
         let t = Tmp::new();
         let contents = vec![b's'; 8 << 20];
-        write(&t.path("src"), &contents);
-        write(&t.path("dst"), &vec![b'd'; contents.len()]);
+        write(&t.path("src/file"), &contents);
+        write(&t.path("src/other"), &vec![b'o'; 5 << 20]);
+        write(&t.path("dst/file"), &vec![b'd'; contents.len()]);
         write(&t.path("outside"), b"unchanged");
-        set_mtime(&t.path("src"), 1_700_000_000);
-        set_mtime(&t.path("dst"), 1_600_000_000);
+        set_mtime(&t.path("src/file"), 1_700_000_000);
+        set_mtime(&t.path("dst/file"), 1_600_000_000);
         let ready = t.path("copy-local-ready");
 
         let mut child = compat_command()
@@ -1000,8 +1003,8 @@ fn inplace_copy_local_replaces_a_raced_destination_symlink() {
                 "--inplace",
                 "--syq-connections",
                 "1",
-                &t.s("src"),
-                &t.s("dst"),
+                &t.s("src/"),
+                &t.s("dst/"),
                 "--no-progress",
             ])
             .env("SYQ_TEST_COPY_LOCAL_READY_FILE", &ready)
@@ -1023,14 +1026,14 @@ fn inplace_copy_local_replaces_a_raced_destination_symlink() {
         }
         assert!(ready.exists(), "local copy did not reach the test hook");
 
-        fs::remove_file(t.path("dst")).unwrap();
-        std::os::unix::fs::symlink("outside", t.path("dst")).unwrap();
+        fs::remove_file(t.path("dst/file")).unwrap();
+        std::os::unix::fs::symlink("../outside", t.path("dst/file")).unwrap();
 
         let output = child.wait_with_output().unwrap();
         assert_output_ok(&output);
         assert_eq!(read(&t.path("outside")), b"unchanged");
-        assert!(fs::symlink_metadata(t.path("dst")).unwrap().is_file());
-        assert_eq!(read(&t.path("dst")), contents);
+        assert!(fs::symlink_metadata(t.path("dst/file")).unwrap().is_file());
+        assert_eq!(read(&t.path("dst/file")), contents);
     }
 }
 
@@ -11546,6 +11549,94 @@ fn copy_local_disk_exdev_uses_parallel_whole_file_workers() {
 
 #[cfg(all(debug_assertions, target_os = "linux"))]
 #[test]
+fn copy_local_disk_whole_files_write_concurrently() {
+    let t = Tmp::new();
+    for name in ["first", "second"] {
+        write(&t.path(&format!("src/{name}")), &prng(8 << 20, 459));
+    }
+    let continuation = t.path("continue");
+    let mut child = compat_command()
+        .args([
+            "-a",
+            "--syq-connections",
+            "2",
+            "--no-progress",
+            &t.s("src/"),
+            &t.s("dst/"),
+        ])
+        .env("SYQ_DEBUG", "1")
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_WRITTEN_FILE", t.path("ready"))
+        .env("SYQ_TEST_COPY_LOCAL_CONTINUE_FILE", &continuation)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut both_written = false;
+    while std::time::Instant::now() < deadline {
+        let partials = partial_files(&t.path("dst"));
+        if partials.len() == 2
+            && partials
+                .iter()
+                .all(|path| fs::metadata(path).is_ok_and(|metadata| metadata.len() == 1 << 20))
+        {
+            both_written = true;
+            break;
+        }
+        if child.try_wait().unwrap().is_some() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    // Release both workers before checking the result, including on failure.
+    write(&continuation, b"continue");
+    let out = child.wait_with_output().unwrap();
+    assert!(both_written, "whole-file copies were serialized: {out:?}");
+    assert_output_ok(&out);
+    assert_same_tree(&t.path("src"), &t.path("dst"));
+    let observed = tuning_observed(&out);
+    assert_eq!(observed["local_whole_files"], 2);
+    assert_eq!(observed["range_requests"], 0);
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn copy_local_disk_single_file_retains_parallel_ranges() {
+    for connections in [None, Some("2")] {
+        let t = Tmp::new();
+        let contents = prng(8 << 20, 458);
+        write(&t.path("src"), &contents);
+        let mut command = compat_command();
+        command.args(["-a", "--stats", "--no-progress", &t.s("src"), &t.s("dst")]);
+        if let Some(connections) = connections {
+            command.args(["--syq-connections", connections]);
+        }
+        let out = command
+            .env("SYQ_DEBUG", "1")
+            .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .run()
+            .unwrap();
+        assert_output_ok(&out);
+        assert_eq!(read(&t.path("dst")), contents);
+        let observed = tuning_observed(&out);
+        assert_eq!(observed["local_whole_files"], 0);
+        assert!(observed["range_requests"].as_u64().unwrap() > 0);
+        if connections.is_none() {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            assert!(
+                stdout.contains(&format!(
+                    "connections: auto: settled at {0} (path {0}, peak {0})",
+                    expected_local_start()
+                )),
+                "{stdout}"
+            );
+        }
+    }
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
 fn copy_local_disk_exdev_preserves_range_controls() {
     for (args, synchronous) in [
         (vec!["--checksum"], false),
@@ -11553,9 +11644,10 @@ fn copy_local_disk_exdev_preserves_range_controls() {
         (vec![], true),
     ] {
         let t = Tmp::new();
-        write(&t.path("src"), &prng(5 << 20, 455));
+        write(&t.path("src/small"), b"parallel file work");
+        write(&t.path("src/file"), &prng(5 << 20, 455));
         let out = compat_command()
-            .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+            .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
             .args(args)
             .env("SYQ_DEBUG", "1")
             .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
@@ -11563,7 +11655,7 @@ fn copy_local_disk_exdev_preserves_range_controls() {
             .run()
             .unwrap();
         assert_output_ok(&out);
-        assert_eq!(read(&t.path("src")), read(&t.path("dst")));
+        assert_eq!(read(&t.path("src/file")), read(&t.path("dst/file")));
         let observed = tuning_observed(&out);
         assert_eq!(observed["local_whole_files"], 0);
         assert!(observed["range_requests"].as_u64().unwrap() > 0);
@@ -11574,11 +11666,12 @@ fn copy_local_disk_exdev_preserves_range_controls() {
 #[test]
 fn copy_local_disk_write_failure_keeps_old_destination_and_resumes_changed_source() {
     let t = Tmp::new();
+    write(&t.path("src/small"), b"parallel file work");
     let original = prng(8 << 20, 456);
-    write(&t.path("src"), &original);
-    write(&t.path("dst"), b"old destination");
+    write(&t.path("src/file"), &original);
+    write(&t.path("dst/file"), b"old destination");
     let out = compat_command()
-        .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
         .env("SYQ_DEBUG", "1")
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
         .env("SYQ_TEST_FAIL_COPY_LOCAL_AFTER_WRITE", "1")
@@ -11586,8 +11679,8 @@ fn copy_local_disk_write_failure_keeps_old_destination_and_resumes_changed_sourc
         .unwrap();
     assert_eq!(out.status.code(), Some(1), "{out:?}");
     assert!(stderr_of(&out).contains("test local-copy write failure"));
-    assert_eq!(read(&t.path("dst")), b"old destination");
-    let partials = partial_files(&t.0);
+    assert_eq!(read(&t.path("dst/file")), b"old destination");
+    let partials = partial_files(&t.path("dst"));
     assert_eq!(partials.len(), 1);
     assert_eq!(fs::metadata(&partials[0]).unwrap().len(), 1 << 20);
     let observed = tuning_observed(&out);
@@ -11598,30 +11691,31 @@ fn copy_local_disk_write_failure_keeps_old_destination_and_resumes_changed_sourc
     // checking bytes that changed in the source before the retry.
     let mut changed = original;
     changed[..1 << 20].fill(b'c');
-    write(&t.path("src"), &changed);
+    write(&t.path("src/file"), &changed);
     let out = compat_command()
-        .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
         .env("SYQ_DEBUG", "1")
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
         .run()
         .unwrap();
     assert_output_ok(&out);
-    assert_eq!(read(&t.path("dst")), changed);
+    assert_eq!(read(&t.path("dst/file")), changed);
     let observed = tuning_observed(&out);
     assert_eq!(observed["local_whole_files"], 0);
     assert!(observed["range_requests"].as_u64().unwrap() > 0);
-    assert!(partial_files(&t.0).is_empty());
+    assert!(partial_files(&t.path("dst")).is_empty());
 }
 
 #[cfg(all(debug_assertions, target_os = "linux"))]
 #[test]
 fn copy_local_disk_source_shrink_is_not_published() {
     let t = Tmp::new();
-    write(&t.path("src"), &prng(8 << 20, 457));
+    write(&t.path("src/small"), b"parallel file work");
+    write(&t.path("src/file"), &prng(8 << 20, 457));
     let ready = t.path("written");
     let resume = t.path("continue");
     let mut child = compat_command()
-        .args(["-a", "--no-progress", &t.s("src"), &t.s("dst")])
+        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
         .env("SYQ_TEST_COPY_LOCAL_WRITTEN_FILE", &ready)
         .env("SYQ_TEST_COPY_LOCAL_CONTINUE_FILE", &resume)
@@ -11635,13 +11729,13 @@ fn copy_local_disk_source_shrink_is_not_published() {
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
     assert!(ready.exists(), "copy did not reach the first-write barrier");
-    File::create(t.path("src")).unwrap();
+    File::create(t.path("src/file")).unwrap();
     write(&resume, b"continue");
     let out = child.wait_with_output().unwrap();
     assert_eq!(out.status.code(), Some(23), "{out:?}");
     assert!(stderr_of(&out).contains("source shortened while copying"));
-    assert!(!t.path("dst").exists());
-    assert_eq!(partial_files(&t.0).len(), 1);
+    assert!(!t.path("dst/file").exists());
+    assert_eq!(partial_files(&t.path("dst")).len(), 1);
 }
 
 #[cfg(all(debug_assertions, target_os = "linux"))]


### PR DESCRIPTION
When a local multi-file copy cannot use `copy_file_range`, eligible ext4/XFS/tmpfs pairs now reuse the receiver's descriptor-based userspace copy loop. Large-file contents avoid local TCP framing and per-range hashing, while file workers remain parallel. This is automatic and adds no tuning options.

Single-file copies retain adaptive ranges when kernel offload is unavailable. Small-file batching and the independently gated asynchronous-NFS fallback remain intact. Unknown filesystems, NFS sources, synchronous destinations, checksum comparisons, resumed data and bandwidth limits retain their existing fallback behavior. Registered sources, rooted destinations, partial ownership and publication use the established primitives.

Test portability at `475973d`: the userspace-copy tests explicitly select eligible filesystem traits through a debug-only override, independent of the temporary filesystem. A separate case selects unsupported traits and asserts range copying. All 15 local-copy tests passed on the host and inside an isolated container with `/tmp` on overlayfs. Formatting, all-target/all-feature Clippy, diff checks, and 571 unit tests passed (one inherited ignored). This test-only revision does not change release behavior; performance and the broader real-SSH/full-suite validation below were not rerun.

Production-path validation at `ad5bf4b`:

- Formatting, all-target/all-feature Clippy with warnings denied, documentation links and diff checks passed.
- Full locked all-target Rust suite: 1,040 passed, one inherited ignored test. Focused coverage includes concurrent userspace copies, source/destination races, short reads, ENOSPC, partial resume, checksum/bandwidth exclusions and NFS policy boundaries.
- Default three-container real-SSH suite passed using the same production source tree; its snapshot was built before the final commit. Owned lab resources were removed. Manual process-group interruption and changed-source retry passed.
- The new `CopyLocal` policy bit only changes the ephemeral helper protocol. Actual `ba59c33` and `ad5bf4b` release-profile binaries rejected mismatched build identities in both directions before decoding request frames. Unchanged released v0.4.0 preamble fixtures also passed. No CLI or persisted state changes.

Local performance comparison against locked master `ba59c33`, automatic workers:

| Mixed-tree workload | Repeats per binary | Mean elapsed, before → after | Aggregate CPU seconds, before → after |
| --- | ---: | ---: | ---: |
| Original 8 GiB / 8,000 files | 3 | 1.996 → 1.676 s | 46.230 → 27.862 |
| Scaled 32 GiB / 32,000 files | 2 | 6.050 → 5.002 s | 161.181 → 94.857 |

These replay the pinned syq-bench `df90a23` mixed-tree generator and original seed, interleaving binaries on ext4 → tmpfs. All contents verified. Fixture-only eviction was requested before each trial; actual residency was unverified and metadata stayed warm. No final flush entered the timed interval. This shared development machine is not the original two-NVMe host. The original trials and one scaled candidate trial (4.981 s) fall below the five-second timing floor, so these are local evidence, not a public performance claim.

A separate 48-copy matrix covered single/mixed/small trees, same/cross filesystem and automatic/four-worker controls. Single-file cross-filesystem copies still issued the same range requests: automatic mean elapsed varied 7.896 → 8.229 s, while four-worker times were 9.317 → 9.241 s. Small-file and same-filesystem controls showed no consistent gain. No macOS, physical-NFS performance or separate disk-to-disk testing was run.

`branch-status.sh` results for the current head are recorded in the review handoff. Existing master Linux and macOS workflows are red; rsync compatibility is green. This is ready for review, not a claim of merge readiness:

- [Linux failure](https://github.com/greaber/syq/actions/runs/34158071070)
- [macOS failure](https://github.com/greaber/syq/actions/runs/34158071195)
- [rsync compatibility success](https://github.com/greaber/syq/actions/runs/34158071156)
