### PR TITLE
Explain missing receiving names instead of private registry errors

### DIFF
--- a/docs/exec.md
+++ b/docs/exec.md
@@ -16,6 +16,12 @@ Run `syq persist connect server` on the receiving machine to enable persistence
 and wait for the connection. No SSH server or incoming network port is needed on the receiving machine.
 Requests work from independent server shells, including existing tmux sessions.
 
+Exec needs no separate enablement beyond receiving and its connection.
+`@laptop` in these examples is a name, not an alias for any connected laptop.
+Run `syq persist destinations list` on the server to find your receiving
+machine's actual name and connection status. On the receiving machine,
+`syq persist receive status` shows its advertised name.
+
 `--on` selects a receiving name. Both `laptop` and `@laptop` require a live
 return connection; neither falls back to DNS or an SSH connection. If the server
 command is a different build, it automatically invokes the matching helper

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -289,10 +289,21 @@ pub(crate) fn registered_names() -> Vec<String> {
 fn load_registration(name: &str) -> Result<Registration> {
     validate_name(name)?;
     let path = registry()?.join(format!("{name}.json"));
-    let encoded = crate::delegation::read_private_regular(&path, "named destination", MAX_MESSAGE)
-        .with_context(|| {
-            format!("destination @{name} is unavailable; connect from the laptop with syq while persist is on")
-        })?;
+    let encoded = match crate::delegation::read_private_regular(&path, "named destination", MAX_MESSAGE) {
+        Ok(encoded) => encoded,
+        Err(error) if error.chain().any(|cause| cause.downcast_ref::<std::io::Error>()
+            .is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound)) => {
+            let names = registered_names();
+            let advice = if names.is_empty() {
+                "On the receiving machine, run `syq persist connect SERVER`, using the SSH endpoint for this server account.".to_owned()
+            } else {
+                let shown = names.iter().take(8).map(|name| format!("@{name}")).collect::<Vec<_>>().join(", ");
+                format!("Registered names: {shown}{}. Use one of these names, or connect another receiving machine with `syq persist connect SERVER`.", if names.len() > 8 { ", ..." } else { "" })
+            };
+            bail!("no receiving machine named @{name} is registered for this account.\n{advice}\nRun `syq persist destinations list` to see names and connection status.");
+        }
+        Err(error) => return Err(error).with_context(|| format!("cannot read the registration for @{name}; check its permissions or reconnect from the receiving machine")),
+    };
     let registration: Registration = serde_json::from_slice(&encoded)?;
     if registration.version != REGISTRATION_VERSION {
         bail!("unsupported destination registration; reconnect from the receiving machine");
@@ -316,7 +327,7 @@ fn exchange(
         );
     }
     let mut stream = UnixStream::connect(&registration.socket).context(
-        "receiving machine is offline; it must reconnect before this transfer can start",
+        "receiving machine is offline; run `syq persist connect SERVER` on that machine to reconnect to this server account",
     )?;
     stream.set_read_timeout(Some(timeout))?;
     stream.set_write_timeout(Some(timeout))?;

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -19591,8 +19591,56 @@ fn return_exec_completion_and_offline_selection_never_contact_ssh() {
             .output()
             .unwrap();
         assert!(!output.status.success());
+        if matches!(name, "absent" | "@absent") {
+            let error = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                error.contains("no receiving machine named @absent is registered"),
+                "{error}"
+            );
+            assert!(error.contains("Registered names: @laptop"), "{error}");
+            assert!(error.contains("syq persist destinations list"), "{error}");
+            assert!(
+                !error.contains(".syq-destinations") && !error.contains("os error"),
+                "{error}"
+            );
+        }
         assert!(!t.path("home/ssh-used").exists());
     }
+    // An empty registry gives setup instructions instead of suggesting a name.
+    fs::remove_file(t.path("home/.syq-destinations-v3/laptop.json")).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["exec", "--on", "@laptop", "--", "true"])
+        .env("HOME", t.path("home"))
+        .env("PATH", t.path("bin"))
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("On the receiving machine, run `syq persist connect SERVER`"),
+        "{error}"
+    );
+    assert!(!error.contains("Registered names:"), "{error}");
+    // Other read failures still explain their cause rather than claiming absence.
+    write(&t.path("home/.syq-destinations-v3/laptop.json"), b"{}");
+    fs::set_permissions(
+        t.path("home/.syq-destinations-v3/laptop.json"),
+        fs::Permissions::from_mode(0o666),
+    )
+    .unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["exec", "--on", "@laptop", "--", "true"])
+        .env("HOME", t.path("home"))
+        .env("PATH", t.path("bin"))
+        .output()
+        .unwrap();
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    assert!(
+        error.contains("cannot read the registration for @laptop"),
+        "{error}"
+    );
+    assert!(!error.contains("no receiving machine"), "{error}");
     let output = completion_command(
         &t,
         &[


### PR DESCRIPTION
`syq exec --on @laptop -- ls` reported an unavailable destination and a missing private JSON file when the machine was actually registered under another name. A missing name now explains that it is not registered for this server account, lists up to eight registered alternatives, and points to `syq persist destinations list`. An empty registry gives `syq persist connect SERVER` instructions for the receiving machine. Other read failures retain their diagnostic cause, and offline connections get a concrete reconnect command.

Document that exec requires no extra enablement and that `@laptop` is an example name, not a universal alias.

Compatibility: v0.5.1 command syntax, registration JSON, discovery/handoff protocols, and successful connection behavior are unchanged. Missing and unreadable registrations still fail; human error text changes. Name suggestions use local registry names and do not contact SSH or request approval.

Validation at 6dc7e17:
- Formatting, all-target/all-feature Clippy, documentation links, and whitespace checks passed.
- `cargo test --bin syq`: 591 passed, 1 existing ignored test.
- Focused `return_exec_completion_and_offline_selection_never_contact_ssh` integration test passed, including missing names, alternative names, empty registry, and unreadable registration diagnostics.
- Full isolated OpenSSH suite passed against this committed source tree, including return-copy/exec, notification, reconnect, routing, and benchmark-cleanup cases.
