### PR TITLE
Document streaming defaults in 0.5.2 notes

### DIFF
--- a/.github/release-notes/v0.5.2.md
+++ b/.github/release-notes/v0.5.2.md
@@ -1,6 +1,6 @@
 syq 0.5.2 adds independent receiving profiles, makes direct copy paths more
-efficient, and improves the guidance around the command-line and Python SDK
-interfaces.
+efficient, uses smaller streaming blocks by default, and improves the guidance
+around the command-line and Python SDK interfaces.
 
 - `syq recv` can now keep separate named receiving profiles, each with its own
   settings, approvals, and worker. Existing single-profile settings continue
@@ -8,6 +8,8 @@ interfaces.
 - Uncompressed copy frames can be written directly into buffered output, and
   frame headers share one implementation, reducing copying and allocation in
   eligible transfers.
+- Streaming transfers now use 2 MiB blocks by default, which reduces the
+  memory reserved for each active streaming worker.
 - Receiving errors now name the available registered destinations, and copy
   approval prompts warn about overwriting an existing destination only when it
   applies.


### PR DESCRIPTION
Updates the prepared v0.5.2 release notes for the streaming-block default now on master.

Check at 9dec052: python3 scripts/check-doc-links.py; git diff --check.