### PR TITLE
Fix inode snapshot test synchronization

### DIFF
--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -5024,17 +5024,12 @@ impl FsOps {
             file,
         });
         #[cfg(debug_assertions)]
-        if let Some(ready) = std::env::var_os("SYQ_TEST_BASIS_READY_FILE") {
-            fs::write(&ready, b"ready").with_context(|| {
-                format!("write basis-ready signal {}", Path::new(&ready).display())
-            })?;
-        }
-        #[cfg(debug_assertions)]
-        if let Some(ms) = std::env::var_os("SYQ_TEST_HOLD_BASIS_MS") {
-            if let Ok(ms) = ms.to_string_lossy().parse::<u64>() {
-                std::thread::sleep(std::time::Duration::from_millis(ms));
-            }
-        }
+        test_race_barrier(
+            "SYQ_TEST_BASIS_READY_FILE",
+            "SYQ_TEST_BASIS_CONTINUE_FILE",
+            "SYQ_TEST_HOLD_BASIS_MS",
+            "basis-ready",
+        )?;
         // Hashing is intentionally limited to the source length. Report the
         // retained inode's length afterward so a file that grew since the
         // planner's stat cannot be mistaken for an exact content match.

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -11058,6 +11058,7 @@ fn final_hash_and_partial_seed_use_one_inode_snapshot() {
     set_mtime(&t.path("first"), 1_600_000_001);
     set_mtime(&t.path("second"), 1_600_000_002);
     let ready = t.path("basis-ready");
+    let continuation = t.path("basis-continue");
 
     let mut first = compat_command()
         .args([
@@ -11071,18 +11072,10 @@ fn final_hash_and_partial_seed_use_one_inode_snapshot() {
             &t.s("basis"),
         ])
         .env("SYQ_TEST_BASIS_READY_FILE", &ready)
-        .env("SYQ_TEST_HOLD_BASIS_MS", "2000")
+        .env("SYQ_TEST_BASIS_CONTINUE_FILE", &continuation)
         .start()
         .unwrap();
-    let held = (0..300).any(|_| {
-        if ready.exists() {
-            true
-        } else {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-            false
-        }
-    });
-    assert!(held, "first copy never retained its destination basis");
+    wait_for_confinement_marker(&mut first, &ready, "destination basis retention");
     assert!(
         partial_files(&t.0).is_empty(),
         "hashing alone must not create a sidecar"
@@ -11099,6 +11092,9 @@ fn final_hash_and_partial_seed_use_one_inode_snapshot() {
     ]);
     assert_output_ok(&second);
     assert_eq!(read(&t.path("basis")), second_contents);
+    // Publish the second copy before allowing the first to seed its partial
+    // from the retained inode, regardless of how long the second copy takes.
+    release_confinement_barrier(&continuation);
     assert!(first.wait().unwrap().success());
     assert_eq!(read(&t.path("basis")), first_contents);
     assert!(partial_files(&t.0).is_empty());


### PR DESCRIPTION
The inode-snapshot test failed on master at `da182ab` when the second copy outlasted the first copy’s two-second pause. Use the existing bounded ready/continue barrier to keep the first copy paused after retaining its basis until the second copy has completed and its published contents have been checked. The original final-content and sidecar assertions remain intact.

Only debug test synchronization changes; release behavior and persisted or wire formats are unchanged. Existing basis-hook users retain their timed-pause behavior.

Validation at `0e131f1`:
- Formatting, all-target/all-feature Clippy, and unit tests passed (571 passed, one ignored). The first unit run hit an unrelated `Text file busy` error in the enrollment-upload fixture; the full rerun passed.
- The exact failing integration test and all four `basis`-filtered integration tests passed.
- A disposable slow-copy reproduction passed with the second copy limited to 2 MiB/s: it took 4.07 seconds, the first remained paused, and explicit continuation produced the expected final contents.
- Full all-target tests, macOS, and real-SSH suites were not run for this debug-hook change.

Branch status: clean, upstream matches `0e131f1`. Latest master at `da182ab`: CI failed (the reported test), rsync compatibility and macOS passed. No merge has been performed.
