### PR TITLE
Wait for async process reaping on macOS

### DIFF
--- a/sdk/python/src/syq/async_client.py
+++ b/sdk/python/src/syq/async_client.py
@@ -64,21 +64,24 @@ AsyncEventCallback = Callable[[AutomationEvent], object | Awaitable[object]]
 _T = TypeVar("_T")
 _LINE_LIMIT = 16 * 1024 * 1024
 _STDERR_LIMIT = 8 * 1024
+_REAP_WAIT_TIMEOUT = 0.5
 
 
 async def _kill_process_group(process: asyncio.subprocess.Process) -> None:
     try:
         try:
             os.killpg(process.pid, signal.SIGKILL)
-        except PermissionError:
-            # Darwin can reject a zombie-only group. Give its child watcher one
-            # turn to reap the exited leader, then retry so descendants still
-            # receive the signal. A live process keeps the original permission
-            # failure visible.
-            if process.returncode is None:
-                await asyncio.sleep(0)
-            if process.returncode is None:
-                raise
+        except PermissionError as error:
+            # Darwin can reject a zombie-only group before the child watcher
+            # reaps its exited leader. Wait briefly for that reaping, then
+            # retry so descendants still receive the signal. A live process
+            # keeps the original permission failure visible.
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(process.wait()), timeout=_REAP_WAIT_TIMEOUT
+                )
+            except asyncio.TimeoutError as timeout:
+                raise error from timeout
             os.killpg(process.pid, signal.SIGKILL)
     except ProcessLookupError:
         pass

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import signal
 import subprocess
@@ -62,7 +63,8 @@ class AsyncProcessGroupCleanupTests(unittest.IsolatedAsyncioTestCase):
     async def test_permission_error_reaps_exited_leader_and_retries_group(self):
         from syq.async_client import _kill_process_group
 
-        process = mock.Mock(pid=123, returncode=0)
+        process = mock.Mock(pid=123, returncode=None)
+        process.wait = mock.AsyncMock(return_value=0)
         for retry in (None, ProcessLookupError()):
             with self.subTest(retry=retry), mock.patch(
                 "syq.async_client.os.killpg", side_effect=[PermissionError(), retry]
@@ -76,12 +78,14 @@ class AsyncProcessGroupCleanupTests(unittest.IsolatedAsyncioTestCase):
         from syq.async_client import _kill_process_group
 
         process = mock.Mock(pid=123, returncode=None)
+        process.wait = mock.AsyncMock(side_effect=asyncio.TimeoutError)
         with mock.patch(
             "syq.async_client.os.killpg", side_effect=PermissionError("denied")
         ) as kill:
             with self.assertRaisesRegex(PermissionError, "denied"):
                 await _kill_process_group(process)
             self.assertEqual(kill.call_count, 1)
+            process.wait.assert_awaited_once()
 
 
 FAKE_SYQ = """#!/bin/sh


### PR DESCRIPTION
On macOS, a just-exited async mapping process can still have `returncode == None` when its zombie-only process group rejects `SIGKILL` with `EPERM`. One event-loop turn was insufficient to reap it.

Wait up to 0.5 seconds for the child watcher only after that error, then retry the group signal. A genuinely live process still surfaces the original permission error. The tests cover both paths.

Validation: full and focused Python SDK suites, `scripts/test-python-sdk-release-tools.sh`, and `python3 scripts/check-python-api-sync.py`.
