### PR TITLE
Keep local batch selection independent of range request size

### DIFF
--- a/docs/speed.md
+++ b/docs/speed.md
@@ -343,9 +343,11 @@ copy authorization.
 
 Same-machine Linux copies first try kernel or NFS server-side copying. If
 that is unavailable between ext4, XFS, or tmpfs filesystems during a multi-file
-copy, syq copies eligible large files directly through their open source and destination files. It runs
-these file copies in parallel without sending their contents through local TCP
-connections. Small files still use batches. This happens automatically, without
+copy, syq copies eligible files larger than 64 KiB directly through their open
+source and destination files. It runs these file copies in parallel without
+sending their contents through local TCP connections. Files up to 64 KiB still
+use batches, subject to the hash block, request-size and batch-byte limits.
+This local batch ceiling does not reduce the size of ordinary range requests. This happens automatically, without
 tuning options. Single-file copies retain parallel range copying when offload
 is unavailable.
 

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -347,8 +347,8 @@ copy, syq copies eligible files larger than 64 KiB directly through their open
 source and destination files. It runs these file copies in parallel without
 sending their contents through local TCP connections. Files up to 64 KiB still
 use batches, subject to the hash block, request-size and batch-byte limits.
-This local batch ceiling does not reduce the size of ordinary range requests. This happens automatically, without
-tuning options. Single-file copies retain parallel range copying when offload
+This local batch ceiling does not reduce the size of ordinary range requests.
+This happens automatically, without tuning options. Single-file copies retain parallel range copying when offload
 is unavailable.
 
 Syq also uses a sequential destination writer for eligible local-disk to

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -113,13 +113,23 @@ fn record_setup_event_for_test(event: &str) -> Result<()> {
     Ok(())
 }
 
-fn fast_file_size_limit(opts: &Opts) -> u64 {
-    opts.block
+// Keep tiny files batched, but let eligible local medium files reach the
+// guarded receiver-side copy path without shrinking ordinary range requests.
+const LOCAL_FAST_FILE_BYTES: u64 = 64 * 1024;
+
+fn fast_file_size_limit(opts: &Opts, bwlimit: Option<&BandwidthLimit>) -> u64 {
+    let limit = opts
+        .block
         .min(opts.tuning.batch_bytes())
         .min(
             opts.tuning
-                .request_size(opts.block, None, opts.restricted_receiver),
-        )
+                .request_size(opts.block, bwlimit, opts.restricted_receiver),
+        );
+    if opts.same_host && !opts.checksum && bwlimit.is_none() {
+        limit.min(LOCAL_FAST_FILE_BYTES)
+    } else {
+        limit
+    }
 }
 
 pub struct Opts {
@@ -3119,7 +3129,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             {
                 files += 1;
                 bytes = bytes.saturating_add(entry.size);
-                all_small &= entry.size <= fast_file_size_limit(&opts);
+                all_small &= entry.size <= fast_file_size_limit(&opts, bwlimit.as_deref());
             }
         }
         if files > 0 && all_small {
@@ -3198,7 +3208,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                             && !opts.tuning.force_ranges()
                             && bwlimit.is_none()
                             && jobs.iter().all(|job| {
-                                job.entry.size <= fast_file_size_limit(&opts)
+                                job.entry.size <= fast_file_size_limit(&opts, bwlimit.as_deref())
                                     && job.dst_entry.is_none()
                                     && (!opts.inplace
                                         || (job.target_condition == TargetCondition::Any
@@ -7621,16 +7631,11 @@ impl Worker {
                         // accumulate locally and then hit the network in a burst.
                         if self.bwlimit.is_none() {
                             let first_bytes = self.job(idx).entry.size;
-                            batch.extend(
-                                self.sched.take_small(
-                                    self.opts
-                                        .block
-                                        .min(self.transfer_block())
-                                        .min(self.opts.tuning.batch_bytes()),
-                                    target - batch.len(),
-                                    self.opts.tuning.batch_bytes().saturating_sub(first_bytes),
-                                ),
-                            );
+                            batch.extend(self.sched.take_small(
+                                fast_file_size_limit(&self.opts, self.bwlimit.as_deref()),
+                                target - batch.len(),
+                                self.opts.tuning.batch_bytes().saturating_sub(first_bytes),
+                            ));
                         }
                         let (fast, slow): (Vec<usize>, Vec<usize>) =
                             batch.into_iter().partition(|&i| self.fast_eligible(i));
@@ -7730,12 +7735,7 @@ impl Worker {
         let j = &jobs[idx];
         !self.opts.verify_only
             && !self.opts.tuning.force_ranges()
-            && j.entry.size
-                <= self
-                    .opts
-                    .block
-                    .min(self.transfer_block())
-                    .min(self.opts.tuning.batch_bytes())
+            && j.entry.size <= fast_file_size_limit(&self.opts, self.bwlimit.as_deref())
             && j.dst_entry.is_none()
             && (!self.opts.inplace
                 || (j.target_condition == TargetCondition::Any && j.container_guard.is_none()))

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -125,7 +125,7 @@ fn fast_file_size_limit(opts: &Opts, bwlimit: Option<&BandwidthLimit>) -> u64 {
             opts.tuning
                 .request_size(opts.block, bwlimit, opts.restricted_receiver),
         );
-    if opts.same_host && !opts.checksum && bwlimit.is_none() {
+    if cfg!(target_os = "linux") && opts.same_host && !opts.checksum && bwlimit.is_none() {
         limit.min(LOCAL_FAST_FILE_BYTES)
     } else {
         limit

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -19952,3 +19952,5 @@ fn native_only_new_later_sources_stamp_directories_created_by_this_copy() {
         }
     }
 }
+
+mod local_copy_selection;

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -6516,10 +6516,11 @@ fn streaming_read_errors_do_not_publish_a_file() {
 #[test]
 fn tuning_options_batch_limits_include_the_first_file() {
     let t = Tmp::new();
+    // Stay inside the local tiny-file ceiling while exercising both batch limits.
     for i in 0..7 {
-        write(&t.path(&format!("source/{i}")), &prng(600 << 10, i));
+        write(&t.path(&format!("source/{i}")), &prng(60 << 10, i));
     }
-    for (files, bytes, expected_files) in [(3, 2 << 20, 3), (10, 1 << 20, 1)] {
+    for (files, bytes, expected_files) in [(3, 200 << 10, 3), (10, 100 << 10, 1)] {
         let destination = t.s(&format!("destination-{files}"));
         let out = Command::new(env!("CARGO_BIN_EXE_syq"))
             .args([

--- a/tests/local_copy_selection/mod.rs
+++ b/tests/local_copy_selection/mod.rs
@@ -220,3 +220,50 @@ fn platforms_without_direct_copy_keep_medium_batches() {
     assert_eq!(observed["range_requests"], 0);
     assert_eq!(observed["small_batches"], 1);
 }
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn fresh_medium_failure_does_not_publish_and_changed_source_resumes() {
+    let t = Tmp::new();
+    let mut contents = prng(2 << 20, 83);
+    write(&t.path("src/file"), &contents);
+    write(
+        &t.path("src/tiny"),
+        b"another file enables the local sequential fallback",
+    );
+    let run = || {
+        let mut command = compat_command();
+        command
+            .args([
+                "-a",
+                "--syq-no-tcp",
+                "--no-progress",
+                &t.s("src/"),
+                &t.s("dst/"),
+            ])
+            .env("SYQ_DEBUG", "1")
+            .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .env("SYQ_TEST_COPY_LOCAL_FS", "local");
+        command
+    };
+    let failed = run()
+        .env("SYQ_TEST_FAIL_COPY_LOCAL_AFTER_WRITE", "1")
+        .run()
+        .unwrap();
+    assert_eq!(failed.status.code(), Some(1), "{failed:?}");
+    assert!(stderr_of(&failed).contains("test local-copy write failure"));
+    assert!(!t.path("dst/file").exists());
+    let partials = partial_files(&t.path("dst"));
+    assert_eq!(partials.len(), 1);
+    assert_eq!(fs::metadata(&partials[0]).unwrap().len(), 1 << 20);
+
+    contents[..1 << 20].fill(b'x');
+    write(&t.path("src/file"), &contents);
+    let resumed = run().run().unwrap();
+    assert_output_ok(&resumed);
+    assert_same_tree(&t.path("src"), &t.path("dst"));
+    assert!(partial_files(&t.path("dst")).is_empty());
+    let observed = tuning_observed(&resumed);
+    assert_eq!(observed["local_whole_files"], 0);
+    assert!(observed["range_requests"].as_u64().unwrap() > 0);
+}

--- a/tests/local_copy_selection/mod.rs
+++ b/tests/local_copy_selection/mod.rs
@@ -1,0 +1,188 @@
+//! Selection coverage, kept separate from receiver dispatch tests.
+use super::*;
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn local_batch_boundary_and_scheduler_agree() {
+    for connections in ["1", "4"] {
+        let t = Tmp::new();
+        let sizes = [0, 1, 65535, 65536, 65537, 1 << 20, 4 << 20];
+        for (index, size) in sizes.into_iter().enumerate() {
+            write(
+                &t.path(&format!("src/file{index}")),
+                &prng(size, index as u64),
+            );
+        }
+        let out = compat_command()
+            .args([
+                "-a",
+                "--syq-no-tcp",
+                "--syq-connections",
+                connections,
+                "--block-size=4M",
+                "--tuning-options=request-size=4M",
+                "--no-progress",
+                &t.s("src/"),
+                &t.s("dst/"),
+            ])
+            .env("SYQ_DEBUG", "1")
+            .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+            .env("SYQ_TEST_COPY_LOCAL_FS", "local")
+            .run()
+            .unwrap();
+        assert_output_ok(&out);
+        assert_same_tree(&t.path("src"), &t.path("dst"));
+        let observed = tuning_observed(&out);
+        assert_eq!(observed["local_whole_files"], 3, "{out:?}");
+        assert_eq!(observed["range_requests"], 0);
+        assert!(observed["small_batches"].as_u64().unwrap() > 0);
+        assert!(partial_files(&t.0).is_empty());
+    }
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn local_medium_unsupported_keeps_full_size_range_requests() {
+    let t = Tmp::new();
+    for i in 0..2 {
+        write(&t.path(&format!("src/file{i}")), &prng(4 << 20, i));
+    }
+    let out = compat_command()
+        .args([
+            "-a",
+            "--syq-no-tcp",
+            "--syq-connections=2",
+            "--block-size=4M",
+            "--tuning-options=request-size=4M",
+            "--no-progress",
+            &t.s("src/"),
+            &t.s("dst/"),
+        ])
+        .env("SYQ_DEBUG", "1")
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_FS", "unsupported")
+        .run()
+        .unwrap();
+    assert_output_ok(&out);
+    assert_same_tree(&t.path("src"), &t.path("dst"));
+    let observed = tuning_observed(&out);
+    assert_eq!(observed["local_whole_files"], 0);
+    assert_eq!(observed["small_batches"], 0);
+    assert_eq!(observed["max_request_bytes"], 4 << 20);
+    assert!(partial_files(&t.0).is_empty());
+}
+
+#[test]
+fn checksum_and_paced_medium_files_keep_batches() {
+    for control in ["--checksum", "--bwlimit=1G"] {
+        let t = Tmp::new();
+        write(&t.path("src/file"), &prng(1 << 20, 80));
+        let out = compat_command()
+            .args([
+                "-a",
+                "--syq-no-tcp",
+                "--syq-connections=1",
+                "--no-progress",
+                control,
+                &t.s("src/"),
+                &t.s("dst/"),
+            ])
+            .env("SYQ_DEBUG", "1")
+            .run()
+            .unwrap();
+        assert_output_ok(&out);
+        assert_same_tree(&t.path("src"), &t.path("dst"));
+        let observed = tuning_observed(&out);
+        assert_eq!(observed["local_whole_files"], 0);
+        assert_eq!(observed["range_requests"], 0);
+        assert_eq!(observed["small_batches"], 1);
+    }
+}
+
+#[test]
+fn remote_medium_files_keep_batches() {
+    for pull in [false, true] {
+        let t = Tmp::new();
+        let rsh = fake_rsh(&t);
+        write(&t.path("src/file"), &prng(4 << 20, 81));
+        let src = if pull {
+            format!("fake:{}/", t.s("src"))
+        } else {
+            t.s("src/")
+        };
+        let dst = if pull {
+            t.s("dst/")
+        } else {
+            format!("fake:{}/", t.s("dst"))
+        };
+        let out = remote_syq_command(
+            &t,
+            &rsh,
+            &[
+                "-a",
+                "--rsync-path",
+                env!("CARGO_BIN_EXE_syq"),
+                "--syq-no-bootstrap",
+                "--block-size=4M",
+                "--tuning-options=request-size=4M",
+                &src,
+                &dst,
+            ],
+        )
+        .env("SYQ_DEBUG", "1")
+        .run()
+        .unwrap();
+        assert_output_ok(&out);
+        assert_same_tree(&t.path("src"), &t.path("dst"));
+        let observed = tuning_observed(&out);
+        assert_eq!(observed["local_whole_files"], 0);
+        assert_eq!(observed["range_requests"], 0);
+        assert_eq!(observed["small_batches"], 1);
+    }
+}
+
+#[cfg(all(debug_assertions, target_os = "linux"))]
+#[test]
+fn medium_failure_keeps_old_destination_and_resumes_changed_source() {
+    let t = Tmp::new();
+    write(&t.path("src/small"), b"parallel file work");
+    let original = prng(2 << 20, 456);
+    write(&t.path("src/file"), &original);
+    write(&t.path("dst/file"), b"old destination");
+    let out = compat_command()
+        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
+        .env("SYQ_DEBUG", "1")
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_FS", "local")
+        .env("SYQ_TEST_FAIL_COPY_LOCAL_AFTER_WRITE", "1")
+        .run()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1), "{out:?}");
+    assert!(stderr_of(&out).contains("test local-copy write failure"));
+    assert_eq!(read(&t.path("dst/file")), b"old destination");
+    let partials = partial_files(&t.path("dst"));
+    assert_eq!(partials.len(), 1);
+    assert_eq!(fs::metadata(&partials[0]).unwrap().len(), 1 << 20);
+    let observed = tuning_observed(&out);
+    assert_eq!(observed["local_whole_files"], 0);
+    assert_eq!(observed["range_requests"], 0);
+
+    // The failed userspace write is a resumable basis, not authority to skip
+    // checking bytes that changed in the source before the retry.
+    let mut changed = original;
+    changed[..1 << 20].fill(b'c');
+    write(&t.path("src/file"), &changed);
+    let out = compat_command()
+        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
+        .env("SYQ_DEBUG", "1")
+        .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
+        .env("SYQ_TEST_COPY_LOCAL_FS", "local")
+        .run()
+        .unwrap();
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("dst/file")), changed);
+    let observed = tuning_observed(&out);
+    assert_eq!(observed["local_whole_files"], 0);
+    assert!(observed["range_requests"].as_u64().unwrap() > 0);
+    assert!(partial_files(&t.path("dst")).is_empty());
+}

--- a/tests/local_copy_selection/mod.rs
+++ b/tests/local_copy_selection/mod.rs
@@ -26,11 +26,21 @@ fn local_batch_boundary_and_scheduler_agree() {
                 &t.s("dst/"),
             ])
             .env("SYQ_DEBUG", "1")
+            .env("SYQ_TEST_WORKER_EVENTS", t.path("workers"))
             .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
             .env("SYQ_TEST_COPY_LOCAL_FS", "local")
             .run()
             .unwrap();
         assert_output_ok(&out);
+        let workers = fs::read_to_string(t.path("workers")).unwrap();
+        assert_eq!(
+            workers
+                .lines()
+                .filter(|line| line.starts_with("connected "))
+                .count(),
+            connections.parse::<usize>().unwrap(),
+            "{workers}"
+        );
         assert_same_tree(&t.path("src"), &t.path("dst"));
         let observed = tuning_observed(&out);
         assert_eq!(observed["local_whole_files"], 3, "{out:?}");
@@ -185,4 +195,28 @@ fn medium_failure_keeps_old_destination_and_resumes_changed_source() {
     assert_eq!(observed["local_whole_files"], 0);
     assert!(observed["range_requests"].as_u64().unwrap() > 0);
     assert!(partial_files(&t.path("dst")).is_empty());
+}
+
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn platforms_without_direct_copy_keep_medium_batches() {
+    let t = Tmp::new();
+    write(&t.path("src/file"), &prng(1 << 20, 82));
+    let out = compat_command()
+        .args([
+            "-a",
+            "--syq-no-tcp",
+            "--no-progress",
+            &t.s("src/"),
+            &t.s("dst/"),
+        ])
+        .env("SYQ_DEBUG", "1")
+        .run()
+        .unwrap();
+    assert_output_ok(&out);
+    assert_same_tree(&t.path("src"), &t.path("dst"));
+    let observed = tuning_observed(&out);
+    assert_eq!(observed["local_whole_files"], 0);
+    assert_eq!(observed["range_requests"], 0);
+    assert_eq!(observed["small_batches"], 1);
 }


### PR DESCRIPTION
Linux local copies with the default 4 MiB request size previously transported medium files in small-file batches. Cap local batch eligibility at 64 KiB so eligible medium files reach the existing guarded receiver-side copy path while ordinary range requests keep their configured size.

Use the same eligibility limit in planner startup, scheduler collection and worker dispatch. Preserve existing limits for checksum, bandwidth-limited and non-Linux copies, and for all remote copies. No new public tuning knob or change to direct-copy authorization, publication or fallback implementation.

Validation: formatting and all-target/all-feature Clippy pass. The full Rust suite passed on the implementation commit; six focused selection tests pass at final head, including the final test-only addition. Coverage includes the 64 KiB boundary and worker startup, unsupported-copy fallback retaining 4 MiB range requests, checksum/pacing, simulated SSH push/pull selection, and interrupted publication/resume after the source changes. Existing direct-copy safety tests pass. Non-Linux execution and the real-SSH suite were not run for this local selection change.

Performance evidence is retained in the private syq-bench Task A artifacts; host identifiers and measured result files are excluded from git. The public ext4 comparison uses verified, rotated repeats with fixed hash blocks, ordinary request size and worker policy; the 64 KiB request workaround is an explicit separate control. Tiny-file, large-file, same/cross ext4/XFS, mounted-filesystem and automatic A/B interaction results are reported with cache, offload, sample-length and shared-host limitations. The experimental A+B build is separate from this PR and passes the full Rust suite.

Final branch status: head matches `1d37db0`, worktree clean, no registered PR checks. Latest upstream master `37ab1d4` passes Linux, rsync-compat and macOS CI. This PR remains unmerged pending review of all four tasks.
