### PR TITLE
Prepare syq 0.5.2

### DIFF
--- a/.github/release-notes/v0.5.2.md
+++ b/.github/release-notes/v0.5.2.md
@@ -1,0 +1,18 @@
+syq 0.5.2 adds independent receiving profiles, makes direct copy paths more
+efficient, and improves the guidance around the command-line and Python SDK
+interfaces.
+
+- `syq recv` can now keep separate named receiving profiles, each with its own
+  settings, approvals, and worker. Existing single-profile settings continue
+  to work as the default profile.
+- Uncompressed copy frames can be written directly into buffered output, and
+  frame headers share one implementation, reducing copying and allocation in
+  eligible transfers.
+- Receiving errors now name the available registered destinations, and copy
+  approval prompts warn about overwriting an existing destination only when it
+  applies.
+
+The receiving-profile settings format cannot be read by syq 0.5.1 or earlier.
+Upgrade every syq command that shares those settings before creating or using
+named profiles. Remote helpers and return peers must continue to run the same
+syq build as the command that starts a copy.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Prepares the authorized syq 0.5.2 release.

- Bumps the Cargo package and lockfile to 0.5.2.
- Adds curated release notes, including the receiving-profile format compatibility boundary.

Checks at b0b6506:
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --bin syq (602 passed, 1 existing ignored)
- python3 scripts/check-doc-links.py
- scripts/release-readiness.py v0.5.2 --check-ssh (default real-SSH release lab passed)

branch-status: clean; latest master ci, rsync-compat, and macos runs at 39432bc are successful.