### PR TITLE
Keep user guides concise and add a release docs audit

### DIFF
--- a/.agents/skills/syq-docs-audit/SKILL.md
+++ b/.agents/skills/syq-docs-audit/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: syq-docs-audit
+description: Audit syq documentation for user focus, excess detail, duplication, and unsupported claims. Use for requested editorial audits and during syq release preparation.
+---
+
+# Audit syq documentation
+
+Read repository `AGENTS.md` and current task notes first; use its worktree,
+commit, and review workflow. This skill does not authorize a release.
+
+Treat the docs as a guide to useful behavior, not an inventory of implementation
+facts. Start with README, the sidebar, and setup, then read affected task guides
+and references, including the Python sources included by mdBook. For a release,
+inspect documentation changes since the previous release and read their
+surrounding sections. Reuse an audit recorded for the same content; review
+subsequent changes rather than repeating it mechanically.
+
+For each section, identify what the reader is trying to do. Keep instructions,
+examples, meaningful tradeoffs, and limitations they need to choose or use the
+feature. Put detailed option interactions and machine-output contracts in the
+owning reference; link security consequences to the relevant security section.
+Delete algorithm narration, patch histories, defensive explanations of ordinary
+behavior, repeated material, and unsupported tuning advice. Moving every excess
+paragraph into reference is not a substitute for editing it.
+
+Revise the existing explanation when a feature changes. Do not turn each bug fix
+or edge case into another paragraph. Prefer a brief introduction with a link over
+restating the reference on setup pages. Avoid specific syq versions in guides
+unless a reader needs one to take an upgrade action.
+
+Check examples and claims against code and measured evidence. Keep benchmark
+workloads, source links, and important qualifications with their numbers; do not
+present another benchmark tool's results as quick-script output. A favorable
+measured example is useful when its context is clear.
+
+If simplifying a passage raises a runtime safety or product question, investigate
+and report it separately. Do not silently weaken a guarantee, change an interface,
+or remove a necessary warning to shorten the docs. Make supported editorial fixes
+without waiting for approval; ask about unresolved choices that materially change
+behavior or leave the release documentation incorrect.
+
+Build the book and check links, included SDK pages, and existing published
+anchors. Preserve URLs when moving material. Inspect changed visuals at desktop
+and phone widths in light and dark themes. Provide a browser preview for an
+editorial review, following the current task's preview setup where available.
+
+Report the edited SHA, principal cuts or moves, verification, preview, and any
+remaining decisions. Keep only brief active state in `current-plans/`; do not add
+an audit report, benchmark dump, or editorial checklist to the user docs. A release
+audit does not impose an extra approval step when there is no unresolved decision.

--- a/.agents/skills/syq-docs-audit/SKILL.md
+++ b/.agents/skills/syq-docs-audit/SKILL.md
@@ -21,7 +21,10 @@ feature. Put detailed option interactions and machine-output contracts in the
 owning reference; link security consequences to the relevant security section.
 Delete algorithm narration, patch histories, defensive explanations of ordinary
 behavior, repeated material, and unsupported tuning advice. Moving every excess
-paragraph into reference is not a substitute for editing it.
+paragraph into reference is not a substitute for editing it. Shorten by removing
+unnecessary ideas, not by stripping sentences into terse fragments. Read the
+result as connected prose: explain how an instruction relates to the reader's
+task instead of stacking isolated facts or command names.
 
 Revise the existing explanation when a feature changes. Do not turn each bug fix
 or edge case into another paragraph. Prefer a brief introduction with a link over

--- a/.agents/skills/syq-docs-audit/agents/openai.yaml
+++ b/.agents/skills/syq-docs-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Syq docs audit"
+  short_description: "Keep syq guides concise and directed toward users"
+  default_prompt: "Use $syq-docs-audit to audit syq documentation for user focus and excess detail."

--- a/.agents/skills/syq-release/SKILL.md
+++ b/.agents/skills/syq-release/SKILL.md
@@ -34,6 +34,14 @@ and release notes in `current-plans/`. Read `sdk/RELEASING.md` for SDK publicati
 Resolve scripts from that checkout, not the installed skill directory. Follow
 task-worktree discipline; fetch current master, tags, and publication state.
 
+Before finalizing release preparation, run the repository's
+[docs audit](../syq-docs-audit/SKILL.md) against changes since the previous
+release. Include needed editorial fixes in preparation before validation and
+tagging. Reuse completed audit evidence for unchanged content. Ask the user
+only when the audit leaves a material editorial or product decision unresolved;
+a clean audit adds no approval gate. Recovery of an already published tag does
+not authorize changing its documentation tree.
+
 Honor a requested version. Otherwise inspect shipped changes and existing tags:
 reuse an appropriate already-prepared unpublished package version, or explain
 and prepare the next version. An existing requested tag calls for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,19 @@ report actual access or decision blockers instead of bypassing them.
   belong there. Keep only brief `current-plans/` notes needed to continue
   active work. State a limitation as a fact about today's behavior, not as
   an intention.
+- Match documentation detail to the page's job. Setup and task guides should
+  give a useful example, explain consequential choices, and link to reference
+  material. Reference pages hold option interactions and scripting contracts;
+  security pages explain trust boundaries. Algorithm mechanics and regression
+  histories usually belong in code, tests, or the PR description.
+- When adding behavior, revise the paragraph that owns it rather than appending
+  a new explanation everywhere it is mentioned. Read the surrounding section
+  as a new user: keep details that help them act or interpret a result. A fixed
+  bug does not automatically need a new paragraph. Avoid release-number history
+  and unmeasured tuning advice in guides; benchmark claims need linked evidence.
+- Use [the docs audit skill](.agents/skills/syq-docs-audit/SKILL.md) for requested
+  editorial audits and during release preparation. An audit can identify a
+  product question without changing runtime behavior to simplify its explanation.
 - Keep the selected data route fixed. TCP may fall back to SSH between the
   same endpoints, but failure must never silently relay file data through the
   invoking or authorizing machine. Relaying requires an explicit route choice.

--- a/README.md
+++ b/README.md
@@ -51,29 +51,9 @@ examples.
 
 ## Developing syq
 
-Build from source only when developing syq itself. For everyday use, install
-an official release: it can fetch the right remote executable across platforms.
-
-With [rustup](https://rustup.rs/), Git, and a C compiler installed:
-
-```sh
-git clone https://github.com/greaber/syq.git
-cd syq
-cargo build --locked --release
-./target/release/syq cp data --to server
-```
-
-Local edits work without a commit or published branch. A source build uploads
-its running executable to compatible SSH hosts automatically; OS, CPU, and
-required system libraries must match.
-
-Direct server-to-server copies use a separate restricted receiver. The first
-copy can enroll it automatically, but after rebuilding, repeat
-`./target/release/syq receiver enroll hostB:/archive` to update an existing
-receiver. The local executable must run on hostB.
-
-See [Developing syq](docs/development.md) for the rebuild/copy workflow,
-manual setup on another platform, and checks to run before a pull request.
+For source builds, remote testing, and contribution checks, see
+[Developing syq](docs/development.md). For everyday use, install a release
+using the commands above.
 
 ## License
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -23,6 +23,8 @@
 # Reference
 
 - [Remote copy details](remote-reference.md)
+- [Persistence details](persistence-reference.md)
+- [Tuning options](tuning.md)
 - [Automation results](automation.md)
 - [Rsync compatibility](rsync-compat.md)
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -248,3 +248,20 @@ Within a schema version, required fields keep their types and meanings;
 existing types, actions, dispositions, statuses, classes, and reasons are not
 renamed or reused. New record types and optional fields may be added. Human
 messages may change at any time.
+
+## Connection status
+
+`syq persist status --json` reports the persistence setting, scope, and endpoints
+without starting connections. Endpoint states are `starting`, `connecting`,
+`ready`, `reconnecting`, `failed`, or `inactive`. Each entry also reports whether
+SSH is connected and the receiving state and errors.
+
+With receiving enabled, `ready` means the return connection is online; SSH can
+reconnect on its next use. If receiving preferences cannot be read, SSH entries
+are still listed, `receiving_error` explains the failure, and each entry's
+`receiving_enabled` is `null`.
+
+Command approvals in `syq persist receive pending --json` use `kind: "command"`
+and include `argv`, `cwd`, and `permission`. Argument and directory strings in
+this summary are escaped for display. Use an up-to-date syq binary to inspect
+and approve commands; clients that only support copy requests omit them.

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -22,24 +22,14 @@ Run `syq persist destinations list` on the server to find your receiving
 machine's actual name and connection status. On the receiving machine,
 `syq persist receive status` shows its advertised name.
 
-`--on` selects a receiving name. Both `laptop` and `@laptop` require a live
-return connection; neither falls back to DNS or an SSH connection. If the server
-command is a different build, it automatically invokes the matching helper
-registered by the receiving machine before requesting approval. Names and
-options complete from local information; completion does not contact the
-receiving machine or request approval.
+`--on` requires a live receiving name. Both `laptop` and `@laptop` fail while
+offline; neither tries an SSH host instead.
 
 ## Approve each command locally
 
-Each command waits for approval on the receiving machine. Its desktop prompt
-puts the program and literal arguments first, followed by the requesting server,
-working directory, and a reminder that it runs with your permissions outside the
-copy root and limits. On
-macOS, **Details** shows the fuller permission explanation and **Back** returns
-to the short view. Opening Details does not approve or extend the request.
-Desktop notifications may truncate long commands and hide trailing arguments.
-Use `syq persist receive pending` on the receiving machine to inspect the complete request before approving a command whose full
-text is not visible. You can inspect and decide requests from a terminal there:
+Each command waits for approval on the receiving machine. Review the program,
+arguments, requesting server, and working directory. Desktop notifications may
+truncate long commands; inspect the complete request from a local terminal:
 
 ```sh
 syq persist receive pending
@@ -58,14 +48,7 @@ An approved command runs with your local user's permissions, including access
 to files and credentials. **The receiving `--root` and copy limits do not
 contain commands.** Build tools and scripts can execute code from their input
 files; approving a displayed command does not establish that those files are
-safe. Commands have a separate approval type in `persist receive pending --json`, with
-`kind: "command"`, `argv`, `cwd`, and `permission` fields. Argument and directory
-strings in that summary are escaped for display.
-
-Older clients that only understand copies cannot approve command requests.
-Use the matching new binary to list and approve them; old clients omit command
-requests from their pending list. They can still list and approve copies from
-other server connections, and their stop request still works.
+safe.
 
 ## Arguments and working directories
 
@@ -100,13 +83,11 @@ signal and returns `128 + signal`. A setup error or connection failure is a
 nonzero result. A connection that closes before delivering the exit status is
 an error even if some output arrived successfully.
 
-Interrupting the requesting syq process, losing the connection, changing
-receiving settings, `persist receive off`, or `persist off` cancels execution. Syq kills
-the command's process group with `SIGKILL` and reaps its leader. It also kills
-remaining processes in that group when the foreground program exits, without
-giving them time to run cleanup handlers. A program that deliberately creates a
-separate process session, or an application launched through macOS `open`, can
-outlive that group. Syq does not manage detached jobs.
+Interrupting the request, losing the connection, changing receiving settings,
+or stopping receiving cancels execution. Syq forcibly stops the command's
+process group, including remaining children when the foreground program exits;
+cleanup handlers do not run. Detached processes and applications launched
+through macOS `open` can outlive the request. Syq does not manage detached jobs.
 
 A command may already have changed files when interrupted. It is never retried
 automatically after a lost connection. Inspect the outcome before requesting

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -11,19 +11,16 @@ The second command uses macOS's `open` program to display an artifact. Any
 program installed on the receiving machine can be requested, including a
 native application or a version of syq you have just built there.
 
-Commands use the same background connection as [return copies](receive.md).
-Run `syq persist connect server` on the receiving machine to enable persistence
-and wait for the connection. No SSH server or incoming network port is needed on the receiving machine.
-Requests work from independent server shells, including existing tmux sessions.
+If you have already set up [receiving files](receive.md), you can request
+commands through the same connection. Otherwise, run `syq persist connect server`
+on your desktop first. Your desktop needs no SSH server or incoming network
+port, and you can make requests from any shell on the server, including an
+existing tmux session.
 
-Exec needs no separate enablement beyond receiving and its connection.
-`@laptop` in these examples is a name, not an alias for any connected laptop.
-Run `syq persist destinations list` on the server to find your receiving
-machine's actual name and connection status. On the receiving machine,
-`syq persist receive status` shows its advertised name.
-
-`--on` requires a live receiving name. Both `laptop` and `@laptop` fail while
-offline; neither tries an SSH host instead.
+Replace `@laptop` with your desktop's receiving name. You can find it by running
+`syq persist destinations list` on the server or `syq persist receive status`
+on your desktop. The desktop must be connected: both `--on laptop` and
+`--on @laptop` fail while it is offline.
 
 ## Approve each command locally
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -84,90 +84,22 @@ source <(syq completion zsh)
 syq completion fish | source
 ```
 
-Path completion also shows file details. In Bash, press Tab again until the
-match list appears (or press Alt+? to list matches directly). Zsh shows one
-entry per line; fish shows details in its completion pager. Completing or
-selecting an entry still inserts only its path.
-
-The listing shows permissions, owner, group, human-readable file size, and
-modification time in UTC. Symlinks include their targets. A directory's size
-is shown as `—`: completion does not scan its contents or calculate tree totals.
-Owner and group names come from the machine holding the files, with numeric
-IDs when names are unavailable. Files that disappear or cannot be inspected
-are marked `[metadata unavailable]`. If fetching details takes more than two
-seconds after the names arrive, completion keeps the names and marks their
-metadata unavailable.
-
-Bash fetches metadata only when listing matches. Zsh and fish fetch it while
-preparing their menus. Remote completion uses the same SSH login as copying;
-connection persistence is optional. After upgrading, open a new shell or
-source the completion adapter again to use the new display.
+Completion suggests options, hosts, and paths, with file details beside path
+matches. In Bash, press Tab again to list matches. Remote paths use your usual
+SSH login. Open a new shell after adding the setup line or upgrading syq.
 
 ## Keep connections open
 
-Connect to a server without copying any files:
+Keep an SSH connection ready for repeated copies:
 
 ```sh
 syq persist connect server
-syq persist status
-syq persist off
 ```
 
-`connect` enables persistence, installs or reuses the matching remote helper,
-and waits until receiving is ready when it is enabled. Calling it again reuses
-a healthy connection, or restarts receiving if its service has stopped or failed.
-It does not cancel requests on a healthy connection. `--timeout 30` controls
-how long it waits for receiving after SSH and helper setup; it does not limit
-authentication or helper installation. When `connect` turns persistence on,
-it says so before connecting. A failed connection leaves the setting on; use
-`syq persist off` to disable it.
+This enables persistence and connects without copying files. It also lets you
+[send files back from the server](receive.md), with approval on your machine.
+Connections stay open until you close them with `syq persist off`.
+Use `syq persist status` to see them.
 
-You can also run `syq persist on` to enable persistence for later ordinary syq
-connections. No separate receiving startup command is needed. Receiving is on
-by default and [incoming copies and commands require local approval](receive.md).
-Use `syq persist receive off` to disable receiving, or
-`syq persist receive on --root DIRECTORY` to contain copies in an existing directory.
-
-Durable connections have no idle expiry. Keepalives detect network failures; receiving
-reconnects automatically after a dropped connection or laptop sleep. Ordinary
-copies reopen a broken SSH login when used again. Reconnection needs an available
-SSH key or agent; background receiving cannot ask for a password. After reboot,
-run `syq persist connect server` again. Syq does not install a login service.
-
-While an SSH login remains connected, other processes running as your local
-user can reuse it without another key touch or agent approval. Incoming requests
-still have their own approval checks. `persist off` closes both directions.
-Connections started by an older binary keep that binary's idle policy until
-closed and reopened; upgrading does not interrupt a working connection solely
-to change its timeout.
-
-`syq persist status --json` reports the persistence setting, scope, and one
-entry per endpoint. Each entry includes its state (`starting`, `connecting`,
-`ready`, `reconnecting`, `failed`, or `inactive`), whether ordinary SSH is connected,
-and receiving state and errors. With receiving enabled, `ready` means that the
-return connection is online; ordinary SSH can reconnect on its next use.
-Inspecting status does not start connections. A configuration failure is shown
-as `failed`; correct it and run `syq persist connect server` to retry. If receiving
-preferences cannot be read, status still lists SSH connections. JSON includes
-`receiving_error`, and each connection's `receiving_enabled` is `null` because
-the setting could not be determined.
-
-For an isolated script, `syq persist on --ephemeral` prints a scope path;
-pass it to `syq persist connect server --pscope PATH` and later copy commands.
-`syq persist off --pscope PATH` closes it without changing the user setting.
-Ephemeral scopes reuse forward SSH logins only: they do not enable return copies,
-forwarded authorization, or commands on your machine. SSH logins expire five
-minutes after their last session closes. An unused helper pool can hold a session
-for another five minutes, so an abandoned script leaves at most ten idle minutes
-of connection reuse. Closing the scope explicitly ends both immediately.
-
-Syq 0.4.1 also enabled receiving in ephemeral scopes. Replacing the executable
-does not replace background receivers that are already running, so those old
-receivers can keep working until stopped. Running an old executable can start
-them again. With the current executable, `syq persist receive on` stops existing
-receivers to apply the settings and restarts them only for durable persistence.
-
-To replace an old ephemeral scope, close it with
-`syq persist off --pscope PATH` and create a new one. If your script needs
-return copies or commands, use `syq persist connect server` without `--pscope`
-to establish a durable connection.
+See [background connections](receive.md#background-connections) for reconnecting,
+turning receiving off, and using persistence in scripts.

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,40 +26,25 @@ Compare syq with rsync on your own machines, or with rsync and cp locally:
 curl --proto '=https' --tlsv1.2 -fLsS https://raw.githubusercontent.com/greaber/syq/master/scripts/try-benchmark.sh | bash
 ```
 
-Choose a local or SSH copy and a workload. The script automatically sizes
-throwaway data with syq and cleans up afterward. No syq-bench install is needed;
-if syq is missing, it offers to install it.
+Choose an SSH copy to compare syq with rsync, or a local copy to include cp.
+The script creates test data, checks the copied contents, and cleans up afterward.
+If syq is missing, it offers to install it. See [quick comparison](speed.md#quick-comparison)
+to download the script and run it again.
 
 <figure class="benchmark-example">
-<div class="benchmark-example-grid">
-<section aria-label="Example benchmark choices">
-<div class="visual-step">1 <span>Choose your test</span></div>
-<dl class="benchmark-choices">
-<dt>Copy where?</dt><dd>local</dd>
-<dt>Workloads?</dt><dd>both</dd>
-<dt>Test size</dt><dd>automatic by default</dd>
-</dl>
-<p class="visual-note">Results pictured: fixed-size sample<br>64 MiB + 1,024 files of 8 KiB</p>
-</section>
-<section aria-label="Example benchmark results">
-<div class="visual-step">2 <span>Compare the results</span></div>
 <table>
-<caption>Mean MB/s · higher is faster · 3 trials</caption>
-<thead><tr><th scope="col">Tool</th><th scope="col">Large file</th><th scope="col">Small files</th></tr></thead>
+<caption>Published example: Germany → US East Coast</caption>
+<thead><tr><th scope="col">Tool</th><th scope="col">Average speed</th></tr></thead>
 <tbody>
-<tr><th scope="row">syq</th><td>710.0</td><td>50.1</td></tr>
-<tr><th scope="row">rsync</th><td>567.3</td><td>71.1</td></tr>
-<tr><th scope="row">cp</th><td>1379.1</td><td>160.4</td></tr>
+<tr><th scope="row">syq</th><td>159.1 MB/s</td></tr>
+<tr><th scope="row">syq over SSH</th><td>87.2 MB/s</td></tr>
+<tr><th scope="row">rsync</th><td>18.0 MB/s</td></tr>
 </tbody>
 </table>
-<p class="visual-note">✓ Copied contents checked</p>
-</section>
-</div>
-<figcaption>Speeds from a fixed-size local sample, not a speed promise. Your results will differ.</figcaption>
+<figcaption>One 1.07 GB file, held in memory at both ends; three runs per tool.
+From the separate <a href="https://greaber.github.io/syq-bench/all-results.html#public-wan-forward">syq-bench project</a>,
+which provides more extensive benchmarks. Your results will depend on your machines and connection.</figcaption>
 </figure>
-
-For requirements, options and how to read the results, see
-[the benchmark guide](speed.md#quick-comparison).
 
 ## Updates
 

--- a/docs/persistence-reference.md
+++ b/docs/persistence-reference.md
@@ -1,0 +1,142 @@
+# Persistence details
+
+For everyday setup, start with [Send files home from a server](receive.md).
+
+## Names and profiles
+
+Give different receiving locations their own names:
+
+```sh
+syq persist receive on --name laptop --cwd ~
+syq persist receive on --name project --root ~/work/project
+syq persist connect server
+```
+
+Both names work from the same server account: `syq cp results --to @project`
+and `syq cp report.pdf --to @laptop`. Each profile has its own directory, copy
+root, limits, approval policy, and background connection to each connected server.
+New profiles start with the usual defaults, including asking for approval; they
+do not inherit another profile's trust or confinement settings. Up to 32 profiles
+can be saved.
+
+`receive on --name NAME` creates a profile or updates that name's settings.
+Without `--name`, `receive on` updates the first saved profile, shown first by
+`receive status`. The initial hostname profile becomes a saved profile when
+persistence first connects; adding a new name then keeps that original profile.
+If no preferences have been saved yet, the first explicitly chosen name replaces
+the implicit hostname default.
+
+```sh
+syq persist receive status
+syq persist receive status --name project
+syq persist receive off --name project
+syq persist receive on --name project
+syq persist receive remove project
+syq persist receive wait server --name laptop --timeout 30
+```
+
+Updating, stopping, or removing a profile cancels only that profile's copies,
+commands, and pending approvals. Other profiles keep working. `receive off`
+without a name stops all profiles; `receive on` enables the first profile, and
+`receive on --name NAME` enables another. Removing the first profile makes the
+next saved profile the default. The last profile can be disabled but cannot be
+removed. `pending`, `approve`, and `deny` work across all profiles; prompts name
+the receiving profile. Without `--name`, `receive wait` waits for every enabled
+profile on that server.
+
+Names belong to a server account. Different laptops can receive through the same
+account under different names. If a name already has a live connection, another
+client's attempt is rejected without disturbing the existing connection. Other
+profiles remain usable. Choose a different name, or stop the original connection
+and run `syq persist connect server` on the waiting client to retry.
+
+## Directories
+
+`--cwd` chooses the starting directory; `--root` also contains copies within it.
+Both require an existing directory with a UTF-8 path. Invalid settings leave the
+saved configuration unchanged. If a saved directory disappears, you can still
+inspect, disable, or reconfigure the profile. Filenames inside it may use normal
+Unix filename bytes.
+
+## Copy limits
+
+Copies support directories, symlinks, modification times, filters, hashing,
+resume, mappings, `--preserve=permissions`, `--verify-only`, and the
+[overwrite policies](reference.md#choose-which-existing-files-to-update).
+Ownership and special-file preservation, `--inplace`, and `--min-size` are
+unsupported. Timestamp comparisons trust the source's reported modification
+times.
+
+Each copy is limited to 100 GiB and one million touched entries by default.
+Change these ceilings with `syq persist receive on --max-bytes 20G --max-entries 100000`.
+Lower limits requested by the sender also apply. Limits are per copy; repeated
+copies can fill the disk. Copies support at most 32 workers each.
+
+Pruning is disabled unless the laptop sets a positive `--max-delete`.
+A sending `--prune` command must also supply its own `--max-delete` ceiling,
+no higher than the laptop's. Validation failures leave the copy unstarted.
+Errors during copying fail visibly and may leave partial files for retry.
+The sender verifies a signed receipt before reporting success.
+
+## Connection lifetime and waits
+
+`persist on` enables persistence for subsequent syq SSH connections.
+`persist connect server` enables it and connects immediately. With receiving
+enabled, it waits until receiving is ready. `--timeout 30` limits that wait
+after SSH and helper setup, not authentication or installation. Failure leaves
+persistence enabled; a healthy connection is reused without cancelling requests.
+
+Connections have no idle expiry. Receiving reconnects after interruptions;
+other SSH logins reopen on their next use. Syq installs no login service, so
+connect again after reboot. Copies are not queued or retried automatically.
+A return copy must finish within seven days of approval.
+
+Use `syq persist receive wait server --timeout 30` to wait without starting or
+restarting a connection. On the server:
+
+```sh
+syq persist destinations list
+syq persist destinations wait laptop --timeout 30
+syq persist destinations forget laptop
+```
+
+`forget` removes a stale entry while its connection is stopped. For structured
+status and approval requests, see [connection status](automation.md#connection-status).
+
+## Isolated script scopes
+
+`syq persist on --ephemeral` prints a scope path. Pass it as `--pscope PATH`
+to `syq persist connect server` and subsequent copy commands, then close it
+with `syq persist off --pscope PATH`. This does not change your user setting.
+
+These scopes reuse SSH logins only. They do not enable receiving, authorization
+through your machine, or commands on it. Idle connections close within ten
+minutes, including helper sessions. Explicitly closing the scope ends reuse
+immediately. For return copies or commands, use persistence without `--pscope`.
+
+## Setup and recovery
+
+Linux desktop prompts need libnotify 0.7.10 or later and a running notification
+service. macOS uses a native dialog. Start receiving from a terminal in your
+desktop session. After changing sessions, run `syq persist receive off`, then
+enable the profiles you need from a terminal in the new session.
+
+`syq persist receive pending` shows complete requests and prompt errors.
+Overwrite warnings are advisory; destination entries can change before copying.
+`--notify off` selects terminal approval; `--notify desktop` restores prompts.
+
+Receiving uses syq's managed SSH connections. A second SSH hop does not carry
+your laptop's receiving name to another host. The server command uses the
+matching helper installed by the receiving connection. If it is missing or an
+option is unsupported, update syq on both machines and reconnect from the laptop.
+
+## Updating connections
+
+Before upgrading, run `syq persist off` on the receiving machine to stop its
+background services. Replacing the executable alone does not update running
+services. Close script scopes with `syq persist off --pscope PATH` too.
+After upgrading both machines, run `syq persist connect server` for each server.
+
+Saved names, directories, and limits carry over. Settings predating approval
+prompts require approval after upgrading. Older binaries may not read updated
+preferences; use the newer binary to manage receiving.

--- a/docs/persistence-reference.md
+++ b/docs/persistence-reference.md
@@ -125,10 +125,19 @@ enable the profiles you need from a terminal in the new session.
 Overwrite warnings are advisory; destination entries can change before copying.
 `--notify off` selects terminal approval; `--notify desktop` restores prompts.
 
-Receiving uses syq's managed SSH connections. A second SSH hop does not carry
-your laptop's receiving name to another host. The server command uses the
-matching helper installed by the receiving connection. If it is missing or an
-option is unsupported, update syq on both machines and reconnect from the laptop.
+Start the connection from your laptop with `syq persist connect server`.
+Opening a plain SSH session does not enable receiving, and connecting onward
+from that server to another host does not carry your laptop's receiving name
+with you.
+
+For automatic reconnection to work, your SSH key or agent must be available and
+the server's host key must already be trusted. The background service cannot
+ask for a password. The server must allow remote Unix socket forwarding;
+OpenSSH 9.2 also requires permission for remote TCP forwarding.
+
+The server command uses the matching helper installed by the receiving
+connection. If that helper is missing or does not recognize an option, update
+syq on both machines and reconnect from your laptop.
 
 ## Updating connections
 

--- a/docs/receive.md
+++ b/docs/receive.md
@@ -44,84 +44,34 @@ local approval, to build a project there or open a copied artifact.
 
 ## Multiple receiving profiles
 
-Give different receiving locations their own names:
+Give a project its own receiving name and directory:
 
 ```sh
-syq persist receive on --name laptop --cwd ~
 syq persist receive on --name project --root ~/work/project
 syq persist connect server
 ```
 
-Both names work from the same server account: `syq cp results --to @project`
-and `syq cp report.pdf --to @laptop`. Each profile has its own directory, copy
-root, limits, approval policy, and background connection to each connected server.
-New profiles start with the usual defaults, including asking for approval; they
-do not inherit another profile's trust or confinement settings. Up to 32 profiles
-can be saved.
+Then run `syq cp results --to @project` on the server. The directory must already
+exist. Each name has its own settings and approval policy, so you can keep a
+project separate from your general `laptop` destination.
 
-`receive on --name NAME` creates a profile or updates that name's settings.
-Without `--name`, `receive on` updates the first saved profile, shown first by
-`receive status`. The initial hostname profile becomes a saved profile when
-persistence first connects; adding a new name then keeps that original profile.
-If no preferences have been saved yet, the first explicitly chosen name replaces
-the implicit hostname default.
-
-```sh
-syq persist receive status
-syq persist receive status --name project
-syq persist receive off --name project
-syq persist receive on --name project
-syq persist receive remove project
-syq persist receive wait server --name laptop --timeout 30
-```
-
-Updating, stopping, or removing a profile cancels only that profile's copies,
-commands, and pending approvals. Other profiles keep working. `receive off`
-without a name stops all profiles; `receive on` enables the first profile, and
-`receive on --name NAME` enables another. Removing the first profile makes the
-next saved profile the default. The last profile can be disabled but cannot be
-removed. `pending`, `approve`, and `deny` work across all profiles; prompts name
-the receiving profile. Without `--name`, `receive wait` waits for every enabled
-profile on that server.
-
-Names belong to a server account. Different laptops can receive through the same
-account under different names. If a name already has a live connection, another
-client's attempt is rejected without disturbing the existing connection. Other
-profiles remain usable. Choose a different name, or stop the original connection
-and run `syq persist connect server` on the waiting client to retry.
+Use `syq persist receive status` to list profiles and
+`syq persist receive off --name project` to stop one. See
+[profile management](persistence-reference.md#names-and-profiles) for more options.
 
 ## Approving copies
 
-Desktop approval needs a running notification service on Linux (libnotify
-0.7.10 or later); macOS uses a native dialog. Start receiving from a terminal
-in your desktop session. After changing sessions, run `syq persist receive off`,
-then enable the profiles you need from a terminal in the new session.
-
-An overwrite warning means the destination exists or could not be checked.
-The check is only advisory: files can change before the copy runs. Review
-**Details** or `persist receive pending` for the full permissions and limits,
-especially before allowing overwrites or deletion.
-
-You can also decide from any local terminal:
+Approve or deny from the desktop prompt, or from a terminal on your laptop:
 
 ```sh
 syq persist receive pending
-syq persist receive pending --wait --timeout 30 --json
 syq persist receive approve REQUEST_ID
 syq persist receive deny REQUEST_ID
 ```
 
-Use the complete ID printed by `pending`. Each ID works once for that request.
-Requests expire after five minutes. Disconnecting the sender, losing the return
-connection, changing receiving settings, or stopping receiving cancels pending
-requests. An approval cannot carry over to a reconnected or retried copy.
-One request may await approval per profile per server connection; other senders must retry.
-
-If a desktop prompt is unavailable or dismissed without a decision, the copy
-stays pending for a local command until it expires. `persist receive pending` shows prompt
-errors. A missing notification service never grants permission. To use only
-terminal approval, set `syq persist receive on --notify off`; `--notify desktop` restores
-prompts.
+Requests expire after five minutes. If a prompt is missing or dismissed, the
+request stays pending; it is never approved automatically. To use only terminal
+approval, run `syq persist receive on --notify off`.
 
 For unattended copies from trusted server accounts, explicitly enable automatic
 approval:
@@ -131,18 +81,11 @@ syq persist receive on --approve always
 syq persist receive on --approve ask   # require approval again
 ```
 
-Automatic approval trusts every process running as those server accounts,
-including for overwrites. An approved copy can inspect destination entries
-needed for copying, write unwanted content, or consume disk space within its
-limits. The server does not receive your SSH agent. [Command requests](exec.md) require
-a separate local decision for every execution, including when copies are
-automatically approved.
-
-To send files from that server to another SSH host using this machine's
-permission, use `syq cp results --to hostB`. Eligible copies discover a live
-receiving machine automatically; `--auth-from @laptop` selects one explicitly
-and `--auth-from ssh` uses the server's own SSH access. These requests always
-need a local decision. See [Start a copy from the source server](remote-to-remote.md#start-a-copy-from-the-source-server).
+Automatic approval trusts all processes running as the connected server accounts,
+including for overwrites. [Commands](exec.md) and
+[copies to another server](remote-to-remote.md#start-a-copy-from-the-source-server)
+still require separate approval. See [persistence security](security.md#persistent-connections)
+for the trust boundary.
 
 ## Names and paths
 
@@ -168,112 +111,47 @@ The root itself cannot be replaced with `--as .`. Changing to `--cwd` removes
 containment. Changing a profile’s settings closes its existing return copies
 before restarting that profile with the new settings. Other profiles keep running.
 
-Explicit `--cwd` and `--root` paths must name existing directories with UTF-8
-paths; invalid paths leave saved settings unchanged. If a saved directory later
-disappears, you can still inspect, disable, or reconfigure its profile. Names
-inside receiving directories may use normal Unix filename bytes. Syq protects its own receiving control files,
-executable, and SSH authority files from return copies even without `--root`.
+Syq also protects its own receiving files, executable, and SSH authority files
+from incoming copies. See [directory requirements](persistence-reference.md#directories)
+if a receiving location cannot be opened.
 
 ## Copy permissions and limits
 
-Copies support directories, symlinks, modification times, filters, hashing,
-resume, mappings, `--preserve=permissions`, `--verify-only`, and the
-[overwrite policies](reference.md#choose-which-existing-files-to-update).
-Ownership and special-file preservation, `--inplace`, and `--min-size` are
-unsupported. Timestamp comparisons trust the source's reported modification
-times.
+By default, each copy is limited to 100 GiB and one million entries. Pruning
+requires a positive deletion limit on both machines. Change limits with
+`syq persist receive on --max-bytes SIZE --max-entries N --max-delete N`.
 
-Each copy is limited to 100 GiB and one million touched entries by default.
-Change these ceilings with `syq persist receive on --max-bytes 20G --max-entries 100000`.
-Lower limits requested by the sender also apply. Limits are per copy; repeated
-copies can fill the disk. Copies support at most 32 workers each.
-
-Pruning is disabled unless the laptop sets a positive `--max-delete`.
-A sending `--prune` command must also supply its own `--max-delete` ceiling,
-no higher than the laptop's. Validation failures leave the copy unstarted.
-Errors during copying fail visibly and may leave partial files for retry.
-The sender verifies a signed receipt before reporting success.
+Most copy options work here; ownership and special-file preservation,
+`--inplace`, and `--min-size` are unsupported. See
+[copy limits](persistence-reference.md#copy-limits) for details.
 
 ## Background connections
 
-```sh
-syq persist status
-syq persist status --json
-syq persist connect server
-syq persist receive off
-syq persist receive on
-syq persist off
-```
+Use `syq persist status` to inspect connections. `syq persist receive off`
+stops receiving; `syq persist off` also closes reusable SSH logins.
 
-`persist receive off` stops receiving while keeping SSH persistence enabled.
-`persist receive on` enables it again. `persist off` closes both directions.
-You can also enable persistence ahead of your next copy with `syq persist on`.
-
-Connections have no idle expiry. Receiving reconnects after network interruptions
-or laptop sleep; other SSH connections reopen on their next use. Interrupted
-copies fail and are not queued or retried automatically. Rerun the copy after
-reconnection to resume it. A copy must finish within seven days of approval.
-After reboot, run `syq persist connect server` again; syq does not install a
-login service.
-
-Other processes running as your local user can reuse an open SSH login without
-another key touch or agent approval. Use `syq persist off` to close it.
-Incoming requests still need their own approval.
-
-If `syq persist status` reports a failure, correct the reported problem and run
-`syq persist connect server` to retry. Healthy connections and their requests
-keep working. `connect --timeout 30` limits the wait for receiving after SSH
-and helper setup; it does not limit authentication or installation. A failed
-connection leaves persistence enabled.
-
-To wait without starting or restarting a connection:
-
-```sh
-syq persist receive wait server --timeout 30
-```
-
-On the server, `syq persist destinations list` shows availability and
-`syq persist destinations wait laptop --timeout 30` waits for a destination.
-`syq persist destinations forget laptop` removes a stale entry while its
-connection is stopped. For scripts, see [JSON connection status](automation.md#connection-status).
+Receiving reconnects after a network interruption or laptop sleep. Rerun an
+interrupted copy to resume it. After reboot, run `syq persist connect server`
+again. If status reports a failure, fix the reported problem and run that
+command to retry.
 
 ### Persistence in scripts
 
-`syq persist on --ephemeral` prints a scope path. Pass it as `--pscope PATH`
-to `syq persist connect server` and subsequent copy commands, then close it
-with `syq persist off --pscope PATH`. This does not change your user setting.
-
-Ephemeral scopes reuse SSH logins only; they do not enable receiving,
-authorization through your machine, or commands on it. Idle connections close
-within ten minutes, including helper sessions. Close the scope explicitly to
-end reuse immediately. For return copies or commands, use
-`syq persist connect server` without `--pscope`.
+Scripts can use isolated SSH connection scopes and wait for destinations to
+become available. See [persistence details](persistence-reference.md).
 
 ## SSH setup
 
-Automatic receiving applies to syq's managed persistent SSH connections.
-Opening an unrelated plain `ssh` session does not start it. A second SSH hop
-does not automatically carry the laptop's destination through to another host.
+Start receiving with syq from your laptop; an unrelated `ssh` session does not
+start it. Reconnection needs an available SSH key or agent and a trusted host
+key. Background receiving cannot ask for a password.
 
-Reconnects require an available SSH key or agent and a trusted server host key.
-No agent is forwarded. The server must permit remote Unix socket forwarding;
-OpenSSH 9.2 also requires remote TCP forwarding permission. Syq does not change
-server configuration. `persist receive status` reports setup errors; after correcting one,
-run `syq persist connect server` to retry. A failed return setup does not
-invalidate an ordinary copy.
-
-The server can run a different syq build: it uses the matching helper installed
-by your receiving connection. If that helper is missing or an option is
-unsupported, update syq on both machines and reconnect from the receiving
-machine.
+The server must permit remote Unix socket forwarding. OpenSSH 9.2 also needs
+remote TCP forwarding permission. If receiving cannot start, inspect
+`syq persist receive status`; see [setup and recovery](persistence-reference.md#setup-and-recovery).
 
 ### Updating receiving connections
 
-Before upgrading, run `syq persist off` on the receiving machine to stop its
-background services. Replacing the executable alone does not update running
-services. Close any script scopes with `syq persist off --pscope PATH` too.
-After upgrading both machines, run `syq persist connect server` for each server.
-
-Saved receiving names, directories, and limits carry over. Settings that predate
-approval prompts require approval after upgrading. Older binaries may be unable
-to read updated preferences; use the newer binary to manage receiving.
+Stop persistence before upgrading, then reconnect with the updated syq.
+See [updating connections](persistence-reference.md#updating-connections) for
+script scopes and saved settings.

--- a/docs/receive.md
+++ b/docs/receive.md
@@ -10,14 +10,12 @@ With syq installed on both machines, connect from your laptop:
 syq persist connect server
 ```
 
-This enables persistence and waits until receiving is ready. You can run it
-again to reuse a working connection or recover a stopped service. Alternatively,
-`syq persist on` starts receiving with later ordinary syq connections.
+This keeps a connection open so the server can send files back to your laptop.
+Once the command finishes, you can close the terminal and continue working on
+the server. By default, your laptop is available under its short hostname, and
+received files go into your home directory.
 
-When syq connects to an SSH server, it also starts a background return
-connection. The default destination name is your laptop's short hostname,
-and files go into your home directory. No receiving terminal needs to stay open.
-To choose a name and a different starting directory:
+To give it the name `laptop` and choose a different starting directory:
 
 ```sh
 mkdir -p ~/Downloads/server
@@ -89,15 +87,14 @@ for the trust boundary.
 
 ## Names and paths
 
-A bare name uses a live return connection before trying an SSH host of the same
-name. When the laptop is offline, the name falls back to ordinary SSH resolution
-and authentication. Use `--to @laptop` to require a return connection: that form
-fails while offline and never tries SSH. After selecting a return connection,
-a denied or interrupted copy fails; it does not switch destinations.
+When you use `--to laptop`, syq looks for a connected receiving machine with
+that name. If it is offline, syq tries an SSH host called `laptop` instead.
+Use `--to @laptop` when you want the command to fail if your laptop is offline.
+Once a copy starts, it keeps the same destination even if the connection fails.
 
-`--cwd` chooses the starting directory. Destination `--into` and `--as` paths
-are relative to it, but absolute paths and `..` can select other locations.
-With no placement, `--to laptop` means `--into .` there.
+The directory you set with `--cwd` is where incoming copies start. You can
+choose a path relative to it with `--into` or `--as`, or use an absolute path
+to copy elsewhere. Without either option, files go into the starting directory.
 
 To contain copies within a directory instead:
 
@@ -105,11 +102,13 @@ To contain copies within a directory instead:
 syq persist receive on --name laptop --root ~/Downloads/server
 ```
 
-`--root` sets both the starting directory and the boundary. It rejects absolute
-paths and `..`, and copies cannot traverse symlinks to escape that directory.
-The root itself cannot be replaced with `--as .`. Changing to `--cwd` removes
-containment. Changing a profile’s settings closes its existing return copies
-before restarting that profile with the new settings. Other profiles keep running.
+With `--root`, all incoming copies must stay inside that directory. Absolute
+paths and `..` are rejected, and symlinks cannot lead outside it. A copy cannot
+replace the root itself with `--as .`. Switching back to `--cwd` removes this
+restriction.
+
+Changing a profile's settings stops its active copies so the new settings can
+take effect. Other profiles keep working.
 
 Syq also protects its own receiving files, executable, and SSH authority files
 from incoming copies. See [directory requirements](persistence-reference.md#directories)
@@ -125,33 +124,20 @@ Most copy options work here; ownership and special-file preservation,
 `--inplace`, and `--min-size` are unsupported. See
 [copy limits](persistence-reference.md#copy-limits) for details.
 
+<a id="ssh-setup"></a>
+<a id="persistence-in-scripts"></a>
+<a id="updating-receiving-connections"></a>
+
 ## Background connections
 
-Use `syq persist status` to inspect connections. `syq persist receive off`
-stops receiving; `syq persist off` also closes reusable SSH logins.
+You can inspect your connections with `syq persist status`. To stop receiving
+while keeping SSH connections open for your own copies, run
+`syq persist receive off`. Use `syq persist off` to close both directions.
 
-Receiving reconnects after a network interruption or laptop sleep. Rerun an
-interrupted copy to resume it. After reboot, run `syq persist connect server`
-again. If status reports a failure, fix the reported problem and run that
-command to retry.
+After a network interruption or laptop sleep, syq reconnects automatically.
+An interrupted copy still needs to be rerun so it can resume. After rebooting
+your laptop, run `syq persist connect server` again.
 
-### Persistence in scripts
-
-Scripts can use isolated SSH connection scopes and wait for destinations to
-become available. See [persistence details](persistence-reference.md).
-
-## SSH setup
-
-Start receiving with syq from your laptop; an unrelated `ssh` session does not
-start it. Reconnection needs an available SSH key or agent and a trusted host
-key. Background receiving cannot ask for a password.
-
-The server must permit remote Unix socket forwarding. OpenSSH 9.2 also needs
-remote TCP forwarding permission. If receiving cannot start, inspect
-`syq persist receive status`; see [setup and recovery](persistence-reference.md#setup-and-recovery).
-
-### Updating receiving connections
-
-Stop persistence before upgrading, then reconnect with the updated syq.
-See [updating connections](persistence-reference.md#updating-connections) for
-script scopes and saved settings.
+If a connection fails to start, `syq persist receive status` shows the error.
+The [persistence reference](persistence-reference.md) covers troubleshooting,
+upgrading, and using connections in scripts.

--- a/docs/receive.md
+++ b/docs/receive.md
@@ -33,15 +33,11 @@ syq cp results --to laptop
 syq cp report.pdf --to laptop --as reports/latest.pdf
 ```
 
-Receiving is enabled by default with durable persistence. Each incoming copy waits for
-approval **on your laptop** before it can inspect or change destination entries.
-The prompt puts the destination first, followed by the connected server account
-and permission to change files. A positive deletion limit is shown too. Choose
-**Allow once** or **Deny**. On macOS, **Details** shows the full explanation,
-including size and entry limits; **Back** returns to the short view. On either
-platform, `syq persist receive pending` shows the complete request. Allowing a
-copy trusts the server to supply its contents: syq cannot prove what you typed in the remote
-shell or that the files contain what you intended.
+Each incoming copy waits for approval **on your laptop** before it can inspect
+or change destination entries. Review the destination and permissions, then
+choose **Allow once** or **Deny**. Use **Details** on macOS or
+`syq persist receive pending` in a local terminal to see the complete request.
+Approving a copy trusts the server to supply its contents.
 
 You can also [run commands on the receiving machine](exec.md), with separate
 local approval, to build a project there or open a copied artifact.
@@ -94,31 +90,17 @@ client's attempt is rejected without disturbing the existing connection. Other
 profiles remain usable. Choose a different name, or stop the original connection
 and run `syq persist connect server` on the waiting client to retry.
 
-Existing single-profile preferences become the first profile, preserving their
-settings. The new preferences format cannot be read by syq 0.5.1 or earlier;
-use the newer binary to manage it. After upgrading, run `syq persist connect
-server` for each server to replace older background services. This does not
-change saved enrollments, grants, receipts, or partial copies.
-
 ## Approving copies
 
-On Linux, desktop prompts use `/usr/bin/notify-send` with action support
-(libnotify 0.7.10 or later) and your desktop notification service. On macOS,
-syq opens a native dialog through `/usr/bin/osascript`, with Allow once on the
-left and Deny on the right. Deny remains the highlighted default and the
-Return/Escape action in both the short and detailed views. Opening Details does not approve
-the request or extend its five-minute deadline. The background connection
-inherits the desktop session in which you start it. After changing desktop sessions, run `syq persist receive off`, then enable the
-profiles you need from a terminal in the current session to restart receiving.
+Desktop approval needs a running notification service on Linux (libnotify
+0.7.10 or later); macOS uses a native dialog. Start receiving from a terminal
+in your desktop session. After changing sessions, run `syq persist receive off`,
+then enable the profiles you need from a terminal in the new session.
 
-The short copy prompt warns about overwrites when a destination entry already
-exists, including a merge into an existing directory. It omits that warning
-when a quick local check finds all the requested destination names absent.
-Syq checks only a small number of names, without scanning directory contents;
-it shows a caution if the request is too large or inspection fails. For a copy
-to another SSH host, the destination is not checked before approval.
-The check is advisory: entries can change before the copy runs. Details and
-`persist receive pending` always show the full permitted copy policy and limits.
+An overwrite warning means the destination exists or could not be checked.
+The check is only advisory: files can change before the copy runs. Review
+**Details** or `persist receive pending` for the full permissions and limits,
+especially before allowing overwrites or deletion.
 
 You can also decide from any local terminal:
 
@@ -170,11 +152,6 @@ and authentication. Use `--to @laptop` to require a return connection: that form
 fails while offline and never tries SSH. After selecting a return connection,
 a denied or interrupted copy fails; it does not switch destinations.
 
-Names belong to live connections, not permanent registrations. A second live
-connection cannot advertise the same name on the same server account. When a
-connection closes, its name becomes available again. Choose distinct names for
-different laptops.
-
 `--cwd` chooses the starting directory. Destination `--into` and `--as` paths
 are relative to it, but absolute paths and `..` can select other locations.
 With no placement, `--to laptop` means `--into .` there.
@@ -199,15 +176,12 @@ executable, and SSH authority files from return copies even without `--root`.
 
 ## Copy permissions and limits
 
-Each request is checked on the laptop before syq issues permission for that
-copy. The restricted filesystem executor then checks individual operations.
-Directory recursion, symlinks, modification times, filters, hashing, resume,
-and staged publication work as in other syq copies. `--preserve=permissions`,
-`--verify-only`, `--only-new`, `--only-existing`, `--skip-newer`, and mappings
-are supported. Ownership, special-file preservation, `--inplace`, and
-`--min-size` are refused. Timestamp selection uses source-supplied modification
-times; a compromised source can invent those times. The receiver still enforces
-the approved destination paths, operations, and limits.
+Copies support directories, symlinks, modification times, filters, hashing,
+resume, mappings, `--preserve=permissions`, `--verify-only`, and the
+[overwrite policies](reference.md#choose-which-existing-files-to-update).
+Ownership and special-file preservation, `--inplace`, and `--min-size` are
+unsupported. Timestamp comparisons trust the source's reported modification
+times.
 
 Each copy is limited to 100 GiB and one million touched entries by default.
 Change these ceilings with `syq persist receive on --max-bytes 20G --max-entries 100000`.
@@ -231,36 +205,49 @@ syq persist receive on
 syq persist off
 ```
 
-`persist receive off` stops receiving while keeping ordinary SSH persistence enabled.
-`persist receive on` enables it again and can restart previously connected endpoints
-in durable persistence.
-`persist off` stops both kinds of connection. Ephemeral scopes selected with
-`--pscope` only reuse forward SSH connections; they do not enable receiving.
+`persist receive off` stops receiving while keeping SSH persistence enabled.
+`persist receive on` enables it again. `persist off` closes both directions.
+You can also enable persistence ahead of your next copy with `syq persist on`.
 
-To wait for receiving without starting or restarting a connection, use:
+Connections have no idle expiry. Receiving reconnects after network interruptions
+or laptop sleep; other SSH connections reopen on their next use. Interrupted
+copies fail and are not queued or retried automatically. Rerun the copy after
+reconnection to resume it. A copy must finish within seven days of approval.
+After reboot, run `syq persist connect server` again; syq does not install a
+login service.
+
+Other processes running as your local user can reuse an open SSH login without
+another key touch or agent approval. Use `syq persist off` to close it.
+Incoming requests still need their own approval.
+
+If `syq persist status` reports a failure, correct the reported problem and run
+`syq persist connect server` to retry. Healthy connections and their requests
+keep working. `connect --timeout 30` limits the wait for receiving after SSH
+and helper setup; it does not limit authentication or installation. A failed
+connection leaves persistence enabled.
+
+To wait without starting or restarting a connection:
 
 ```sh
 syq persist receive wait server --timeout 30
 ```
 
-Return connections have no idle expiry. After a network interruption or laptop
-sleep, the laptop reconnects with delays of one to thirty seconds, including
-when a return-connection heartbeat times out. Ordinary
-reusable SSH logins in durable persistence also have no idle expiry and reconnect on the next use.
-An interrupted copy fails: rerun it after reconnection to reuse eligible partial files. Copies are
-not queued while offline. A copy must open its control channel within sixty
-seconds of authorization and finish within seven days. Closing that control
-channel revokes its workers and prevents further requests.
-
-If `syq persist status` reports a failed return connection, fix the reported
-configuration or permission problem and run `syq persist connect server` to retry
-that endpoint. A healthy connection is reused without cancelling its copies,
-commands, or pending approvals. There is no need to toggle receiving or persistence.
-
 On the server, `syq persist destinations list` shows availability and
-`syq persist destinations wait laptop --timeout 30` waits with a deadline. Stale records
-left by a crash do not reserve a name; `syq persist destinations forget laptop` removes
-one while its connection is stopped.
+`syq persist destinations wait laptop --timeout 30` waits for a destination.
+`syq persist destinations forget laptop` removes a stale entry while its
+connection is stopped. For scripts, see [JSON connection status](automation.md#connection-status).
+
+### Persistence in scripts
+
+`syq persist on --ephemeral` prints a scope path. Pass it as `--pscope PATH`
+to `syq persist connect server` and subsequent copy commands, then close it
+with `syq persist off --pscope PATH`. This does not change your user setting.
+
+Ephemeral scopes reuse SSH logins only; they do not enable receiving,
+authorization through your machine, or commands on it. Idle connections close
+within ten minutes, including helper sessions. Close the scope explicitly to
+end reuse immediately. For return copies or commands, use
+`syq persist connect server` without `--pscope`.
 
 ## SSH setup
 
@@ -275,35 +262,18 @@ server configuration. `persist receive status` reports setup errors; after corre
 run `syq persist connect server` to retry. A failed return setup does not
 invalidate an ordinary copy.
 
-The server command can be a different syq build from the receiving machine.
-It automatically hands the command to the matching helper already installed
-by the receiving machine's connection, including an explicit `--syq-path`.
-Arguments, working directory, stdin, and output streams are preserved.
-`--ignore-from` inputs are read once by the executing build after handoff,
-before requesting approval or opening result files. Inline patterns and input
-files keep their command-line order. The helper then requests approval and runs
-the copy using the receiving machine's build. A missing or replaced helper produces an error; reconnect with syq from
-the receiving machine to refresh it. An option unknown to that helper is
-rejected before approval.
+The server can run a different syq build: it uses the matching helper installed
+by your receiving connection. If that helper is missing or an option is
+unsupported, update syq on both machines and reconnect from the receiving
+machine.
 
-Handoff requires support in both installations. When upgrading from a build
-that required matching server and client commands, run `syq persist off` on
-the receiving machine before replacing the binaries on both machines. Then
-run `syq persist on` and connect to the server with syq again. This refreshes
-the helper and return registration without deleting preferences or enrollments.
+### Updating receiving connections
 
-Receiving preferences live in `receive.json` beside the ordinary persistence
-preferences, under `$XDG_CONFIG_HOME/syq` or `~/.config/syq`. Runtime services
-belong to their persistence scope. Transient server advertisements live in the
-private directory `~/.syq-destinations-v3`. These files do not change restricted
-receiver enrollments or signed-grant replay records.
+Before upgrading, run `syq persist off` on the receiving machine to stop its
+background services. Replacing the executable alone does not update running
+services. Close any script scopes with `syq persist off --pscope PATH` too.
+After upgrading both machines, run `syq persist connect server` for each server.
 
-Receiving settings from the earlier automatic-only format keep their name,
-directory, and limits when upgraded, but require approval. Syq saves the new
-format before starting or reusing a return service. After upgrading, run
-`syq persist receive on` to stop old receiving services, then connect to each server with
-the new syq build. Merely replacing the executable or inspecting status does
-not change a service that is already running. Older binaries reject the new
-preferences; use the newer binary to manage receiving, including `persist receive off`, before
-switching versions. Pending requests and approval decisions exist only in the
-running service, never in preference files.
+Saved receiving names, directories, and limits carry over. Settings that predate
+approval prompts require approval after upgrading. Older binaries may be unable
+to read updated preferences; use the newer binary to manage receiving.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -234,12 +234,10 @@ Rerun the same command. Completed files are skipped; partially copied files
 reuse matching blocks. By default, syq writes a partial file beside the
 destination and replaces the final file only when complete.
 
-Do not run the same logical copy twice concurrently: the runs share partial
-files. To abandon a copy, stop it and delete its hidden partial files from the
-destination. They are named `.FILENAME.syq-part.ID`, beside the intended final
-file; long names may be shortened or hashed. For example, a partial for
-`video.mp4` is `.video.mp4.syq-part.ID`. Use `ls -a` to see it, then `rm --`
-with its exact name. Keep partials belonging to copies still running.
+Running the same copy twice at once can cause errors as the runs share temporary
+files. Wait for it to finish or stop it before restarting. To abandon a copy,
+stop all its runs before removing hidden files with `.syq-part.` in their names
+at the destination.
 
 ## Check file contents
 
@@ -265,23 +263,30 @@ To compare without writing, use `--verify-only`:
 syq cp --verify-only --srcs-in project --into backup
 ```
 
-This hashes selected regular files even when size and modification time match,
-compares symlink targets, and checks selected directory and special-file types
-(and device identity). It reports differences and missing entries; either a
-difference or an inspection error makes the run fail. It does not compare
-permissions, ownership, or timestamps, or look for destination-only entries.
-Special files are selected only with `--preserve=specials`.
+This compares file contents, symlink targets, and entry types without writing.
+Missing or different entries make the command fail. It does not compare metadata
+or look for extra destination files.
 
-Source and destination contents stay unchanged; a requested results file is
-still written and remote helper setup may write cache files. Verification
-cannot combine with `--dry-run`, `--prune`, `--inplace`, or overwrite policies.
-Filters and size limits still select what is compared. Matching regular files
-appear as unchanged in [automation results](automation.md); no files or bytes
-are reported as transferred.
+For two servers, add `--coordinate-at local` to compare through your machine
+using ordinary SSH access, with no restricted receiver enrollment. This also
+supports `--results`. See [remote verification](remote-reference.md#verification).
 
-Restricted remote-to-remote verification requires an existing receiver
-enrollment; it will not install one. Use `--coordinate-at local` to compare
-through your machine, including when you need comparison results in JSON.
+## In-place writes
+
+By default, syq builds an updated file beside the old one and replaces it when
+complete. `--inplace` writes directly into the destination file instead:
+
+```sh
+syq cp --inplace large-file --to server --into /backup
+```
+
+This saves temporary disk space and can avoid copying unchanged data into a
+new file. Readers can see a mixture of old and new contents during the copy.
+If interrupted, the incomplete file stays at its final name until you finish
+the copy. Writes through a hard link also affect its other names.
+
+Use the default when other programs need to read a complete file throughout
+an update. [Copies sent back to your laptop](receive.md) do not support `--inplace`.
 
 ## Preserve metadata
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -21,14 +21,6 @@ syq cp -vv --stats project --into backup
 See [diagnosing a slow copy](speed.md#diagnose-a-slow-copy) for interpreting
 transport and performance details.
 
-To initiate a copy from a server to your laptop, use a [named receiving
-destination](receive.md), such as `syq cp results --to laptop`. `persist on`
-enables background receiving with later SSH connections; ephemeral `--pscope`
-connections do not enable it. Bare names prefer live return
-connections; `@laptop` requires one and fails while offline.
-You can also [request a command on the receiving machine](exec.md), such as
-`syq exec --on @laptop --cwd work/project -- cargo test`, with local approval.
-
 ## See where files go
 
 A named directory brings its name along. `--srcs-in` copies its contents;
@@ -97,34 +89,23 @@ Enclose IPv6 addresses in brackets: `alice@[2001:db8::1]:2222`.
 A colon in a native path is simply part of the path.
 
 For two remote endpoints, see [Copy between servers](remote-to-remote.md).
-From a server shell, `syq cp results --to hostB` automatically looks for a live
-receiving machine that can authorize the copy while data flows directly to
-hostB. Use `--auth-from @laptop` to select one, or `--auth-from ssh` to use
-SSH from this machine. See [authorization selection](remote-to-remote.md#start-a-copy-from-the-source-server)
-for ordering, supported options, and approval behavior. `--via @laptop` remains
-an alias for the explicit receiving-machine selection.
+To send files to your laptop from a server shell, see
+[Send files home from a server](receive.md).
 
 ## Progress
 
-When stderr is a terminal, syq shows one progress bar for the whole copy.
-The bar stays in place as files and workers change. It shows bytes processed
-out of the discovered total; while syq is still scanning, the percentage is
-unknown. Wider terminals also show elapsed time, speed, ETA, and file counts.
+Syq shows a progress bar when running in a terminal. It tracks bytes processed;
+while files are still being discovered, the percentage is unknown. Wider
+terminals also show elapsed time, speed, ETA, and file counts.
+
 Use `--progress` to force the display or `--no-progress` to hide it. `--quiet`
-hides it too. `--progress-json` selects JSON progress instead of the bar.
-JSON progress and warning records preserve their original string values,
-including Unicode characters; terminal escaping applies only to human output.
+hides it too. After five seconds without a byte update, `no update` shows how
+long it has been; this does not by itself mean the connection has failed.
+Wait for the final summary to confirm success, even if the byte bar looks full.
 
-The bar advances when syq processes a block or completes a file. On a slow
-link, or during a local server-side copy, it can stay at the same position
-for a while. After five seconds without a byte update, `no update` shows how
-long it has been; this does not mean the connection has failed. Syq does not
-guess extra completed bytes between updates. A final `done` or `incomplete`
-bar stays visible when the copy settles. Reaching the end of the byte bar
-alone does not mean all files have finished or that the copy succeeded.
-
-The bar also covers `syq rm`, counting entries instead of bytes. For scripts,
-use [results records](automation.md) rather than parsing the terminal bar.
+The bar also covers `syq rm`, counting entries instead of bytes.
+`--progress-json` provides JSON progress for displays; use
+[results records](automation.md) to track completion in scripts.
 
 ## Choose a destination
 
@@ -162,36 +143,27 @@ syq cp --only-new --srcs-in incoming --into archive
 syq cp --only-existing --srcs-in project --into deployed
 ```
 
-With `--only-new`, directories already present when syq first checks them keep
-their permissions, ownership, and timestamps. Missing children are still added.
-Adding children requires write access to that directory; syq does not
-temporarily widen its permissions. If access is denied, the entry fails
-and the copy reports an error. A dry run previews intended changes without
-testing whether writes will be permitted.
-Adding or removing children can change directory timestamps through normal
-filesystem behavior. Directories copied as new receive normal copy metadata.
-If several sources supply the same new directory, the last source supplies
-its metadata, as in a copy without `--only-new`.
-If a source directory meets an existing non-directory,
-it keeps the destination entry and skips that source subtree.
-`--only-existing` also skips a source directory and its subtree when the destination
-is missing or is not a directory. `--only-existing` cannot combine with
-`--into-new` or `--as-new`. These policies differ from
-`--into-existing` and `--as-existing`, which check the placement path only.
+`--only-new` keeps existing entries and their metadata, while adding missing
+children to existing directories. Those directories must be writable; syq
+does not change their permissions to add files. Adding children can still
+change directory timestamps. A dry run does not test write access.
+
+If a source directory meets an existing non-directory, `--only-new` skips that
+subtree. `--only-existing` skips a subtree when its destination is missing or
+is not a directory. It cannot combine with `--into-new` or `--as-new`.
+The placement options `--into-existing` and `--as-existing` check only the
+placement path, rather than every copied entry.
 
 `--skip-newer` compares timestamps, not the age of the contents. It affects only
-regular-file pairs: replacing a different entry type still occurs.
-Combine it with `--only-existing` to avoid creating missing entries too.
-`--only-new` cannot combine with either policy. Neither
-`--only-new` nor `--skip-newer` can combine with `--inplace`: an interrupted
-in-place write could otherwise leave an incomplete file that the next run skips.
+regular-file pairs; replacing a different entry type still occurs. Combine it
+with `--only-existing` to avoid creating missing entries too.
+
+`--only-new` cannot combine with either policy. Neither `--only-new` nor
+`--skip-newer` can combine with `--inplace`: an interrupted write could leave
+an incomplete file that the next run skips. Restricted receivers also refuse
+`--only-existing --inplace`.
 
 These options do not disable `--prune`; requested pruning still removes extras.
-Command-restricted copies support `--skip-newer` too. The comparison uses source
-timestamps, which a compromised source can invent. The receiver still enforces
-the permitted destination paths, operations, and limits; `--only-existing --skip-newer`
-also keeps the receiver's independent existing-object protection.
-The restricted path also refuses `--only-existing --inplace`.
 
 ## Preview changes
 
@@ -254,10 +226,7 @@ Ignored directories are not scanned. To keep part of one, include the parent:
 syq cp --ignore 'logs/*' --ignore '!logs/keep/' --srcs-in project --into backup
 ```
 
-Ignored paths are also protected from pruning. When pulling from another
-machine, syq independently checks the returned names and their ancestors.
-A source that returns an excluded path causes the copy to fail before that
-entry is planned.
+Ignored paths are also protected from pruning.
 
 ## Resume an interrupted copy
 
@@ -382,16 +351,7 @@ Use `--min-size` and `--max-size` to select regular files by size.
 For parallelism and bandwidth controls, see [Speed](speed.md). For scripts,
 see [Automation results](automation.md).
 
-At each command, `--help` (or `-h`) shows everyday options and lists the public
-subcommands. Commands for manual setup, recovery, or scripting have brief
-“Advanced” descriptions; `--help-all` expands their descriptions and lists all
-public options. For example, `syq receiver enroll --help` explains manual
-enrollment, and `syq receiver enroll --help-all` also shows the jump-host option.
-Use `syq help COMMAND` to read the same help without invoking the command.
-In `syq rsync`, `-h` means human-readable sizes; use `--help` for help.
-
-Helper overrides, ephemeral connection scopes, JSON status output, specialized
-receiving limits, and performance tuning appear in `--help-all`. Copies tune
-performance automatically; manual tuning is for troubleshooting and controlled
-experiments. `--bwlimit` stays in ordinary help because it sets how much
-bandwidth you want to use.
+Use `--help` (or `-h`) for everyday options and `--help-all` for the full list,
+including tuning, scripting, and manual setup. `syq help COMMAND` shows the
+same help without running the command. In `syq rsync`, `-h` means
+human-readable sizes; use `--help` for help.

--- a/docs/remote-reference.md
+++ b/docs/remote-reference.md
@@ -140,3 +140,20 @@ On this route, quoted `~` and `~/archive` select the destination account's home
 directory. Use `./~/archive` for a literal directory called `~`. Avoid
 `~//archive`: explicit receiving authorization keeps it under the home directory,
 but automatic selection uses ordinary SSH, where it resolves to `/archive`.
+
+## Verification
+
+For comparisons between two servers, `--coordinate-at local` uses ordinary
+SSH access from your machine to both endpoints. It needs no restricted receiver
+enrollment and supports `--verify-only --results FILE`. Files are hashed on
+the servers; your machine compares their hashes and receives listings and
+results, not the full file contents.
+
+Direct restricted verification requires an existing enrollment and cannot
+produce `--results`; a receiver receipt cannot attest to the source's comparison.
+Verification never installs an enrollment.
+
+`--verify-only` cannot combine with `--dry-run`, `--prune`, `--inplace`, or
+overwrite policies. Filters and size limits select the entries to compare;
+special files require `--preserve=specials`. Metadata is not compared, but device
+identity is. A requested results file and remote helper caches may still be written.

--- a/docs/remote-reference.md
+++ b/docs/remote-reference.md
@@ -23,16 +23,25 @@ SSH configuration, programs, or enrollment state. Manage that state with
 
 Repeating `enroll` updates the receiver to match your local build. A pending
 enrollment can be retried or revoked. Revoke and enroll again to rotate its
-receipt key. Revocation stops active receivers for that enrollment before
-removing its state; see [revocation and upgrades](remote-to-remote.md#first-copy-and-access-management)
-for interruption, retry, and older-receiver behavior.
+receipt key. Revocation stops active receivers before removing their state;
+see [access management](remote-to-remote.md#first-copy-and-access-management)
+for interruption and retry behavior.
 
-Enrollment detects the destination platform. When it matches your machine,
-setup uploads the running executable without a release download. For a different
-platform, official releases install the matching executable after verifying the
-signed release manifest and artifact. Source builds require matching platforms.
-Enrollment does not use `--syq-path`. See [Developing syq](development.md#direct-server-to-server-copies)
-for refreshing a receiver after rebuilding.
+Stop active copies before upgrading: replacing the executable does not update
+running receivers. Repeat `syq receiver enroll hostB:/destination` afterward
+to refresh the installed receiver. Compatible enrollment keys and replay records
+are preserved. Different client builds cannot share one installed receiver
+concurrently; each needs a matching receiver.
+
+An incompatible enrollment requires fresh setup, which needs ordinary SSH
+access. Eligible copies install it automatically, or you can use `enroll`.
+Incompatible old enrollments are not listed or removed by the new build;
+they require manual cleanup on both machines.
+
+Enrollment detects the destination platform and installs a matching executable.
+Source builds require compatible platforms; `--syq-path` does not select the
+restricted receiver. See [Developing syq](development.md#direct-server-to-server-copies)
+for testing source builds.
 
 ## Limits and unsupported options
 
@@ -61,17 +70,6 @@ workers from the source to the destination. Both transports share the same
 copy authorization, limits, revocation, and signed receipt. A failed direct
 connection never selects a relay through your machine; choose
 `--coordinate-at local` explicitly to send data through it.
-
-After upgrading syq, repeat `syq receiver enroll hostB:/destination` to refresh
-an older installed receiver before using the new build. Refresh preserves the
-enrollment keys and replay records. Older clients need a matching receiver
-build too; clients of different builds cannot share one installed receiver
-concurrently.
-
-TCP listeners must advertise a port in the requested range. An invalid port
-fails TCP setup before any address is probed. Special-file creation accepts
-only FIFO, socket, and device types; permission bits follow the grant's
-permission-preservation setting.
 
 ## Signed results
 
@@ -117,3 +115,28 @@ Save the reported remote log location. The log is not a signed receipt.
 If printing the location fails, the command reports an error but the job may
 still be running. The coordinating server needs `/bin/kill` and either
 `setsid` or `perl`.
+
+## Authorization selection
+
+For `syq cp` with local sources and an SSH destination, `--auth-from auto`
+tries live receiving machines in alphabetical order, allowing up to two seconds
+for each reply. Offline or unsupported connections are skipped. With none
+available, or with unsupported options, it uses the source machine's SSH access.
+Once approval is requested, refusal or failure ends the attempt.
+
+`--auth-from NAME` and `--auth-from @NAME` require that receiving machine.
+Names `ssh` and `auto` need the `@` prefix to distinguish them from the option
+values. `--via NAME` always means a receiving name. `--auth-from ssh` always
+treats `--to` as an SSH endpoint, even if it matches a receiving name.
+
+Authorization through a receiving machine does not support `--detach`, custom
+`--rsh` or `--syq-path`, `--no-bootstrap`, `--pscope`, alternative `--peer-auth`
+or `--coordinate-at`, `--no-tcp`, or `--tcp-plain`. It requires direct encrypted
+TCP from source to destination. Destination completion does not request
+permission through a receiving machine; use `--auth-from ssh` for completion
+through the source's own SSH access.
+
+On this route, quoted `~` and `~/archive` select the destination account's home
+directory. Use `./~/archive` for a literal directory called `~`. Avoid
+`~//archive`: explicit receiving authorization keeps it under the home directory,
+but automatic selection uses ordinary SSH, where it resolves to `/archive`.

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -31,21 +31,16 @@ ls -lh results
 syq cp results --to hostB --into /archive
 ```
 
-Syq looks for a live receiving machine automatically before trying SSH from
-hostA. It checks names in alphabetical order, allowing up to two seconds for
-each readiness reply, and uses the first available registration. If its build
-differs, the command automatically hands off to that machine's registered
-helper. Offline or unsupported registrations are skipped. With none available,
-it uses ordinary SSH. Options this route cannot support also use ordinary SSH automatically.
-A copy addressed to a live receiving name still goes to that machine itself.
+Syq uses the first available receiving machine in alphabetical name order.
+If none is available, or the requested options are unsupported on this route,
+it uses hostA's SSH access. A copy addressed to a live receiving name goes to
+that machine itself.
 
-These choices apply to `syq cp` with local sources and an SSH destination.
-To choose explicitly, use `--auth-from @laptop` (or `--auth-from laptop`).
-`--auth-from ssh` uses hostA's SSH access and interprets `--to` as an SSH
-endpoint, even if its bare name matches a receiving name. `--auth-from auto`
-is the default. Names `ssh` and `auto` need `@` with this option.
-The older `--via NAME` spelling remains an alias for `--auth-from @NAME`;
-every bare `--via` value is still a receiving name.
+Use `--auth-from @laptop` to choose your laptop explicitly, or `--auth-from ssh`
+to use hostA's SSH access. The default is `--auth-from auto`. `--via NAME` is
+an alias for choosing a receiving machine. See
+[authorization selection](remote-reference.md#authorization-selection) for
+name rules and route restrictions.
 
 The selected laptop asks for approval before contacting hostB. Approve with the desktop
 prompt or `syq persist receive pending` and `syq persist receive approve REQUEST_ID` on the laptop.
@@ -64,30 +59,15 @@ encrypted TCP. HostB must expose a [reachable data port](server-tuning.md#make-t
 to hostA. Failure to reach it fails the copy without switching to SSH data.
 
 The prompt shows the requested SSH endpoint and destination path. Relative
-destination paths start in that account's home directory on hostB. A quoted
-`~` or `~/archive` also uses hostB's home directory; use `./~/archive` to name a
-literal directory called `~`. On this route, `~//archive` also stays under that
-home directory. Automatic selection leaves `~//archive` on ordinary SSH,
-where that spelling resolves to `/archive`. Receiving `--cwd` and `--root` govern copies onto the laptop;
-they do not describe hostB's filesystem. Receiving byte, entry, and deletion
-ceilings still apply. The helper on hostB checks the approved copy permissions and protects its own
-control and SSH authority files. The source verifies its signed receipt before
-reporting success. No durable receiver enrollment or reusable grant is created.
+paths start in that account's home directory on hostB. Your laptop's receiving
+root does not contain this copy, but its byte, entry, and deletion limits still
+apply.
 
-The source command may be a different build: it invokes the laptop's registered
-helper before requesting approval. That helper and the helper started on hostB
-use the laptop's build. Keep the source command and the laptop's return
-connection alive until completion. Stopping receiving or
-losing that connection cancels the copy. After hostB approves setup, the source
-has 60 seconds to start its handshake and then 10 seconds to complete it.
-Retry with a new approval to resume eligible partial files. This route accepts
-local sources and an ordinary SSH `--to` endpoint. It does not accept `--detach`, custom `--rsh`/`--syq-path`,
-`--no-bootstrap`, `--pscope`, alternative `--peer-auth`/`--coordinate-at`,
-`--no-tcp`, or `--tcp-plain`. Copy permissions and supported filesystem options
-match [return copies](receive.md#copy-permissions-and-limits). These restrictions
-also determine whether automatic selection can use a receiving machine.
-Destination path completion never asks a receiving machine for authorization;
-use `--auth-from ssh` for completion through hostA's own SSH access.
+Keep the source command and your laptop's connection alive until completion.
+Stopping receiving or losing that connection cancels the copy. Retry with a
+new approval to resume it. Supported copy options match
+[return copies](receive.md#copy-permissions-and-limits), with additional
+[route restrictions](remote-reference.md#authorization-selection).
 
 ## What you need
 
@@ -117,12 +97,6 @@ syq receiver enroll hostB:/archive
 syq cp --dry-run -v --from hostA --srcs-in data --to hostB --into /archive
 ```
 
-After an incompatible upgrade, syq installs a fresh receiver on the next
-eligible copy. You can also prepare it explicitly with `syq receiver enroll`.
-Installing the receiver requires ordinary SSH access. Enrollments from an
-incompatible older version are not shown by `syq receiver list` or removed by re-enrollment; they require
-manual cleanup on both machines.
-
 Inspect or remove this access with:
 
 ```sh
@@ -141,10 +115,8 @@ If receivers have not stopped within ten seconds, revocation reports failure
 and keeps the enrollment marked revoked. Retry `receiver revoke` to finish
 cleanup; an enrollment with unfinished revocation cannot be refreshed.
 
-Before upgrading from released v0.4.1 or an older binary, stop its active copies:
-those running processes have no shutdown watcher. Updating the installed
-executable does not add revocation support to a process already running it.
-The seven-day finish window is unchanged.
+For upgrading or sharing a receiver between installations, see
+[enrollment details](remote-reference.md#enrollment).
 
 If your machine reaches hostB through hostA, add `--via hostA` to `enroll` or
 `revoke`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -61,44 +61,22 @@ reads still use its directory handles and refuse descendant symlink traversal.
 
 ## TCP data connections
 
-TCP workers authenticate with a token delivered through the control connection.
-Their ten-second Hello deadline remains active across partial reads, including
-when encryption is off. After Hello succeeds, it does not limit copy duration.
-There is no general coordinator I/O deadline: a stalled peer can leave a copy
-waiting until you cancel it.
+TCP workers authenticate using credentials delivered through the control
+connection. The initial handshake has a ten-second deadline, but there is no
+general copy I/O timeout: a stalled peer can leave a copy waiting until you
+cancel it.
 
-TCP discovery accepts at most 64 advertised addresses plus the SSH target,
-and at most 128 resolved socket addresses in total. Excessive replies fail
-TCP setup visibly; ordinary copies can still fall back to SSH data.
-
-Encrypted TCP rejects reused connection IDs and IDs outside its 24-bit nonce
-space. If a copying process exhausts those IDs, it reports an error; restart the
-copy to continue with a fresh session.
-
-Framed input has a separate memory allowance from the signed transfer's disk
-limits. Hello is limited to 1 MiB, ordinary metadata messages to 8 MiB, and
-bulk-data or hash messages to 65 MiB. Compression cannot bypass these limits;
-zstd windows are limited to 8 MiB. Both endpoints apply the smaller Hello
-limit before reading or decompressing its body.
-
-A shared 512 MiB allowance bounds decoded collection storage, including queued
-collections, because a short frame can advertise a very large collection.
-Exhaustion fails the connection visibly. Flat byte buffers, strings, and
-compression workspace use the frame-size limits and each connection's bounded
-queue instead of competing for that shared allowance. Their aggregate memory
-use grows with the connection count, request size, and pipeline depth; reduce
-those settings to use less memory. The collection allowance is not a limit on
-total process memory or disk usage.
+Syq bounds incoming messages, decompression, and decoded collections to limit
+memory use from malformed peers. These are not a total process memory cap;
+memory also grows with connection count and request size. Invalid replies
+fail the connection visibly. Ordinary copies can fall back to SSH if TCP setup
+fails, keeping the same endpoints.
 
 ## A compromised source server
 
-The coordinator rejects stat, apply, and partial-path replies whose entry
-counts differ from their requests. It also checks each source data block's
-offset and length against the outstanding read before forwarding it to the
-destination. An offset or length mismatch fails the copy and closes that
-worker's connections without reusing them for another file. These checks expose
-malformed replies; they cannot establish that a source's file listing or contents
-are truthful.
+Syq checks peer-supplied paths and data ranges before using them. These checks
+reject malformed replies; they cannot establish that a source's file listing
+or contents are truthful.
 
 For a default direct remote-to-remote copy, the source gets permission for one
 transfer, not your SSH agent or a reusable destination credential. The
@@ -128,8 +106,8 @@ an outbound connection maintained by your laptop. `persist on` enables this
 for syq's SSH connections by default. Each request requires approval on the
 receiving machine through a desktop prompt or `persist receive approve`. Paths and limits
 are validated before prompting; the restricted filesystem executor checks
-every operation after approval. The server receives no SSH agent or
-command-execution interface.
+every operation after approval. The server receives no SSH agent.
+[Commands](exec.md) need separate approval.
 
 Approval permits that pending copy's destination, overwrite policy, and limits.
 It does not authenticate what you typed on a remote server or attest to source

--- a/docs/security.md
+++ b/docs/security.md
@@ -145,8 +145,6 @@ host resolution. A copy never switches routes after selecting its destination.
   durability guarantee.
 - **Preserving authority is a choice.** Leave `--preserve=ownership` and
   `--preserve=permissions` off when copying from an untrusted source.
-- **Persistent logins stay usable.** Processes running as your local user
-  can reuse them until they close. Use `syq persist off` to end the window.
 - **Protocol assurance is still developing.** Syq's process protocol has
   not been fuzzed as extensively as rsync's.
 
@@ -199,3 +197,17 @@ and interruption behavior.
 
 Human copy listings escape control characters in filenames. Diagnostics also
 escape terminal control sequences from peers; NDJSON keeps its JSON encoding.
+
+## Persistent connections
+
+An open SSH login can be reused by other processes running as your local user
+without another key touch or agent approval. Persistence keeps that access
+available until the connection closes. `syq persist off` ends it; use
+`syq persist receive off` to stop incoming requests while keeping SSH reuse.
+
+Persistence also enables [receiving](#named-receiving-destinations) by default.
+Its approvals and copy limits are separate from the SSH login's authority.
+
+[Isolated script scopes](persistence-reference.md#isolated-script-scopes) reuse
+SSH logins without enabling receiving. Stop background services when upgrading;
+replacing a binary does not change services already running it.

--- a/docs/server-tuning.md
+++ b/docs/server-tuning.md
@@ -130,7 +130,7 @@ system settings:
 
 - **Transport and parallelism:** inspect the selected transport and connection
   count with `-vv --stats`. For a controlled worker-count comparison, use
-  `--connections N`; see [benchmark tuning](speed.md#benchmark-tuning). Use the
+  `--connections N`; see [benchmark tuning](tuning.md). Use the
   same reporting options in each run, and start with defaults for everyday
   copies. More workers need not help once storage or an NFS service is saturated;
   compare repeated runs before choosing a lower count.

--- a/docs/server-tuning.md
+++ b/docs/server-tuning.md
@@ -58,8 +58,7 @@ syq cp --tcp-congestion bbr --stats data --to server --into /backup
 This changes only syq's TCP sockets, not the host default. If BBR is missing,
 ask the server administrator to enable it; see the
 [BBR setup guidance](https://github.com/google/bbr/blob/master/Documentation/bbr-faq.md#how-can-i-try-out-linux-tcp-bbr).
-The option cannot tune SSH's own connections and is not supported by the
-restricted server-to-server receiver.
+The option cannot tune SSH's own connections.
 
 Compare with `--tcp-congestion cubic` using the same data and an empty test
 destination each time. Try both directions. Use `--bwlimit` if you need to
@@ -84,9 +83,8 @@ bursts from unrelated clients, so choose limits that suit the server.
 
 `MaxSessions` is a different limit: channels sharing one SSH connection.
 Very low values can force extra logins when syq tries to reuse a connection.
-Syq can start up to two data workers through the copy's control connection; other
-large-copy workers use independent connections. Raising this limit alone does
-not increase their capacity.
+Larger copies also open independent connections, so raising `MaxSessions` alone
+does not remove login limits.
 
 Validate configuration changes with `sshd -t`, then reload SSH using your
 system's normal procedure. Keep an administrative session open while doing

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -1,76 +1,31 @@
 # Speed
 
-Start with the defaults. Syq copies files in parallel and adjusts the connection
-count during a transfer. It uses encrypted TCP for data when reachable and SSH
-otherwise. Small copies avoid extra connections when setup would cost more
-than it saves.
-
-Measure your own workload before changing settings. Network distance, storage,
-file sizes, and how much data already exists at the destination all affect speed.
-
-## Benchmarks
-
-See the [published syq-bench results](https://greaber.github.io/syq-bench/)
-for comparisons with rsync, cp, and other tools, including the workloads,
-commands, and measured limitations. Use
-[syq-bench on your own machines](https://greaber.github.io/syq-bench/reproduce.html)
-to compare settings and track performance over time.
+Syq copies files in parallel and adjusts its connection count automatically.
+Start with the defaults. For repeated remote copies, [keep the connection
+open](install.md#keep-connections-open) to avoid logging in each time.
 
 ## Quick comparison
 
-The [interactive benchmark](install.md#try-a-benchmark) gives you a small
-comparison without installing a benchmark package. After downloading the
-script, you can repeat the same choices explicitly:
+Use the quick script to get a sense of performance on your own machines:
 
 ```sh
-bash try-benchmark.sh --yes --mode push --host server --workload both --rounds 3
-bash try-benchmark.sh --yes --mode local --source-dir /data --dest-dir /mnt/nfs --workload small
+curl --proto '=https' --tlsv1.2 -fLsS -o try-benchmark.sh \
+  https://raw.githubusercontent.com/greaber/syq/master/scripts/try-benchmark.sh
+bash try-benchmark.sh
 ```
 
-The script needs Bash, rsync, OpenSSL, Perl (with JSON::PP), and standard Unix
-utilities locally. Remote tests also need SSH access and rsync on the other
-machine. Use an SSH config alias for custom ports or IPv6. `--install` installs
-syq locally if missing; `--help` lists the choices.
+Choose an SSH copy to compare syq with rsync, or a local copy to include cp.
+The script creates test data, checks the copied contents, and cleans up afterward.
+Use `bash try-benchmark.sh --help` for options.
 
-Scratch parents must already exist. `--source-dir` is the local scratch parent;
-for SSH tests, `--dest-dir` is the remote one, including when pulling.
+## Benchmarks
 
-Automatic sizing increases throwaway data until a syq copy takes about five
-seconds, subject to available space. Setup and verification take additional
-time, and there is no fixed total runtime limit. To use a fixed workload:
+The separate [syq-bench project](https://greaber.github.io/syq-bench/) runs more
+extensive experiments across workloads, storage systems, and network routes.
+Browse its results, or [run its experiments](https://greaber.github.io/syq-bench/reproduce.html)
+for a more detailed comparison. The quick script above does not use syq-bench.
 
-| Option | Large file | Small files (8 KiB each) |
-|---|---|---|
-| `--size quick` | 64 MiB | 1,024 |
-| `--size medium` | 1 GiB | 4,096 |
-| `--size large` | 8 GiB | 16,384 |
-
-Each tool copies the same reproducible, hard-to-compress data into an empty
-destination. The script rotates tool order and checks contents after every
-trial. It compares syq's defaults with permissions preserved, `rsync -rpt`,
-and local `cp -pR`. A failed copy or content check stops the comparison.
-
-Results show mean, minimum, and maximum speed in decimal MB/s; higher is
-faster. Timings include process startup and buffered writes, but exclude data
-generation, sizing, and verification. Caches are not flushed, and copies do
-not wait for durable storage. Small tests can mostly measure startup costs;
-filesystem cloning can favor cp. Syq may be slower on your workload.
-
-The script cleans up its test data, including after Ctrl-C. If SSH is unavailable
-during cleanup, it reports the remote path to remove later. See the
-[published methodology](https://greaber.github.io/syq-bench/) for more controlled
-measurements.
-
-## When rsync or cp is faster
-
-- **Tiny jobs:** setup can cost more than the copy. [`syq persist on`](install.md#keep-connections-open) avoids
-  repeated logins.
-- **One spinning disk:** parallel reads can cause extra seeks. Try
-  `--connections 1`.
-- **Shifted file contents:** rsync can reuse data after an insertion changes
-  byte offsets. Syq's fixed-block resume resends the shifted tail.
-- **Storage-limited jobs:** extra network capacity cannot make a full-speed
-  disk write faster. Check disk and CPU use at both ends.
+<a id="when-rsync-or-cp-is-faster"></a>
 
 ## Diagnose a slow copy
 
@@ -78,214 +33,67 @@ measurements.
 syq cp -vv --stats data --to server --into /backup
 ```
 
-`-vv` shows the chosen transport and connections. `--stats` adds totals and
-available TCP statistics. Its copying interval measures file work, which can
-overlap setup; use total elapsed time when comparing complete commands.
+`-vv` shows the chosen transport and connections; `--stats` adds totals and
+available TCP statistics.
 
 | Symptom | Try |
 |---|---|
 | Data falls back to SSH | Check [TCP reachability](server-tuning.md#make-tcp-reachable) |
 | Many short commands spend time logging in | `syq persist on` |
-| A spinning disk is busy but throughput is poor | `--connections 1` |
 | CPU is saturated on a fast link | Compare with `--no-compress` |
-| A long-distance path suffers loss | A scoped [congestion-control comparison](server-tuning.md#test-congestion-control) |
-| You need to leave bandwidth for other users | `--bwlimit RATE` |
+| A long-distance path suffers loss | Investigate [congestion control](server-tuning.md#test-congestion-control) |
 
-Compare the same workload and direction, resetting only a disposable test
-destination between runs. Otherwise a second copy may just measure skipping
-already copied files.
-
-## How many connections
-
-Without `--connections`, syq adjusts parallelism automatically. Successful
-remote copies can remember a useful count for that path; local copies,
-including mounted NFS paths, do not use the tuning cache.
-
-`-j N` / `--connections N` fixes the count and disables tuning. Use
-`--bwlimit` to cap bandwidth rather than trying to control it indirectly
-through worker count. Short copies may finish before tuning has enough data.
-
-## Benchmark tuning
-
-Use `--tuning-options` for controlled comparisons when the defaults perform
-poorly. These experimental controls appear in `--help-all`; their keys and
-bounds may change between releases.
-
-`syq cp` and `syq rsync` accept `--tuning-options`. Supply
-comma-separated `KEY=VALUE` pairs:
-
-```sh
-syq cp large-file --to server --as /scratch/benchmark-copy \
-  --connections 1 -v \
-  --tuning-options copy-path=ranges,request-size=1M,pipeline-depth=8
-```
-
-| Key | Default | Accepted values |
-|---|---|---|
-| `request-size` | Hash block size (normally 4 MiB) for ordinary requests; at most 2 MiB for streaming | 512 bytes through 64 MiB |
-| `pipeline-depth` | 4 | 1 through 64 outstanding range requests per endpoint per worker |
-| `copy-path` | `auto` | `auto`, `ranges`, or experimental `streaming` / `auto-streaming` |
-| `batch-files` | 128 or 512, depending on transport and latency | 1 through 4096 files per worker batch |
-| `batch-bytes` | 16 MiB | 512 bytes through 64 MiB per worker batch, including the first file |
-| `split-min-size` | 32 MiB, at least two hash blocks | 1 byte through 1 GiB, raised to at least two hash blocks |
-| `bw-pacing` | `125ms` when capped | `average`, or an integer interval from `1ms` through `10s`; requires a nonzero `--bwlimit` |
-
-Sizes accept `K`, `M`, and `G`, using powers of 1024. Unknown keys, repeated
-keys, and out-of-range values fail the command. Overrides apply to the remote
-coordinator too. They are not saved, and these runs neither read nor update
-the remembered connection count. Connection auto-tuning still runs unless you
-fix `--connections` (`--syq-connections` with `syq rsync`). These are experimental
-controls whose keys and bounds may change between releases.
-
-Larger requests reduce overhead per byte; deeper pipelines allow more requests
-to await replies at once. Both can increase memory use. Neither changes the
-hash blocks used for integrity checks and resume.
-
-`copy-path=ranges` disables small-file batches and whole-file shortcuts,
-including local kernel copying. Matching data can still be skipped or reused.
-`auto` lets syq choose normally.
-
-### Streaming and request windows
-
-Syq automatically streams larger remote ranges (usually above 16 MiB), using
-blocks of at most 2 MiB by default. Streaming still checks contents and write
-errors and supports resume. No setting is needed for everyday copies.
-
-For comparisons, `copy-path=streaming` forces streaming and disables whole-file
-and small-file shortcuts. `copy-path=auto-streaming` keeps those shortcuts and
-streams the remaining ranges. Both include local and short ranges.
-
-An explicit `request-size` also sets the streaming block size; bandwidth and
-receiver limits may reduce it. An explicit `pipeline-depth` disables automatic
-streaming. Neither forced streaming mode accepts `pipeline-depth`.
-
-For a controlled comparison, use fresh scratch destinations:
-
-```sh
-syq cp data.bin --to host --as /scratch/pipeline.bin --connections 1 -v \
-  --tuning-options copy-path=ranges,request-size=1M,pipeline-depth=4
-syq cp data.bin --to host --as /scratch/streaming.bin --connections 1 -v \
-  --tuning-options copy-path=streaming,request-size=1M
-```
-
-Streaming can be slower on short or CPU-limited copies. Memory use depends on
-request size, worker count, compression, and transport buffering. With
-`--bwlimit`, a remote source can send ahead of paced destination writes, so the
-limit is an average copy rate, not a strict cap on incoming bursts.
-
-### Batch size and splitting
-
-For example, compare small-file batches with:
-
-```sh
-syq cp --srcs-in small-files --to server --into /scratch/benchmark-small \
-  --connections 1 -v --tuning-options batch-files=256,batch-bytes=8M
-```
-
-Explicit batch controls replace the small-copy shortcut with worker batches.
-File and byte limits are ceilings; syq may choose smaller batches. Files larger
-than the byte limit use another copy method. With `--bwlimit`, each batch
-contains at most one file. Batch controls cannot combine with `copy-path=ranges`
-or `copy-path=streaming`; `auto-streaming` accepts them.
-
-`split-min-size` sets the smallest file region an idle worker can take from
-another worker. Lower values allow finer sharing; higher values avoid small
-assignments. Splits align to hash blocks and need at least twice the minimum
-remaining size.
-
-### Average rate and burst patterns
-
-`--bwlimit` caps logical file-data bytes per second across workers, before
-compression, encryption, and protocol overhead.
-
-- **Timed pacing** (`bw-pacing=125ms`, the default) sends smaller requests at
-  regular intervals. The first request can start immediately, so a short copy
-  can exceed the average by that initial request.
-- **Average pacing** (`bw-pacing=average`) waits for each request's byte budget
-  before sending it, including the first. It allows larger requests, which can
-  arrive in bursts. A 2 MiB request at 1 MiB/s waits about two seconds.
-
-For example, to test larger requests under an average rate cap:
-
-```sh
-syq cp large-file --to server --as /scratch/benchmark-capped \
-  --connections 1 --bwlimit 1M -v \
-  --tuning-options copy-path=ranges,request-size=4M,bw-pacing=average
-```
-
-Neither mode limits the size of every network burst. Streaming, queues, and
-transport buffering affect when bytes cross the link. Restricted receivers
-also enforce their authorized rate and request-size limits. Measure both
-sustained throughput and short-interval traffic when comparing capped runs.
-
-### Recording a comparison
-
-With overrides, `-v` reports effective request sizes and a final
-`syq: tuning observed:` diagnostic with copy-method counts and request and batch
-sizes. Retries can count more than once. These experimental diagnostics are
-separate from [completion records](automation.md).
-
-Use the same reporting options and fresh disposable destinations for each
-comparison. Prefer `-v`: `--stats` bypasses the small-copy shortcut and can
-change what you measure. Use explicit defaults for the baseline, such as
-`--tuning-options copy-path=auto`.
-
-Record the source data, transport, connections, settings, elapsed time, CPU use,
-and peak memory. Check exit status and copied contents. Leave `--bwlimit` unset
-when measuring unrestricted throughput.
+Compare the same workload and direction using empty test destinations.
+A second copy into the same destination may just measure skipping existing files.
 
 ## TCP data connections
 
-SSH authenticates and controls remote copies. When reachable, encrypted TCP
-carries file data on one port from `47600–47699`; change it with
-`--tcp-ports LO-HI`. Syq discovers reachable IPv4 and IPv6 addresses and can
-use multiple network interfaces.
+SSH authenticates remote copies. When reachable, encrypted TCP carries file
+data on a port in `47600–47699`; otherwise copies use SSH on the same route.
+See [server setup](server-tuning.md#make-tcp-reachable) for firewall settings.
+Copies [authorized through another machine](remote-to-remote.md#start-a-copy-from-the-source-server)
+require direct encrypted TCP.
 
-If no TCP route is reachable, it reports `data over ssh`. Use `-vv` for
-the connection details. This also works for restricted server-to-server
-copies: SSH keeps file data on the source-to-destination route. Copies
-[authorized through another machine](remote-to-remote.md#start-a-copy-from-the-source-server)
-still require direct encrypted TCP and fail if it is unavailable.
-
-`--no-tcp` selects SSH data transport, including for enrolled restricted
-receivers. `--tcp-plain` removes data encryption and authentication and should
-be used only on a trusted network; restricted receivers refuse it.
-
-On Linux, `--tcp-congestion ALGO` chooses an available algorithm for syq's
-TCP sockets on both ends, without changing host defaults. Unsupported choices
-fail the copy. Restricted receivers enforce the algorithm signed into the
-copy authorization.
+Use `--no-tcp` to select SSH data transport or `--tcp-ports LO-HI` to choose a
+port range. On Linux, `--tcp-congestion ALGO` selects an available congestion
+control algorithm. `--tcp-plain` disables data encryption and authentication;
+use it only on a trusted network. Restricted receivers refuse it.
 
 ## Local copies and NFS
 
-Check [source and destination storage placement](server-tuning.md#check-local-storage-placement):
-copies within a filesystem that supports cloning can share data extents instead
-of physically copying every byte.
+Syq uses kernel or NFS server-side copying when available. Filesystems that
+support cloning can avoid physically copying every byte. These choices are
+automatic; [storage placement](server-tuning.md#check-local-storage-placement)
+can make a large difference.
 
-Syq uses kernel or NFS server-side copying when available, and otherwise copies
-files in parallel. These choices are automatic. Check elapsed time as well as
-reported throughput: storage optimizations can avoid moving every logical byte.
+## Limit bandwidth
+
+Use `--bwlimit` to leave bandwidth for other work:
 
 ```sh
-syq cp /raid/data --into /mnt/nfs/backup
+syq cp data --to server --into /backup --bwlimit 10M
 ```
 
-NFS mount tuning, such as `nconnect`, belongs to the host's storage setup.
-Benchmark before changing it; server-side copying and ordinary read/write
-traffic have different limits.
+This limits file data to 10 MiB/s across the copy's workers. It controls the
+average copy rate; buffering and protocol overhead can cause network bursts.
 
-## Options that change the tradeoff
+<a id="options-that-change-the-tradeoff"></a>
 
-By default, syq builds an updated file beside the old one, then replaces the
-old file when the new version is complete. `--inplace` writes directly into
-the destination file instead. This uses less disk space, but readers can see
-a mixture of old and new contents while the copy runs. If interrupted, that
-incomplete version stays at the final filename until you finish the copy.
+## Compression and in-place writes
 
-`--no-compress` saves CPU at the cost of potentially sending more bytes; it
-does not affect file contents or integrity checks. Compression applies across
-the network, not between syq and its receiver process on the same machine.
+`--no-compress` can help when compression costs more CPU time than it saves in
+network traffic. `--inplace` saves temporary disk space, but exposes incomplete
+updates to readers. Read [in-place writes](reference.md#in-place-writes) before
+using it.
 
-Examples use native options. In rsync mode, syq-specific options have a
-`--syq-` prefix, such as `--syq-connections` and `--syq-no-tcp`.
-See [rsync extensions](rsync-compat.md#syq-extensions).
+<a id="how-many-connections"></a>
+<a id="benchmark-tuning"></a>
+<a id="streaming-and-request-windows"></a>
+<a id="batch-size-and-splitting"></a>
+<a id="average-rate-and-burst-patterns"></a>
+<a id="recording-a-comparison"></a>
+
+## Investigate tuning
+
+Manual connection counts and other [tuning options](tuning.md) are for
+troubleshooting and development. Normal copies should not need them.

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -1,28 +1,12 @@
 # Speed
 
-Start with the defaults. Syq copies files in parallel, splits large files
-between workers, and adjusts connection count during the transfer. If a TCP
-data port is reachable, it sends data through separate encrypted connections.
-Otherwise, ordinary copies send their data over SSH. Small copies can stay
-on the SSH control connection to avoid extra setup. Larger copies start up to
-two workers on the copy's existing SSH connection while the others open
-independent connections for parallel throughput. A fixed connection count
-reuses it for only one worker. This reuse does not apply to a cross-run
-persistent connection or a custom `--rsh` command. Automatic SSH copies into
-new or empty directories, or to missing single-file destinations, also limit
-their initial worker count to the available files and splittable ranges.
-Updates keep their usual count. If a missing file has a resumable partial,
-syq restores that count when it discovers the partial: one file can contain
-many separate changed regions.
-With automatic concurrency, syq divides a single large fresh file over SSH
-before copying starts, so workers that connect later can help without waiting for a large enough
-remaining range to split. Earlier workers can keep taking work while those
-connections start.
-When pushing into an
-existing directory, syq pipelines destination setup checks to reduce network
-round trips. For eligible small-file trees in an empty destination, TCP workers
-connect while destination planning finishes. These overlap setup work without
-skipping destination checks.
+Start with the defaults. Syq copies files in parallel and adjusts the connection
+count during a transfer. It uses encrypted TCP for data when reachable and SSH
+otherwise. Small copies avoid extra connections when setup would cost more
+than it saves.
+
+Measure your own workload before changing settings. Network distance, storage,
+file sizes, and how much data already exists at the destination all affect speed.
 
 ## Benchmarks
 
@@ -43,61 +27,39 @@ bash try-benchmark.sh --yes --mode push --host server --workload both --rounds 3
 bash try-benchmark.sh --yes --mode local --source-dir /data --dest-dir /mnt/nfs --workload small
 ```
 
-The script needs Bash, rsync, OpenSSL and standard Unix utilities locally;
-automatic sizing uses Perl with its core JSON::PP module. Terminal runs also
-use Perl to keep SSH prompts interruptible. Remote tests
-need SSH access and rsync on the other machine. Syq prepares a helper matching
-your local build and shows installation progress when one is needed.
-Use an SSH config alias for custom ports or IPv6. `--install` installs syq
-locally if missing; `--help` lists the choices.
+The script needs Bash, rsync, OpenSSL, Perl (with JSON::PP), and standard Unix
+utilities locally. Remote tests also need SSH access and rsync on the other
+machine. Use an SSH config alias for custom ports or IPv6. `--install` installs
+syq locally if missing; `--help` lists the choices.
 
-Scratch parents must already exist. For SSH tests, `--dest-dir` is the remote
-scratch parent, including when pulling; `--source-dir` is always the local
-scratch parent.
+Scratch parents must already exist. `--source-dir` is the local scratch parent;
+for SSH tests, `--dest-dir` is the remote one, including when pulling.
 
-By default, the script starts with 64 MiB for the large file and 1,024 files
-of 8 KiB for the small-file workload. It makes verified, unscored syq copies
-and increases each workload until syq's copying interval reaches about five
-seconds. Each increase is between 25% and tenfold, avoiding repeated
-near-identical tests when timings fluctuate. Available space at both ends limits
-growth, with room reserved for the copies and filesystem overhead; if space
-prevents a long enough copy, the script warns and uses the tested size.
-There is no fixed total-data or runtime limit. A slow first copy can take longer
-than five seconds, and generation and verification also take time.
+Automatic sizing increases throwaway data until a syq copy takes about five
+seconds, subject to available space. Setup and verification take additional
+time, and there is no fixed total runtime limit. To use a fixed workload:
 
-All tools then copy the same dataset into empty destinations. Three rounds mean
-six scored copies per workload over SSH (syq and rsync), or nine locally (also
-cp). Choosing both workloads doubles those counts. A faster cp result does not
-cause further growth.
+| Option | Large file | Small files (8 KiB each) |
+|---|---|---|
+| `--size quick` | 64 MiB | 1,024 |
+| `--size medium` | 1 GiB | 4,096 |
+| `--size large` | 8 GiB | 16,384 |
 
-Automatic sizing requires syq to report `copying_elapsed_ms` in its automation
-results. Older builds can use `--size quick`, `--size medium`, or `--size large`
-for fixed workloads: respectively 64 MiB / 1,024 files, 1 GiB / 4,096 files,
-and 8 GiB / 16,384 files. Small files remain 8 KiB each. These flags also let
-you repeat a fixed-size comparison.
+Each tool copies the same reproducible, hard-to-compress data into an empty
+destination. The script rotates tool order and checks contents after every
+trial. It compares syq's defaults with permissions preserved, `rsync -rpt`,
+and local `cp -pR`. A failed copy or content check stops the comparison.
 
-Data comes from a fixed AES-CTR byte stream, making it reproducible and
-hard to compress. Every trial has an empty, pre-created destination; interrupted trials are
-never resumed. On Ctrl-C the script stops its local workers, moves remote
-scratch out of the transfer path, and deletes its temporary data. If SSH
-is unavailable, it reports the remote path for later cleanup. The script rotates
-tool order and reports speeds in decimal MB/s (1 MB = 1,000,000 bytes):
-each trial’s copied bytes divided by its elapsed time, followed by the mean,
-minimum and maximum trial speeds. Higher is faster. It uses
-syq's defaults with permissions preserved, `rsync -rpt`, and local `cp -pR`.
-These copy the same regular files and request permissions and modification
-times; the tools still differ in compression, integrity checks, and filesystem
-optimizations.
+Results show mean, minimum, and maximum speed in decimal MB/s; higher is
+faster. Timings include process startup and buffered writes, but exclude data
+generation, sizing, and verification. Caches are not flushed, and copies do
+not wait for durable storage. Small tests can mostly measure startup costs;
+filesystem cloning can favor cp. Syq may be slower on your workload.
 
-Generation, preparation, calibration, and POSIX `cksum` comparisons are
-outside the scored timers. Preparation shows helper installation messages without
-a throughput result. A failed command or content check stops the comparison.
-Caches are not flushed, so this is a cache-friendly test rather than a cold
-disk benchmark. Times include process startup and buffered writes, without
-waiting for durable storage. Small tests can mostly measure startup costs;
-local filesystem cloning can favor cp. Results do not predict every workload,
-and syq may be slower. Use the full published benchmark methodology for more
-controlled measurements.
+The script cleans up its test data, including after Ctrl-C. If SSH is unavailable
+during cleanup, it reports the remote path to remove later. See the
+[published methodology](https://greaber.github.io/syq-bench/) for more controlled
+measurements.
 
 ## When rsync or cp is faster
 
@@ -116,14 +78,9 @@ controlled measurements.
 syq cp -vv --stats data --to server --into /backup
 ```
 
-`-vv` shows helper selection, reachable addresses, the chosen transport, and
-initial parallelism. `--stats` shows totals, connection count, and TCP
-statistics where available. It also reports the copying interval when bytes moved:
-the span from first file work to last completed file work across all workers.
-This includes per-file checks, finalization and gaps; it may overlap planning
-and connection setup. It is not pure network time or a separate phase you can
-add to setup time. `SYQ_DEBUG=1` adds engineering timings for a
-detailed investigation.
+`-vv` shows the chosen transport and connections. `--stats` adds totals and
+available TCP statistics. Its copying interval measures file work, which can
+overlap setup; use total elapsed time when comparing complete commands.
 
 | Symptom | Try |
 |---|---|
@@ -150,10 +107,9 @@ through worker count. Short copies may finish before tuning has enough data.
 
 ## Benchmark tuning
 
-Normal copies tune automatically. Manual connection counts and
-`--tuning-options` appear in `--help-all` for troubleshooting performance issues
-and controlled experiments; leave them unset for everyday copies. `--bwlimit`
-appears in ordinary help because it sets your bandwidth budget.
+Use `--tuning-options` for controlled comparisons when the defaults perform
+poorly. These experimental controls appear in `--help-all`; their keys and
+bounds may change between releases.
 
 `syq cp` and `syq rsync` accept `--tuning-options`. Supply
 comma-separated `KEY=VALUE` pairs:
@@ -181,53 +137,27 @@ the remembered connection count. Connection auto-tuning still runs unless you
 fix `--connections` (`--syq-connections` with `syq rsync`). These are experimental
 controls whose keys and bounds may change between releases.
 
-Request size limits the payload of one range read or write. A final request or
-a range selected for repair can be smaller. Larger requests reduce overhead
-per byte; deeper pipelines allow more work to remain outstanding while replies
-travel back. Both increase potential buffering. In-process endpoints handle
-one request at a time; the response queue on worker connections follows the
-pipeline depth. These settings do not change hash blocks or partial identities.
+Larger requests reduce overhead per byte; deeper pipelines allow more requests
+to await replies at once. Both can increase memory use. Neither changes the
+hash blocks used for integrity checks and resume.
 
-`copy-path=ranges` makes file contents use range requests, bypassing both
-small-file batches and whole-file copying, including local kernel offload.
-Matching data can still be skipped or reused. With `auto`, syq chooses the copy
-method as usual. Explicit batch controls select worker batching instead of the
-native small-copy shortcut. Files larger than the batch byte limit use another
-copy path. File and byte limits are ceilings, and the scheduler can choose a
-smaller batch to share work among workers. With `--bwlimit`, worker batches
-contain at most one file. Batch controls cannot be combined with
-`copy-path=ranges` or `copy-path=streaming`.
+`copy-path=ranges` disables small-file batches and whole-file shortcuts,
+including local kernel copying. Matching data can still be skipped or reused.
+`auto` lets syq choose normally.
 
 ### Streaming and request windows
 
-Syq automatically streams remote ranges larger than one normal request
-window (usually 16 MiB). Local ranges and shorter remote ranges use ordinary
-requests. Whole-file and small-file shortcuts keep their usual eligibility.
-No streaming or pipeline setting is needed for ordinary copies.
-The `syq: tuning:` diagnostic describes the selection policy: a pipeline depth
-applies only to ordinary ranges, and automatic remote selection also reports
-the size above which ranges stream. It does not claim which paths ran; use
-the observed range and streaming counters for that.
+Syq automatically streams larger remote ranges (usually above 16 MiB), using
+blocks of at most 2 MiB by default. Streaming still checks contents and write
+errors and supports resume. No setting is needed for everyday copies.
 
-Streaming uses blocks of at most 2 MiB by default, reducing the payload retained
-per block. Smaller hash blocks still bound the streaming block
-size. This does not change hash/resume blocks, ordinary request sizes, or which
-ranges automatically stream. An explicit `request-size` overrides streaming
-block size too; bandwidth pacing and receiver limits can reduce either size.
+For comparisons, `copy-path=streaming` forces streaming and disables whole-file
+and small-file shortcuts. `copy-path=auto-streaming` keeps those shortcuts and
+streams the remaining ranges. Both include local and short ranges.
 
-Streaming sends
-checked source blocks and collects destination write replies concurrently,
-instead of limiting the number of blocks awaiting replies. It still verifies
-block hashes, checks all write errors before completion, and supports resume
-and parallel workers on different parts of one large file. It does not add
-a disk flush.
-
-For experiments, `copy-path=streaming` forces streaming even for local and
-short ranges, bypassing the same copy shortcuts as `copy-path=ranges`.
-`copy-path=auto-streaming` keeps the normal whole-file and small-file shortcuts,
-but forces streaming for all remaining ranges, including local and short ones.
-An explicit `pipeline-depth` uses ordinary requests instead of automatic
-streaming, allowing comparisons with the credit-window implementation.
+An explicit `request-size` also sets the streaming block size; bandwidth and
+receiver limits may reduce it. An explicit `pipeline-depth` disables automatic
+streaming. Neither forced streaming mode accepts `pipeline-depth`.
 
 For a controlled comparison, use fresh scratch destinations:
 
@@ -238,20 +168,10 @@ syq cp data.bin --to host --as /scratch/streaming.bin --connections 1 -v \
   --tuning-options copy-path=streaming,request-size=1M
 ```
 
-Both streaming modes reject `pipeline-depth`. Forced `streaming` also rejects
-batch controls; `auto-streaming` allows them, with the usual effect on small
-copies. Their data queues remain
-bounded, but memory also depends on request size, worker count, compression
-and transport buffering. It may be slower on short or CPU-limited copies:
-starting/stopping streams and collecting replies add work. Work-stealing can
-also discard already-read source data when another worker takes a suffix.
-With `--bwlimit`, pacing happens before destination writes; a remote source
-can send ahead into bounded buffers. This also applies to automatically selected
-streaming, without any tuning override. On pulls, initial incoming traffic can
-include the response-reader queue and in-flight frames and socket buffers;
-it is not limited to one paced block or one request window. The limit controls
-the average accepted copy rate, not a strict source-side burst limit.
-Restricted receivers still enforce their signed limits.
+Streaming can be slower on short or CPU-limited copies. Memory use depends on
+request size, worker count, compression, and transport buffering. With
+`--bwlimit`, a remote source can send ahead of paced destination writes, so the
+limit is an average copy rate, not a strict cap on incoming bursts.
 
 ### Batch size and splitting
 
@@ -262,28 +182,28 @@ syq cp --srcs-in small-files --to server --into /scratch/benchmark-small \
   --connections 1 -v --tuning-options batch-files=256,batch-bytes=8M
 ```
 
-`split-min-size` controls when an idle worker can take part of another worker's
-remaining file region. Lower values permit smaller divisions; higher values
-avoid small assignments. A division remains aligned to hash blocks. The
-scheduler divides a region only when at least twice the effective minimum
-remains. This is a work-assignment threshold, separate from request size.
+Explicit batch controls replace the small-copy shortcut with worker batches.
+File and byte limits are ceilings; syq may choose smaller batches. Files larger
+than the byte limit use another copy method. With `--bwlimit`, each batch
+contains at most one file. Batch controls cannot combine with `copy-path=ranges`
+or `copy-path=streaming`; `auto-streaming` accepts them.
+
+`split-min-size` sets the smallest file region an idle worker can take from
+another worker. Lower values allow finer sharing; higher values avoid small
+assignments. Splits align to hash blocks and need at least twice the minimum
+remaining size.
 
 ### Average rate and burst patterns
 
-`--bwlimit` budgets logical file-data bytes across the copy's workers, before
-compression, encryption, and protocol overhead. It caps a rate, not a total
-byte count. The request pacing modes make different trade-offs:
+`--bwlimit` caps logical file-data bytes per second across workers, before
+compression, encryption, and protocol overhead.
 
-- **Timed pacing**, such as `bw-pacing=125ms`, limits request size to the smaller
-  of the configured request size and `max(rate * interval, 512 bytes)`. Workers
-  wait for the start of each reserved interval. The first request can start
-  immediately, so a short copy can exceed the configured average by that
-  initial request. The default `125ms` retains the existing sizing and pacing.
-- **Average pacing**, `bw-pacing=average`, leaves request size independent of
-  `--bwlimit`. Workers wait for the *end* of each reservation before issuing the
-  request, including the first one. A single 2 MiB request at 1 MiB/s therefore
-  waits about two seconds before it is issued. Large requests can then travel
-  in bursts, while their full byte budgets have already been paid.
+- **Timed pacing** (`bw-pacing=125ms`, the default) sends smaller requests at
+  regular intervals. The first request can start immediately, so a short copy
+  can exceed the average by that initial request.
+- **Average pacing** (`bw-pacing=average`) waits for each request's byte budget
+  before sending it, including the first. It allows larger requests, which can
+  arrive in bursts. A 2 MiB request at 1 MiB/s waits about two seconds.
 
 For example, to test larger requests under an average rate cap:
 
@@ -293,39 +213,26 @@ syq cp large-file --to server --as /scratch/benchmark-capped \
   --tuning-options copy-path=ranges,request-size=4M,bw-pacing=average
 ```
 
-Neither mode promises a maximum network burst or uninterrupted service for
-other traffic. Ordinary ranges pace source requests, while streamed ranges pace
-destination writes after receiving the source block; helper processing, queues,
-compression, and transport buffering affect when bytes actually cross a link.
-A deeper pipeline can accumulate more data before forwarding it. A restricted
-receiver also enforces its signed rate ceiling independently, including its
-existing `max(rate * 125ms, 512 bytes)` request-size ceiling. Both tuning modes
-respect that additional ceiling; `-v` shows the effective size. Average pacing
-decouples size from rate where this signed receiver constraint does not apply.
-Measure both sustained throughput and short-interval traffic when evaluating
-capped runs.
+Neither mode limits the size of every network burst. Streaming, queues, and
+transport buffering affect when bytes cross the link. Restricted receivers
+also enforce their authorized rate and request-size limits. Measure both
+sustained throughput and short-interval traffic when comparing capped runs.
 
 ### Recording a comparison
 
-With overrides, `-v` reports effective ordinary request and streaming block
-sizes, including any reduction in request size or increase in the split threshold. A final `syq: tuning observed:`
-line contains diagnostic JSON with copy-path counts, range request count,
-streaming-range and streamed-block counts,
-largest requested range, and largest worker batch by file count and content
-bytes. These are observations of attempted work, so retries can contribute
-more than once. They are experimental diagnostics, separate from completion
-records. `--stats` also enables them, but currently bypasses the native
-small-copy shortcut; use `-v` to compare that shortcut with other paths.
-`SYQ_DEBUG=1` also records path counts without any tuning override, allowing
-automatic selection to be inspected without changing the tuning-cache policy.
+With overrides, `-v` reports effective request sizes and a final
+`syq: tuning observed:` diagnostic with copy-method counts and request and batch
+sizes. Retries can count more than once. These experimental diagnostics are
+separate from [completion records](automation.md).
 
-Use the same reporting options for every comparison, a fresh disposable
-destination, and explicit defaults for the baseline, such as
-`--tuning-options copy-path=auto`. Record the source data, transport, connection
-count, effective settings, elapsed time, CPU use, and peak memory. Check the
-exit status and copied contents. Leave `--bwlimit` unset when measuring
-unrestricted throughput. Default request size and pipeline depth are not
-automatically tuned.
+Use the same reporting options and fresh disposable destinations for each
+comparison. Prefer `-v`: `--stats` bypasses the small-copy shortcut and can
+change what you measure. Use explicit defaults for the baseline, such as
+`--tuning-options copy-path=auto`.
+
+Record the source data, transport, connections, settings, elapsed time, CPU use,
+and peak memory. Check exit status and copied contents. Leave `--bwlimit` unset
+when measuring unrestricted throughput.
 
 ## TCP data connections
 
@@ -355,21 +262,9 @@ Check [source and destination storage placement](server-tuning.md#check-local-st
 copies within a filesystem that supports cloning can share data extents instead
 of physically copying every byte.
 
-Same-machine Linux copies first try kernel or NFS server-side copying. If
-that is unavailable between ext4, XFS, or tmpfs filesystems during a multi-file
-copy, syq copies eligible files larger than 64 KiB directly through their open
-source and destination files. It runs these file copies in parallel without
-sending their contents through local TCP connections. Files up to 64 KiB still
-use batches, subject to the hash block, request-size and batch-byte limits.
-This local batch ceiling does not reduce the size of ordinary range requests.
-This happens automatically, without tuning options. Single-file copies retain parallel range copying when offload
-is unavailable.
-
-Syq also uses a sequential destination writer for eligible local-disk to
-asynchronous-NFS copies. NFS sources, synchronous destinations, and other
-filesystems retain parallel range copying when offload is unavailable.
-Checksum comparisons, resumed data, and bandwidth limits keep their usual
-range-based behavior.
+Syq uses kernel or NFS server-side copying when available, and otherwise copies
+files in parallel. These choices are automatic. Check elapsed time as well as
+reported throughput: storage optimizations can avoid moving every logical byte.
 
 ```sh
 syq cp /raid/data --into /mnt/nfs/backup

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -61,10 +61,11 @@ use it only on a trusted network. Restricted receivers refuse it.
 
 ## Local copies and NFS
 
-Syq uses kernel or NFS server-side copying when available. Filesystems that
-support cloning can avoid physically copying every byte. These choices are
-automatic; [storage placement](server-tuning.md#check-local-storage-placement)
-can make a large difference.
+For local copies, syq uses the filesystem's copy optimizations automatically
+when it can. On filesystems that support cloning, this can avoid physically
+copying every byte. You can also copy to or from a mounted NFS directory using
+its local path. See [storage placement](server-tuning.md#check-local-storage-placement)
+for how the source and destination filesystems affect performance.
 
 ## Limit bandwidth
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,0 +1,133 @@
+# Tuning options
+
+Syq adjusts performance automatically. These controls are for developers and
+for investigating copies where the defaults perform poorly. These experimental controls appear in `--help-all`; their keys and
+bounds may change between releases.
+
+`--connections N` (or `-j N`) fixes the connection count and disables automatic
+adjustment. In `syq rsync`, use `--syq-connections N`. Use the same count when
+comparing other tuning settings. Leave it unset for everyday copies.
+
+`syq cp` and `syq rsync` accept `--tuning-options`. Supply
+comma-separated `KEY=VALUE` pairs:
+
+```sh
+syq cp large-file --to server --as /scratch/benchmark-copy \
+  --connections 1 -v \
+  --tuning-options copy-path=ranges,request-size=1M,pipeline-depth=8
+```
+
+| Key | Default | Accepted values |
+|---|---|---|
+| `request-size` | Hash block size (normally 4 MiB) for ordinary requests; at most 2 MiB for streaming | 512 bytes through 64 MiB |
+| `pipeline-depth` | 4 | 1 through 64 outstanding range requests per endpoint per worker |
+| `copy-path` | `auto` | `auto`, `ranges`, or experimental `streaming` / `auto-streaming` |
+| `batch-files` | 128 or 512, depending on transport and latency | 1 through 4096 files per worker batch |
+| `batch-bytes` | 16 MiB | 512 bytes through 64 MiB per worker batch, including the first file |
+| `split-min-size` | 32 MiB, at least two hash blocks | 1 byte through 1 GiB, raised to at least two hash blocks |
+| `bw-pacing` | `125ms` when capped | `average`, or an integer interval from `1ms` through `10s`; requires a nonzero `--bwlimit` |
+
+Sizes accept `K`, `M`, and `G`, using powers of 1024. Unknown keys, repeated
+keys, and out-of-range values fail the command. Overrides apply to the remote
+coordinator too. They are not saved, and these runs neither read nor update
+the remembered connection count. Connection auto-tuning still runs unless you
+fix `--connections` (`--syq-connections` with `syq rsync`). These are experimental
+controls whose keys and bounds may change between releases.
+
+Larger requests reduce overhead per byte; deeper pipelines allow more requests
+to await replies at once. Both can increase memory use. Neither changes the
+hash blocks used for integrity checks and resume.
+
+`copy-path=ranges` disables small-file batches and whole-file shortcuts,
+including local kernel copying. Matching data can still be skipped or reused.
+`auto` lets syq choose normally.
+
+### Streaming and request windows
+
+Syq automatically streams larger remote ranges (usually above 16 MiB), using
+blocks of at most 2 MiB by default. Streaming still checks contents and write
+errors and supports resume. No setting is needed for everyday copies.
+
+For comparisons, `copy-path=streaming` forces streaming and disables whole-file
+and small-file shortcuts. `copy-path=auto-streaming` keeps those shortcuts and
+streams the remaining ranges. Both include local and short ranges.
+
+An explicit `request-size` also sets the streaming block size; bandwidth and
+receiver limits may reduce it. An explicit `pipeline-depth` disables automatic
+streaming. Neither forced streaming mode accepts `pipeline-depth`.
+
+For a controlled comparison, use fresh scratch destinations:
+
+```sh
+syq cp data.bin --to host --as /scratch/pipeline.bin --connections 1 -v \
+  --tuning-options copy-path=ranges,request-size=1M,pipeline-depth=4
+syq cp data.bin --to host --as /scratch/streaming.bin --connections 1 -v \
+  --tuning-options copy-path=streaming,request-size=1M
+```
+
+Streaming can be slower on short or CPU-limited copies. Memory use depends on
+request size, worker count, compression, and transport buffering. With
+`--bwlimit`, a remote source can send ahead of paced destination writes, so the
+limit is an average copy rate, not a strict cap on incoming bursts.
+
+### Batch size and splitting
+
+For example, compare small-file batches with:
+
+```sh
+syq cp --srcs-in small-files --to server --into /scratch/benchmark-small \
+  --connections 1 -v --tuning-options batch-files=256,batch-bytes=8M
+```
+
+Explicit batch controls replace the small-copy shortcut with worker batches.
+File and byte limits are ceilings; syq may choose smaller batches. Files larger
+than the byte limit use another copy method. With `--bwlimit`, each batch
+contains at most one file. Batch controls cannot combine with `copy-path=ranges`
+or `copy-path=streaming`; `auto-streaming` accepts them.
+
+`split-min-size` sets the smallest file region an idle worker can take from
+another worker. Lower values allow finer sharing; higher values avoid small
+assignments. Splits align to hash blocks and need at least twice the minimum
+remaining size.
+
+### Average rate and burst patterns
+
+`--bwlimit` caps logical file-data bytes per second across workers, before
+compression, encryption, and protocol overhead.
+
+- **Timed pacing** (`bw-pacing=125ms`, the default) sends smaller requests at
+  regular intervals. The first request can start immediately, so a short copy
+  can exceed the average by that initial request.
+- **Average pacing** (`bw-pacing=average`) waits for each request's byte budget
+  before sending it, including the first. It allows larger requests, which can
+  arrive in bursts. A 2 MiB request at 1 MiB/s waits about two seconds.
+
+For example, to test larger requests under an average rate cap:
+
+```sh
+syq cp large-file --to server --as /scratch/benchmark-capped \
+  --connections 1 --bwlimit 1M -v \
+  --tuning-options copy-path=ranges,request-size=4M,bw-pacing=average
+```
+
+Neither mode limits the size of every network burst. Streaming, queues, and
+transport buffering affect when bytes cross the link. Restricted receivers
+also enforce their authorized rate and request-size limits. Measure both
+sustained throughput and short-interval traffic when comparing capped runs.
+
+### Recording a comparison
+
+With overrides, `-v` reports effective request sizes and a final
+`syq: tuning observed:` diagnostic with copy-method counts and request and batch
+sizes. Retries can count more than once. These experimental diagnostics are
+separate from [completion records](automation.md).
+
+Use the same reporting options and fresh disposable destinations for each
+comparison. Prefer `-v`: `--stats` bypasses the small-copy shortcut and can
+change what you measure. Use explicit defaults for the baseline, such as
+`--tuning-options copy-path=auto`.
+
+Record the source data, transport, connections, settings, elapsed time, CPU use,
+and peak memory. Check exit status and copied contents. Leave `--bwlimit` unset
+when measuring unrestricted throughput.
+

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -96,14 +96,10 @@ In addition to the shared arguments above, it accepts:
 Option behavior is covered in [Copy files](https://greaber.github.io/syq/reference.html)
 and [Remote copy details](https://greaber.github.io/syq/remote-reference.html).
 
-The SDK passes `pscope` unchanged to the selected syq executable, which controls
-the scope and its background receivers. Ephemeral scopes in the current
-CLI reuse forward SSH connections only. For return copies or commands, establish
-durable persistence with `syq persist connect server` and omit `pscope`. This
-also applies to `AsyncClient` and to `rm`. If the SDK selects an older executable,
-its scope behavior still applies: syq 0.4.1 also enabled receiving in ephemeral
-scopes. See [connection persistence](https://greaber.github.io/syq/install.html#keep-connections-open)
-for lifetime, cleanup, and upgrade behavior, and
+`pscope` selects an isolated scope for reusing SSH connections. For return
+copies or commands, use `syq persist connect server` and omit `pscope`. See
+[persistence in scripts](https://greaber.github.io/syq/receive.html#persistence-in-scripts)
+for setup and cleanup, and
 [Compatibility](https://greaber.github.io/syq/python-reference.html#compatibility)
 for executable selection.
 
@@ -604,11 +600,9 @@ Python exceptions. Exceptions from application callbacks or mapping iterators
 are re-raised unchanged. Async cancellation remains `asyncio.CancelledError`.
 These exceptions are not wrapped in `SyqError`.
 
-Timeout, cancellation, early mapping exit, and streaming failures terminate and
-reap the local process group, including SSH children. Closing a mapping whose
-producer has already exited still cleans up its children; the exited producer
-alone does not cause a cleanup permission error on macOS. Filesystem changes
-already completed are not rolled back.
+Timeout, cancellation, early mapping exit, and streaming failures stop the
+local process group, including SSH children. Filesystem changes already
+completed are not rolled back.
 
 <a id="deliberate-exclusions"></a>
 

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -98,7 +98,7 @@ and [Remote copy details](https://greaber.github.io/syq/remote-reference.html).
 
 `pscope` selects an isolated scope for reusing SSH connections. For return
 copies or commands, use `syq persist connect server` and omit `pscope`. See
-[persistence in scripts](https://greaber.github.io/syq/receive.html#persistence-in-scripts)
+[persistence in scripts](https://greaber.github.io/syq/persistence-reference.html#isolated-script-scopes)
 for setup and cleanup, and
 [Compatibility](https://greaber.github.io/syq/python-reference.html#compatibility)
 for executable selection.

--- a/theme/README.md
+++ b/theme/README.md
@@ -51,15 +51,14 @@ end-of-page navigation provide the chapter routes.
 Documentation walkthroughs use semantic HTML styled in `docs.css`, keeping text
 selectable and readable without JavaScript, in both palettes and on narrow
 screens. Prefer a compact example or flow diagram where it replaces a long
-explanation; keep detailed benchmark methodology on the speed page rather than
-the installation path. The benchmark figure is a condensed real local quick
-run (release-profile syq `9e73649`, three trials, 1 × 64 MiB and 1,024 × 8 KiB;
-original mean times: syq 0.095/0.167 s, rsync 0.118/0.118 s, cp 0.049/0.052 s).
-The figure shows arithmetic mean trial speeds in decimal MB/s, calculated
-from the individual recorded durations rather than those rounded mean times. It illustrates
-the workflow, not comparative performance evidence. The choices now show automatic
-sizing; the example speeds still come from that fixed-size sample: the run shared the machine
-with other work. Preserve the example caption if updating its presentation.
+explanation; keep tuning details in the tuning reference rather than
+the installation path. The install-page table uses the public syq-bench
+Germany → US East Coast large-file comparison: one 1.07 GB file in memory,
+three verified runs per tool, with reported speeds of 159.1 MB/s for syq,
+87.2 MB/s for syq over SSH, and 18.0 MB/s for rsync. The caption links to
+`all-results.html#public-wan-forward` and identifies syq-bench as a separate
+project; these are not results from the quick script. Keep the measured
+workload and source attached to any replacement figures.
 
 Anchor navigation scrolls smoothly, matching benchmarks. The reduced-motion
 preference disables this animation. Both sites use 20px Open Sans main prose

--- a/theme/docs.css
+++ b/theme/docs.css
@@ -126,17 +126,8 @@ a:focus-visible,button:focus-visible,label:focus-visible {outline:2px solid var(
 
 /* Readable, theme-aware walkthroughs; no JavaScript or text baked into images. */
 .benchmark-example,.transfer-flow{margin:28px 0;font:16px/1.5 var(--display)}
-.benchmark-example-grid{display:grid;grid-template-columns:1fr 1.45fr;border:1px solid var(--line);border-radius:8px;overflow:hidden;background:var(--panel)}
-.benchmark-example section{padding:22px;min-width:0}
-.benchmark-example section+section{background:var(--bg);border-left:1px solid var(--line)}
-.visual-step{display:flex;align-items:center;gap:12px;color:var(--syq);font:600 20px var(--mono)}
-.visual-step span{color:var(--ink);font:600 16px var(--display)}
-.benchmark-choices{display:grid;grid-template-columns:1fr auto;gap:12px;margin:24px 0}
-.benchmark-choices dt{color:var(--muted)}
-.benchmark-choices dd{margin:0;font-family:var(--mono);color:var(--syq)}
-.content .visual-note{font-size:14px;color:var(--muted);line-height:1.6;margin:18px 0 0}
-.content .benchmark-example table{display:table;width:100%;margin-top:18px;font-size:14px}
-.benchmark-example caption{text-align:left;color:var(--muted);padding-bottom:8px}
+.content .benchmark-example table{display:table;width:100%;margin:0;font-size:16px;table-layout:fixed}
+.benchmark-example caption{text-align:left;color:var(--muted);padding-bottom:12px;font-size:16px}
 .content .benchmark-example th,.content .benchmark-example td{padding:8px 6px;background:transparent;border:0;border-bottom:1px solid var(--line)}
 .benchmark-example td{text-align:right;font-family:var(--mono);font-variant-numeric:tabular-nums}
 .benchmark-example th{text-align:left;white-space:nowrap}
@@ -152,9 +143,6 @@ a:focus-visible,button:focus-visible,label:focus-visible {outline:2px solid var(
 .flow-arrow{display:flex;flex-direction:column;align-items:center;color:var(--syq);font-size:14px}
 .flow-arrow b{font-size:44px;line-height:1;font-weight:400}
 @media(max-width:600px){
-  .benchmark-example-grid{grid-template-columns:1fr}
-  .benchmark-example section+section{border-left:0;border-top:1px solid var(--line)}
-  .benchmark-example section{padding:18px}
   .transfer-flow{padding:16px 10px}.flow-data{gap:6px}.flow-machine{padding:12px 6px}
 }
 


### PR DESCRIPTION
Setup and task guides had accumulated implementation details, upgrade history, and repeated reference material. Keep them focused on getting started and choosing useful behavior. The install page now briefly introduces completion and persistence; the receiving and speed guides link to dedicated persistence and tuning references. Bandwidth limits and in-place writes have their own explanations. Remove unsupported spinning-disk advice and specific syq release histories while preserving actionable upgrade guidance.

Replace the misaligned local benchmark graphic with a simple table from the published syq-bench Germany–US result (one 1.07 GB file, memory at both ends, three verified runs). Clearly distinguish that separate benchmark project from the quick script, and show how to download the quick script. Existing URLs and heading anchors remain usable.

Add concise editorial guidance to AGENTS.md and a repository `syq-docs-audit` skill, run during release preparation. Routine audits add no approval gate; unresolved material product or editorial decisions require user input. No release authorization changed and no release operation was performed.

[Preview the edited docs](https://colors-grad-intermediate-replacement.trycloudflare.com/install.html).

Validation at `a0702e9`: mdBook 0.5.4, 22-file Markdown link check, 1,350 rendered local links/assets, 138 existing chapter heading anchors, skill validation, whitespace, and public-preview checks. Earlier benchmark columns and four guide/reference pages checked at 320/390/820/1440 pixels in both themes, with no-JS table visibility; desktop and mobile table screenshots visually inspected. Table numbers independently reproduced from the published capture.

Removed the standalone SSH setup section and rewrote the receiving guides in connected prose. Narrowed the NFS wording: the Linux copy path uses `copy_file_range`, which can enable NFS offload, but actual NFS offload was not established for the benchmarks.

No runtime changes. Built the existing binary and confirmed that verify-only detects different contents with identical size/time without writing. Investigated 59 local concurrent copies, including a forced overlap: several small-file/local-copy invocations failed with shared-partial errors, while all final contents matched. The docs retain a concise warning; this PR does not fix concurrency. Verification semantics, connection-option spelling, and unit parsing remain unchanged pending separate product decisions. Full Rust baseline and real-SSH suite not run for this documentation/theme/skill change.

Branch `docs-user-focus-20260909` is clean and pushed at `a0702e9`. Review-ready, unmerged. Latest master workflow state is reported separately by branch-status at handoff.
