### PR TITLE
Keep stderr diagnostic lines intact across helper processes

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -57,7 +57,10 @@ impl Terminal {
     fn write_line(&mut self, out: &mut impl Write, args: Arguments<'_>) -> io::Result<()> {
         let line = self.line.clone();
         self.clear(out)?;
-        writeln!(out, "{args}")?;
+        // Helpers can inherit the same stderr pipe but have their own locks.
+        // Keep the newline in the same write as the message so lines within
+        // PIPE_BUF cannot be interleaved by those other processes.
+        out.write_all(format!("{args}\n").as_bytes())?;
         if let Some(line) = line {
             self.draw(out, line)?;
         }
@@ -140,6 +143,41 @@ pub(crate) use human_stdout;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn concurrent_process_diagnostics_do_not_split_lines() {
+        // Model another process writing to the same stderr pipe after each
+        // write. The in-process terminal lock cannot exclude that writer.
+        #[derive(Default)]
+        struct SharedPipe(Vec<u8>);
+        impl Write for SharedPipe {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                self.0.extend_from_slice(bytes);
+                self.0.extend_from_slice(b"syq: helper closed\n");
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut output = SharedPipe::default();
+        let mut terminal = Terminal::default();
+        let counters = serde_json::json!({"range_requests": 0});
+        terminal
+            .diagnostic(
+                &mut output,
+                format_args!("syq: tuning observed: {counters}"),
+            )
+            .unwrap();
+        terminal
+            .write_line(&mut output, format_args!("{counters}"))
+            .unwrap();
+        assert_eq!(
+            String::from_utf8(output.0).unwrap(),
+            format!("syq: tuning observed: {counters}\nsyq: helper closed\n{counters}\nsyq: helper closed\n")
+        );
+    }
 
     #[test]
     fn json_output_preserves_unicode_and_json_escapes() {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -6058,7 +6058,8 @@ fn tuning_observed(out: &Output) -> serde_json::Value {
         .lines()
         .find_map(|line| line.strip_prefix("syq: tuning observed: "))
         .unwrap_or_else(|| panic!("missing benchmark observations: {diagnostic}"));
-    serde_json::from_str(line).unwrap()
+    serde_json::from_str(line)
+        .unwrap_or_else(|error| panic!("invalid benchmark observations ({error}): {diagnostic}"))
 }
 
 #[test]


### PR DESCRIPTION
When helpers share the coordinator’s stderr pipe, diagnostic text and its newline can be emitted by separate writes. Another process can insert a message between them, corrupting a line such as the tuning JSON parsed by integration tests. This is consistent with the trailing-characters failure in `copy_local_disk_write_failure_keeps_old_destination_and_resumes_changed_source` in master CI at `c86f0c7` ([failed run](https://github.com/greaber/syq/actions/runs/34359384966)).

Serialize the complete stderr line before writing it, including its newline. Lines within the pipe’s atomic-write limit now stay together across helper processes. Add a deterministic competing-writer regression for both diagnostics and JSON, and include the captured diagnostics if the integration test’s JSON parsing fails.

Validation at `af73f84`:
- The new regression fails with the old writer and passes with the fix. Syscall traces of the original integration test confirm separate text/newline writes before the fix and a complete-line write afterward. Fifty unmodified integration-test reruns passed; the original CI log did not capture the malformed line, so its exact interleaving is not known.
- Formatting, all-target/all-feature Clippy, and all 604 active unit tests pass.
- `cargo test --all-targets` passes: 1,087 tests, one existing opt-in test ignored.
- Full default three-container real-SSH suite passes, including benchmark-script checks and interruption cleanup. The runner removed its containers; no containers remain for the test project.
- Candidate macOS and standalone SDK suites were not run.

No CLI, serialized state, helper protocol, or output format changes. The old writer is also present in released `v0.5.2`; the fix changes write boundaries, so old consumers continue to receive the same bytes. Lines exceeding the pipe’s atomic-write limit can still interleave.

<details>
<summary>Branch status at review handoff</summary>

```text
Worktree: /home/grant/repos/syq/.worktrees/investigate-ci-c86f0c7
Branch:   investigate-ci-c86f0c7 at af73f84 (clean)
Upstream: origin/investigate-ci-c86f0c7 (ahead 0, behind 0)
Master:   86e5526 from refs/heads/master (branch is ahead 8, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      b89d4ea  https://github.com/greaber/syq/actions/runs/34362204475
  rsync-compat.yml success      b89d4ea  https://github.com/greaber/syq/actions/runs/34362204195
  macos.yml        in_progress  b89d4ea  https://github.com/greaber/syq/actions/runs/34362204215

Pull request: #321 https://github.com/greaber/syq/pull/321
  base master, open, review none, merge state clean
  GitHub head af73f84: matches local af73f84
  checks: none registered yet
```
</details>

Review-ready at `af73f84`, clean and pushed. Not merged. No retained task stash. Latest master Linux CI has passed on the subsequent docs merge `b89d4ea`; that does not remove the demonstrated output race.
