### PR TITLE
Align README opening with the documentation landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # syq
 
-Syq (pronounced "sick") copies and removes files in parallel, on one machine
-or over SSH.
+Syq (pronounced "sick") copies, reorganizes, and removes files—locally or
+across machines. Resume interrupted transfers, send files home or request
+commands on your desktop from a remote shell, and automate with JSON.
 It aims to perform well across file sizes, directory sizes, and network speeds.
 
-- **Parallel copies and removal**, with automatic connection tuning.
-- **Resume interrupted copies** by rerunning the command.
-- **Direct server-to-server transfers** without forwarding your SSH agent.
-- **Approved commands on your receiving machine**, for local builds and opening artifacts.
-- **Gitignore-style filters**, programmable file placement, and JSON results.
-
 [Documentation](https://greaber.github.io/syq/) ·
-[Benchmarks](https://greaber.github.io/syq-bench/)
+[Benchmarks](https://greaber.github.io/syq-bench/) ·
+[Send files home](https://greaber.github.io/syq/receive.html) ·
+[Run commands at home](https://greaber.github.io/syq/exec.html) ·
+[Copy between servers](https://greaber.github.io/syq/remote-to-remote.html) ·
+[Script file placement](https://greaber.github.io/syq/mappings.html) ·
+[Python SDK](https://greaber.github.io/syq/python.html)
 
 ## Install
 


### PR DESCRIPTION
The README opening omitted sending files home from a server. Align it with the documentation landing page’s opening and task buttons: copying, reorganizing, removal, resume, sending files home, desktop commands, and automation, with direct links to the corresponding guides and Python SDK. Installation remains near the top.

Validation at `0c90562`: documentation link check (20 files, zero problems) and whitespace check passed. README-only change; Rust and SSH tests were not run.

Branch status:
```text
Worktree: /home/grant/repos/syq/.worktrees/readme-main-uses
Branch:   readme-main-uses at 0c90562 (clean)
Upstream: origin/readme-main-uses (ahead 0, behind 0)
Master:   37ab1d4 from refs/heads/master (branch is ahead 25, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      888e091  https://github.com/greaber/syq/actions/runs/34274933578
  rsync-compat.yml success      888e091  https://github.com/greaber/syq/actions/runs/34274933711
  macos.yml        success      888e091  https://github.com/greaber/syq/actions/runs/34274933543

Pull request: #303 https://github.com/greaber/syq/pull/303
  base master, open, review none, merge state clean
  GitHub head 0c90562: matches local 0c90562
  checks: none registered yet
```
