### PR TITLE
Avoid cloning payloads during destination request mapping

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -535,7 +535,7 @@ impl LocalConn {
 }
 
 impl Conn for LocalConn {
-    fn send(&mut self, req: Request) -> Result<()> {
+    fn send(&mut self, mut req: Request) -> Result<()> {
         anyhow::ensure!(
             self.write_stream.is_none() || matches!(req, Request::WriteRange { .. }),
             "only range writes are valid during streaming writes"
@@ -611,7 +611,7 @@ impl Conn for LocalConn {
             }
             _ => {}
         }
-        let resp = self.ops.handle(&req);
+        let resp = self.ops.handle_in_place(&mut req);
         if let Some(state) = &mut self.write_stream {
             state.record(resp);
             return Ok(());
@@ -623,7 +623,7 @@ impl Conn for LocalConn {
         if self.pending.is_empty() {
             if let Some(stream) = &mut self.read_stream {
                 if stream.off < self.read_stream_limit {
-                    let response = self.ops.handle(&stream.next_request());
+                    let response = self.ops.handle_in_place(&mut stream.next_request());
                     if let Response::Block { data, .. } = &response {
                         stream.off += data.len() as u64;
                     } else {

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -2713,16 +2713,15 @@ impl FsOps {
         }))
     }
 
-    fn map_request(&self, req: &Request) -> Result<Request> {
+    fn map_request(&self, req: &mut Request) -> Result<()> {
         if self.destination_prefix.is_none() {
-            return Ok(req.clone());
+            return Ok(());
         }
-        let mut req = req.clone();
         let map = |path: &mut PathBytes| -> Result<()> {
             *path = self.destination_relative(path)?;
             Ok(())
         };
-        match &mut req {
+        match req {
             Request::Scan { root, guard, .. } => {
                 if guard.is_none() {
                     map(root)?;
@@ -2815,7 +2814,7 @@ impl FsOps {
             | Request::MappingChunk { .. }
             | Request::StopReadStream => {}
         }
-        Ok(req)
+        Ok(())
     }
 
     pub fn scan_root(&self, root: &[u8]) -> Result<PathBytes> {
@@ -6051,18 +6050,25 @@ impl FsOps {
         })
     }
 
-    /// Dispatch a request that has a single response (everything except Scan).
+    // Borrowed test fixtures may be reused across calls. Production dispatch
+    // always maps its already-owned request without cloning payload buffers.
+    #[cfg(test)]
     pub fn handle(&mut self, req: &Request) -> Response {
+        self.handle_in_place(&mut req.clone())
+    }
+
+    /// Dispatch a single-response request, rewriting its paths in place.
+    /// The caller must not dispatch the mapped request again.
+    pub fn handle_in_place(&mut self, req: &mut Request) -> Response {
         if let Err(error) = self
             .validate_source_session_request(req)
             .and_then(|()| self.validate_destination_session_request(req))
         {
             return Response::Err(errstr(&error));
         }
-        let req = match self.map_request(req) {
-            Ok(req) => req,
-            Err(error) => return Response::EndpointError(wire_error(&error)),
-        };
+        if let Err(error) = self.map_request(req) {
+            return Response::EndpointError(wire_error(&error));
+        }
         // HashAndHold's next request must consume the retained descriptor.
         // Any other request means the controller abandoned that comparison
         // (for example because the source hash failed), so release it here.
@@ -10388,3 +10394,7 @@ mod completion_details_tests {
         ));
     }
 }
+
+#[cfg(test)]
+#[path = "fsops_dispatch_tests.rs"]
+mod dispatch_tests;

--- a/src/fsops_dispatch_tests.rs
+++ b/src/fsops_dispatch_tests.rs
@@ -1,0 +1,184 @@
+use super::*;
+
+fn put(path: &[u8]) -> SmallPut {
+    let data = vec![42; 256 * 1024];
+    SmallPut {
+        path: path.to_vec(),
+        copy_id: [9; 16],
+        hash: content_digest(&data),
+        data,
+        meta: Meta {
+            mode: 0o600,
+            uid: 0,
+            gid: 0,
+            mtime: 0,
+            mtime_nsec: 0,
+        },
+        flags: 0,
+        inplace: false,
+        condition: TargetCondition::Any,
+        guard: None,
+    }
+}
+
+fn rooted(dir: &Path) -> FsOps {
+    let mut ops = FsOps::new();
+    ops.install_destination(File::open(dir).unwrap(), b"logical")
+        .unwrap();
+    ops
+}
+
+#[test]
+fn mapping_keeps_batch_and_range_payload_allocations() {
+    let dir = tempfile::tempdir().unwrap();
+    for prefix in [false, true] {
+        let ops = if prefix {
+            rooted(dir.path())
+        } else {
+            FsOps::new()
+        };
+        let mut request = Request::PutSmallBatch(vec![put(b"logical/one"), put(b"logical/two")]);
+        let Request::PutSmallBatch(puts) = &request else {
+            unreachable!()
+        };
+        let batch = puts.as_ptr();
+        let payloads: Vec<_> = puts
+            .iter()
+            .map(|p| (p.data.as_ptr(), p.data.capacity(), p.hash))
+            .collect();
+        ops.map_request(&mut request).unwrap();
+        let Request::PutSmallBatch(puts) = &request else {
+            unreachable!()
+        };
+        assert_eq!(puts.as_ptr(), batch);
+        for (i, p) in puts.iter().enumerate() {
+            assert_eq!((p.data.as_ptr(), p.data.capacity(), p.hash), payloads[i]);
+            assert_eq!(content_digest(&p.data), p.hash);
+        }
+        assert_eq!(
+            puts[0].path,
+            if prefix {
+                b"one".as_slice()
+            } else {
+                b"logical/one".as_slice()
+            }
+        );
+
+        let data = vec![73; 256 * 1024];
+        let pointer = data.as_ptr();
+        let mut request = Request::WriteRange {
+            path: b"logical/range".to_vec(),
+            inplace: false,
+            copy_id: [9; 16],
+            attempt: 0,
+            off: 0,
+            hash: content_digest(&data),
+            data,
+            guard: None,
+        };
+        ops.map_request(&mut request).unwrap();
+        let Request::WriteRange { path, data, .. } = &request else {
+            unreachable!()
+        };
+        assert_eq!(data.as_ptr(), pointer);
+        assert_eq!(
+            path,
+            if prefix {
+                b"range".as_slice()
+            } else {
+                b"logical/range".as_slice()
+            }
+        );
+    }
+}
+
+#[test]
+fn dispatch_validates_before_mapping_or_writing() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut ops = FsOps::new();
+    // Set only a prefix so mapping would fail if it ran before validation.
+    ops.destination_prefix = Some(b"logical".to_vec());
+    let mut request = Request::PutSmallBatch(vec![put(b"outside/file")]);
+    let response = ops.handle_in_place(&mut request);
+    assert!(
+        matches!(response, Response::Err(message) if message.contains("before a destination root"))
+    );
+    let Request::PutSmallBatch(puts) = request else {
+        unreachable!()
+    };
+    assert_eq!(puts[0].path, b"outside/file");
+    assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 0);
+}
+
+#[test]
+fn invalid_later_batch_path_prevents_all_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut ops = rooted(dir.path());
+    let mut request = Request::PutSmallBatch(vec![put(b"logical/valid"), put(b"outside/invalid")]);
+    assert!(matches!(
+        ops.handle_in_place(&mut request),
+        Response::EndpointError(_)
+    ));
+    assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 0);
+}
+
+#[test]
+fn mapped_batch_preserves_hash_checks_conditions_and_publication() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut ops = rooted(dir.path());
+    fs::write(dir.path().join("bad-hash"), b"old").unwrap();
+    fs::write(dir.path().join("exists"), b"old").unwrap();
+    let mut bad_hash = put(b"logical/bad-hash");
+    bad_hash.hash = [0; 32];
+    let mut exists = put(b"logical/exists");
+    exists.condition = TargetCondition::Absent;
+    let mut request = Request::PutSmallBatch(vec![put(b"logical/good"), bad_hash, exists]);
+    let Request::PutSmallBatch(puts) = &request else {
+        unreachable!()
+    };
+    let pointer = puts[0].data.as_ptr();
+    let Response::Applied(errors) = ops.handle_in_place(&mut request) else {
+        panic!("expected batch response")
+    };
+    assert!(errors[0].is_none());
+    assert!(errors[1].is_some());
+    assert!(errors[2].is_some());
+    let Request::PutSmallBatch(puts) = &request else {
+        unreachable!()
+    };
+    assert_eq!(puts[0].data.as_ptr(), pointer);
+    assert_eq!(fs::read(dir.path().join("good")).unwrap(), puts[0].data);
+    assert_eq!(fs::read(dir.path().join("bad-hash")).unwrap(), b"old");
+    assert_eq!(fs::read(dir.path().join("exists")).unwrap(), b"old");
+    let sidecar = partial_path_with_name_max(Path::new("good"), &[9; 16], 255).unwrap();
+    assert!(!dir.path().join(sidecar).exists());
+}
+
+#[test]
+fn guarded_batch_keeps_absolute_paths_and_rejects_mixed_authority() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = Root::open(dir.path()).unwrap();
+    let identity = root.identity();
+    let path = dir.path().join("guarded");
+    let mut item = put(path.as_os_str().as_bytes());
+    item.guard = Some(ContainerGuard {
+        root: dir.path().as_os_str().as_bytes().to_vec(),
+        dev: identity.dev,
+        ino: identity.ino,
+    });
+    let mut request = Request::PutSmallBatch(vec![item]);
+    let Response::Applied(errors) = rooted(dir.path()).handle_in_place(&mut request) else {
+        panic!("expected batch response")
+    };
+    assert!(errors[0].is_some());
+    assert!(!path.exists());
+    let Request::PutSmallBatch(puts) = &request else {
+        unreachable!()
+    };
+    assert_eq!(puts[0].path, path.as_os_str().as_bytes());
+    let Response::Applied(errors) = FsOps::new().handle_in_place(&mut request) else {
+        panic!("expected batch response")
+    };
+    assert!(errors[0].is_none());
+    assert_eq!(fs::read(path).unwrap(), vec![42; 256 * 1024]);
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -579,7 +579,7 @@ fn serve<R: Read + Send + 'static, W: Write>(
                         continue;
                     }
                     let t0 = std::time::Instant::now();
-                    let response = ops.handle(&stream.next_request());
+                    let response = ops.handle_in_place(&mut stream.next_request());
                     t[1] += t0.elapsed().as_secs_f64();
                     if let Response::Block { data, .. } = &response {
                         stream.off += data.len() as u64;
@@ -823,9 +823,9 @@ fn serve<R: Read + Send + 'static, W: Write>(
                     "receipts are issued only by a command-restricted receiver".into(),
                 ))?,
             },
-            other => {
+            mut other => {
                 let t0 = std::time::Instant::now();
-                let resp = ops.handle(&other);
+                let resp = ops.handle_in_place(&mut other);
                 if let (Some(authority), Some(settlement)) = (&authority, settlement) {
                     authority.settle(settlement, &resp);
                 }


### PR DESCRIPTION
Destination dispatch cloned the decoded request before mapping paths, duplicating every small-file batch and ranged-write payload. Map the already-owned request in place in both server and local-connection dispatch, including when a destination prefix is registered. Validation still precedes mapping; the server retains its queue-memory hold, authority settlement, and post-operation test hook in the same scope and order.

The borrowed fixture helper is now test-only. Five focused tests check that mapping retains batch and range payload allocations, validation precedes mapping, an invalid later batch path prevents all writes, and hashes, overwrite conditions, publication, and guarded authority retain their behavior. Copy selection, batching, worker policy, and the wire protocol are unchanged.

Validation at `80ec388`: formatting, all-target/all-feature Clippy with warnings denied, all 1,062 active Rust tests (one existing ignored), and the full default isolated real-SSH suite passed. The SSH build started before the commit with identical source content. Candidate macOS execution was not run.

A/B comparison against exact master `b6a5752`: 16,384 generated files (4 KiB–1 MiB), 5.266 GiB total, same ext4 filesystem, eight fixed workers and identical request/batch settings. Four alternating clean repeats per build and route, with separate phase-instrumented runs; all copies SHA-256 verified. Every run used exactly 384 small-file batches and no range/direct-file shortcuts.

| Route | Baseline median | Candidate median | Baseline → candidate logical throughput |
|---|---:|---:|---:|
| Local | 4.049 s | 4.060 s | 1,332 → 1,328 MiB/s |
| Remote-shaped stdio harness | 3.838 s | 3.764 s | 1,405 → 1,433 MiB/s |

Local wall time and CPU were essentially unchanged; median maximum-process RSS fell from 398.6 to 315.4 MiB. The stdio median elapsed improvement was about 2%, with overlapping sample ranges; this exercises real remote-helper dispatch through local pipes and is not physical-network performance. Separate diagnostic destination dispatch elapsed sums fell from 0.480 to 0.00350 s locally and 0.481 to 0.00365 s over stdio. Concurrent phase sums overlap and must not be treated as application wall time or CPU time.

Data eviction was requested per fixture file; residency was not measured, metadata stayed warm, and copy time excluded a final flush. Logical throughput is not physical I/O bandwidth. GNU time RSS is the largest process high-water mark, not simultaneous aggregate memory. The shared development host was scheduled between other tasks. Raw captures, provenance, source manifests, sample spread, and cleanup are in syq-bench's ignored `.worktrees/destination-payload/results/task-b-mixed/`. An initial diagnostic parser failure was retained, its destination verified, and that diagnostic trial rerun; no clean samples were discarded. All owned scratch and test containers were removed.
