### PR TITLE
Use Docker for Homebrew release verification

### DIFF
--- a/.agents/skills/syq-release/SKILL.md
+++ b/.agents/skills/syq-release/SKILL.md
@@ -82,6 +82,15 @@ publication is incomplete, including a missing matching PyPI version. Apply the
 provisional/permanent tag rules in `AGENTS.md`; never move a permanent tag,
 including any pushed Go module tag.
 
+When the release host does not have Homebrew, verify the Homebrew install path
+in a disposable Docker container instead of asking the user to install Homebrew
+on the host. Use the official x86-64 Linux Homebrew image pinned as
+`homebrew/brew@sha256:b0072bfdebf5934ae24b93b44a1928a88057399b3283ffa0177bb86084fdedfd`,
+run `brew install greaber/tap/syq` inside it, check the released version, and
+exercise a local copy with the installed binary. The container must be removed
+when it exits. Update the pinned digest deliberately when that image becomes
+unavailable or no longer supports the release check.
+
 Run `scripts/release-timings.py v<version>` at completion and include its
 observable GitHub window and slowest phases in the release report. The phases
 can overlap, so use the window as wall time and job durations as optimization


### PR DESCRIPTION
Release verification repeatedly stopped when the Linux release host lacked Homebrew. Teach the release skill to use an official Homebrew Docker image pinned by digest, install the public tap there, verify the released version, and run a local copy without changing the host.

Validation: exercised brew install greaber/tap/syq in the pinned disposable image for v0.5.1; syq --version and a local copy passed.
