### PR TITLE
Prepare v0.5.1 release

### DIFF
--- a/.github/release-notes/v0.5.1.md
+++ b/.github/release-notes/v0.5.1.md
@@ -1,0 +1,12 @@
+syq 0.5.1 improves local-copy efficiency while preserving existing copy and
+fallback behavior.
+
+- Eligible medium-sized files on Linux now reach the guarded receiver-side copy
+  path with the default request size. This avoids transporting their contents
+  through userspace when the filesystem can copy them directly.
+- Destination path mapping reuses owned request payloads instead of cloning
+  them, reducing peak memory use for small-file batches and ranged writes.
+
+Remote helpers and return peers must run the same syq build as the command that
+starts a copy. Managed helpers update automatically; explicitly selected helpers
+must be updated before use.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Prepare syq 0.5.1 from the local-copy improvements already merged on `master`.

This updates the Cargo package version and adds curated release notes. The release highlights eligible Linux medium files reaching guarded receiver-side copy with the default request size and lower peak memory use from mapping owned destination payloads in place. There are no CLI, SDK, wire-protocol, or persistent-state compatibility changes.

Validation at `50d9670`:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin syq` (591 passed, 1 ignored)
- `scripts/release-readiness.py v0.5.1 --check-ssh` (default three-container OpenSSH suite passed; exact-tree evidence recorded)
- `scripts/branch-status.sh --check`

The released compatibility baseline remains syq/Python SDK 0.5.0. Remote helpers and return peers require the exact syq build, as before.
