### PR TITLE
Avoid encrypted TCP overhead in concurrent-copy regression

### DIFF
--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -61,7 +61,10 @@ pub(crate) fn test_race_barrier(
             .with_context(|| format!("write {label} signal {}", Path::new(&ready).display()))?;
     }
     if let Some(continuation) = continuation {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        // Some race tests finish a competing copy before releasing this worker.
+        // Leave room for that work under suite load, especially on macOS. This
+        // is a deadlock safety bound, not an assertion about transfer speed.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
         loop {
             match File::open(&continuation) {
                 Ok(_) => return Ok(()),

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -20275,6 +20275,9 @@ fn clean_partials_selects_only_current_regular_files() {
 #[cfg(debug_assertions)]
 #[test]
 fn concurrent_identical_and_different_copies_publish_complete_files() {
+    // Exercise publication and retained-basis races through isolated receiver
+    // processes, without spending seconds encrypting bulk data in debug builds.
+    // Pipes preserve the same file operations and multi-block fixtures.
     for identical in [true, false] {
         for existing in [false, true] {
             let t = Tmp::new();
@@ -20304,6 +20307,7 @@ fn concurrent_identical_and_different_copies_publish_complete_files() {
                 .args([
                     "cp",
                     "--hash",
+                    "--no-tcp",
                     "--bwlimit",
                     "1G",
                     "-j",
@@ -20320,14 +20324,12 @@ fn concurrent_identical_and_different_copies_publish_complete_files() {
                 .start()
                 .unwrap();
             wait_for_confinement_marker(&mut first, &ready, "overlapping copy preparation");
-            // One competitor deliberately takes longer than the old ten-second
-            // barrier deadline. Publication order must depend on the handshake,
-            // including on a busy runner, rather than on copying speed.
             let second_started = std::time::Instant::now();
             let second = Command::new(env!("CARGO_BIN_EXE_syq"))
                 .args([
                     "cp",
                     "--hash",
+                    "--no-tcp",
                     "--bwlimit",
                     "1G",
                     "-j",
@@ -20337,10 +20339,6 @@ fn concurrent_identical_and_different_copies_publish_complete_files() {
                     "--as",
                     &t.s("out"),
                 ])
-                .env(
-                    "SYQ_TEST_HOLD_SOURCE_ROOTS_MS",
-                    if identical && !existing { "11000" } else { "0" },
-                )
                 .run()
                 .unwrap();
             let second_published = fs::read(t.path("out"));

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -20320,6 +20320,10 @@ fn concurrent_identical_and_different_copies_publish_complete_files() {
                 .start()
                 .unwrap();
             wait_for_confinement_marker(&mut first, &ready, "overlapping copy preparation");
+            // One competitor deliberately takes longer than the old ten-second
+            // barrier deadline. Publication order must depend on the handshake,
+            // including on a busy runner, rather than on copying speed.
+            let second_started = std::time::Instant::now();
             let second = Command::new(env!("CARGO_BIN_EXE_syq"))
                 .args([
                     "cp",
@@ -20333,12 +20337,27 @@ fn concurrent_identical_and_different_copies_publish_complete_files() {
                     "--as",
                     &t.s("out"),
                 ])
+                .env(
+                    "SYQ_TEST_HOLD_SOURCE_ROOTS_MS",
+                    if identical && !existing { "11000" } else { "0" },
+                )
                 .run()
                 .unwrap();
+            let second_published = fs::read(t.path("out"));
             release_confinement_barrier(&continuation);
             let first = first.wait_with_output().unwrap();
             assert_output_ok(&second);
-            assert_output_ok(&first);
+            assert!(
+                first.status.success(),
+                "first copy failed: identical={identical}, existing={existing}, \
+                 competitor elapsed={:?}, first={first:?}, second={second:?}",
+                second_started.elapsed(),
+            );
+            assert_eq!(
+                second_published.unwrap(),
+                second_data,
+                "competitor publication: identical={identical}, existing={existing}"
+            );
             assert_eq!(
                 read(&t.path("out")),
                 first_data,


### PR DESCRIPTION
The concurrent-copy regression held one copy at a ten-second barrier while completing another 8 MiB copy. Native local copies used encrypted TCP to isolated receivers, making the fixture CPU-heavy in unoptimized builds and causing the macOS barrier timeout.

Use local pipes for this filesystem race test. Preserve receiver processes, all four identical/different and existing/missing destination cases, the full 8 MiB two-block fixtures, both publication-content assertions, and partial cleanup checks. Keep a 60-second debug-only hang safeguard and report both child outputs and competitor elapsed time on failure. No release-build behavior or public interface changes.

Measurements on Linux:
- One unchanged 8 MiB copy: encrypted TCP ~2.0 s and ~3.8 CPU-seconds; plain TCP ~0.07 s; pipes ~0.05 s. Hashing each 4 MiB block took ~1 ms.
- The original four-case test took ~13.3 s. At 6f4ade5 it takes ~0.67 s.
- Twelve full test repetitions, four running concurrently, all passed in 0.651–0.672 s each. A second set of twelve repetitions, again four at a time but with all their processes restricted to the same three Linux CPUs, passed in 0.722–0.806 s each.

Validation at 6f4ade5:
- `cargo fmt --all -- --check` passed.
- `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo test --bin syq` passed: 612 passed, one existing ignored.
- Focused regression and twelve concurrent repetitions passed.
- Full [macOS workflow 34414973847](https://github.com/greaber/syq/actions/runs/34414973847) passed at exact 6f4ade5: Clippy, full native suite (including all 434 local integration tests), all three SDKs, benchmark script, and release shell suites.
- Full Linux all-target tests passed at preceding fe7660f; the subsequent change only adjusts this test's transport and removes its deliberate delay. Real-SSH containers and rsync-compat were not rerun for this test-only repair.

The original ten-second failure was also reproduced on Linux using an intentionally delayed competitor. That experiment is not retained as an eleven-second sleep in the final test. The dedicated encrypted transport tests remain unchanged.

Branch-status output at review handoff (the coordination checkout intentionally retains its older local master ref; this branch is based on remote master aaeb23d):

```text
Worktree: /home/grant/repos/syq/.worktrees/macos-copy-barrier
Branch:   macos-copy-barrier at 6f4ade5 (clean)
Upstream: origin/macos-copy-barrier (ahead 0, behind 0)
Master:   31ee972 from refs/heads/master (branch is ahead 18, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      aaeb23d  https://github.com/greaber/syq/actions/runs/34396440882
  rsync-compat.yml success      aaeb23d  https://github.com/greaber/syq/actions/runs/34396440901
  macos.yml        failure      aaeb23d  https://github.com/greaber/syq/actions/runs/34396440956

Pull request: #323 https://github.com/greaber/syq/pull/323
  base master, open, review none, merge state clean
  GitHub head 6f4ade5: matches local 6f4ade5
  checks: none registered yet

WARNING: master is red: macos.yml failure at aaeb23d https://github.com/greaber/syq/actions/runs/34396440956
```
