### PR TITLE
Clarify server-copy and scripting links in the introductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Quick links to docs for common tasks:
 - [Run commands on your laptop from a server](https://greaber.github.io/syq/exec.html)
 - [Copy directly between servers without forwarding your SSH agent](https://greaber.github.io/syq/remote-to-remote.html)
 - [Rename and reorganize files during a copy](https://greaber.github.io/syq/mappings.html)
-- Use syq from [scripts](https://greaber.github.io/syq/automation.html) or
-  [Python](https://greaber.github.io/syq/python.html).
+- Script syq using the [JSON API](https://greaber.github.io/syq/automation.html) or
+  [Python SDK](https://greaber.github.io/syq/python.html).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Quick links to docs for common tasks:
 - [Send files to your laptop from a server you’re SSHed into](https://greaber.github.io/syq/receive.html).
   Your laptop needs no SSH server or incoming network port.
 - [Run commands on your laptop from a server](https://greaber.github.io/syq/exec.html)
-- [Copy between servers](https://greaber.github.io/syq/remote-to-remote.html)
+- [Copy directly between servers without forwarding your SSH agent](https://greaber.github.io/syq/remote-to-remote.html)
 - [Rename and reorganize files during a copy](https://greaber.github.io/syq/mappings.html)
 - Use syq from [scripts](https://greaber.github.io/syq/automation.html) or
   [Python](https://greaber.github.io/syq/python.html).

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@
 
 Copy, reorganize and remove files—locally or across machines. Resume interrupted
 transfers, send files to your laptop or run commands there from a server’s
-remote shell, and use syq from scripts or Python. Your laptop needs no SSH
-server or incoming network port.
+remote shell, and script syq using the [JSON API](automation.md) or
+[Python SDK](python.md). Your laptop needs no SSH server or incoming network port.
 
 <nav class="landing-actions" aria-label="Explore syq">
 <a class="landing-primary" href="install.html">Install syq</a>
@@ -15,8 +15,8 @@ server or incoming network port.
 <a href="exec.html">Run commands on your laptop</a>
 <a href="remote-to-remote.html">Copy directly between servers without forwarding your SSH agent</a>
 <a href="mappings.html">Rename and reorganize files during a copy</a>
-<a href="automation.html">Use syq from scripts</a>
-<a href="python.html">Use syq from Python</a>
+<a href="automation.html">JSON API</a>
+<a href="python.html">Python SDK</a>
 </nav>
 
 ## Try a copy

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ server or incoming network port.
 <a href="https://greaber.github.io/syq-bench/">Benchmarks ↗</a>
 <a href="receive.html">Send files to your laptop</a>
 <a href="exec.html">Run commands on your laptop</a>
-<a href="remote-to-remote.html">Copy between servers</a>
+<a href="remote-to-remote.html">Copy directly between servers without forwarding your SSH agent</a>
 <a href="mappings.html">Rename and reorganize files during a copy</a>
 <a href="automation.html">Use syq from scripts</a>
 <a href="python.html">Use syq from Python</a>


### PR DESCRIPTION
Clarify task wording in the README and docs introduction:

- “Copy directly between servers without forwarding your SSH agent” explains the route and agent-forwarding benefit.
- “Script syq using the JSON API or Python SDK” links to each interface; docs buttons use those interface names.

Validation at `24f94e5`: documentation links (20 files, zero problems) and whitespace checks passed. Documentation-only change; code tests not run.

```text
Worktree: /home/grant/repos/syq/.worktrees/readme-direct-copy
Branch:   readme-direct-copy at 24f94e5 (clean)
Upstream: origin/readme-direct-copy (ahead 0, behind 0)
Master:   c7ec794 from refs/heads/master (branch is ahead 5, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      e4bd102  https://github.com/greaber/syq/actions/runs/34278014407
  rsync-compat.yml success      e4bd102  https://github.com/greaber/syq/actions/runs/34278014527
  macos.yml        success      e4bd102  https://github.com/greaber/syq/actions/runs/34278014422

Pull request: #306 https://github.com/greaber/syq/pull/306
  base master, open, review none, merge state clean
  GitHub head 24f94e5: matches local 24f94e5
  checks: none registered yet
```
