### PR TITLE
Simplify README opening and list common task links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # syq
 
 Syq (pronounced "sick") copies, reorganizes, and removes files—locally or
-across machines. Resume interrupted transfers, send files home or request
-commands on your desktop from a remote shell, and automate with JSON.
+across machines.
 It aims to perform well across file sizes, directory sizes, and network speeds.
 
 [Documentation](https://greaber.github.io/syq/) ·
-[Benchmarks](https://greaber.github.io/syq-bench/) ·
-[Send files home](https://greaber.github.io/syq/receive.html) ·
-[Run commands at home](https://greaber.github.io/syq/exec.html) ·
-[Copy between servers](https://greaber.github.io/syq/remote-to-remote.html) ·
-[Script file placement](https://greaber.github.io/syq/mappings.html) ·
-[Python SDK](https://greaber.github.io/syq/python.html)
+[Benchmarks](https://greaber.github.io/syq-bench/)
+
+Quick links to docs for common tasks:
+
+- [Send files home](https://greaber.github.io/syq/receive.html)
+- [Run commands at home](https://greaber.github.io/syq/exec.html)
+- [Copy between servers](https://greaber.github.io/syq/remote-to-remote.html)
+- [Script file placement](https://greaber.github.io/syq/mappings.html)
+- [Python SDK](https://greaber.github.io/syq/python.html)
 
 ## Install
 


### PR DESCRIPTION
Remove the extra feature-summary sentence from the README opening and put task links in a separate bulleted list under “Quick links to docs for common tasks:”.

Validation at `94c9b7e`: documentation links (20 files, zero problems) and whitespace checks passed. README-only change; code tests not run.

```text
Worktree: /home/grant/repos/syq/.worktrees/readme-task-links
Branch:   readme-task-links at 94c9b7e (clean)
Upstream: origin/readme-task-links (ahead 0, behind 0)
Master:   37ab1d4 from refs/heads/master (branch is ahead 27, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      091c28e  https://github.com/greaber/syq/actions/runs/34276012008
  rsync-compat.yml success      091c28e  https://github.com/greaber/syq/actions/runs/34276011935
  macos.yml        success      091c28e  https://github.com/greaber/syq/actions/runs/34276011944

Pull request: #304 https://github.com/greaber/syq/pull/304
  base master, open, review none, merge state clean
  GitHub head 94c9b7e: matches local 94c9b7e
  checks: none registered yet
```
