### PR TITLE
Test metadata pool configuration and source stat batches

### DIFF
--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -9870,46 +9870,50 @@ mod tests {
         assert_eq!(entries[0].link.as_deref(), Some(target.as_bytes()));
     }
 
+    fn checked_metadata_batch_threads(items: &[usize]) -> Vec<std::thread::ThreadId> {
+        let observations = parallel_map(items, |&index| {
+            let thread = std::thread::current();
+            (
+                index,
+                thread.id(),
+                thread.name().map(str::to_owned),
+                rayon::current_num_threads(),
+            )
+        });
+        // Assert on the calling test thread so diagnostics reach this test's
+        // capture buffer, regardless of which test initialized the static pool.
+        assert_eq!(observations.len(), items.len());
+        observations
+            .into_iter()
+            .zip(items)
+            .map(|((index, thread, name, count), expected)| {
+                assert_eq!(index, *expected);
+                assert_eq!(
+                    count, PAR_THREADS,
+                    "metadata pool must retain its configured parallelism"
+                );
+                assert!(
+                    name.as_deref()
+                        .is_some_and(|name| name.starts_with("syq-metadata-")),
+                    "unexpected metadata thread name: {name:?}"
+                );
+                thread
+            })
+            .collect()
+    }
+
     #[test]
     fn parallel_metadata_batches_share_a_bounded_pool() {
-        let mut owners = HashMap::new();
-        let mut shared = false;
-        // More callers than pool threads guarantees reuse without depending on
-        // scheduling or the number of available CPUs. Run callers sequentially
-        // so a broken per-caller pool cannot exhaust the test host's thread limit.
-        for caller in 0..=PAR_THREADS {
-            let results = std::thread::spawn(|| {
-                let items: Vec<_> = (0..128).collect();
-                parallel_map(&items, |&index| {
-                    assert_eq!(
-                        rayon::current_num_threads(),
-                        PAR_THREADS,
-                        "metadata pool must retain its configured parallelism"
-                    );
-                    let thread = std::thread::current();
-                    assert!(thread
-                        .name()
-                        .is_some_and(|name| name.starts_with("syq-metadata-")));
-                    (index, thread.id())
-                })
-            })
-            .join()
-            .unwrap();
-            assert_eq!(
-                results.iter().map(|&(index, _)| index).collect::<Vec<_>>(),
-                (0..128).collect::<Vec<_>>()
-            );
-            for (_, thread) in results {
-                shared |= *owners.entry(thread).or_insert(caller) != caller;
-            }
+        let mut threads = std::collections::HashSet::new();
+        let items: Vec<_> = (0..128).collect();
+        // More calls than pool threads guarantees reuse without depending on
+        // scheduling or CPU count: disjoint per-call pools exceed the bound.
+        for _ in 0..=PAR_THREADS {
+            threads.extend(checked_metadata_batch_threads(&items));
         }
         assert!(
-            shared,
-            "different callers must execute on shared metadata workers"
-        );
-        assert!(
-            owners.len() <= PAR_THREADS,
-            "metadata concurrency must not multiply by caller count"
+            threads.len() <= PAR_THREADS,
+            "metadata batches must reuse a bounded shared pool"
         );
     }
 
@@ -9926,7 +9930,7 @@ mod tests {
         })
         .expect_err("worker panics must reach the caller");
         assert_eq!(panic.downcast_ref::<&str>(), Some(&"metadata test panic"));
-        assert_eq!(parallel_map(&items, |&index| index), items);
+        checked_metadata_batch_threads(&items);
     }
 
     #[test]
@@ -9970,7 +9974,7 @@ mod tests {
     }
 
     #[test]
-    fn source_stat_batches_recover_after_a_missing_source() {
+    fn source_stat_batches_report_missing_sources_and_accept_restored_files() {
         let temporary = crate::test_support::tempdir().unwrap();
         let path = temporary.path().join("selected");
         fs::write(&path, b"original").unwrap();
@@ -9981,18 +9985,35 @@ mod tests {
             follow: false,
             guard: None,
         };
-        assert!(matches!(worker.handle(&request), Response::Stats(entries) if entries.len() == 64));
+        let response = worker.handle(&request);
+        assert!(
+            matches!(&response, Response::Stats(entries) if entries.len() == 64),
+            "unexpected initial response: {response:?}"
+        );
 
-        // A missing file must fail the batch; restoring it permits the next
-        // batch to return fresh results without carrying over the earlier error.
         fs::rename(&path, temporary.path().join("original")).unwrap();
-        assert!(matches!(
-            worker.handle(&request),
-            Response::EndpointError(_)
-        ));
+        let response = worker.handle(&request);
+        let Response::EndpointError(error) = response else {
+            panic!("expected missing-source error: {response:?}");
+        };
+        assert!(
+            error.message.contains("inspect registered source leaf"),
+            "{error:?}"
+        );
+        assert_eq!(error.io_kind, Some(WireIoKind::NotFound), "{error:?}");
+
         fs::rename(temporary.path().join("original"), &path).unwrap();
-        assert!(matches!(worker.handle(&request), Response::Stats(entries)
-            if entries.len() == 64 && entries.iter().all(|entry| entry.as_ref().is_some_and(|e| e.size == 8))));
+        let response = worker.handle(&request);
+        let Response::Stats(entries) = response else {
+            panic!("expected restored-file metadata: {response:?}");
+        };
+        assert_eq!(entries.len(), 64);
+        assert!(
+            entries
+                .iter()
+                .all(|entry| entry.as_ref().is_some_and(|e| e.size == 8)),
+            "{entries:?}"
+        );
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1464,6 +1464,7 @@ pub struct FsOps {
     operator_selection: Option<OperatorDirectorySelection>,
     descriptor_session: DescriptorSessionSlot,
     source_roots: HashMap<RegisteredRootId, SourceRootHandle>,
+    source_stats: SourceStatPool,
     allow_unconfined_source_paths: bool,
     destination_root: Option<Arc<Root>>,
     destination_prefix: Option<PathBytes>,
@@ -1617,6 +1618,7 @@ impl FsOps {
             operator_selection: None,
             descriptor_session,
             source_roots: HashMap::new(),
+            source_stats: SourceStatPool::default(),
             allow_unconfined_source_paths: false,
             destination_root: None,
             destination_prefix: None,
@@ -3136,36 +3138,7 @@ impl FsOps {
             // `follow` describes the legacy pathname request. A registered
             // selection has already applied the operator-root policy, and no
             // descendant component gains symlink-traversal authority here.
-            return parallel_map(&targets, |target| {
-                let Some(expected) = target.expected_leaf.as_ref() else {
-                    let Some(metadata) = target.root.metadata(&target.relative).ok() else {
-                        return Ok(None);
-                    };
-                    return Ok(
-                        rooted_entry(&target.root, &target.relative, Vec::new(), metadata).ok(),
-                    );
-                };
-                let metadata = target
-                    .root
-                    .metadata(&target.relative)
-                    .context("inspect registered source leaf")?;
-                require_source_leaf_identity(expected, metadata)?;
-                let entry = rooted_source_entry(
-                    &target.root,
-                    &target.relative,
-                    Vec::new(),
-                    metadata,
-                    Some(expected),
-                )?;
-                let after = target
-                    .root
-                    .metadata(&target.relative)
-                    .context("recheck registered source leaf")?;
-                require_source_leaf_identity(expected, after)?;
-                Ok(Some(entry))
-            })
-            .into_iter()
-            .collect();
+            return self.source_stats.stat(targets);
         }
         if self.destination_root.is_none()
             && !self.source_roots.is_empty()
@@ -4434,6 +4407,133 @@ fn fail_put_small_before_rename_for_test(p: &Path) -> Result<()> {
 
 const PAR_THREADS: usize = 32;
 const PAR_MIN: usize = 32;
+
+fn stat_registered_source(target: &RegisteredSourceTarget) -> Result<Option<Entry>> {
+    let Some(expected) = target.expected_leaf.as_ref() else {
+        let Some(metadata) = target.root.metadata(&target.relative).ok() else {
+            return Ok(None);
+        };
+        return Ok(rooted_entry(&target.root, &target.relative, Vec::new(), metadata).ok());
+    };
+    let metadata = target
+        .root
+        .metadata(&target.relative)
+        .context("inspect registered source leaf")?;
+    require_source_leaf_identity(expected, metadata)?;
+    let entry = rooted_source_entry(
+        &target.root,
+        &target.relative,
+        Vec::new(),
+        metadata,
+        Some(expected),
+    )?;
+    let after = target
+        .root
+        .metadata(&target.relative)
+        .context("recheck registered source leaf")?;
+    require_source_leaf_identity(expected, after)?;
+    Ok(Some(entry))
+}
+
+struct SourceStatTask {
+    targets: Vec<RegisteredSourceTarget>,
+    reply: std::sync::mpsc::Sender<Vec<Result<Option<Entry>>>>,
+}
+
+struct SourceStatThread {
+    tasks: Option<std::sync::mpsc::Sender<SourceStatTask>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl SourceStatThread {
+    fn new() -> Result<Self> {
+        let (tasks, pending) = std::sync::mpsc::channel::<SourceStatTask>();
+        let thread = std::thread::Builder::new()
+            .name("source-stat".into())
+            .spawn(move || {
+                for task in pending {
+                    let results = task.targets.iter().map(stat_registered_source).collect();
+                    let _ = task.reply.send(results);
+                }
+            })
+            .context("start source metadata worker")?;
+        Ok(Self {
+            tasks: Some(tasks),
+            thread: Some(thread),
+        })
+    }
+}
+
+impl Drop for SourceStatThread {
+    fn drop(&mut self) {
+        self.tasks.take();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Source rechecks use the same parallelism as other metadata batches, but
+/// repeat after every small-file batch. Keep their threads for this filesystem
+/// worker's lifetime; channel receives park them between requests.
+#[derive(Default)]
+struct SourceStatPool {
+    workers: Vec<SourceStatThread>,
+}
+
+impl SourceStatPool {
+    fn stat(&mut self, targets: Vec<RegisteredSourceTarget>) -> Result<Vec<Option<Entry>>> {
+        let result = self.stat_inner(targets);
+        if result.is_err() {
+            // Join outstanding work and replace any worker that stopped before
+            // replying. A later request cannot consume an earlier batch's data.
+            self.workers.clear();
+        }
+        result
+    }
+
+    fn stat_inner(&mut self, targets: Vec<RegisteredSourceTarget>) -> Result<Vec<Option<Entry>>> {
+        if targets.len() < PAR_MIN {
+            return targets.iter().map(stat_registered_source).collect();
+        }
+        let chunk = targets.len().div_ceil(PAR_THREADS);
+        let n = targets.len().div_ceil(chunk);
+        while self.workers.len() < n {
+            self.workers.push(SourceStatThread::new()?);
+        }
+        let mut targets = targets.into_iter();
+        let mut replies = Vec::with_capacity(n);
+        for worker in &self.workers[..n] {
+            let (reply, results) = std::sync::mpsc::channel();
+            worker
+                .tasks
+                .as_ref()
+                .expect("live source metadata worker")
+                .send(SourceStatTask {
+                    targets: targets.by_ref().take(chunk).collect(),
+                    reply,
+                })
+                .map_err(|_| anyhow!("source metadata worker stopped before receiving work"))?;
+            replies.push(results);
+        }
+        // Drain every chunk, including later chunks after an earlier file's
+        // error, before allowing the next request to use these workers.
+        let results = replies
+            .into_iter()
+            .map(|reply| {
+                reply
+                    .recv()
+                    .context("source metadata worker stopped before replying")
+            })
+            .collect::<Vec<_>>();
+        results
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect()
+    }
+}
 
 fn parallel_map<T: Sync, R: Send>(items: &[T], f: impl Fn(&T) -> R + Sync) -> Vec<R> {
     if items.len() < PAR_MIN {
@@ -9863,6 +9963,117 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].kind, Kind::Symlink);
         assert_eq!(entries[0].link.as_deref(), Some(target.as_bytes()));
+    }
+
+    #[test]
+    fn source_stat_pool_returns_fresh_ordered_batches_and_joins_on_drop() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let (mut worker, selections, _control) =
+            registered_source_worker(&[temporary.path()], false);
+        let root = worker.source_roots[&selections[0].root()].root.clone();
+        let outside = crate::test_support::tempdir().unwrap();
+        fs::write(outside.path().join("secret"), b"secret").unwrap();
+        std::os::unix::fs::symlink(outside.path(), temporary.path().join("link")).unwrap();
+        let mut first_threads = Vec::new();
+        for (round, count) in [31, 32, 65, 128, 7, 512].into_iter().enumerate() {
+            for idx in 0..64 {
+                fs::write(
+                    temporary.path().join(format!("f{idx}")),
+                    vec![0; idx + round],
+                )
+                .unwrap();
+            }
+            let sources: Vec<_> = (0..count)
+                .map(|idx| {
+                    selections[0]
+                        .join(
+                            if idx == 3 {
+                                b"link/secret".to_vec()
+                            } else {
+                                format!("f{}", idx % 64).into_bytes()
+                            }
+                            .as_slice(),
+                        )
+                        .unwrap()
+                })
+                .collect();
+            let response = worker.handle(&Request::StatMany {
+                paths: vec![b"/display/path/is/not/authority".to_vec(); count],
+                sources: Some(sources),
+                follow: true,
+                guard: None,
+            });
+            let Response::Stats(entries) = response else {
+                panic!("unexpected response: {response:?}");
+            };
+            assert_eq!(entries.len(), count);
+            for (idx, entry) in entries.into_iter().enumerate() {
+                assert_eq!(
+                    entry.map(|e| e.size),
+                    (idx != 3).then_some((idx % 64 + round) as u64)
+                );
+            }
+            let threads: Vec<_> = worker
+                .source_stats
+                .workers
+                .iter()
+                .map(|worker| worker.thread.as_ref().unwrap().thread().id())
+                .collect();
+            if round == 0 {
+                assert!(threads.is_empty(), "short batches must not start threads");
+            } else if round == 1 {
+                first_threads = threads;
+            } else {
+                assert_eq!(
+                    threads, first_threads,
+                    "reuse workers across different batch sizes"
+                );
+            }
+        }
+        drop(worker);
+        assert_eq!(
+            Arc::strong_count(&root),
+            1,
+            "shutdown must release all task capabilities"
+        );
+    }
+
+    #[test]
+    fn source_stat_pool_reports_failed_workers_and_recovers_without_stale_replies() {
+        let temporary = crate::test_support::tempdir().unwrap();
+        let path = temporary.path().join("selected");
+        fs::write(&path, b"original").unwrap();
+        let (mut worker, selections, _control) = registered_source_worker(&[&path], false);
+        let request = Request::StatMany {
+            paths: vec![b"ignored".to_vec(); 64],
+            sources: Some(vec![selections[0].clone(); 64]),
+            follow: false,
+            guard: None,
+        };
+        let (tasks, pending) = std::sync::mpsc::channel();
+        drop(pending);
+        worker.source_stats.workers.push(SourceStatThread {
+            tasks: Some(tasks),
+            thread: None,
+        });
+        assert!(matches!(
+            worker.handle(&request),
+            Response::EndpointError(_)
+        ));
+        assert!(worker.source_stats.workers.is_empty());
+        assert!(matches!(worker.handle(&request), Response::Stats(entries) if entries.len() == 64));
+
+        // Exact-leaf identity errors must also drain the entire batch. Restoring
+        // the retained original then permits a fresh, correctly ordered reply.
+        fs::rename(&path, temporary.path().join("original")).unwrap();
+        fs::write(&path, b"replacement").unwrap();
+        assert!(
+            matches!(worker.handle(&request), Response::EndpointError(error)
+            if error.message.contains("registered source leaf changed identity"))
+        );
+        fs::rename(temporary.path().join("original"), &path).unwrap();
+        assert!(matches!(worker.handle(&request), Response::Stats(entries)
+            if entries.len() == 64 && entries.iter().all(|entry| entry.as_ref().is_some_and(|e| e.size == 8))));
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -9883,15 +9883,18 @@ mod tests {
         // Assert on the calling test thread so diagnostics reach this test's
         // capture buffer, regardless of which test initialized the static pool.
         assert_eq!(observations.len(), items.len());
+        // Catch accidentally selecting a single-thread or host-sized pool.
+        // Its size is static within the batch, so inspect it only once.
+        assert_eq!(
+            observations[0].3, PAR_THREADS,
+            "metadata pool must retain its configured parallelism"
+        );
         observations
             .into_iter()
             .zip(items)
-            .map(|((index, thread, name, count), expected)| {
+            .map(|((index, thread, name, _), expected)| {
                 assert_eq!(index, *expected);
-                assert_eq!(
-                    count, PAR_THREADS,
-                    "metadata pool must retain its configured parallelism"
-                );
+                // Catch bypassing the dedicated metadata pool.
                 assert!(
                     name.as_deref()
                         .is_some_and(|name| name.starts_with("syq-metadata-")),
@@ -9903,11 +9906,22 @@ mod tests {
     }
 
     #[test]
+    fn small_metadata_batches_run_inline() {
+        let caller = std::thread::current().id();
+        assert_eq!(
+            parallel_map(&[(); PAR_MIN - 1], |_| std::thread::current().id()),
+            vec![caller; PAR_MIN - 1]
+        );
+    }
+
+    #[test]
     fn parallel_metadata_batches_share_a_bounded_pool() {
         let mut threads = std::collections::HashSet::new();
-        let items: Vec<_> = (0..128).collect();
-        // More calls than pool threads guarantees reuse without depending on
-        // scheduling or CPU count: disjoint per-call pools exceed the bound.
+        let items: Vec<_> = (0..PAR_MIN).collect();
+        // Rust ThreadIds are never reused, even after threads exit. Each nonempty
+        // call contributes at least one ID, so PAR_THREADS + 1 calls must exceed
+        // this bound with per-call pools. Passing proves reuse across calls
+        // without assumptions about scheduling or native thread-ID recycling.
         for _ in 0..=PAR_THREADS {
             threads.extend(checked_metadata_batch_threads(&items));
         }
@@ -9934,20 +9948,14 @@ mod tests {
     }
 
     #[test]
-    fn source_stat_batches_return_fresh_ordered_results_and_release_roots_on_close() {
+    fn source_stat_batches_preserve_order_across_sizes() {
         let temporary = crate::test_support::tempdir().unwrap();
         let (mut worker, selections, _control) =
             registered_source_worker(&[temporary.path()], false);
-        let root = worker.source_roots[&selections[0].root()].root.clone();
-        let sizes = [31, 32, 65, 128, 7, 129];
-        for (round, count) in sizes.into_iter().enumerate() {
-            for idx in 0..129 {
-                fs::write(
-                    temporary.path().join(format!("f{idx}")),
-                    vec![0; idx + round * 129],
-                )
-                .unwrap();
-            }
+        for idx in 0..129 {
+            fs::write(temporary.path().join(format!("f{idx}")), vec![0; idx]).unwrap();
+        }
+        for count in [31, 32, 65, 128, 7, 129] {
             let sources: Vec<_> = (0..count)
                 .map(|idx| selections[0].join(format!("f{idx}").as_bytes()).unwrap())
                 .collect();
@@ -9962,15 +9970,9 @@ mod tests {
             };
             assert_eq!(entries.len(), count);
             for (idx, entry) in entries.into_iter().enumerate() {
-                assert_eq!(entry.map(|e| e.size), Some((idx + round * 129) as u64));
+                assert_eq!(entry.map(|e| e.size), Some(idx as u64));
             }
         }
-        drop(worker);
-        assert_eq!(
-            Arc::strong_count(&root),
-            1,
-            "closing the filesystem worker must release its source root"
-        );
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -9872,33 +9872,38 @@ mod tests {
 
     #[test]
     fn parallel_metadata_batches_share_a_bounded_pool() {
-        let callers = 4;
-        let start = std::sync::Barrier::new(callers);
-        let threads: std::collections::HashSet<_> = std::thread::scope(|scope| {
-            let batches: Vec<_> = (0..callers)
-                .map(|_| {
-                    scope.spawn(|| {
-                        start.wait();
-                        let items: Vec<_> = (0..128).collect();
-                        parallel_map(&items, |&index| (index, std::thread::current().id()))
-                    })
+        let mut owners = HashMap::new();
+        let mut shared = false;
+        // More callers than pool threads guarantees reuse without depending on
+        // scheduling or the number of available CPUs. Run callers sequentially
+        // so a broken per-caller pool cannot exhaust the test host's thread limit.
+        for caller in 0..=PAR_THREADS {
+            let results = std::thread::spawn(|| {
+                let items: Vec<_> = (0..128).collect();
+                parallel_map(&items, |&index| {
+                    let thread = std::thread::current();
+                    assert!(thread
+                        .name()
+                        .is_some_and(|name| name.starts_with("syq-metadata-")));
+                    (index, thread.id())
                 })
-                .collect();
-            batches
-                .into_iter()
-                .flat_map(|batch| {
-                    let results = batch.join().unwrap();
-                    assert_eq!(
-                        results.iter().map(|&(index, _)| index).collect::<Vec<_>>(),
-                        (0..128).collect::<Vec<_>>()
-                    );
-                    results.into_iter().map(|(_, thread)| thread)
-                })
-                .collect()
-        });
-        assert!(!threads.is_empty());
+            })
+            .join()
+            .unwrap();
+            assert_eq!(
+                results.iter().map(|&(index, _)| index).collect::<Vec<_>>(),
+                (0..128).collect::<Vec<_>>()
+            );
+            for (_, thread) in results {
+                shared |= *owners.entry(thread).or_insert(caller) != caller;
+            }
+        }
         assert!(
-            threads.len() <= PAR_THREADS,
+            shared,
+            "different callers must execute on shared metadata workers"
+        );
+        assert!(
+            owners.len() <= PAR_THREADS,
             "metadata concurrency must not multiply by caller count"
         );
     }
@@ -9938,15 +9943,16 @@ mod tests {
     }
 
     #[test]
-    fn source_stat_batches_preserve_order_confinement_and_release_capabilities() {
+    fn source_stat_batches_return_fresh_ordered_results_and_release_roots() {
         let temporary = crate::test_support::tempdir().unwrap();
         let (mut worker, selections, _control) =
             registered_source_worker(&[temporary.path()], false);
         let root = worker.source_roots[&selections[0].root()].root.clone();
-        let outside = crate::test_support::tempdir().unwrap();
-        fs::write(outside.path().join("secret"), b"secret").unwrap();
-        std::os::unix::fs::symlink(outside.path(), temporary.path().join("link")).unwrap();
-        for (round, count) in [31, 32, 65, 128, 7, 512].into_iter().enumerate() {
+        let sizes = [31, 32, 65, 128, 7, 129];
+        let mut previous_cycle_refs = None;
+        // Repeat the size sweep to allow caches to warm before checking that
+        // requests do not keep accumulating references to the source root.
+        for (round, count) in sizes.into_iter().cycle().take(sizes.len() * 2).enumerate() {
             for idx in 0..64 {
                 fs::write(
                     temporary.path().join(format!("f{idx}")),
@@ -9957,38 +9963,31 @@ mod tests {
             let sources: Vec<_> = (0..count)
                 .map(|idx| {
                     selections[0]
-                        .join(
-                            if idx == 3 {
-                                b"link/secret".to_vec()
-                            } else {
-                                format!("f{}", idx % 64).into_bytes()
-                            }
-                            .as_slice(),
-                        )
+                        .join(format!("f{}", idx % 64).as_bytes())
                         .unwrap()
                 })
                 .collect();
-            let root_refs = Arc::strong_count(&root);
             let response = worker.handle(&Request::StatMany {
                 paths: vec![b"/display/path/is/not/authority".to_vec(); count],
                 sources: Some(sources),
                 follow: true,
                 guard: None,
             });
-            assert_eq!(
-                Arc::strong_count(&root),
-                root_refs,
-                "release batch capabilities before replying"
-            );
             let Response::Stats(entries) = response else {
                 panic!("unexpected response: {response:?}");
             };
             assert_eq!(entries.len(), count);
             for (idx, entry) in entries.into_iter().enumerate() {
-                assert_eq!(
-                    entry.map(|e| e.size),
-                    (idx != 3).then_some((idx % 64 + round) as u64)
-                );
+                assert_eq!(entry.map(|e| e.size), Some((idx % 64 + round) as u64));
+            }
+            if (round + 1) % sizes.len() == 0 {
+                let refs = Arc::strong_count(&root);
+                if let Some(previous) = previous_cycle_refs.replace(refs) {
+                    assert!(
+                        refs <= previous,
+                        "source-root references must not grow across size sweeps"
+                    );
+                }
             }
         }
         drop(worker);
@@ -10000,7 +9999,7 @@ mod tests {
     }
 
     #[test]
-    fn source_stat_batches_recover_after_exact_leaf_identity_errors() {
+    fn source_stat_batches_recover_after_a_missing_source() {
         let temporary = crate::test_support::tempdir().unwrap();
         let path = temporary.path().join("selected");
         fs::write(&path, b"original").unwrap();
@@ -10013,25 +10012,16 @@ mod tests {
         };
         assert!(matches!(worker.handle(&request), Response::Stats(entries) if entries.len() == 64));
 
-        let leaf = worker.source_roots[&selections[0].root()]
-            ._leaf_object
-            .as_ref()
-            .unwrap()
-            .clone();
-        let leaf_refs = Arc::strong_count(&leaf);
-        // A failed batch must release its exact-leaf capabilities before replying.
-        // Restoring the selected inode then permits a fresh successful batch.
+        // A missing file must fail the batch; restoring it permits the next
+        // batch to return fresh results without carrying over the earlier error.
         fs::rename(&path, temporary.path().join("original")).unwrap();
-        fs::write(&path, b"replacement").unwrap();
-        assert!(
-            matches!(worker.handle(&request), Response::EndpointError(error)
-            if error.message.contains("registered source leaf changed identity"))
-        );
-        assert_eq!(Arc::strong_count(&leaf), leaf_refs);
+        assert!(matches!(
+            worker.handle(&request),
+            Response::EndpointError(_)
+        ));
         fs::rename(temporary.path().join("original"), &path).unwrap();
         assert!(matches!(worker.handle(&request), Response::Stats(entries)
             if entries.len() == 64 && entries.iter().all(|entry| entry.as_ref().is_some_and(|e| e.size == 8))));
-        assert_eq!(Arc::strong_count(&leaf), leaf_refs);
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1464,7 +1464,6 @@ pub struct FsOps {
     operator_selection: Option<OperatorDirectorySelection>,
     descriptor_session: DescriptorSessionSlot,
     source_roots: HashMap<RegisteredRootId, SourceRootHandle>,
-    source_stats: SourceStatPool,
     allow_unconfined_source_paths: bool,
     destination_root: Option<Arc<Root>>,
     destination_prefix: Option<PathBytes>,
@@ -1618,7 +1617,6 @@ impl FsOps {
             operator_selection: None,
             descriptor_session,
             source_roots: HashMap::new(),
-            source_stats: SourceStatPool::default(),
             allow_unconfined_source_paths: false,
             destination_root: None,
             destination_prefix: None,
@@ -3138,7 +3136,36 @@ impl FsOps {
             // `follow` describes the legacy pathname request. A registered
             // selection has already applied the operator-root policy, and no
             // descendant component gains symlink-traversal authority here.
-            return self.source_stats.stat(targets);
+            return parallel_map(&targets, |target| {
+                let Some(expected) = target.expected_leaf.as_ref() else {
+                    let Some(metadata) = target.root.metadata(&target.relative).ok() else {
+                        return Ok(None);
+                    };
+                    return Ok(
+                        rooted_entry(&target.root, &target.relative, Vec::new(), metadata).ok(),
+                    );
+                };
+                let metadata = target
+                    .root
+                    .metadata(&target.relative)
+                    .context("inspect registered source leaf")?;
+                require_source_leaf_identity(expected, metadata)?;
+                let entry = rooted_source_entry(
+                    &target.root,
+                    &target.relative,
+                    Vec::new(),
+                    metadata,
+                    Some(expected),
+                )?;
+                let after = target
+                    .root
+                    .metadata(&target.relative)
+                    .context("recheck registered source leaf")?;
+                require_source_leaf_identity(expected, after)?;
+                Ok(Some(entry))
+            })
+            .into_iter()
+            .collect();
         }
         if self.destination_root.is_none()
             && !self.source_roots.is_empty()
@@ -4407,133 +4434,6 @@ fn fail_put_small_before_rename_for_test(p: &Path) -> Result<()> {
 
 const PAR_THREADS: usize = 32;
 const PAR_MIN: usize = 32;
-
-fn stat_registered_source(target: &RegisteredSourceTarget) -> Result<Option<Entry>> {
-    let Some(expected) = target.expected_leaf.as_ref() else {
-        let Some(metadata) = target.root.metadata(&target.relative).ok() else {
-            return Ok(None);
-        };
-        return Ok(rooted_entry(&target.root, &target.relative, Vec::new(), metadata).ok());
-    };
-    let metadata = target
-        .root
-        .metadata(&target.relative)
-        .context("inspect registered source leaf")?;
-    require_source_leaf_identity(expected, metadata)?;
-    let entry = rooted_source_entry(
-        &target.root,
-        &target.relative,
-        Vec::new(),
-        metadata,
-        Some(expected),
-    )?;
-    let after = target
-        .root
-        .metadata(&target.relative)
-        .context("recheck registered source leaf")?;
-    require_source_leaf_identity(expected, after)?;
-    Ok(Some(entry))
-}
-
-struct SourceStatTask {
-    targets: Vec<RegisteredSourceTarget>,
-    reply: std::sync::mpsc::Sender<Vec<Result<Option<Entry>>>>,
-}
-
-struct SourceStatThread {
-    tasks: Option<std::sync::mpsc::Sender<SourceStatTask>>,
-    thread: Option<std::thread::JoinHandle<()>>,
-}
-
-impl SourceStatThread {
-    fn new() -> Result<Self> {
-        let (tasks, pending) = std::sync::mpsc::channel::<SourceStatTask>();
-        let thread = std::thread::Builder::new()
-            .name("source-stat".into())
-            .spawn(move || {
-                for task in pending {
-                    let results = task.targets.iter().map(stat_registered_source).collect();
-                    let _ = task.reply.send(results);
-                }
-            })
-            .context("start source metadata worker")?;
-        Ok(Self {
-            tasks: Some(tasks),
-            thread: Some(thread),
-        })
-    }
-}
-
-impl Drop for SourceStatThread {
-    fn drop(&mut self) {
-        self.tasks.take();
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
-        }
-    }
-}
-
-/// Source rechecks use the same parallelism as other metadata batches, but
-/// repeat after every small-file batch. Keep their threads for this filesystem
-/// worker's lifetime; channel receives park them between requests.
-#[derive(Default)]
-struct SourceStatPool {
-    workers: Vec<SourceStatThread>,
-}
-
-impl SourceStatPool {
-    fn stat(&mut self, targets: Vec<RegisteredSourceTarget>) -> Result<Vec<Option<Entry>>> {
-        let result = self.stat_inner(targets);
-        if result.is_err() {
-            // Join outstanding work and replace any worker that stopped before
-            // replying. A later request cannot consume an earlier batch's data.
-            self.workers.clear();
-        }
-        result
-    }
-
-    fn stat_inner(&mut self, targets: Vec<RegisteredSourceTarget>) -> Result<Vec<Option<Entry>>> {
-        if targets.len() < PAR_MIN {
-            return targets.iter().map(stat_registered_source).collect();
-        }
-        let chunk = targets.len().div_ceil(PAR_THREADS);
-        let n = targets.len().div_ceil(chunk);
-        while self.workers.len() < n {
-            self.workers.push(SourceStatThread::new()?);
-        }
-        let mut targets = targets.into_iter();
-        let mut replies = Vec::with_capacity(n);
-        for worker in &self.workers[..n] {
-            let (reply, results) = std::sync::mpsc::channel();
-            worker
-                .tasks
-                .as_ref()
-                .expect("live source metadata worker")
-                .send(SourceStatTask {
-                    targets: targets.by_ref().take(chunk).collect(),
-                    reply,
-                })
-                .map_err(|_| anyhow!("source metadata worker stopped before receiving work"))?;
-            replies.push(results);
-        }
-        // Drain every chunk, including later chunks after an earlier file's
-        // error, before allowing the next request to use these workers.
-        let results = replies
-            .into_iter()
-            .map(|reply| {
-                reply
-                    .recv()
-                    .context("source metadata worker stopped before replying")
-            })
-            .collect::<Vec<_>>();
-        results
-            .into_iter()
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .flatten()
-            .collect()
-    }
-}
 
 fn parallel_map<T: Sync, R: Send>(items: &[T], f: impl Fn(&T) -> R + Sync) -> Vec<R> {
     if items.len() < PAR_MIN {
@@ -9971,7 +9871,74 @@ mod tests {
     }
 
     #[test]
-    fn source_stat_pool_returns_fresh_ordered_batches_and_joins_on_drop() {
+    fn parallel_metadata_batches_share_a_bounded_pool() {
+        let callers = 4;
+        let start = std::sync::Barrier::new(callers);
+        let threads: std::collections::HashSet<_> = std::thread::scope(|scope| {
+            let batches: Vec<_> = (0..callers)
+                .map(|_| {
+                    scope.spawn(|| {
+                        start.wait();
+                        let items: Vec<_> = (0..128).collect();
+                        parallel_map(&items, |&index| (index, std::thread::current().id()))
+                    })
+                })
+                .collect();
+            batches
+                .into_iter()
+                .flat_map(|batch| {
+                    let results = batch.join().unwrap();
+                    assert_eq!(
+                        results.iter().map(|&(index, _)| index).collect::<Vec<_>>(),
+                        (0..128).collect::<Vec<_>>()
+                    );
+                    results.into_iter().map(|(_, thread)| thread)
+                })
+                .collect()
+        });
+        assert!(!threads.is_empty());
+        assert!(
+            threads.len() <= PAR_THREADS,
+            "metadata concurrency must not multiply by caller count"
+        );
+    }
+
+    #[test]
+    fn parallel_metadata_batches_drain_errors_and_propagate_panics() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let completed = AtomicUsize::new(0);
+        let items: Vec<_> = (0..128).collect();
+        let results: Vec<std::result::Result<usize, usize>> = parallel_map(&items, |&index| {
+            completed.fetch_add(1, Ordering::Relaxed);
+            if index == 1 || index == 64 {
+                Err(index)
+            } else {
+                Ok(index)
+            }
+        });
+        assert_eq!(completed.load(Ordering::Relaxed), items.len());
+        assert_eq!(
+            results
+                .into_iter()
+                .collect::<std::result::Result<Vec<_>, _>>(),
+            Err(1)
+        );
+
+        let panic = std::panic::catch_unwind(|| {
+            parallel_map(&items, |&index| {
+                if index == 64 {
+                    std::panic::panic_any("metadata test panic");
+                }
+                index
+            })
+        })
+        .expect_err("worker panics must reach the caller");
+        assert_eq!(panic.downcast_ref::<&str>(), Some(&"metadata test panic"));
+        assert_eq!(parallel_map(&items, |&index| index), items);
+    }
+
+    #[test]
+    fn source_stat_batches_preserve_order_confinement_and_release_capabilities() {
         let temporary = crate::test_support::tempdir().unwrap();
         let (mut worker, selections, _control) =
             registered_source_worker(&[temporary.path()], false);
@@ -9979,7 +9946,6 @@ mod tests {
         let outside = crate::test_support::tempdir().unwrap();
         fs::write(outside.path().join("secret"), b"secret").unwrap();
         std::os::unix::fs::symlink(outside.path(), temporary.path().join("link")).unwrap();
-        let mut first_threads = Vec::new();
         for (round, count) in [31, 32, 65, 128, 7, 512].into_iter().enumerate() {
             for idx in 0..64 {
                 fs::write(
@@ -10002,12 +9968,18 @@ mod tests {
                         .unwrap()
                 })
                 .collect();
+            let root_refs = Arc::strong_count(&root);
             let response = worker.handle(&Request::StatMany {
                 paths: vec![b"/display/path/is/not/authority".to_vec(); count],
                 sources: Some(sources),
                 follow: true,
                 guard: None,
             });
+            assert_eq!(
+                Arc::strong_count(&root),
+                root_refs,
+                "release batch capabilities before replying"
+            );
             let Response::Stats(entries) = response else {
                 panic!("unexpected response: {response:?}");
             };
@@ -10018,33 +9990,17 @@ mod tests {
                     (idx != 3).then_some((idx % 64 + round) as u64)
                 );
             }
-            let threads: Vec<_> = worker
-                .source_stats
-                .workers
-                .iter()
-                .map(|worker| worker.thread.as_ref().unwrap().thread().id())
-                .collect();
-            if round == 0 {
-                assert!(threads.is_empty(), "short batches must not start threads");
-            } else if round == 1 {
-                first_threads = threads;
-            } else {
-                assert_eq!(
-                    threads, first_threads,
-                    "reuse workers across different batch sizes"
-                );
-            }
         }
         drop(worker);
         assert_eq!(
             Arc::strong_count(&root),
             1,
-            "shutdown must release all task capabilities"
+            "closing the filesystem worker must release its source root"
         );
     }
 
     #[test]
-    fn source_stat_pool_reports_failed_workers_and_recovers_without_stale_replies() {
+    fn source_stat_batches_recover_after_exact_leaf_identity_errors() {
         let temporary = crate::test_support::tempdir().unwrap();
         let path = temporary.path().join("selected");
         fs::write(&path, b"original").unwrap();
@@ -10055,30 +10011,27 @@ mod tests {
             follow: false,
             guard: None,
         };
-        let (tasks, pending) = std::sync::mpsc::channel();
-        drop(pending);
-        worker.source_stats.workers.push(SourceStatThread {
-            tasks: Some(tasks),
-            thread: None,
-        });
-        assert!(matches!(
-            worker.handle(&request),
-            Response::EndpointError(_)
-        ));
-        assert!(worker.source_stats.workers.is_empty());
         assert!(matches!(worker.handle(&request), Response::Stats(entries) if entries.len() == 64));
 
-        // Exact-leaf identity errors must also drain the entire batch. Restoring
-        // the retained original then permits a fresh, correctly ordered reply.
+        let leaf = worker.source_roots[&selections[0].root()]
+            ._leaf_object
+            .as_ref()
+            .unwrap()
+            .clone();
+        let leaf_refs = Arc::strong_count(&leaf);
+        // A failed batch must release its exact-leaf capabilities before replying.
+        // Restoring the selected inode then permits a fresh successful batch.
         fs::rename(&path, temporary.path().join("original")).unwrap();
         fs::write(&path, b"replacement").unwrap();
         assert!(
             matches!(worker.handle(&request), Response::EndpointError(error)
             if error.message.contains("registered source leaf changed identity"))
         );
+        assert_eq!(Arc::strong_count(&leaf), leaf_refs);
         fs::rename(temporary.path().join("original"), &path).unwrap();
         assert!(matches!(worker.handle(&request), Response::Stats(entries)
             if entries.len() == 64 && entries.iter().all(|entry| entry.as_ref().is_some_and(|e| e.size == 8))));
+        assert_eq!(Arc::strong_count(&leaf), leaf_refs);
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -9881,6 +9881,11 @@ mod tests {
             let results = std::thread::spawn(|| {
                 let items: Vec<_> = (0..128).collect();
                 parallel_map(&items, |&index| {
+                    assert_eq!(
+                        rayon::current_num_threads(),
+                        PAR_THREADS,
+                        "metadata pool must retain its configured parallelism"
+                    );
                     let thread = std::thread::current();
                     assert!(thread
                         .name()
@@ -9909,26 +9914,8 @@ mod tests {
     }
 
     #[test]
-    fn parallel_metadata_batches_drain_errors_and_propagate_panics() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        let completed = AtomicUsize::new(0);
+    fn parallel_metadata_batches_propagate_panics_and_remain_usable() {
         let items: Vec<_> = (0..128).collect();
-        let results: Vec<std::result::Result<usize, usize>> = parallel_map(&items, |&index| {
-            completed.fetch_add(1, Ordering::Relaxed);
-            if index == 1 || index == 64 {
-                Err(index)
-            } else {
-                Ok(index)
-            }
-        });
-        assert_eq!(completed.load(Ordering::Relaxed), items.len());
-        assert_eq!(
-            results
-                .into_iter()
-                .collect::<std::result::Result<Vec<_>, _>>(),
-            Err(1)
-        );
-
         let panic = std::panic::catch_unwind(|| {
             parallel_map(&items, |&index| {
                 if index == 64 {
@@ -9943,29 +9930,22 @@ mod tests {
     }
 
     #[test]
-    fn source_stat_batches_return_fresh_ordered_results_and_release_roots() {
+    fn source_stat_batches_return_fresh_ordered_results_and_release_roots_on_close() {
         let temporary = crate::test_support::tempdir().unwrap();
         let (mut worker, selections, _control) =
             registered_source_worker(&[temporary.path()], false);
         let root = worker.source_roots[&selections[0].root()].root.clone();
         let sizes = [31, 32, 65, 128, 7, 129];
-        let mut previous_cycle_refs = None;
-        // Repeat the size sweep to allow caches to warm before checking that
-        // requests do not keep accumulating references to the source root.
-        for (round, count) in sizes.into_iter().cycle().take(sizes.len() * 2).enumerate() {
-            for idx in 0..64 {
+        for (round, count) in sizes.into_iter().enumerate() {
+            for idx in 0..129 {
                 fs::write(
                     temporary.path().join(format!("f{idx}")),
-                    vec![0; idx + round],
+                    vec![0; idx + round * 129],
                 )
                 .unwrap();
             }
             let sources: Vec<_> = (0..count)
-                .map(|idx| {
-                    selections[0]
-                        .join(format!("f{}", idx % 64).as_bytes())
-                        .unwrap()
-                })
+                .map(|idx| selections[0].join(format!("f{idx}").as_bytes()).unwrap())
                 .collect();
             let response = worker.handle(&Request::StatMany {
                 paths: vec![b"/display/path/is/not/authority".to_vec(); count],
@@ -9978,16 +9958,7 @@ mod tests {
             };
             assert_eq!(entries.len(), count);
             for (idx, entry) in entries.into_iter().enumerate() {
-                assert_eq!(entry.map(|e| e.size), Some((idx % 64 + round) as u64));
-            }
-            if (round + 1) % sizes.len() == 0 {
-                let refs = Arc::strong_count(&root);
-                if let Some(previous) = previous_cycle_refs.replace(refs) {
-                    assert!(
-                        refs <= previous,
-                        "source-root references must not grow across size sweeps"
-                    );
-                }
+                assert_eq!(entry.map(|e| e.size), Some((idx + round * 129) as u64));
             }
         }
         drop(worker);


### PR DESCRIPTION
Add five focused tests for the metadata pool introduced by #314 and source stat batch results. The final diff against `31ee972` is tests-only in `src/fsops.rs`; production code is unchanged.

Coverage:

- Batches below `PAR_MIN` execute entirely on the calling thread.
- Parallel batches report `PAR_THREADS` workers, use metadata-named threads, preserve order and reuse a bounded set of worker IDs across calls. Assertions run on the calling test thread. Pool size is asserted once per batch; comments explain the separate size, name and reuse regressions. The sharing proof uses Rust's non-reused thread IDs and `PAR_THREADS + 1` calls at the parallel threshold.
- A panic through `parallel_map` reaches the caller; a subsequent batch checks order, pool size and thread names again.
- Source stat batches preserve order across counts of 31, 32, 65, 128, 7 and 129. The fixture writes 129 distinct file sizes once.
- A temporarily absent registered source produces the “inspect registered source leaf” context and `NotFound`; a request after restoration succeeds and unexpected responses are printed.

These are configuration and result checks, not a latency guard. They do not prove that a single batch uses multiple workers or test leaf replacement between the two identity checks. The effective pool-size assertion detects omission of an explicit size only when the default differs from 32. No freshness/cache, root-release or shutdown coverage is claimed.

Validation at `2bf7e1b`, synchronized with master `31ee972`:

- `cargo fmt --all -- --check`: passed.
- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
- `cargo test --bin syq --quiet`: 609 passed, 0 failed; the existing opt-in v0.3.2 binary replay test remains ignored.
- Temporarily disabling the short-batch inline path made its new test fail under single-CPU affinity; source restored exactly afterward.
- Production equality to `31ee972` and `git diff --check`: passed.

Earlier validation at `a442484` rejected per-call and one-thread pool mutations on two/four-CPU masks and verified correct failure capture while sharing and panic tests ran together. Integration, real-SSH and performance suites were not rerun locally for this tests-only follow-up. Four-vCPU small-file and Japanese NFS comparisons remain separate performance work.
