### PR TITLE
Clarify README and documentation introduction for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ It aims to perform well across file sizes, directory sizes, and network speeds.
 
 Quick links to docs for common tasks:
 
-- [Send files to your laptop from a server you’re SSHed into](https://greaber.github.io/syq/receive.html)
+- [Send files to your laptop from a server you’re SSHed into](https://greaber.github.io/syq/receive.html).
+  Your laptop needs no SSH server or incoming network port.
 - [Run commands on your laptop from a server](https://greaber.github.io/syq/exec.html)
 - [Copy between servers](https://greaber.github.io/syq/remote-to-remote.html)
-- [Script file placement](https://greaber.github.io/syq/mappings.html)
-- [Python SDK](https://greaber.github.io/syq/python.html)
+- [Rename and reorganize files during a copy](https://greaber.github.io/syq/mappings.html)
+- Use syq from [scripts](https://greaber.github.io/syq/automation.html) or
+  [Python](https://greaber.github.io/syq/python.html).
 
 ## Install
 
@@ -32,6 +34,20 @@ brew install greaber/tap/syq
 
 See [installation details](https://greaber.github.io/syq/install.html) for
 updates and shell completion.
+
+## Try a copy
+
+Replace `server` with an SSH hostname or alias you normally connect to,
+and `project` with a local directory:
+
+```sh
+syq cp project --to server --into backup
+```
+
+This creates or updates `backup/project` in your home directory on the server.
+Add `--dry-run` to preview the copy. If interrupted, rerun the same command to
+resume. See [Copy files](https://greaber.github.io/syq/reference.html) for more
+examples.
 
 ## Developing syq
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It aims to perform well across file sizes, directory sizes, and network speeds.
 
 Quick links to docs for common tasks:
 
-- [Send files home](https://greaber.github.io/syq/receive.html)
-- [Run commands at home](https://greaber.github.io/syq/exec.html)
+- [Send files to your laptop from a server you’re SSHed into](https://greaber.github.io/syq/receive.html)
+- [Run commands on your laptop from a server](https://greaber.github.io/syq/exec.html)
 - [Copy between servers](https://greaber.github.io/syq/remote-to-remote.html)
 - [Script file placement](https://greaber.github.io/syq/mappings.html)
 - [Python SDK](https://greaber.github.io/syq/python.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,30 +4,35 @@
 </h1>
 
 Copy, reorganize and remove files—locally or across machines. Resume interrupted
-transfers, send files home or request commands on your desktop from a remote
-shell, and automate with JSON.
+transfers, send files to your laptop or run commands there from a server’s
+remote shell, and use syq from scripts or Python. Your laptop needs no SSH
+server or incoming network port.
 
 <nav class="landing-actions" aria-label="Explore syq">
 <a class="landing-primary" href="install.html">Install syq</a>
 <a href="https://greaber.github.io/syq-bench/">Benchmarks ↗</a>
-<a href="receive.html">Send files home</a>
-<a href="exec.html">Run commands at home</a>
+<a href="receive.html">Send files to your laptop</a>
+<a href="exec.html">Run commands on your laptop</a>
 <a href="remote-to-remote.html">Copy between servers</a>
-<a href="mappings.html">Script file placement</a>
-<a href="python.html">Python SDK</a>
+<a href="mappings.html">Rename and reorganize files during a copy</a>
+<a href="automation.html">Use syq from scripts</a>
+<a href="python.html">Use syq from Python</a>
 </nav>
 
 ## Try a copy
 
+Replace `server` with an SSH hostname or alias you normally connect to,
+and `project` with a local directory:
+
 ```sh
-syq cp project --to server --into /backup
+syq cp project --to server --into backup
 ```
 
-This creates or updates `/backup/project` on `server`. To copy the contents
-of `project` directly into `/backup`, use `--srcs-in`:
+This creates or updates `backup/project` in your home directory on the server.
+To copy the contents of `project` directly into `backup`, use `--srcs-in`:
 
 ```sh
-syq cp --srcs-in project --to server --into /backup
+syq cp --srcs-in project --to server --into backup
 ```
 
 Use `--dry-run` to preview a summary without copying, or `--dry-run -v`
@@ -58,6 +63,7 @@ substituting it in an existing script.
 | Skip build files or use `.gitignore` | [Ignoring paths](reference.md#ignoring-paths) |
 | Mirror a directory | [Mirroring](reference.md#mirror-a-directory) |
 | Remove files in parallel | [Removal](remove.md) |
+| Send files to my laptop from a server’s shell | [Receiving files](receive.md) |
 | Run a build or open an artifact on my desktop from a server | [Commands on your receiving machine](exec.md) |
 | Copy between two servers | [Remote-to-remote transfers](remote-to-remote.md) |
 | Rename or reorganize files during a copy | [Mappings](mappings.md) |


### PR DESCRIPTION
Make the README and documentation landing page clearer for first-time users. Describe server-to-laptop tasks explicitly and explain that the laptop needs no SSH server or incoming network port. Rename the file-placement link around renaming and reorganizing, and link to using syq from scripts or Python.

Add an everyday copy example after README installation. Both introductions explain the SSH hostname/alias placeholder and use a destination under the remote home directory instead of `/backup`. The README also explains preview and resume; the docs task table now includes sending files to a laptop.

Validation at `58b9a18`: documentation link check (20 files, zero problems) and whitespace check passed. Documentation-only changes; code tests and live SSH examples were not run.

Branch status:
```text
Worktree: /home/grant/repos/syq/.worktrees/readme-task-descriptions
Branch:   readme-task-descriptions at 58b9a18 (clean)
Upstream: origin/readme-task-descriptions (ahead 0, behind 0)
Master:   c7ec794 from refs/heads/master (branch is ahead 2, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      c7ec794  https://github.com/greaber/syq/actions/runs/34277233104
  rsync-compat.yml success      c7ec794  https://github.com/greaber/syq/actions/runs/34277233115
  macos.yml        success      c7ec794  https://github.com/greaber/syq/actions/runs/34277233103

Pull request: #305 https://github.com/greaber/syq/pull/305
  base master, open, review none, merge state clean
  GitHub head 58b9a18: matches local 58b9a18
  checks: none registered yet
```
