### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/.github/release-notes/v0.5.0.md
+++ b/.github/release-notes/v0.5.0.md
@@ -1,0 +1,23 @@
+syq 0.5.0 adds safer remote-copy controls, automatic streaming for large remote
+transfers, and more capable persistent receiving.
+
+- Large remote file ranges stream automatically while short and local copies keep
+  their existing copy behavior. SSH startup also reserves work before workers
+  read, which makes a missing destination fail promptly.
+- A receiving machine can accept explicitly approved commands through `syq exec`.
+  Each command requires its own local decision; copy approval and receiver roots
+  do not grant command permission.
+- Restricted receivers can copy a mapping directly between servers and support
+  `--only-new`, `--only-existing`, and `--skip-newer`. They continue to confine
+  writes to the approved destinations and verify signed results before success.
+- Persistent connections use the `syq persist` command group: use `persist
+  connect`, `persist receive`, and `persist destinations` in place of the former
+  top-level receiving and destination commands. Durable connections reconnect
+  when needed and may be reused by independent shells.
+- The Python SDK has expanded typed mapping, result, and error APIs. Its matching
+  0.5.0 package will be prepared from this immutable syq release before it is
+  published.
+
+Remote helpers and return peers must run the same syq build as the command that
+starts a copy. Managed helpers update automatically; explicitly selected helpers
+must be updated before use.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Prepares syq v0.5.0 with the Cargo version and curated release notes.\n\nValidated with format, Clippy, unit tests, Python API synchronization, documentation links, and the default real-SSH release suite.