### PR TITLE
Warm up network benchmarks and report copying throughput

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -26,8 +26,9 @@ Compare syq with rsync on your own machines, or with rsync and cp locally:
 curl --proto '=https' --tlsv1.2 -fLsS https://raw.githubusercontent.com/greaber/syq/master/scripts/try-benchmark.sh | bash
 ```
 
-Choose a local or SSH copy and a workload. The script automatically sizes
-throwaway data with syq and cleans up afterward. No syq-bench install is needed;
+The default sends 1,024 small throwaway files to an SSH host you choose and
+compares syq with rsync over three rounds. Local copies, large files, and
+automatic sizing are optional. It cleans up afterward. No syq-bench install is needed;
 if syq is missing, it offers to install it.
 
 <figure class="benchmark-example">
@@ -37,25 +38,25 @@ if syq is missing, it offers to install it.
 <dl class="benchmark-choices">
 <dt>Copy where?</dt><dd>local</dd>
 <dt>Workloads?</dt><dd>both</dd>
-<dt>Test size</dt><dd>automatic by default</dd>
+<dt>Test size</dt><dd>quick</dd>
 </dl>
 <p class="visual-note">Results pictured: fixed-size sample<br>64 MiB + 1,024 files of 8 KiB</p>
 </section>
 <section aria-label="Example benchmark results">
 <div class="visual-step">2 <span>Compare the results</span></div>
 <table>
-<caption>Mean MB/s · higher is faster · 3 trials</caption>
+<caption>Approximate seconds · lower is faster</caption>
 <thead><tr><th scope="col">Tool</th><th scope="col">Large file</th><th scope="col">Small files</th></tr></thead>
 <tbody>
-<tr><th scope="row">syq</th><td>710.0</td><td>50.1</td></tr>
-<tr><th scope="row">rsync</th><td>567.3</td><td>71.1</td></tr>
-<tr><th scope="row">cp</th><td>1379.1</td><td>160.4</td></tr>
+<tr><th scope="row">syq</th><td>0.095</td><td>0.167</td></tr>
+<tr><th scope="row">rsync</th><td>0.118</td><td>0.118</td></tr>
+<tr><th scope="row">cp</th><td>0.049</td><td>0.052</td></tr>
 </tbody>
 </table>
 <p class="visual-note">✓ Copied contents checked</p>
 </section>
 </div>
-<figcaption>Speeds from a fixed-size local sample, not a speed promise. Your results will differ.</figcaption>
+<figcaption>Optional local comparison, converted from a fixed-size sample. Filesystem cloning can shorten copy times; these are not disk bandwidth measurements. Your results will differ.</figcaption>
 </figure>
 
 For requirements, options and how to read the results, see

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,7 +27,8 @@ curl --proto '=https' --tlsv1.2 -fLsS https://raw.githubusercontent.com/greaber/
 ```
 
 The default sends 1,024 small throwaway files to an SSH host you choose and
-compares syq with rsync over three rounds. Local copies, large files, and
+compares syq with rsync over three rounds, following an untimed tuning warm-up
+(`--warmup off` skips it). Local copies, large files, and
 automatic sizing are optional. The script checks the copied contents and cleans up afterward.
 If syq is missing, it offers to install it. See [quick comparison](speed.md#quick-comparison)
 to download the script and run it again.

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -158,14 +158,17 @@ outside the scored timers. Preparation shows helper installation messages withou
 a throughput result. A failed command or content check stops the comparison.
 
 The main table always uses total command time, including connection startup.
-A separate syq table shows mean total time, its copying interval, and other time
-(total minus copying). Other time covers work outside that interval, such as
+A separate syq table shows mean total time, its copying interval, other time
+(total minus copying), and copying speed in decimal MB/s. Copying speed is
+copied bytes divided by copying seconds and 1,000,000, averaged across trial
+speeds. It also appears after each syq trial. A copying interval below timer
+resolution makes copying speed unavailable. Other time covers work outside that interval, such as
 setup and finishing. Copying spans the first file work through the last completed
 work: it includes waiting and per-file overhead, and can overlap planning and
 connection setup. It is neither pure network time nor an exact separation of
 setup from transfer. The script does not estimate this breakdown for rsync or cp.
 
-The script adds a note when at least half of syq's total time falls outside
+The script adds a note when at least 20% of syq's total time falls outside
 copying, or its mean copying interval is under one second. These are diagnostic
 thresholds, not guarantees that longer tests saturate the link. Short jobs still
 measure useful completion time; use `--workload large --size auto` or a larger

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -30,6 +30,9 @@ An untimed tiny copy still prepares the helper. Options after `--` apply to
 syq's setup, calibration and scored copies; path, removal and output-file
 options are excluded to keep copies inside the disposable dataset. Use
 `--tool rsync` for a separate rsync comparison, omitting syq options after `--`.
+Full commands and scratch paths appear only with `-v`, `-vv`, or `--verbose`
+after `--`. Syq's extra summary appears with those flags or `--stats`; the
+benchmark always reports verified trial results and failures.
 See [tuning options](tuning.md#streaming-and-request-windows) for request-window
 and small-file batch experiments, and `bash try-benchmark.sh --help` for all options.
 
@@ -48,7 +51,9 @@ Generation and checks keep the launch directory visible to tmux.
 Generation, helper preparation and content checks are untimed. Each scored
 copy uses an empty destination, with permissions and modification times
 preserved. Syq persistence is disabled in private settings and rsync uses fresh
-SSH connections, so the total timer includes connection startup. Caches are
+SSH connections, so the total timer includes connection startup. This leaves
+the normal [learned connection counts](tuning.md#remembered-connection-counts)
+active unless you override tuning; trials can reuse and update them. Caches are
 not flushed and copies do not wait for durable storage. Failed commands or
 content checks stop the comparison.
 

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -39,7 +39,8 @@ comparison without installing a benchmark package. After downloading the
 script, you can repeat the same choices explicitly:
 
 ```sh
-bash try-benchmark.sh --yes --mode push --host server --workload both --rounds 3
+bash try-benchmark.sh --yes --host server
+bash try-benchmark.sh --yes --host server --workload both --size auto
 bash try-benchmark.sh --yes --mode local --source-dir /data --dest-dir /mnt/nfs --workload small
 ```
 
@@ -55,8 +56,18 @@ Scratch parents must already exist. For SSH tests, `--dest-dir` is the remote
 scratch parent, including when pulling; `--source-dir` is always the local
 scratch parent.
 
-By default, the script starts with 64 MiB for the large file and 1,024 files
-of 8 KiB for the small-file workload. It makes verified, unscored syq copies
+The default is a push to a second machine, with 1,024 files of 8 KiB each
+and three rounds. Supply an SSH host when prompted, or use `--host` with
+`--yes`. Choose a fast link with some latency to exercise parallel network
+copying; reachable TCP data ports `47600–47699` allow the default encrypted
+TCP path. The script uses normal syq settings and fresh SSH connections for
+both tools. A faster result is not guaranteed. `--mode local` compares local
+copies, and `--workload large` or `--workload both` includes large files.
+Large files measure sustained throughput; small files also exercise per-file
+overhead, so the two workloads can have very different results.
+
+With `--size auto`, the script starts with 64 MiB for the large file and 1,024
+files of 8 KiB for the small-file workload. It makes verified, unscored syq copies
 and increases each workload until syq's copying interval reaches about five
 seconds. Each increase is between 25% and tenfold, avoiding repeated
 near-identical tests when timings fluctuate. Available space at both ends limits
@@ -71,7 +82,8 @@ cp). Choosing both workloads doubles those counts. A faster cp result does not
 cause further growth.
 
 Automatic sizing requires syq to report `copying_elapsed_ms` in its automation
-results. Older builds can use `--size quick`, `--size medium`, or `--size large`
+results. Fixed sizes need no timing field: use `--size quick` (the default),
+`--size medium`, or `--size large`
 for fixed workloads: respectively 64 MiB / 1,024 files, 1 GiB / 4,096 files,
 and 8 GiB / 16,384 files. Small files remain 8 KiB each. These flags also let
 you repeat a fixed-size comparison.
@@ -81,10 +93,18 @@ hard to compress. Every trial has an empty, pre-created destination; interrupted
 never resumed. On Ctrl-C the script stops its local workers, moves remote
 scratch out of the transfer path, and deletes its temporary data. If SSH
 is unavailable, it reports the remote path for later cleanup. The script rotates
-tool order and reports speeds in decimal MB/s (1 MB = 1,000,000 bytes):
-each trial’s copied bytes divided by its elapsed time, followed by the mean,
-minimum and maximum trial speeds. Higher is faster. It uses
-syq's defaults with permissions preserved, `rsync -rpt`, and local `cp -pR`.
+tool order. Network tests report speeds in decimal MB/s (1 MB = 1,000,000
+bytes): each trial’s copied bytes divided by its elapsed time, followed by the
+mean, minimum and maximum trial speeds. Higher is faster. Local tests instead
+report elapsed seconds, where lower is faster. A filesystem clone creates an
+independent copy that initially shares storage with its source; changing either
+file keeps the other intact. Its time measures that useful operation, not
+physical data transfer. The script permits each tool’s normal optimizations.
+To compare copying between storage devices, choose scratch parents on those
+devices. Generation and checks use explicit paths without entering the
+scratch directories, so they keep the launch directory visible to tmux.
+
+The script uses syq's defaults with permissions preserved, `rsync -rpt`, and local `cp -pR`.
 These copy the same regular files and request permissions and modification
 times; the tools still differ in compression, integrity checks, and filesystem
 optimizations.

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -19,6 +19,22 @@ with rsync over three rounds. Use `--mode pull` for downloads or `--mode local`
 to include cp. `--workload large` selects one 64 MiB file; `--workload both`
 runs both workloads. The script checks every copy and cleans up afterward.
 
+Before scoring each network workload, an untimed syq warm-up gives automatic
+tuning time to refine the remembered connection count. It uses the same
+direction, transport options and file type as the scored copies. It starts
+with 64 MiB or 1,024 small files and grows toward 30 seconds of copying,
+stopping after at most four copies or at 1 GiB per dataset, subject to free
+space. A slow copy can take longer than 30 seconds; preparation and checks
+also add time. The script reports the measured duration and warns if it hits
+a limit before the target. Reaching the target does not prove tuning settled.
+
+Use `--warmup off` for a short comparison using the existing cached or default
+count. Warm-up is skipped for local copies, comparisons without scored syq
+trials, and manual `--connections` or `--tuning-options` overrides. The scored
+dataset size stays the same. For pull warm-ups, identical data is generated
+locally and remotely and checked, avoiding a large preliminary upload; the
+remote host needs Bash, OpenSSL, dd and split for that step.
+
 For one scored syq copy with your own options:
 
 ```sh
@@ -27,7 +43,7 @@ bash try-benchmark.sh --yes --mode pull --host j5 --tool syq --rounds 1 \
 ```
 
 An untimed tiny copy still prepares the helper. Options after `--` apply to
-syq's setup, calibration and scored copies; path, removal and output-file
+syq's setup, warm-up, calibration and scored copies; path, removal and output-file
 options are excluded to keep copies inside the disposable dataset. Use
 `--tool rsync` for a separate rsync comparison, omitting syq options after `--`.
 Full commands and scratch paths appear only with `-v`, `-vv`, or `--verbose`
@@ -48,7 +64,7 @@ rsync on the other machine. Scratch parents must exist: `--source-dir` is
 always local and `--dest-dir` is the remote scratch parent for push and pull.
 Generation and checks keep the launch directory visible to tmux.
 
-Generation, helper preparation and content checks are untimed. Each scored
+Generation, helper preparation, warm-up and content checks are untimed. Each scored
 copy uses an empty destination, with permissions and modification times
 preserved. Syq persistence is disabled in private settings and rsync uses fresh
 SSH connections, so the total timer includes connection startup. This leaves

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -44,6 +44,26 @@ bash try-benchmark.sh --yes --host server --workload both --size auto
 bash try-benchmark.sh --yes --mode local --source-dir /data --dest-dir /mnt/nfs --workload small
 ```
 
+For one scored copy with syq and your own tuning options:
+
+```sh
+bash try-benchmark.sh --yes --mode push --host j5 --tool syq --rounds 1 \
+  -- --no-tcp --connections 4
+```
+
+Change `push` to `pull` for downloads. The default small workload is 1,024 files
+of 8 KiB, with no automatic sizing. The script still prepares the helper with
+an untimed tiny copy, checks every copied file, and cleans up. `--size auto`
+also makes unscored calibration copies. Use `--tool rsync` for a separate rsync
+comparison, omitting the syq options after `--`.
+
+Options after `--` apply to syq's setup, calibration and scored copies. They
+accept connection count, transport, compression, bandwidth and batching controls,
+in-place copying, and diagnostics; `--help` lists them. For example, append
+`--tuning-options batch-files=256,batch-bytes=2M` or `-vv`.
+Path selection, removal and output-file options are excluded so all copies stay
+inside the disposable dataset. With `--tool all`, tuning applies only to syq.
+
 The script needs Bash, rsync, OpenSSL and standard Unix utilities locally;
 automatic sizing uses Perl with its core JSON::PP module. Terminal runs also
 use Perl to keep SSH prompts interruptible. Remote tests

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -64,8 +64,31 @@ in-place copying, and diagnostics; `--help` lists them. For example, append
 Path selection, removal and output-file options are excluded so all copies stay
 inside the disposable dataset. With `--tool all`, tuning applies only to syq.
 
+To test the amount of outstanding large-file work over SSH, keep the worker
+count and copy method fixed, then vary only the request window:
+
+```sh
+bash try-benchmark.sh --yes --mode pull --host j5 --workload large \
+  --tool syq --rounds 1 --size quick -- --no-tcp --connections 1 -v \
+  --tuning-options copy-path=ranges,request-size=1M,pipeline-depth=4
+```
+
+Repeat with `pipeline-depth=8` and `16`. With 1 MiB requests, these allow up to
+4, 8 and 16 MiB of outstanding range requests per endpoint per worker. They
+do not resize TCP or SSH flow-control windows. Compare separately with a run
+omitting `--tuning-options`: long remote ranges normally stream, and an explicit
+pipeline depth disables that behavior. The ordinary defaults already allow
+4 MiB × 4 requests; a larger application request window may not help.
+Use a larger fixed size if the timing notes show the test is too short.
+
+For the small-file workload, vary `batch-files` and `batch-bytes` instead,
+such as `--tuning-options batch-files=512,batch-bytes=4M`. Those are batch
+ceilings, and the scheduler may choose smaller batches. `pipeline-depth` does
+not multiply small-file batches. After testing these controls, vary
+`--connections` separately to assess parallelism and its startup cost.
+
 The script needs Bash, rsync, OpenSSL and standard Unix utilities locally;
-automatic sizing uses Perl with its core JSON::PP module. Terminal runs also
+syq timing uses Perl with its core JSON::PP module. Terminal runs also
 use Perl to keep SSH prompts interruptible. Remote tests
 need SSH access and rsync on the other machine. Syq prepares a helper matching
 your local build and shows installation progress when one is needed.
@@ -83,8 +106,8 @@ copying; reachable TCP data ports `47600–47699` allow the default encrypted
 TCP path. The script uses normal syq settings and fresh SSH connections for
 both tools. A faster result is not guaranteed. `--mode local` compares local
 copies, and `--workload large` or `--workload both` includes large files.
-Large files measure sustained throughput; small files also exercise per-file
-overhead, so the two workloads can have very different results.
+Sufficiently large tests help measure sustained throughput; small files also
+exercise per-file overhead, so the two workloads can have very different results.
 
 With `--size auto`, the script starts with 64 MiB for the large file and 1,024
 files of 8 KiB for the small-file workload. It makes verified, unscored syq copies
@@ -102,7 +125,8 @@ cp). Choosing both workloads doubles those counts. A faster cp result does not
 cause further growth.
 
 Automatic sizing requires syq to report `copying_elapsed_ms` in its automation
-results. Fixed sizes need no timing field: use `--size quick` (the default),
+results. With older syq versions, fixed sizes still report total times but show
+the copying breakdown as unavailable. Use `--size quick` (the default),
 `--size medium`, or `--size large`
 for fixed workloads: respectively 64 MiB / 1,024 files, 1 GiB / 4,096 files,
 and 8 GiB / 16,384 files. Small files remain 8 KiB each. These flags also let
@@ -132,6 +156,22 @@ optimizations.
 Generation, preparation, calibration, and POSIX `cksum` comparisons are
 outside the scored timers. Preparation shows helper installation messages without
 a throughput result. A failed command or content check stops the comparison.
+
+The main table always uses total command time, including connection startup.
+A separate syq table shows mean total time, its copying interval, and other time
+(total minus copying). Other time covers work outside that interval, such as
+setup and finishing. Copying spans the first file work through the last completed
+work: it includes waiting and per-file overhead, and can overlap planning and
+connection setup. It is neither pure network time nor an exact separation of
+setup from transfer. The script does not estimate this breakdown for rsync or cp.
+
+The script adds a note when at least half of syq's total time falls outside
+copying, or its mean copying interval is under one second. These are diagnostic
+thresholds, not guarantees that longer tests saturate the link. Short jobs still
+measure useful completion time; use `--workload large --size auto` or a larger
+fixed size to investigate sustained throughput. Compare both tools using their
+total times, rather than comparing syq's copying interval with rsync's total.
+
 Caches are not flushed, so this is a cache-friendly test rather than a cold
 disk benchmark. Times include process startup and buffered writes, without
 waiting for durable storage. Small tests can mostly measure startup costs;

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -22,14 +22,15 @@ runs both workloads. The script checks every copy and cleans up afterward.
 Before scoring each network workload, an untimed syq warm-up gives automatic
 tuning time to refine the remembered connection count. It uses the same
 direction, transport options and file type as the scored copies. It starts
-with 64 MiB or 1,024 small files and grows toward 30 seconds of copying,
+with 64 MiB or 1,024 small files and grows toward 60 seconds of copying,
 stopping after at most four copies or at 1 GiB per dataset, subject to free
-space. A slow copy can take longer than 30 seconds; preparation and checks
+space. A slow copy can take longer than 60 seconds; preparation and checks
 also add time. The script reports the measured duration and warns if it hits
 a limit before the target. Reaching the target does not prove tuning settled.
 
 Use `--warmup off` for a short comparison using the existing cached or default
-count. Warm-up is skipped for local copies, comparisons without scored syq
+count. A cached count alone does not currently skip the warm-up automatically.
+Warm-up is skipped for local copies, comparisons without scored syq
 trials, and manual `--connections` or `--tuning-options` overrides. The scored
 dataset size stays the same. For pull warm-ups, identical data is generated
 locally and remotely and checked, avoiding a large preliminary upload; the

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -19,8 +19,10 @@ connection persistence. Its temporary file paths do not change the cache key.
 Learning takes time: syq samples every 2.5 seconds and needs a warm-up interval
 plus two stable samples for one measurement. Saving a count requires a
 successful copy with at least two measured worker counts and an unchanged
-transport. Short copies may only use their starting count; the benchmark's
-five-second automatic sizing target does not ensure tuning has settled.
+transport. Short copies may only use their starting count. The benchmark's
+[untimed warm-up](speed.md#quick-comparison) allows more time before scoring;
+neither its 30-second target nor the separate five-second automatic sizing
+target guarantees tuning has settled.
 
 `--connections N` disables automatic adjustment and cache use. Supplying
 `--tuning-options` bypasses reading and updating learned counts, but live

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -19,9 +19,10 @@ connection persistence. Its temporary file paths do not change the cache key.
 Learning takes time: syq samples every 2.5 seconds and needs a warm-up interval
 plus two stable samples for one measurement. Saving a count requires a
 successful copy with at least two measured worker counts and an unchanged
-transport. Short copies may only use their starting count. The benchmark's
+transport. Failed or aborted copies leave the previous cached count intact.
+If a copy finishes during another probe, syq saves the last accepted count. Short copies may only use their starting count. The benchmark's
 [untimed warm-up](speed.md#quick-comparison) allows more time before scoring;
-neither its 30-second target nor the separate five-second automatic sizing
+neither its 60-second target nor the separate five-second automatic sizing
 target guarantees tuning has settled.
 
 `--connections N` disables automatic adjustment and cache use. Supplying

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -8,6 +8,27 @@ bounds may change between releases.
 adjustment. In `syq rsync`, use `--syq-connections N`. Use the same count when
 comparing other tuning settings. Leave it unset for everyday copies.
 
+## Remembered connection counts
+
+Remote copies start from the last learned count for the same host route,
+direction and transport, or from 8 workers over SSH and 16 over TCP. The cache
+normally lives at `~/.cache/syq/tuning.json` (`XDG_CACHE_HOME` can change its
+parent). The quick benchmark uses this cache, even though it disables SSH
+connection persistence. Its temporary file paths do not change the cache key.
+
+Learning takes time: syq samples every 2.5 seconds and needs a warm-up interval
+plus two stable samples for one measurement. Saving a count requires a
+successful copy with at least two measured worker counts and an unchanged
+transport. Short copies may only use their starting count; the benchmark's
+five-second automatic sizing target does not ensure tuning has settled.
+
+`--connections N` disables automatic adjustment and cache use. Supplying
+`--tuning-options` bypasses reading and updating learned counts, but live
+auto-tuning continues unless you also fix `--connections`. Use `-vv` to see
+when syq starts from a remembered count.
+
+## Transfer controls
+
 `syq cp` and `syq rsync` accept `--tuning-options`. Supply
 comma-separated `KEY=VALUE` pairs:
 

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -20,6 +20,8 @@ SCRIPT = Path(__file__).resolve().with_name('try-benchmark.sh')
 FAKE_SYQ = r'''#!/usr/bin/env python3
 import json, os, pathlib, shutil, subprocess, sys, time
 args=sys.argv[1:]
+if os.environ.get('BENCH_TEST_ARGS_LOG'):
+    with open(os.environ['BENCH_TEST_ARGS_LOG'], 'a') as log: log.write(json.dumps(args)+'\n')
 if args in (['--version'], ['--build-identity']):
     print('syq test double'); sys.exit(0)
 config=pathlib.Path(os.environ['XDG_CONFIG_HOME'])/'syq'/'persistence.json'
@@ -110,6 +112,46 @@ class BenchmarkTests(unittest.TestCase):
     def assert_clean(self):
         self.assertEqual(self.sentinel.read_text(), 'existing user data')
         self.assertEqual(list(self.scratch.iterdir()), [self.sentinel])
+
+    def test_single_syq_trial_with_literal_tuning_options(self):
+        import json
+        log = self.root / 'args.jsonl'
+        tuning = 'batch-files=256,batch-bytes=2M'
+        result = self.invoke('--mode', 'push', '--host', 'test-host', '--tool', 'syq',
+                             '--', '--no-tcp', '--connections', '4', '--tuning-options', tuning,
+                             env=dict(self.env, BENCH_TEST_ARGS_LOG=str(log)))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.count('Command:'), 1)
+        self.assertEqual(result.stdout.count(', trial 1/1'), 1)
+        self.assertNotIn('large rsync', result.stdout)
+        copies = [args for args in map(json.loads, log.read_text().splitlines()) if args[0] == 'cp']
+        self.assertEqual(len(copies), 2)  # setup and one scored copy
+        for args in copies:
+            self.assertIn('--no-tcp', args)
+            self.assertEqual(args[args.index('--connections')+1], '4')
+            self.assertEqual(args[args.index('--tuning-options')+1], tuning)
+        self.assert_clean()
+
+    def test_single_baseline_tool(self):
+        for tool in ['rsync', 'cp']:
+            with self.subTest(tool=tool):
+                result = self.invoke('--tool', tool)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertEqual(result.stdout.count('Command:'), 1)
+                self.assertIn('Command: ' + tool, result.stdout)
+                self.assertNotIn('large syq', result.stdout)
+                self.assert_clean()
+
+    def test_tuning_cannot_redirect_copy_or_output(self):
+        for args in [('--', '--as', str(self.scratch)), ('--', '--results', str(self.sentinel)),
+                     ('--', '--prune'), ('--', '--connections'),
+                     ('--tool', 'cp', '--mode', 'push', '--host', 'test-host'),
+                     ('--tool', 'rsync', '--', '--no-tcp')]:
+            with self.subTest(args=args):
+                result = self.invoke(*args)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn('Versions:', result.stdout)
+                self.assert_clean()
 
     def test_default_noninteractive_requires_host_before_creating_scratch(self):
         result = subprocess.run(

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -124,10 +124,12 @@ class BenchmarkTests(unittest.TestCase):
         log = self.root / 'args.jsonl'
         tuning = 'batch-files=256,batch-bytes=2M'
         result = self.invoke('--mode', 'push', '--host', 'test-host', '--tool', 'syq',
-                             '--', '--no-tcp', '--connections', '4', '--tuning-options', tuning,
+                             '--', '-vv', '--no-tcp', '--connections', '4', '--tuning-options', tuning,
                              env=dict(self.env, BENCH_TEST_ARGS_LOG=str(log)))
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual(result.stdout.count('Command:'), 1)
+        self.assertIn('Local scratch:', result.stdout)
+        self.assertEqual(result.stdout.count('test double: copy statistics'), 1)
         self.assertEqual(result.stdout.count(', trial 1/1'), 1)
         self.assertNotIn('large rsync', result.stdout)
         copies = [args for args in map(json.loads, log.read_text().splitlines()) if args[0] == 'cp']
@@ -143,10 +145,16 @@ class BenchmarkTests(unittest.TestCase):
             with self.subTest(tool=tool):
                 result = self.invoke('--tool', tool)
                 self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-                self.assertEqual(result.stdout.count('Command:'), 1)
-                self.assertIn('Command: ' + tool, result.stdout)
+                self.assertNotIn('Command:', result.stdout)
                 self.assertNotIn('large syq', result.stdout)
                 self.assert_clean()
+
+    def test_explicit_stats_survive_concise_output(self):
+        result = self.invoke('--tool', 'syq', '--', '--stats')
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.count('test double: copy statistics'), 1)
+        self.assertNotIn('Command:', result.stdout)
+        self.assert_clean()
 
     def test_tuning_cannot_redirect_copy_or_output(self):
         for args in [('--', '--as', str(self.scratch)), ('--', '--results', str(self.sentinel)),
@@ -333,8 +341,8 @@ class BenchmarkTests(unittest.TestCase):
                          ['syq', 'rsync', 'cp', 'rsync', 'cp', 'syq', 'cp', 'syq', 'rsync'])
         self.assertIn('small cp', result.stdout)
         self.assertIn('syq: syq test double', result.stdout)
-        self.assertEqual(result.stdout.count('Command:'), 18)
-        self.assertIn('Command: syq cp --preserve=permissions', result.stdout)
+        self.assertNotIn('Command:', result.stdout)
+        self.assertNotIn('Local scratch:', result.stdout)
         # Each reported mean must agree with the untimed per-trial records;
         # range columns show the variability hidden by a mean alone.
         import re
@@ -360,7 +368,7 @@ class BenchmarkTests(unittest.TestCase):
         self.assertEqual(summaries, 6)
 
         self.assertEqual(result.stdout.count('Preparing the benchmark'), 1)
-        self.assertEqual(result.stdout.count('test double: copy statistics'), 6)
+        self.assertNotIn('test double: copy statistics', result.stdout)
         self.assertIn('Setup complete.', result.stdout)
         self.assertIn('test double: preparing matching remote helper', result.stdout)
         for detail in ['14-byte', 'tiny setup copy', 'Caches are NOT flushed', 'twice the selected', 'permissions preserved']:
@@ -376,6 +384,10 @@ class BenchmarkTests(unittest.TestCase):
                 self.assertIn('Preparing syq syq test double on test-host', result.stdout)
                 self.assertIn('test double: preparing matching remote helper', result.stdout)
                 self.assertIn('Setup complete: syq syq test double is ready on test-host', result.stdout)
+                self.assertEqual(result.stdout.count('Connection profile:'), 1)
+                self.assertNotIn('Checking copied data...', result.stdout)
+                self.assertIn('Copying:', result.stdout)
+                self.assertIn('Copy MB/s', result.stdout)
                 self.assert_clean()
 
     def test_persistence_off_ignores_and_preserves_user_policy_and_runtime(self):

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -58,6 +58,8 @@ if '--results' in args:
     if not os.environ.get('BENCH_TEST_OLD'):
         if dst.name == 'calibration':
             copy_ms=2500 if os.environ.get('BENCH_TEST_GROW') and len(list(src.iterdir())) == 1024 else 5000
+        if dst.name == 'warmup':
+            copy_ms=1000 if os.environ.get('BENCH_TEST_SHORT_WARMUP') else 30000
         result['copying_elapsed_ms']=copy_ms
     if os.environ.get('BENCH_TEST_BAD_TIMING'):
         result['copying_elapsed_ms']=999999999
@@ -68,6 +70,8 @@ if '--quiet' not in args and '--suppress-summary' not in args:
     print('test double: copy statistics')
 if mode == 'corrupt':
     next(dst.iterdir()).write_bytes(b'bad')
+if dst.name == 'warmup' and os.environ.get('BENCH_TEST_CORRUPT_WARMUP'):
+    next(dst.iterdir()).write_bytes(b'bad')
 '''
 FAKE_SSH = '''#!/usr/bin/env bash
 set -eu
@@ -77,6 +81,7 @@ fi
 while [[ $1 == -o ]]; do shift 2; done
 shift
 if [[ ${BENCH_TEST_CLEANUP_FAIL:-} == 1 && $* == *cleanup_dir=* ]]; then exit 255; fi
+if [[ ${BENCH_TEST_GENERATION_FAIL:-} == 1 && $* == *'openssl enc'* ]]; then exit 23; fi
 exec /bin/sh -c "$*"
 '''
 
@@ -138,6 +143,67 @@ class BenchmarkTests(unittest.TestCase):
             self.assertIn('--no-tcp', args)
             self.assertEqual(args[args.index('--connections')+1], '4')
             self.assertEqual(args[args.index('--tuning-options')+1], tuning)
+        self.assert_clean()
+
+    def test_warmup_precedes_scored_copies_in_both_directions(self):
+        import json
+        for mode in ['push', 'pull']:
+            with self.subTest(mode=mode):
+                log = self.root / ('warmup-' + mode + '.jsonl')
+                result = self.invoke('--mode', mode, '--host', 'test-host', '--tool', 'syq',
+                                     '--workload', 'both', '--', '--no-tcp',
+                                     env=dict(self.env, BENCH_TEST_ARGS_LOG=str(log)))
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                copies = [a for a in map(json.loads, log.read_text().splitlines()) if a[0] == 'cp']
+                destinations = [Path(a[a.index('--into-existing')+1]).name for a in copies]
+                self.assertEqual(destinations, ['probe', 'warmup', 'trial', 'warmup', 'trial'])
+                self.assertTrue(all('--no-tcp' in a for a in copies))
+                self.assertEqual(result.stdout.count('Verified warm-up;'), 2)
+                self.assertEqual(result.stdout.count(', trial 1/1'), 2)
+                self.assertIn('small: 65536 bytes per trial', result.stdout)
+                if mode == 'pull':
+                    self.assertEqual(result.stdout.count('Generating matching remote warm-up data'), 2)
+                    self.assertEqual(result.stdout.count('Staging source on remote host'), 2)
+                self.assert_clean()
+
+    def test_warmup_can_be_skipped_and_manual_tuning_skips_it(self):
+        options = [('--warmup', 'off'), ('--', '--connections', '1'), ('--', '-j1'),
+                   ('--', '--connections=1'), ('--', '--tuning-options', 'request-size=1M'),
+                   ('--', '--tuning-options=request-size=1M'), ('--tool', 'rsync')]
+        for args in options:
+            with self.subTest(args=args):
+                result = self.invoke('--mode', 'push', '--host', 'test-host', *args)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertNotIn('Warming up syq', result.stdout)
+                self.assertIn('Results (MB/s', result.stdout)
+                self.assert_clean()
+
+    def test_short_warmup_stops_at_limit_and_keeps_scored_size(self):
+        result = self.invoke('--mode', 'pull', '--host', 'test-host', '--tool', 'syq',
+                             '--workload', 'small',
+                             env=dict(self.env, BENCH_TEST_SHORT_WARMUP='1'))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.count('Verified warm-up;'), 2)
+        self.assertIn('limit before 30 copying seconds', result.stdout)
+        self.assertIn('small: 65536 bytes per trial', result.stdout)
+        self.assert_clean()
+
+    def test_warmup_failures_stop_before_scoring(self):
+        for failure in ['BENCH_TEST_CORRUPT_WARMUP', 'BENCH_TEST_GENERATION_FAIL']:
+            with self.subTest(failure=failure):
+                result = self.invoke('--mode', 'pull', '--host', 'test-host',
+                                     env=dict(self.env, **{failure: '1'}))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn(', trial 1/', result.stdout)
+                self.assertNotIn('Results (', result.stdout)
+                self.assert_clean()
+
+    def test_warmup_missing_old_timing_does_not_claim_it_settled(self):
+        result = self.invoke('--mode', 'push', '--host', 'test-host', '--tool', 'syq',
+                             env=dict(self.env, BENCH_TEST_OLD='1'))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn('cannot report copying time; tuning may not have settled', result.stdout)
+        self.assertIn('Results (MB/s', result.stdout)
         self.assert_clean()
 
     def test_single_baseline_tool(self):

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -102,7 +102,7 @@ class BenchmarkTests(unittest.TestCase):
 
     def invoke(self, *args, env=None):
         return subprocess.run(
-            ['/bin/bash', str(SCRIPT), '--yes', '--source-dir', str(self.scratch),
+            ['/bin/bash', str(SCRIPT), '--yes', '--mode', 'local', '--source-dir', str(self.scratch),
              '--dest-dir', str(self.scratch), '--rounds', '1', '--workload', 'large', '--size', 'quick', *args],
             env=env or self.env, capture_output=True, text=True, timeout=60,
         )
@@ -110,6 +110,54 @@ class BenchmarkTests(unittest.TestCase):
     def assert_clean(self):
         self.assertEqual(self.sentinel.read_text(), 'existing user data')
         self.assertEqual(list(self.scratch.iterdir()), [self.sentinel])
+
+    def test_default_noninteractive_requires_host_before_creating_scratch(self):
+        result = subprocess.run(
+            ['/bin/bash', str(SCRIPT), '--yes', '--source-dir', str(self.scratch)],
+            env=self.env, capture_output=True, text=True, timeout=10)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('Pass --host USER@HOST', result.stderr)
+        self.assert_clean()
+
+    def test_generation_and_checks_keep_launch_directory(self):
+        log = self.root / 'working-directories'
+        for name in ['cksum', 'split']:
+            executable = shutil.which(name)
+            path = self.bin / name
+            path.unlink()
+            path.write_text('#!/bin/bash\npwd -P >> ' + shlex.quote(str(log)) +
+                            '\nexec ' + shlex.quote(executable) + ' "$@"\n')
+            path.chmod(0o755)
+        result = self.invoke('--workload', 'small')
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(log.read_text().splitlines())
+        self.assertEqual(set(log.read_text().splitlines()), {str(Path.cwd().resolve())})
+        self.assert_clean()
+
+    def test_checksum_command_failure_is_not_hidden_by_path_normalization(self):
+        executable = shutil.which('cksum')
+        path = self.bin / 'cksum'
+        path.unlink()
+        path.write_text('#!/bin/bash\nif [[ $* == */trial/* ]]; then exit 23; fi\nexec ' +
+                        shlex.quote(executable) + ' "$@"\n')
+        path.chmod(0o755)
+        for mode in ['local', 'push']:
+            with self.subTest(mode=mode):
+                result = self.invoke('--mode', mode, '--host', 'test-host')
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn('Results (', result.stdout)
+                self.assert_clean()
+
+    def test_local_summary_reports_seconds_even_for_a_fast_clone(self):
+        records = self.root / 'results'
+        records.write_text('large cp 0.002 6710886400\nlarge cp 0.004 6710886400\n')
+        definitions = SCRIPT.read_text().removesuffix('main "$@"\n')
+        result = subprocess.run(['/bin/bash', '-c', definitions +
+                                 '\nsummarize_results "$1" seconds', 'summary-test', str(records)],
+                                env=self.env, capture_output=True, text=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(['large', 'cp', '0.003', '0.002', '0.004', '2'],
+                      [line.split() for line in result.stdout.splitlines()])
 
     def test_auto_sizes_with_syq_for_each_direction(self):
         for mode in ['local', 'push', 'pull']:
@@ -199,7 +247,7 @@ class BenchmarkTests(unittest.TestCase):
             match = re.match(r'(large|small): (syq|rsync|cp), trial', line)
             if match:
                 current = tuple(match.groups())
-            match = re.match(r'Verified contents; speed ([0-9.]+) MB/s', line)
+            match = re.match(r'Verified contents; elapsed ([0-9.]+) seconds', line)
             if match:
                 trials.setdefault(current, []).append(float(match[1]))
         summaries = 0
@@ -434,8 +482,8 @@ class BenchmarkTests(unittest.TestCase):
             os.execvpe('/bin/bash', ['/bin/bash', '-c', f'cat {shlex.quote(str(SCRIPT))} | /bin/bash'], dict(self.env, BENCH_TEST_ASK='1'))
         output = b''
         prompts_answered = 0
-        # All four default answers are read from /dev/tty, not the script pipe.
-        os.write(fd, b'\n' * 4)
+        # Accept push and small, supply a host and remote scratch parent.
+        os.write(fd, b'\ntest-host\n\n\n' + str(self.scratch).encode() + b'\n')
         deadline = time.monotonic() + 90
         try:
             while time.monotonic() < deadline:
@@ -455,6 +503,8 @@ class BenchmarkTests(unittest.TestCase):
             _, status = os.waitpid(pid, 0)
             self.assertEqual(os.waitstatus_to_exitcode(status), 0, output.decode())
             self.assertIn(b'Results (MB/s', output)
+            self.assertIn(b'Mode: push; workloads: small; size: quick', output)
+            self.assertNotIn(b'Generating one ', output)
             self.assert_clean()
         finally:
             os.close(fd)

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -209,21 +209,26 @@ class BenchmarkTests(unittest.TestCase):
 
     def test_timing_breakdown_and_short_or_setup_heavy_notes(self):
         records = self.root / 'timings'
-        records.write_text('large 10 8000\nlarge 14 10000\n'
-                           'small 10 3000\nshort 0.4 100\nzero 0.01 0\n'
-                           'old 5 n/a\nold 7 5000\n')
+        records.write_text('large 10 8000 80000000\nlarge 14 10000 80000000\n'
+                           'small 10 3000 6000000\nshort 0.4 100 1000000\n'
+                           'zero 0.01 0 1000\nzero 1 500 1000\n'
+                           'old 5 n/a 1000000\nold 7 5000 1000000\n'
+                           'boundary 10 8000 8000000\nbelow 10 8001 8000000\n')
         definitions = SCRIPT.read_text().removesuffix('main "$@"\n')
         result = subprocess.run(['/bin/bash', '-c', definitions +
                                  '\nsummarize_syq_timings "$1"', 'timing-test', str(records)],
                                 env=self.env, capture_output=True, text=True, timeout=10)
         self.assertEqual(result.returncode, 0, result.stderr)
         rows = [line.split() for line in result.stdout.splitlines()]
-        self.assertIn(['large', '12.000', '9.000', '3.000'], rows)
-        self.assertIn(['old', '6.000', 'n/a', 'n/a'], rows)
-        self.assertIn(['zero', '0.010', '0.000', '0.010'], rows)
+        self.assertIn(['large', '12.000', '9.000', '3.000', '9.000'], rows)
+        self.assertIn(['old', '6.000', 'n/a', 'n/a', 'n/a'], rows)
+        self.assertIn(['zero', '0.505', '0.250', '0.255', 'n/a'], rows)
+        self.assertIn('Note (zero): copying speed unavailable', result.stdout)
         self.assertIn('Note (small): 70%', result.stdout)
         self.assertIn('Note (short): syq copying averaged under 1 second', result.stdout)
-        self.assertNotIn('Note (large)', result.stdout)
+        self.assertIn('Note (large): 25%', result.stdout)
+        self.assertIn('Note (boundary): 20%', result.stdout)
+        self.assertNotIn('Note (below)', result.stdout)
         self.assertIn('not pure network time', result.stdout)
 
     def test_fixed_size_with_old_syq_keeps_total_results(self):

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -50,11 +50,17 @@ if mode == 'hang':
     child=subprocess.Popen(['sleep','300'])
     pathlib.Path(os.environ['BENCH_TEST_PID']).write_text(str(child.pid))
     child.wait(); sys.exit(1)
+copy_start=time.monotonic()
 shutil.copytree(src,dst,dirs_exist_ok=True)
+copy_ms=int((time.monotonic()-copy_start)*1000)
 if '--results' in args:
     result={'type': 'result', 'status': 'success'}
     if not os.environ.get('BENCH_TEST_OLD'):
-        result['copying_elapsed_ms']=2500 if os.environ.get('BENCH_TEST_GROW') and len(list(src.iterdir())) == 1024 else 5000
+        if dst.name == 'calibration':
+            copy_ms=2500 if os.environ.get('BENCH_TEST_GROW') and len(list(src.iterdir())) == 1024 else 5000
+        result['copying_elapsed_ms']=copy_ms
+    if os.environ.get('BENCH_TEST_BAD_TIMING'):
+        result['copying_elapsed_ms']=999999999
     pathlib.Path(args[args.index('--results')+1]).write_text(json.dumps(result)+'\n')
 if '--quiet' not in args and src.name == 'probe':
     print('test double: preparing matching remote helper', flush=True)
@@ -200,6 +206,50 @@ class BenchmarkTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn(['large', 'cp', '0.003', '0.002', '0.004', '2'],
                       [line.split() for line in result.stdout.splitlines()])
+
+    def test_timing_breakdown_and_short_or_setup_heavy_notes(self):
+        records = self.root / 'timings'
+        records.write_text('large 10 8000\nlarge 14 10000\n'
+                           'small 10 3000\nshort 0.4 100\nzero 0.01 0\n'
+                           'old 5 n/a\nold 7 5000\n')
+        definitions = SCRIPT.read_text().removesuffix('main "$@"\n')
+        result = subprocess.run(['/bin/bash', '-c', definitions +
+                                 '\nsummarize_syq_timings "$1"', 'timing-test', str(records)],
+                                env=self.env, capture_output=True, text=True, timeout=10)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        rows = [line.split() for line in result.stdout.splitlines()]
+        self.assertIn(['large', '12.000', '9.000', '3.000'], rows)
+        self.assertIn(['old', '6.000', 'n/a', 'n/a'], rows)
+        self.assertIn(['zero', '0.010', '0.000', '0.010'], rows)
+        self.assertIn('Note (small): 70%', result.stdout)
+        self.assertIn('Note (short): syq copying averaged under 1 second', result.stdout)
+        self.assertNotIn('Note (large)', result.stdout)
+        self.assertIn('not pure network time', result.stdout)
+
+    def test_fixed_size_with_old_syq_keeps_total_results(self):
+        result = self.invoke('--tool', 'syq', env=dict(self.env, BENCH_TEST_OLD='1'))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn('Results (seconds', result.stdout)
+        self.assertIn('copying timing unavailable', result.stdout)
+        self.assert_clean()
+
+    def test_invalid_timing_is_rejected(self):
+        definitions = SCRIPT.read_text().removesuffix('main "$@"\n')
+        records = self.root / 'timings.json'
+        for record in ['{}', '{bad json',
+                       '{"type":"result","status":"failed","copying_elapsed_ms":1}',
+                       '{"type":"result","status":"success","copying_elapsed_ms":-1}']:
+            with self.subTest(record=record):
+                records.write_text(record + '\n')
+                result = subprocess.run(['/bin/bash', '-c', definitions +
+                                         '\ncopying_interval "$1"', 'timing-test', str(records)],
+                                        env=self.env, capture_output=True, text=True, timeout=10)
+                self.assertNotEqual(result.returncode, 0)
+        result = self.invoke('--tool', 'syq', env=dict(self.env, BENCH_TEST_BAD_TIMING='1'))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('copying interval exceeds total trial time', result.stderr)
+        self.assertNotIn('Results (', result.stdout)
+        self.assert_clean()
 
     def test_auto_sizes_with_syq_for_each_direction(self):
         for mode in ['local', 'push', 'pull']:

--- a/scripts/test-try-benchmark.py
+++ b/scripts/test-try-benchmark.py
@@ -59,7 +59,7 @@ if '--results' in args:
         if dst.name == 'calibration':
             copy_ms=2500 if os.environ.get('BENCH_TEST_GROW') and len(list(src.iterdir())) == 1024 else 5000
         if dst.name == 'warmup':
-            copy_ms=1000 if os.environ.get('BENCH_TEST_SHORT_WARMUP') else 30000
+            copy_ms=1000 if os.environ.get('BENCH_TEST_SHORT_WARMUP') else int(os.environ.get('BENCH_TEST_WARMUP_MS', '60000'))
         result['copying_elapsed_ms']=copy_ms
     if os.environ.get('BENCH_TEST_BAD_TIMING'):
         result['copying_elapsed_ms']=999999999
@@ -184,7 +184,7 @@ class BenchmarkTests(unittest.TestCase):
                              env=dict(self.env, BENCH_TEST_SHORT_WARMUP='1'))
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual(result.stdout.count('Verified warm-up;'), 2)
-        self.assertIn('limit before 30 copying seconds', result.stdout)
+        self.assertIn('limit before 60 copying seconds', result.stdout)
         self.assertIn('small: 65536 bytes per trial', result.stdout)
         self.assert_clean()
 
@@ -197,6 +197,16 @@ class BenchmarkTests(unittest.TestCase):
                 self.assertNotIn(', trial 1/', result.stdout)
                 self.assertNotIn('Results (', result.stdout)
                 self.assert_clean()
+
+    def test_thirty_seconds_no_longer_finishes_warmup(self):
+        result = self.invoke('--mode', 'push', '--host', 'test-host', '--tool', 'syq',
+                             '--workload', 'small',
+                             env=dict(self.env, BENCH_TEST_WARMUP_MS='30000'))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(result.stdout.count('Verified warm-up;'), 3)
+        self.assertIn('limit before 60 copying seconds', result.stdout)
+        self.assertIn('small: 65536 bytes per trial', result.stdout)
+        self.assert_clean()
 
     def test_warmup_missing_old_timing_does_not_claim_it_settled(self):
         result = self.invoke('--mode', 'push', '--host', 'test-host', '--tool', 'syq',

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -39,11 +39,13 @@ Use --tool syq --rounds 1 --size quick for one scored syq copy per workload.
 The untimed setup copy and content checks still run. Source/destination,
 removal and output-file options are not accepted after --.
 
-Requires Bash, rsync, OpenSSL, and standard Unix utilities locally. Automatic
-sizing needs Perl with its core JSON::PP module; terminal runs also need Perl. Remote tests
+Requires Bash, rsync, OpenSSL, and standard Unix utilities locally. Syq timing
+uses Perl with its core JSON::PP module; terminal runs also need Perl. Remote tests
 also need SSH locally and rsync plus standard utilities on the remote host.
 SSH tests disable syq persistence in private settings and prevent rsync from
 reusing SSH connections. Every timed trial includes connection startup.
+Syq also reports its copying interval and other time (setup/finish). Short or
+setup-heavy trials get a note: total-time speeds may not show sustained throughput.
 The default push needs --host with --yes. Use a second machine, preferably
 on a fast link with some latency and reachable TCP data ports 47600-47699.
 Local results report seconds: filesystem clones do not measure byte throughput.
@@ -194,7 +196,7 @@ make_data() {
 }
 copy_with() {
     local tool=$1 source=$2 destination=$3
-    local command=() syq_options=(--preserve=permissions)
+    local command=() syq_options=(--preserve=permissions --results "$local_root/trial.json")
     # This repository-owned caller suppresses only the tiny copy's summary,
     # keeping bootstrap diagnostics and authentication prompts live. Supported
     # by the released v0.3.2 CLI as well as current builds.
@@ -262,18 +264,55 @@ next_amount() {
     }'
 }
 calibration_interval() {
+    copying_interval "$1" required
+}
+copying_interval() {
     perl -MJSON::PP -e '
+        my $required=shift @ARGV;
         my $result;
         while (<>) {
             my $record=decode_json($_);
             $result=$record if ($record->{type} // "") eq "result";
         }
-        die "Missing successful copying timing\n" unless
-            $result && $result->{status} eq "success" &&
-            defined($result->{copying_elapsed_ms}) &&
-            $result->{copying_elapsed_ms} =~ /^\d+$/;
+        die "Missing successful result\n" unless
+            $result && ($result->{status} // "") eq "success";
+        if (!defined($result->{copying_elapsed_ms}) && $required ne "required") {
+            print "n/a\n"; exit;
+        }
+        die "Missing or invalid copying timing\n" unless
+            defined($result->{copying_elapsed_ms}) && $result->{copying_elapsed_ms} =~ /^\d+$/;
         print $result->{copying_elapsed_ms}, "\n";
-    ' "$1"
+    ' "${2:-optional}" "$1"
+}
+
+summarize_syq_timings() {
+    [[ -s $1 ]] || return 0
+    printf '\nSyq timing breakdown (mean seconds per trial):\n'
+    awk '{
+        key=$1; if (!(key in n)) order[++count]=key;
+        n[key]++; total[key]+=$2;
+        if ($3 == "n/a") unavailable[key]=1;
+        else copying[key]+=$3 / 1000;
+    } END {
+        printf "%-18s %10s %10s %10s\n", "Workload", "Total", "Copying", "Other";
+        for (i=1; i<=count; i++) {
+            key=order[i];
+            if (unavailable[key]) {
+                printf "%-18s %10.3f %10s %10s\n", key, total[key]/n[key], "n/a", "n/a";
+                print "Note (" key "): copying timing unavailable; update syq for a breakdown.";
+                continue;
+            }
+            other=total[key]-copying[key];
+            printf "%-18s %10.3f %10.3f %10.3f\n", key, total[key]/n[key], copying[key]/n[key], other/n[key];
+            if (total[key] > 0 && other >= total[key]*0.5)
+                printf "Note (%s): %.0f%% of syq total time was outside copying; setup/finish substantially affects this comparison.\n", key, other/total[key]*100;
+            if (copying[key]/n[key] < 1)
+                print "Note (" key "): syq copying averaged under 1 second; this test is too short to assess sustained throughput.";
+        }
+    }' "$1"
+    printf 'Other = total minus copying (setup/finish). Copying includes per-file work and waiting, and can overlap setup.\n'
+    printf 'This is not pure network time or an exact setup measurement. Rsync/cp have total time only.\n'
+    printf 'For sustained-throughput comparisons, try --workload large --size auto or a larger fixed --size.\n'
 }
 
 summarize_results() {
@@ -375,9 +414,10 @@ main() {
     [[ $rounds =~ ^[1-9]$ ]] || fail 'Rounds must be between 1 and 9.'
     for tool in bash rsync openssl dd split cksum cmp awk mktemp mkdir rm cat ps sleep sed; do need "$tool"; done
     [[ $mode != local ]] || need cp
-    if [[ $size == auto ]]; then
-        need df; need perl
-        perl -MJSON::PP -e 1 || fail 'Automatic sizing needs Perl with JSON::PP.'
+    [[ $size != auto ]] || need df
+    if [[ $size == auto || $selected_tool == all || $selected_tool == syq ]]; then
+        need perl
+        perl -MJSON::PP -e 1 || fail 'Syq timing needs Perl with JSON::PP.'
     fi
     if [[ $mode != local ]]; then
         [[ -n $host ]] || fail 'Network benchmarks need an SSH host. Pass --host USER@HOST, or --mode local for a local comparison.'
@@ -448,6 +488,7 @@ main() {
     [[ $selected_tool == all ]] || tools=("$selected_tool")
     [[ $workload == both ]] || workloads=("$workload")
     : > "$local_root/results"
+    : > "$local_root/syq-timings"
     for case_name in "${workloads[@]}"; do
         if [[ $case_name == "${workloads[0]}" ]]; then
             # Do this once, not once per workload. Keep the measured copy's full
@@ -544,6 +585,7 @@ main() {
                 if [[ $mode == push ]]; then destination=$remote_root/trial; remote "mkdir $(quote "$destination")"
                 else mkdir "$destination"; fi
                 printf '\n%s: %s, trial %s/%s (%s bytes)\n' "$case_name" "$tool" "$round" "$rounds" "$bytes"
+                rm -f -- "$local_root/trial.json"
                 run timed_copy "$tool" "$source" "$destination" || fail "$tool failed; no successful result recorded for this trial."
                 seconds=$(cat "$local_root/time")
                 printf 'Checking copied data...\n'
@@ -559,6 +601,16 @@ main() {
                     printf 'Verified contents; elapsed %s seconds.\n' "$seconds"
                 else
                     printf 'Verified contents; speed %s MB/s; elapsed %s seconds.\n' "$speed" "$seconds"
+                fi
+                if [[ $tool == syq ]]; then
+                    copying_ms=$(copying_interval "$local_root/trial.json") || fail 'Cannot read syq trial timing.'
+                    if [[ $copying_ms != n/a ]]; then
+                        awk -v ms="$copying_ms" -v seconds="$seconds" 'BEGIN {
+                            if (ms / 1000 > seconds) exit 1;
+                            printf "Syq copying interval: %.3f seconds; other time (setup/finish): %.3f seconds.\n", ms/1000, seconds-ms/1000;
+                        }' || fail 'Syq copying interval exceeds total trial time.'
+                    fi
+                    printf '%s %s %s\n' "$case_name" "$seconds" "$copying_ms" >> "$local_root/syq-timings"
                 fi
                 if [[ $mode == push ]]; then remote "rm -rf $(quote "$destination")"
                 else rm -rf -- "$destination"; fi
@@ -577,6 +629,7 @@ main() {
     fi
     [[ $mode == local ]] || printf 'Connection profile: syq persistence OFF; rsync fresh SSH; connection startup is timed for every trial.\n'
     summarize_results "$local_root/results" "$metric"
+    summarize_syq_timings "$local_root/syq-timings"
     printf '\nCompare the trial range as well as the mean; small differences may be noise.\n'
     printf 'Results depend on your machines and workload.\n'
 }

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -27,6 +27,8 @@ Without --yes, unanswered choices are prompted through /dev/tty (also with curl 
                            For pull, --source-dir is the local destination parent.
   --tool all|syq|rsync|cp   Tools to time (default: all; cp requires local mode)
   --rounds N               Trials per tool/workload, rotating order (default: 3)
+  --warmup on|off          Untimed syq tuning warm-up before each network workload
+                           (default: on). Skip with manual tuning or other tools.
   --install                Install syq locally if missing, using its official installer
   --yes                    Use defaults for unspecified choices; do not prompt
   --help                   Show this help
@@ -34,10 +36,10 @@ Without --yes, unanswered choices are prompted through /dev/tty (also with curl 
 After --, tune syq with --connections/-j, --tuning-options, --bwlimit,
 --tcp-ports, --tcp-congestion (each takes a value), or --no-tcp, --no-compress,
 --tcp-plain, --inplace, --stats, --no-progress, -v/-vv/--verbose.
-These options also apply to syq setup/calibration; rsync and cp are unchanged.
+These options also apply to syq setup/warm-up/calibration; rsync and cp are unchanged.
 Add -v/-vv/--verbose after -- to show full commands and scratch paths.
 Use --tool syq --rounds 1 --size quick for one scored syq copy per workload.
-The untimed setup copy and content checks still run. Source/destination,
+The untimed setup copy, eligible warm-up, and content checks still run. Source/destination,
 removal and output-file options are not accepted after --.
 
 Requires Bash, rsync, OpenSSL, and standard Unix utilities locally. Syq timing
@@ -46,6 +48,10 @@ also need SSH locally and rsync plus standard utilities on the remote host.
 SSH tests disable syq persistence in private settings and prevent rsync from
 reusing SSH connections. Every timed trial includes connection startup.
 Auto-tuning and remembered counts stay active unless overridden by tuning options.
+Warm-up aims for 30 copying seconds, using up to four growing copies of at most
+1 GiB each, space permitting. This is not a wall-time limit or proof tuning settled.
+Pull warm-ups generate matching source data remotely (needs Bash and OpenSSL).
+Use --warmup off for a short comparison using the existing cached/default count.
 Syq also reports copying time, copying MB/s, and other time (setup/finish).
 A note flags >=20% outside copying or copying under one second: total-time
 speeds may not show sustained throughput.
@@ -183,20 +189,97 @@ manifest() { bash -c "$manifest_command" manifest "$1" | manifest_names; }
 remote_manifest() { remote "set -- $(quote "$1")
 $manifest_command" | manifest_names; }
 
-make_data() {
-    local workload=$1 amount=$2
-    mkdir "$local_root/$workload"
+data_command() {
+    local workload=$1 amount=$2 root=$3 block=8192
     # Fixed AES-CTR stream: deterministic, dense and effectively incompressible.
-    # No keys or user data are involved. Generation is outside measured time.
+    # One generator for local and remote data. Paths are quoted, and the program
+    # stays on one line for transport through the remote shell.
+    [[ $workload != large ]] || block=1048576
+    printf 'set -euo pipefail; mkdir %s; dd if=/dev/zero bs=%s count=%s 2>/dev/null | openssl enc -aes-256-ctr -nosalt -K %s -iv %s' \
+        "$(quote "$root/$workload")" "$block" "$amount" "$key" "$iv"
     if [[ $workload == large ]]; then
-        dd if=/dev/zero bs=1048576 count="$amount" 2>/dev/null |
-            openssl enc -aes-256-ctr -nosalt -K "$key" -iv "$iv" > "$local_root/$workload/data"
+        printf ' > %s\n' "$(quote "$root/$workload/data")"
     else
-        dd if=/dev/zero bs=8192 count="$amount" 2>/dev/null |
-            openssl enc -aes-256-ctr -nosalt -K "$key" -iv "$iv" |
-            split -b 8192 -a 6 - "$local_root/$workload/file-"
+        printf ' | split -b 8192 -a 6 - %s\n' "$(quote "$root/$workload/file-")"
     fi
 }
+make_data() { bash -c "$(data_command "$1" "$2" "$local_root")"; }
+prepare_dataset() {
+    local workload=$1 amount=$2
+    if [[ $workload == large ]]; then
+        printf 'Generating one %s MiB file...\n' "$amount"
+        bytes=$((amount * 1048576))
+    else
+        printf 'Generating %s files of 8 KiB each...\n' "$amount"
+        bytes=$((amount * 8192))
+    fi
+    run make_data "$workload" "$amount"
+    printf 'Preparing content checks...\n'
+    manifest "$local_root/$workload" > "$local_root/expected"
+    source=$local_root/$workload
+    if [[ $mode == pull ]]; then
+        if [[ ${3:-} == warmup ]]; then
+            # Avoid uploading a large tuning fixture over the laptop uplink
+            # before testing its downlink. Generate the identical byte stream.
+            printf 'Generating matching remote warm-up data (untimed)...\n'
+            run remote "bash -c $(quote "$(data_command "$workload" "$amount" "$remote_root")")"
+        else
+            printf 'Staging source on remote host (untimed)...\n'
+            run rsync -rpt -- "$source/" "$host:$(quote "$remote_root/$workload/")"
+        fi
+        source=$remote_root/$workload
+        remote_manifest "$source" > "$local_root/actual"
+        cmp "$local_root/expected" "$local_root/actual" || fail 'Remote staging verification failed.'
+    fi
+}
+
+warm_up() {
+    local workload=$1 amount capacity next copying_ms attempt limit
+    if [[ $workload == large ]]; then amount=64; limit=1024
+    else amount=1024; limit=131072; fi
+    if [[ ${SYQ_BENCHMARK_TEST_SMALL_FIXTURES:-} == 1 ]]; then
+        if [[ $workload == large ]]; then amount=1; limit=4
+        else amount=8; limit=32; fi
+    fi
+    capacity=$(space_capacity "$workload")
+    [[ $capacity -le $limit ]] || capacity=$limit
+    if [[ $capacity -lt 1 ]]; then
+        printf 'Note: no room for the %s warm-up; using existing cached/default tuning.\n' "$workload"
+        return
+    fi
+    [[ $amount -le $capacity ]] || amount=$capacity
+    printf '\nWarming up syq for %s (untimed; target 30 copying seconds, up to 4 copies, 1 GiB per dataset)...\n' "$workload"
+    for ((attempt=1; attempt<=4; attempt++)); do
+        prepare_dataset "$workload" "$amount" warmup
+        destination=$dest_root/warmup
+        if [[ $mode == push ]]; then destination=$remote_root/warmup; remote "mkdir $(quote "$destination")"
+        else mkdir "$destination"; fi
+        rm -f -- "$local_root/warmup.json"
+        run copy_with syq "$source" "$destination" warmup || fail 'Syq warm-up failed.'
+        if [[ $mode == push ]]; then remote_manifest "$destination" > "$local_root/actual"
+        else manifest "$destination" > "$local_root/actual"; fi
+        cmp "$local_root/expected" "$local_root/actual" || fail 'Warm-up content check failed.'
+        copying_ms=$(copying_interval "$local_root/warmup.json") || fail 'Cannot read syq warm-up timing.'
+        if [[ $mode == push ]]; then remote "rm -rf $(quote "$destination")"
+        else rm -rf -- "$destination"; fi
+        # Check space before removing the source, as for automatic sizing.
+        capacity=$(space_capacity "$workload")
+        [[ $capacity -le $limit ]] || capacity=$limit
+        rm -rf -- "${local_root:?}/${workload:?}"
+        [[ $mode != pull ]] || remote "rm -rf $(quote "$source")"
+        if [[ $copying_ms == n/a ]]; then
+            printf 'Note: warm-up verified, but this syq cannot report copying time; tuning may not have settled.\n'
+            return
+        fi
+        awk -v ms="$copying_ms" 'BEGIN {printf "Verified warm-up; copying interval %.3f seconds.\n", ms/1000}'
+        [[ $copying_ms -lt 30000 ]] || return 0
+        next=$(next_amount "$amount" "$copying_ms" "$capacity" 30000)
+        [[ $next -gt $amount && $attempt -lt 4 ]] || break
+        amount=$next
+    done
+    printf 'Note: %s warm-up reached its size, space or attempt limit before 30 copying seconds; tuning may not have settled.\n' "$workload"
+}
+
 copy_with() {
     local tool=$1 source=$2 destination=$3
     local command=() syq_options=(--preserve=permissions --results "$local_root/trial.json")
@@ -206,6 +289,7 @@ copy_with() {
     # by the released v0.3.2 CLI as well as current builds.
     [[ ${4:-} != setup ]] || syq_options=(--preserve=permissions --suppress-summary --no-progress)
     [[ ${4:-} != calibration ]] || syq_options=(--preserve=permissions --suppress-summary --results "$local_root/calibration.json")
+    [[ ${4:-} != warmup ]] || syq_options=(--preserve=permissions --suppress-summary --results "$local_root/warmup.json")
     if $has_syq_options; then syq_options+=("${syq_extra[@]}"); fi
     case $tool in
         syq)
@@ -257,8 +341,8 @@ available_kib() {
          END {if (!found) exit 1; print available}'
 }
 next_amount() {
-    awk -v current="$1" -v ms="$2" -v capacity="$3" 'BEGIN {
-        estimate=current * 5000 / (ms > 0 ? ms : 1);
+    awk -v current="$1" -v ms="$2" -v capacity="$3" -v target="${4:-5000}" 'BEGIN {
+        estimate=current * target / (ms > 0 ? ms : 1);
         amount=int(estimate); if (amount < estimate) amount++;
         minimum=int(current * 1.25); if (minimum < current * 1.25) minimum++;
         if (amount < minimum) amount=minimum;
@@ -354,6 +438,7 @@ main() {
     local mode='' workload='' size='' source_dir='' dest_dir='' rounds=3 yes=false install=false
     local option tool round index offset source destination case_name bytes seconds speed local_parent remote_parent
     local large_mib small_files syq_identity selected_tool=all has_syq_options=false verbose=false show_syq_summary=false
+    local warmup=on warmup_enabled=false manual_tuning=false
     local syq_extra=()
     local key=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
     local iv=000102030405060708090a0b0c0d0e0f
@@ -369,8 +454,10 @@ main() {
                     case $1 in
                         --connections|-j|--tuning-options|--bwlimit|--tcp-ports|--tcp-congestion)
                             [[ $# -ge 2 && -n $2 ]] || fail "$1 needs a value"
+                            case $1 in --connections|-j|--tuning-options) manual_tuning=true ;; esac
                             syq_extra+=("$1" "$2"); shift 2 ;;
                         --connections=?*|--tuning-options=?*|--bwlimit=?*|--tcp-ports=?*|--tcp-congestion=?*|-j[0-9]*)
+                            case $1 in --connections=*|--tuning-options=*|-j[0-9]*) manual_tuning=true ;; esac
                             syq_extra+=("$1"); shift ;;
                         -v|-vv|--verbose)
                             verbose=true; show_syq_summary=true; syq_extra+=("$1"); shift ;;
@@ -383,12 +470,12 @@ main() {
                     has_syq_options=true
                 done
                 break ;;
-            --mode|--host|--workload|--size|--source-dir|--dest-dir|--rounds|--tool)
+            --mode|--host|--workload|--size|--source-dir|--dest-dir|--rounds|--tool|--warmup)
                 [[ $# -ge 2 && -n $2 ]] || fail "$option needs a value"
                 case $option in
                     --mode) mode=$2 ;; --host) host=$2 ;; --workload) workload=$2 ;;
                     --size) size=$2 ;; --source-dir) source_dir=$2 ;; --dest-dir) dest_dir=$2 ;;
-                    --rounds) rounds=$2 ;; --tool) selected_tool=$2 ;;
+                    --rounds) rounds=$2 ;; --tool) selected_tool=$2 ;; --warmup) warmup=$2 ;;
                 esac
                 shift 2 ;;
             *) fail "Unknown option: $option (see --help)" ;;
@@ -420,6 +507,10 @@ main() {
         fail 'Syq tuning options require --tool syq or --tool all.'
     fi
     case $workload in large|small|both) ;; *) fail 'Workload must be large, small or both.' ;; esac
+    case $warmup in on|off) ;; *) fail 'Warmup must be on or off.' ;; esac
+    if [[ $warmup == on && $mode != local && ( $selected_tool == all || $selected_tool == syq ) ]] && ! $manual_tuning; then
+        warmup_enabled=true
+    fi
     case $size in auto|quick) large_mib=64; small_files=1024 ;; medium) large_mib=1024; small_files=4096 ;; large) large_mib=8192; small_files=16384 ;; *) fail 'Size must be auto, quick, medium or large.' ;; esac
     # The script tests exercise real generation, copies, checksums, ordering,
     # and cleanup. Smaller private fixtures keep that coverage without making
@@ -431,7 +522,7 @@ main() {
     [[ $rounds =~ ^[1-9]$ ]] || fail 'Rounds must be between 1 and 9.'
     for tool in bash rsync openssl dd split cksum cmp awk mktemp mkdir rm cat ps sleep sed; do need "$tool"; done
     [[ $mode != local ]] || need cp
-    [[ $size != auto ]] || need df
+    if [[ $size == auto ]] || $warmup_enabled; then need df; fi
     if [[ $size == auto || $selected_tool == all || $selected_tool == syq ]]; then
         need perl
         perl -MJSON::PP -e 1 || fail 'Syq timing needs Perl with JSON::PP.'
@@ -480,6 +571,10 @@ main() {
     else
         printf '\nChecking SSH access and remote tools (normal SSH authentication applies)...\n'
         remote 'command -v rsync >/dev/null && command -v cksum >/dev/null && command -v mktemp >/dev/null && rsync --version' | sed -n '1p' || fail 'Remote needs rsync, cksum and mktemp, and working SSH access.'
+        if $warmup_enabled && [[ $mode == pull ]]; then
+            remote 'command -v bash >/dev/null && command -v openssl >/dev/null && command -v dd >/dev/null && command -v split >/dev/null' ||
+                fail 'Pull warm-up needs Bash, OpenSSL, dd and split remotely; install them or use --warmup off.'
+        fi
         [[ $dest_dir == /* ]] || dest_dir=./$dest_dir
         remote_parent=$(remote "cd $(quote "$dest_dir") && pwd -P")
         [[ $remote_parent == /* && $remote_parent != *$'\n'* ]] || fail 'Remote shell must print only the requested output.'
@@ -534,6 +629,7 @@ main() {
             fi
         fi
         local amount capacity next copying_ms
+        if $warmup_enabled; then warm_up "$case_name"; fi
         if [[ $case_name == large ]]; then amount=$large_mib; else amount=$small_files; fi
         if [[ $size == auto ]]; then
             capacity=$(space_capacity "$case_name")
@@ -542,24 +638,7 @@ main() {
             printf '\nChoosing the %s workload size with syq (aiming for 5 seconds of copying)...\n' "$case_name"
         fi
         while :; do
-            if [[ $case_name == large ]]; then
-                printf 'Generating one %s MiB file...\n' "$amount"
-                bytes=$((amount * 1048576))
-            else
-                printf 'Generating %s files of 8 KiB each...\n' "$amount"
-                bytes=$((amount * 8192))
-            fi
-            run make_data "$case_name" "$amount"
-            printf 'Preparing content checks...\n'
-            manifest "$local_root/$case_name" > "$local_root/expected"
-            source=$local_root/$case_name
-            if [[ $mode == pull ]]; then
-                printf 'Staging source on remote host (untimed)...\n'
-                run rsync -rpt -- "$source/" "$host:$(quote "$remote_root/$case_name/")"
-                source=$remote_root/$case_name
-                remote_manifest "$source" > "$local_root/actual"
-                cmp "$local_root/expected" "$local_root/actual" || fail 'Remote staging verification failed.'
-            fi
+            prepare_dataset "$case_name" "$amount"
             [[ $size == auto ]] || break
             destination=$dest_root/calibration
             if [[ $mode == push ]]; then destination=$remote_root/calibration; remote "mkdir $(quote "$destination")"

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -48,7 +48,7 @@ also need SSH locally and rsync plus standard utilities on the remote host.
 SSH tests disable syq persistence in private settings and prevent rsync from
 reusing SSH connections. Every timed trial includes connection startup.
 Auto-tuning and remembered counts stay active unless overridden by tuning options.
-Warm-up aims for 30 copying seconds, using up to four growing copies of at most
+Warm-up aims for 60 copying seconds, using up to four growing copies of at most
 1 GiB each, space permitting. This is not a wall-time limit or proof tuning settled.
 Pull warm-ups generate matching source data remotely (needs Bash and OpenSSL).
 Use --warmup off for a short comparison using the existing cached/default count.
@@ -248,7 +248,7 @@ warm_up() {
         return
     fi
     [[ $amount -le $capacity ]] || amount=$capacity
-    printf '\nWarming up syq for %s (untimed; target 30 copying seconds, up to 4 copies, 1 GiB per dataset)...\n' "$workload"
+    printf '\nWarming up syq for %s (untimed; target 60 copying seconds, up to 4 copies, 1 GiB per dataset)...\n' "$workload"
     for ((attempt=1; attempt<=4; attempt++)); do
         prepare_dataset "$workload" "$amount" warmup
         destination=$dest_root/warmup
@@ -272,12 +272,12 @@ warm_up() {
             return
         fi
         awk -v ms="$copying_ms" 'BEGIN {printf "Verified warm-up; copying interval %.3f seconds.\n", ms/1000}'
-        [[ $copying_ms -lt 30000 ]] || return 0
-        next=$(next_amount "$amount" "$copying_ms" "$capacity" 30000)
+        [[ $copying_ms -lt 60000 ]] || return 0
+        next=$(next_amount "$amount" "$copying_ms" "$capacity" 60000)
         [[ $next -gt $amount && $attempt -lt 4 ]] || break
         amount=$next
     done
-    printf 'Note: %s warm-up reached its size, space or attempt limit before 30 copying seconds; tuning may not have settled.\n' "$workload"
+    printf 'Note: %s warm-up reached its size, space or attempt limit before 60 copying seconds; tuning may not have settled.\n' "$workload"
 }
 
 copy_with() {

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -10,7 +10,7 @@ usage() {
     cat <<'HELP'
 Compare syq with rsync, and cp for local copies, using disposable synthetic data.
 
-Usage: bash try-benchmark.sh [OPTIONS]
+Usage: bash try-benchmark.sh [OPTIONS] [-- SYQ_OPTIONS...]
 Without --yes, unanswered choices are prompted through /dev/tty (also with curl | bash).
 
   --mode local|push|pull    Copy locally, to an SSH host (default), or from one
@@ -25,10 +25,19 @@ Without --yes, unanswered choices are prompted through /dev/tty (also with curl 
   --dest-dir DIR           Destination scratch parent (default: current directory)
                            For push/pull this is the REMOTE scratch parent.
                            For pull, --source-dir is the local destination parent.
+  --tool all|syq|rsync|cp   Tools to time (default: all; cp requires local mode)
   --rounds N               Trials per tool/workload, rotating order (default: 3)
   --install                Install syq locally if missing, using its official installer
   --yes                    Use defaults for unspecified choices; do not prompt
   --help                   Show this help
+
+After --, tune syq with --connections/-j, --tuning-options, --bwlimit,
+--tcp-ports, --tcp-congestion (each takes a value), or --no-tcp, --no-compress,
+--tcp-plain, --inplace, --stats, --no-progress, -v/-vv/--verbose.
+These options also apply to syq setup/calibration; rsync and cp are unchanged.
+Use --tool syq --rounds 1 --size quick for one scored syq copy per workload.
+The untimed setup copy and content checks still run. Source/destination,
+removal and output-file options are not accepted after --.
 
 Requires Bash, rsync, OpenSSL, and standard Unix utilities locally. Automatic
 sizing needs Perl with its core JSON::PP module; terminal runs also need Perl. Remote tests
@@ -191,6 +200,7 @@ copy_with() {
     # by the released v0.3.2 CLI as well as current builds.
     [[ ${4:-} != setup ]] || syq_options=(--preserve=permissions --suppress-summary --no-progress)
     [[ ${4:-} != calibration ]] || syq_options=(--preserve=permissions --suppress-summary --results "$local_root/calibration.json")
+    if $has_syq_options; then syq_options+=("${syq_extra[@]}"); fi
     case $tool in
         syq)
             case $mode in
@@ -290,7 +300,8 @@ summarize_results() {
 main() {
     local mode='' workload='' size='' source_dir='' dest_dir='' rounds=3 yes=false install=false
     local option tool round index offset source destination case_name bytes seconds speed local_parent remote_parent
-    local large_mib small_files syq_identity
+    local large_mib small_files syq_identity selected_tool=all has_syq_options=false
+    local syq_extra=()
     local key=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
     local iv=000102030405060708090a0b0c0d0e0f
     while [[ $# -gt 0 ]]; do
@@ -299,12 +310,28 @@ main() {
             --help|-h) usage; return ;;
             --yes) yes=true; shift; continue ;;
             --install) install=true; shift; continue ;;
-            --mode|--host|--workload|--size|--source-dir|--dest-dir|--rounds)
+            --)
+                shift
+                while [[ $# -gt 0 ]]; do
+                    case $1 in
+                        --connections|-j|--tuning-options|--bwlimit|--tcp-ports|--tcp-congestion)
+                            [[ $# -ge 2 && -n $2 ]] || fail "$1 needs a value"
+                            syq_extra+=("$1" "$2"); shift 2 ;;
+                        --connections=?*|--tuning-options=?*|--bwlimit=?*|--tcp-ports=?*|--tcp-congestion=?*|-j[0-9]*)
+                            syq_extra+=("$1"); shift ;;
+                        --no-tcp|--no-compress|--tcp-plain|--inplace|--stats|--no-progress|-v|-vv|--verbose)
+                            syq_extra+=("$1"); shift ;;
+                        *) fail "Unsupported syq benchmark option: $1 (see --help for tuning options)" ;;
+                    esac
+                    has_syq_options=true
+                done
+                break ;;
+            --mode|--host|--workload|--size|--source-dir|--dest-dir|--rounds|--tool)
                 [[ $# -ge 2 && -n $2 ]] || fail "$option needs a value"
                 case $option in
                     --mode) mode=$2 ;; --host) host=$2 ;; --workload) workload=$2 ;;
                     --size) size=$2 ;; --source-dir) source_dir=$2 ;; --dest-dir) dest_dir=$2 ;;
-                    --rounds) rounds=$2 ;;
+                    --rounds) rounds=$2 ;; --tool) selected_tool=$2 ;;
                 esac
                 shift 2 ;;
             *) fail "Unknown option: $option (see --help)" ;;
@@ -331,6 +358,11 @@ main() {
     mode=${mode:-push}; workload=${workload:-small}; size=${size:-quick}
     source_dir=${source_dir:-$PWD}; dest_dir=${dest_dir:-.}
     case $mode in local|push|pull) ;; *) fail 'Mode must be local, push or pull.' ;; esac
+    case $selected_tool in all|syq|rsync|cp) ;; *) fail 'Tool must be all, syq, rsync or cp.' ;; esac
+    [[ $selected_tool != cp || $mode == local ]] || fail 'cp requires --mode local.'
+    if $has_syq_options && [[ $selected_tool != all && $selected_tool != syq ]]; then
+        fail 'Syq tuning options require --tool syq or --tool all.'
+    fi
     case $workload in large|small|both) ;; *) fail 'Workload must be large, small or both.' ;; esac
     case $size in auto|quick) large_mib=64; small_files=1024 ;; medium) large_mib=1024; small_files=4096 ;; large) large_mib=8192; small_files=16384 ;; *) fail 'Size must be auto, quick, medium or large.' ;; esac
     # The script tests exercise real generation, copies, checksums, ordering,
@@ -413,6 +445,7 @@ main() {
     exec 4>&1 5>&2
     local tools=(syq rsync) workloads=(large small)
     [[ $mode != local ]] || tools+=(cp)
+    [[ $selected_tool == all ]] || tools=("$selected_tool")
     [[ $workload == both ]] || workloads=("$workload")
     : > "$local_root/results"
     for case_name in "${workloads[@]}"; do

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -44,8 +44,9 @@ uses Perl with its core JSON::PP module; terminal runs also need Perl. Remote te
 also need SSH locally and rsync plus standard utilities on the remote host.
 SSH tests disable syq persistence in private settings and prevent rsync from
 reusing SSH connections. Every timed trial includes connection startup.
-Syq also reports its copying interval and other time (setup/finish). Short or
-setup-heavy trials get a note: total-time speeds may not show sustained throughput.
+Syq also reports copying time, copying MB/s, and other time (setup/finish).
+A note flags >=20% outside copying or copying under one second: total-time
+speeds may not show sustained throughput.
 The default push needs --host with --yes. Use a second machine, preferably
 on a fast link with some latency and reachable TCP data ports 47600-47699.
 Local results report seconds: filesystem clones do not measure byte throughput.
@@ -287,30 +288,37 @@ copying_interval() {
 
 summarize_syq_timings() {
     [[ -s $1 ]] || return 0
-    printf '\nSyq timing breakdown (mean seconds per trial):\n'
+    printf '\nSyq timing breakdown (means per trial):\n'
     awk '{
         key=$1; if (!(key in n)) order[++count]=key;
         n[key]++; total[key]+=$2;
         if ($3 == "n/a") unavailable[key]=1;
-        else copying[key]+=$3 / 1000;
+        else {
+            copying[key]+=$3 / 1000;
+            if ($3 > 0) speed[key]+=$4 / $3 / 1000;
+            else unmeasurable[key]=1;
+        }
     } END {
-        printf "%-18s %10s %10s %10s\n", "Workload", "Total", "Copying", "Other";
+        printf "%-18s %10s %10s %10s %12s\n", "Workload", "Total s", "Copying s", "Other s", "Copy MB/s";
         for (i=1; i<=count; i++) {
             key=order[i];
             if (unavailable[key]) {
-                printf "%-18s %10.3f %10s %10s\n", key, total[key]/n[key], "n/a", "n/a";
+                printf "%-18s %10.3f %10s %10s %12s\n", key, total[key]/n[key], "n/a", "n/a", "n/a";
                 print "Note (" key "): copying timing unavailable; update syq for a breakdown.";
                 continue;
             }
             other=total[key]-copying[key];
-            printf "%-18s %10.3f %10.3f %10.3f\n", key, total[key]/n[key], copying[key]/n[key], other/n[key];
-            if (total[key] > 0 && other >= total[key]*0.5)
+            printf "%-18s %10.3f %10.3f %10.3f %12s\n", key, total[key]/n[key], copying[key]/n[key], other/n[key], (unmeasurable[key] ? "n/a" : sprintf("%.3f", speed[key]/n[key]));
+            if (unmeasurable[key])
+                print "Note (" key "): copying speed unavailable; a copying interval was below timer resolution (0.001 s).";
+            if (total[key] > 0 && other >= total[key]*0.2)
                 printf "Note (%s): %.0f%% of syq total time was outside copying; setup/finish substantially affects this comparison.\n", key, other/total[key]*100;
             if (copying[key]/n[key] < 1)
                 print "Note (" key "): syq copying averaged under 1 second; this test is too short to assess sustained throughput.";
         }
     }' "$1"
     printf 'Other = total minus copying (setup/finish). Copying includes per-file work and waiting, and can overlap setup.\n'
+    printf 'Copy MB/s = copied bytes / copying seconds / 1,000,000, averaged across trials. Compare tools using total-time results above.\n'
     printf 'This is not pure network time or an exact setup measurement. Rsync/cp have total time only.\n'
     printf 'For sustained-throughput comparisons, try --workload large --size auto or a larger fixed --size.\n'
 }
@@ -605,12 +613,13 @@ main() {
                 if [[ $tool == syq ]]; then
                     copying_ms=$(copying_interval "$local_root/trial.json") || fail 'Cannot read syq trial timing.'
                     if [[ $copying_ms != n/a ]]; then
-                        awk -v ms="$copying_ms" -v seconds="$seconds" 'BEGIN {
+                        awk -v ms="$copying_ms" -v seconds="$seconds" -v bytes="$bytes" 'BEGIN {
                             if (ms / 1000 > seconds) exit 1;
                             printf "Syq copying interval: %.3f seconds; other time (setup/finish): %.3f seconds.\n", ms/1000, seconds-ms/1000;
+                            printf "Syq copying speed: %s MB/s (copying interval only).\n", (ms > 0 ? sprintf("%.3f", bytes/ms/1000) : "n/a");
                         }' || fail 'Syq copying interval exceeds total trial time.'
                     fi
-                    printf '%s %s %s\n' "$case_name" "$seconds" "$copying_ms" >> "$local_root/syq-timings"
+                    printf '%s %s %s %s\n' "$case_name" "$seconds" "$copying_ms" "$bytes" >> "$local_root/syq-timings"
                 fi
                 if [[ $mode == push ]]; then remote "rm -rf $(quote "$destination")"
                 else rm -rf -- "$destination"; fi

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -35,6 +35,7 @@ After --, tune syq with --connections/-j, --tuning-options, --bwlimit,
 --tcp-ports, --tcp-congestion (each takes a value), or --no-tcp, --no-compress,
 --tcp-plain, --inplace, --stats, --no-progress, -v/-vv/--verbose.
 These options also apply to syq setup/calibration; rsync and cp are unchanged.
+Add -v/-vv/--verbose after -- to show full commands and scratch paths.
 Use --tool syq --rounds 1 --size quick for one scored syq copy per workload.
 The untimed setup copy and content checks still run. Source/destination,
 removal and output-file options are not accepted after --.
@@ -44,6 +45,7 @@ uses Perl with its core JSON::PP module; terminal runs also need Perl. Remote te
 also need SSH locally and rsync plus standard utilities on the remote host.
 SSH tests disable syq persistence in private settings and prevent rsync from
 reusing SSH connections. Every timed trial includes connection startup.
+Auto-tuning and remembered counts stay active unless overridden by tuning options.
 Syq also reports copying time, copying MB/s, and other time (setup/finish).
 A note flags >=20% outside copying or copying under one second: total-time
 speeds may not show sustained throughput.
@@ -198,8 +200,9 @@ make_data() {
 copy_with() {
     local tool=$1 source=$2 destination=$3
     local command=() syq_options=(--preserve=permissions --results "$local_root/trial.json")
-    # This repository-owned caller suppresses only the tiny copy's summary,
-    # keeping bootstrap diagnostics and authentication prompts live. Supported
+    $show_syq_summary || syq_options+=(--suppress-summary)
+    # Always suppress the tiny setup copy's summary, keeping bootstrap
+    # diagnostics and authentication prompts live. Supported
     # by the released v0.3.2 CLI as well as current builds.
     [[ ${4:-} != setup ]] || syq_options=(--preserve=permissions --suppress-summary --no-progress)
     [[ ${4:-} != calibration ]] || syq_options=(--preserve=permissions --suppress-summary --results "$local_root/calibration.json")
@@ -229,7 +232,7 @@ copy_with() {
 }
 timed_copy() {
     # Separate Bash's timing output from the command's live stdout/stderr.
-    copy_with "$@" show
+    if $verbose; then copy_with "$@" show; fi
     TIMEFORMAT='%R'
     { time copy_with "$@" 1>&4 2>&5; } 2> "$local_root/time"
 }
@@ -311,16 +314,19 @@ summarize_syq_timings() {
             printf "%-18s %10.3f %10.3f %10.3f %12s\n", key, total[key]/n[key], copying[key]/n[key], other/n[key], (unmeasurable[key] ? "n/a" : sprintf("%.3f", speed[key]/n[key]));
             if (unmeasurable[key])
                 print "Note (" key "): copying speed unavailable; a copying interval was below timer resolution (0.001 s).";
-            if (total[key] > 0 && other >= total[key]*0.2)
+            if (total[key] > 0 && other >= total[key]*0.2) {
                 printf "Note (%s): %.0f%% of syq total time was outside copying; setup/finish substantially affects this comparison.\n", key, other/total[key]*100;
-            if (copying[key]/n[key] < 1)
+                short_test=1;
+            }
+            if (copying[key]/n[key] < 1) {
                 print "Note (" key "): syq copying averaged under 1 second; this test is too short to assess sustained throughput.";
+                short_test=1;
+            }
         }
+        if (short_test) print "For longer tests, use --workload large --size auto or a larger fixed --size.";
     }' "$1"
-    printf 'Other = total minus copying (setup/finish). Copying includes per-file work and waiting, and can overlap setup.\n'
-    printf 'Copy MB/s = copied bytes / copying seconds / 1,000,000, averaged across trials. Compare tools using total-time results above.\n'
-    printf 'This is not pure network time or an exact setup measurement. Rsync/cp have total time only.\n'
-    printf 'For sustained-throughput comparisons, try --workload large --size auto or a larger fixed --size.\n'
+    printf 'Other = time outside copying (setup/finish). Copying includes waiting and can overlap setup; it is not pure network time.\n'
+    printf 'Copy MB/s uses copying time; compare tools using total-time results above.\n'
 }
 
 summarize_results() {
@@ -347,7 +353,7 @@ summarize_results() {
 main() {
     local mode='' workload='' size='' source_dir='' dest_dir='' rounds=3 yes=false install=false
     local option tool round index offset source destination case_name bytes seconds speed local_parent remote_parent
-    local large_mib small_files syq_identity selected_tool=all has_syq_options=false
+    local large_mib small_files syq_identity selected_tool=all has_syq_options=false verbose=false show_syq_summary=false
     local syq_extra=()
     local key=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
     local iv=000102030405060708090a0b0c0d0e0f
@@ -366,7 +372,11 @@ main() {
                             syq_extra+=("$1" "$2"); shift 2 ;;
                         --connections=?*|--tuning-options=?*|--bwlimit=?*|--tcp-ports=?*|--tcp-congestion=?*|-j[0-9]*)
                             syq_extra+=("$1"); shift ;;
-                        --no-tcp|--no-compress|--tcp-plain|--inplace|--stats|--no-progress|-v|-vv|--verbose)
+                        -v|-vv|--verbose)
+                            verbose=true; show_syq_summary=true; syq_extra+=("$1"); shift ;;
+                        --stats)
+                            show_syq_summary=true; syq_extra+=("$1"); shift ;;
+                        --no-tcp|--no-compress|--tcp-plain|--inplace|--no-progress)
                             syq_extra+=("$1"); shift ;;
                         *) fail "Unsupported syq benchmark option: $1 (see --help for tuning options)" ;;
                     esac
@@ -385,7 +395,6 @@ main() {
         esac
     done
     [[ -z $host || -n $mode ]] || mode=push
-    printf 'Compare copies on your machines — no speedup is guaranteed.\n'
     if { exec 3</dev/tty; } 2>/dev/null; then
         : # Also allow SSH credential prompts when --yes supplies benchmark choices.
     elif ! $yes; then
@@ -480,16 +489,11 @@ main() {
     fi
     printf '\nMode: %s; workloads: %s; size: %s; rounds: %s\n' "$mode" "$workload" "$size" "$rounds"
     [[ $mode == local ]] || printf 'SSH host: %s\n' "$host"
-    printf 'Local scratch: %s\n' "$local_root"
-    if [[ $mode == local ]]; then printf 'Destination scratch: %s\n' "$dest_root"
-    else printf 'Remote scratch: %s\n' "$remote_root"; fi
-    printf 'Each trial copies fresh test data and checks the result. Dataset preparation and checks are not timed.\n'
-    if [[ $mode == local ]]; then
-        printf 'Local copies may use filesystem cloning (copy-on-write). Times measure completed copies, not physical data throughput.\n'
-    else
-        printf 'Use a second machine; a fast link with some latency can expose the benefit of parallel copying. TCP data ports 47600-47699 must be reachable to test the default TCP path.\n'
+    if $verbose; then
+        printf 'Local scratch: %s\n' "$local_root"
+        if [[ $mode == local ]]; then printf 'Destination scratch: %s\n' "$dest_root"
+        else printf 'Remote scratch: %s\n' "$remote_root"; fi
     fi
-    [[ $mode == local ]] || printf 'Connection profile: syq persistence OFF; rsync fresh SSH; connection startup is timed for every trial.\n'
     exec 4>&1 5>&2
     local tools=(syq rsync) workloads=(large small)
     [[ $mode != local ]] || tools+=(cp)
@@ -503,7 +507,6 @@ main() {
             # transport path, but suppress meaningless throughput for the 14-byte probe.
             if [[ $mode != local ]]; then
                 printf 'Preparing syq %s on %s to match this machine (untimed)...\n' "$syq_identity" "$host"
-                printf 'A matching remote helper is reused, or installed if needed.\n'
             else
                 printf 'Preparing the benchmark (untimed)...\n'
             fi
@@ -596,7 +599,6 @@ main() {
                 rm -f -- "$local_root/trial.json"
                 run timed_copy "$tool" "$source" "$destination" || fail "$tool failed; no successful result recorded for this trial."
                 seconds=$(cat "$local_root/time")
-                printf 'Checking copied data...\n'
                 if [[ $mode == push ]]; then remote_manifest "$destination" > "$local_root/actual"
                 else manifest "$destination" > "$local_root/actual"; fi
                 cmp "$local_root/expected" "$local_root/actual" || fail "$tool destination content check failed."
@@ -615,8 +617,7 @@ main() {
                     if [[ $copying_ms != n/a ]]; then
                         awk -v ms="$copying_ms" -v seconds="$seconds" -v bytes="$bytes" 'BEGIN {
                             if (ms / 1000 > seconds) exit 1;
-                            printf "Syq copying interval: %.3f seconds; other time (setup/finish): %.3f seconds.\n", ms/1000, seconds-ms/1000;
-                            printf "Syq copying speed: %s MB/s (copying interval only).\n", (ms > 0 ? sprintf("%.3f", bytes/ms/1000) : "n/a");
+                            printf "Copying: %.3f s, %s MB/s; other: %.3f s.\n", ms/1000, (ms > 0 ? sprintf("%.3f", bytes/ms/1000) : "n/a"), seconds-ms/1000;
                         }' || fail 'Syq copying interval exceeds total trial time.'
                     fi
                     printf '%s %s %s %s\n' "$case_name" "$seconds" "$copying_ms" "$bytes" >> "$local_root/syq-timings"
@@ -639,8 +640,6 @@ main() {
     [[ $mode == local ]] || printf 'Connection profile: syq persistence OFF; rsync fresh SSH; connection startup is timed for every trial.\n'
     summarize_results "$local_root/results" "$metric"
     summarize_syq_timings "$local_root/syq-timings"
-    printf '\nCompare the trial range as well as the mean; small differences may be noise.\n'
-    printf 'Results depend on your machines and workload.\n'
 }
 # Keep execution last: a script downloaded through a pipe is parsed before prompts run.
 main "$@"

--- a/scripts/try-benchmark.sh
+++ b/scripts/try-benchmark.sh
@@ -13,11 +13,12 @@ Compare syq with rsync, and cp for local copies, using disposable synthetic data
 Usage: bash try-benchmark.sh [OPTIONS]
 Without --yes, unanswered choices are prompted through /dev/tty (also with curl | bash).
 
-  --mode local|push|pull    Copy locally, to an SSH host, or from an SSH host
+  --mode local|push|pull    Copy locally, to an SSH host (default), or from one
   --host USER@HOST          SSH host or config alias (configure ports in ~/.ssh/config)
   --workload large|small|both
+                           Small files by default; large tests are opt-in.
   --size auto|quick|medium|large
-                           Auto sizes with syq (default). Quick: 64 MiB + 1,024 files;
+                           Quick (default): 64 MiB or 1,024 files; auto sizes with syq;
                            medium: 1 GiB + 4,096;
                            large: 8 GiB + 16,384. Small files are 8 KiB each.
   --source-dir DIR         Local scratch parent (default: current directory)
@@ -34,6 +35,9 @@ sizing needs Perl with its core JSON::PP module; terminal runs also need Perl. R
 also need SSH locally and rsync plus standard utilities on the remote host.
 SSH tests disable syq persistence in private settings and prevent rsync from
 reusing SSH connections. Every timed trial includes connection startup.
+The default push needs --host with --yes. Use a second machine, preferably
+on a fast link with some latency and reachable TCP data ports 47600-47699.
+Local results report seconds: filesystem clones do not measure byte throughput.
 Only newly created syq-bench.* directories are used. Existing data is not copied.
 HELP
 }
@@ -151,14 +155,19 @@ run() {
 # shellcheck disable=SC2016 # This is a literal program for bash -c on each host.
 manifest_command='set -eu
 export LC_ALL=C
-set --
-for file in *; do
+root=$1
+shift
+for file in "$root"/*; do
     set -- "$@" "$file"
     if [ "$#" -eq 128 ]; then cksum "$@" || exit; set --; fi
 done
 if [ "$#" -gt 0 ]; then cksum "$@"; fi'
-manifest() { (cd "$1"; bash -c "$manifest_command"); }
-remote_manifest() { remote "cd $(quote "$1") && $manifest_command"; }
+# Generated filenames have no whitespace. Strip the parent from cksum output
+# after checking its exit status through pipefail; never enter the scratch tree.
+manifest_names() { sed 's@ /.*\(/[^/]*\)$@ \1@'; }
+manifest() { bash -c "$manifest_command" manifest "$1" | manifest_names; }
+remote_manifest() { remote "set -- $(quote "$1")
+$manifest_command" | manifest_names; }
 
 make_data() {
     local workload=$1 amount=$2
@@ -171,7 +180,7 @@ make_data() {
     else
         dd if=/dev/zero bs=8192 count="$amount" 2>/dev/null |
             openssl enc -aes-256-ctr -nosalt -K "$key" -iv "$iv" |
-            (cd "$local_root/$workload"; split -b 8192 -a 6 - file-)
+            split -b 8192 -a 6 - "$local_root/$workload/file-"
     fi
 }
 copy_with() {
@@ -258,11 +267,11 @@ calibration_interval() {
 }
 
 summarize_results() {
-    awk '{key=$1 " " $2;
+    awk -v metric="${2:-speed}" '{key=$1 " " $2;
           if (!(key in n)) order[++count]=key;
           n[key]++;
           if ($3 <= 0) {unmeasurable[key]=1; next}
-          speed=$4 / $3 / 1000000;
+          speed=(metric == "seconds" ? $3 : $4 / $3 / 1000000);
           if (!(key in total)) {low[key]=speed; high[key]=speed}
           total[key]+=speed;
           if (speed < low[key]) low[key]=speed; if (speed > high[key]) high[key]=speed}
@@ -274,7 +283,7 @@ summarize_results() {
                       note=1;
                   } else printf "%-18s %10.3f %10.3f %10.3f %8d\n", key, total[key]/n[key], low[key], high[key], n[key];
               }
-              if (note) print "n/a: a copy finished below timer resolution; try a larger test.";
+              if (note) print "n/a: a copy finished below timer resolution (0.001 s); elapsed time is <0.001 s. Try a larger test.";
          }' "$1"
 }
 
@@ -309,9 +318,9 @@ main() {
         fail 'No terminal. Pass --yes and your choices (see --help).'
     fi
     if ! $yes; then
-        if [[ -z $mode ]]; then ask 'Copy where? local / push / pull' local; mode=$REPLY; fi
+        if [[ -z $mode ]]; then ask 'Copy where? push / pull / local' push; mode=$REPLY; fi
         if [[ $mode != local && -z $host ]]; then ask 'SSH host or config alias' ''; host=$REPLY; fi
-        if [[ -z $workload ]]; then ask 'Workloads? large / small / both' both; workload=$REPLY; fi
+        if [[ -z $workload ]]; then ask 'Workloads? small / large / both' small; workload=$REPLY; fi
         if [[ -z $source_dir ]]; then ask 'Local scratch parent' "$PWD"; source_dir=$REPLY; fi
         if [[ -z $dest_dir ]]; then
             if [[ $mode == local ]]; then ask 'Destination scratch parent (can be another disk or NFS mount)' "$source_dir"
@@ -319,7 +328,7 @@ main() {
             dest_dir=$REPLY
         fi
     fi
-    mode=${mode:-local}; workload=${workload:-both}; size=${size:-auto}
+    mode=${mode:-push}; workload=${workload:-small}; size=${size:-quick}
     source_dir=${source_dir:-$PWD}; dest_dir=${dest_dir:-.}
     case $mode in local|push|pull) ;; *) fail 'Mode must be local, push or pull.' ;; esac
     case $workload in large|small|both) ;; *) fail 'Workload must be large, small or both.' ;; esac
@@ -339,6 +348,7 @@ main() {
         perl -MJSON::PP -e 1 || fail 'Automatic sizing needs Perl with JSON::PP.'
     fi
     if [[ $mode != local ]]; then
+        [[ -n $host ]] || fail 'Network benchmarks need an SSH host. Pass --host USER@HOST, or --mode local for a local comparison.'
         need ssh
         [[ $host =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.@-]*$ ]] || fail 'Use an SSH config alias or USER@HOST; configure ports/IPv6 in ~/.ssh/config.'
     fi
@@ -394,6 +404,11 @@ main() {
     if [[ $mode == local ]]; then printf 'Destination scratch: %s\n' "$dest_root"
     else printf 'Remote scratch: %s\n' "$remote_root"; fi
     printf 'Each trial copies fresh test data and checks the result. Dataset preparation and checks are not timed.\n'
+    if [[ $mode == local ]]; then
+        printf 'Local copies may use filesystem cloning (copy-on-write). Times measure completed copies, not physical data throughput.\n'
+    else
+        printf 'Use a second machine; a fast link with some latency can expose the benefit of parallel copying. TCP data ports 47600-47699 must be reachable to test the default TCP path.\n'
+    fi
     [[ $mode == local ]] || printf 'Connection profile: syq persistence OFF; rsync fresh SSH; connection startup is timed for every trial.\n'
     exec 4>&1 5>&2
     local tools=(syq rsync) workloads=(large small)
@@ -507,7 +522,11 @@ main() {
                     if (seconds > 0) printf "%.3f", bytes / seconds / 1000000;
                     else printf "n/a";
                 }')
-                printf 'Verified contents; speed %s MB/s.\n' "$speed"
+                if [[ $mode == local ]]; then
+                    printf 'Verified contents; elapsed %s seconds.\n' "$seconds"
+                else
+                    printf 'Verified contents; speed %s MB/s; elapsed %s seconds.\n' "$speed" "$seconds"
+                fi
                 if [[ $mode == push ]]; then remote "rm -rf $(quote "$destination")"
                 else rm -rf -- "$destination"; fi
             done
@@ -515,9 +534,16 @@ main() {
         rm -rf -- "${local_root:?}/$case_name"
         [[ $mode != pull ]] || remote "rm -rf $(quote "$source") $(quote "$remote_root/probe")"
     done
-    printf '\nResults (MB/s; higher is faster; all copies checked):\n'
+    local metric=speed
+    if [[ $mode == local ]]; then
+        metric=seconds
+        printf '\nResults (seconds; lower is faster; all copies checked):\n'
+        printf 'Filesystem cloning may avoid moving file data; these are copy times, not disk bandwidth.\n'
+    else
+        printf '\nResults (MB/s; higher is faster; all copies checked):\n'
+    fi
     [[ $mode == local ]] || printf 'Connection profile: syq persistence OFF; rsync fresh SSH; connection startup is timed for every trial.\n'
-    summarize_results "$local_root/results"
+    summarize_results "$local_root/results" "$metric"
     printf '\nCompare the trial range as well as the mean; small differences may be noise.\n'
     printf 'Results depend on your machines and workload.\n'
 }

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -919,6 +919,13 @@ for benchmark_mode in push pull; do
         --mode "$benchmark_mode" --host destination --workload small --size auto \
         --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's"
 done
+# One scored syq copy with transport and batch overrides in each direction.
+for benchmark_mode in push pull; do
+    bash /usr/local/libexec/syq-try-benchmark --yes \
+        --mode "$benchmark_mode" --host destination --workload small --size quick \
+        --tool syq --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's" \
+        -- --no-tcp --connections 2 --tuning-options batch-files=256,batch-bytes=2M
+done
 test -z "$(find "$benchmark_parent" -mindepth 1 -print)"
 ssh destination 'test -z "$(find "/tmp/benchmark scratch'"'"'s" -mindepth 1 -print)"'
 rmdir "$benchmark_parent"

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -910,13 +910,13 @@ mkdir "$benchmark_parent"
 ssh destination "mkdir -p \"/tmp/benchmark scratch's\""
 for benchmark_mode in push pull; do
     bash /usr/local/libexec/syq-try-benchmark --yes \
-        --mode "$benchmark_mode" --host destination --workload both --size quick \
+        --mode "$benchmark_mode" --host destination --workload both --size quick --warmup off \
         --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's"
 done
 # Automatic sizing uses the real terminal timing from each remote direction.
 for benchmark_mode in push pull; do
     bash /usr/local/libexec/syq-try-benchmark --yes \
-        --mode "$benchmark_mode" --host destination --workload small --size auto \
+        --mode "$benchmark_mode" --host destination --workload small --size auto --warmup off \
         --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's"
 done
 # One scored syq copy with transport and batch overrides in each direction.
@@ -925,6 +925,25 @@ for benchmark_mode in push pull; do
         --mode "$benchmark_mode" --host destination --workload small --size quick \
         --tool syq --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's" \
         -- --no-tcp --connections 2 --tuning-options batch-files=256,batch-bytes=2M
+done
+# A new route can learn during warm-up before the first scored copy. Speed up
+# only the debug tuner's sample clock and cap traffic to keep this lab bounded.
+# These are correctness checks, not performance measurements.
+for benchmark_mode in push pull; do
+    benchmark_cache="$home/benchmark-tuning-$benchmark_mode.json"
+    SYQ_TUNING_CACHE="$benchmark_cache" SYQ_TEST_TUNE_SAMPLE_MS=100 \
+        bash /usr/local/libexec/syq-try-benchmark --yes \
+        --mode "$benchmark_mode" --host destination --workload small --size quick \
+        --tool syq --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's" \
+        -- --no-tcp --bwlimit 2M
+    python3 - "$benchmark_cache" "$benchmark_mode" <<'PY'
+import json, pathlib, sys
+cache = json.loads(pathlib.Path(sys.argv[1]).read_text())
+key = 'local>destination|ssh' if sys.argv[2] == 'push' else 'destination>local|ssh'
+assert 1 <= cache['paths'][key] <= 64, cache
+print('Verified a learned starting count for', key)
+PY
+    rm -f "$benchmark_cache" "$benchmark_cache.lock"
 done
 test -z "$(find "$benchmark_parent" -mindepth 1 -print)"
 ssh destination 'test -z "$(find "/tmp/benchmark scratch'"'"'s" -mindepth 1 -print)"'
@@ -938,7 +957,7 @@ cancel_parent=$home/benchmark-cancel
 mkdir "$cancel_parent"
 ssh destination 'mkdir /tmp/benchmark-cancel; printf keep > /tmp/benchmark-cancel/keep'
 bash /usr/local/libexec/syq-try-benchmark --yes --mode push --host destination \
-    --workload large --size quick --rounds 1 --source-dir "$cancel_parent" \
+    --workload large --size quick --warmup off --rounds 1 --source-dir "$cancel_parent" \
     --dest-dir /tmp/benchmark-cancel &
 benchmark_pid=$!
 attempt=0

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -916,7 +916,7 @@ done
 # Automatic sizing uses the real terminal timing from each remote direction.
 for benchmark_mode in push pull; do
     bash /usr/local/libexec/syq-try-benchmark --yes \
-        --mode "$benchmark_mode" --host destination --workload small \
+        --mode "$benchmark_mode" --host destination --workload small --size auto \
         --rounds 1 --source-dir "$benchmark_parent" --dest-dir "/tmp/benchmark scratch's"
 done
 test -z "$(find "$benchmark_parent" -mindepth 1 -print)"


### PR DESCRIPTION
Short network benchmarks can finish before syq learns a connection count, so first-use results may reflect the initial count and connection startup more than sustained copying. The old defaults also generated large local workloads and reported implausible cp throughput when filesystem cloning avoided moving bytes.

Default to a network push with 1,024 × 8 KiB scored files and three rounds, preceded by an untimed syq tuning warm-up for each workload. The warm-up uses the same direction, transport options and file type; it grows toward 60 copying seconds with at most four copies and 1 GiB per dataset, subject to free space. These are data/attempt bounds, not a wall-time limit or proof that tuning settled. A cached value alone does not automatically skip warm-up: the script cannot confirm the scored transport through a machine-readable interface. Verify all warm-up copies and report when timing is unavailable or a limit prevents reaching the target. Keep the scored dataset size unchanged.

`--warmup off` uses existing cached/default tuning without training. Warm-up is skipped for local copies, non-syq comparisons and explicit connection/tuning overrides. Syq's existing engine reads and updates the ordinary tuning cache; the script does not parse or modify that state itself. Pull warm-ups generate identical data locally and remotely and compare checksums, avoiding a large preliminary upload over the laptop uplink. Remote generation uses Bash and OpenSSL with quoted paths, checked pipelines and normal cancellation cleanup.

Add `--tool all|syq|rsync|cp` and allowlisted tuning options after `--` for isolated scored copies. Preserve untimed helper preparation, fresh destinations, verification and cleanup. Keep the main comparison based on total command time; add syq copying/other seconds and copying MB/s, averaging trial rates. Flag at least 20% of time outside copying or mean copying below one second. Explain that copying includes waiting and can overlap setup. Local comparisons use seconds to account for cloning. Generation/checks keep the launch directory visible to tmux.

Reduce repeated output, show full commands and scratch paths only with verbose diagnostics, and preserve explicit --stats. Help and task/tuning documentation describe the final behavior and the distinction between connection persistence and learned counts.

Compatibility: existing script choices remain accepted; defaults and human-readable output intentionally change. Fixed-size runs accept successful older result records without copying timing; auto sizing still requires it. Warm-up stops with a note if timing is unavailable. Released v0.5.2 supports all syq options used here; its tuning implementation is unchanged on the current base. No Rust, helper protocol, stored-format or SDK changes relative to master. The script does not implement APFS cloning or claim to fix macOS ENOBUFS or guarantee a speedup.

Validation for d92457d:
- 38 script tests passed (37 together, then the added 30-second regression separately), including warm-up ordering, push/pull generation, fixed scored sizes, growth caps, manual/explicit skips, old missing timing, failed remote generation, corruption and interruption cleanup; existing timing, argument, terminal and cwd regressions also passed.
- ShellCheck, documentation links, pinned mdBook 0.5.4 build and whitespace checks passed.
- At 0caa092, focused real OpenSSH push/pull ran through the repository three-container runner with a scenario bind mount. Isolated manual tuning skipped warm-up. New warm-up cases used empty per-case caches, a debug sampling interval of 100 ms and a 2 MiB/s cap; both directions grew from roughly 4 to 30 copying seconds, verified all contents, kept the scored workload at 1,024 files and produced a learned count in the matching direction/SSH cache key. These checks establish mechanism correctness, not production performance or convergence timing. All owned lab resources cleaned up. Real SSH was not rerun for the later duration-only change to 60 seconds.
- Checks ran before commit; only a help sentence and the existing full-suite interruption test's explicit --warmup off were added after the focused runner started. The latter retains that test's scored-copy scope.
- Full OpenSSH suite was not rerun for this revision; earlier full-suite and quick/auto coverage is supplemented by the script regressions and new focused cases. No Rust changes relative to master, so Rust baseline was not rerun. No Mac/laptop-to-Japan execution.

Branch status: clean and pushed at d92457d; GitHub head matches; no PR checks registered and no merge conflicts. Latest master ci, rsync-compat and macos runs all passed at 73dc3a2. PR remains unmerged.
