### PR TITLE
Add a usage question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,22 @@
+name: Usage question
+description: Ask for help using syq
+labels: ["question"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+      description: Describe your task and what you would like help with.
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: What command did you try?
+      description: If you have tried a command, paste it here with any relevant output. Remove credentials and private information.
+      render: shell
+  - type: textarea
+    id: question
+    attributes:
+      label: What happened, or what is unclear?
+      description: Include your syq version and operating system if they are relevant.


### PR DESCRIPTION
Add a Usage question option to the issue chooser so people can ask for help without using the bug or feature forms. Only the task description is required; commands, output, and additional context are optional. New questions receive the existing `question` label, whose repository description is now “Questions about using syq.”

Validation: reviewed the form against GitHub's documented issue-form syntax and existing repository forms; `git diff --check` passed. No runtime code changed, so Rust tests were not run. `scripts/branch-status.sh` passed: branch clean at 27dcf9c; latest master ci, rsync-compat, and macos runs succeeded at e4bd102.
