### PR TITLE
Skip empty resume scans and unused destination canonicalization

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -238,7 +238,9 @@ destination and replaces the final file only when complete. When resuming,
 syq can copy bytes from a previous partial into its own output, hash the bytes
 it copied, and transfer blocks that differ from the source before publishing.
 The previous partial stays unchanged. Reuse is best effort; local direct copies
-can be faster than looking for reusable blocks and take priority.
+can be faster than looking for reusable blocks and take priority. If a previous
+partial is unavailable and there is no existing destination file, syq transfers
+the whole file.
 
 Resuming requires space for the new output as well as the previous partial.
 This can require enough free space for another complete file, even when only

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -235,12 +235,11 @@ Ignored paths are also protected from pruning.
 Rerun the command. Completed files are skipped; partially copied files can
 reuse matching blocks. Each run writes its own fresh partial beside the
 destination and replaces the final file only when complete. When resuming,
-syq can copy bytes from a previous partial into its own output, hash the bytes
-it copied, and transfer blocks that differ from the source before publishing.
-The previous partial stays unchanged. Reuse is best effort; local direct copies
-can be faster than looking for reusable blocks and take priority. If a previous
-partial is unavailable and there is no existing destination file, syq transfers
-the whole file.
+syq can copy bytes from a previous partial or the existing destination into its
+own output, hash the bytes it copied, and transfer blocks that differ from the
+source before publishing. The previous partial stays unchanged. Reuse is best
+effort; local direct copies can be faster than looking for reusable blocks and
+take priority.
 
 Resuming requires space for the new output as well as the previous partial.
 This can require enough free space for another complete file, even when only

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -5269,10 +5269,17 @@ impl FsOps {
         if basis_size.unwrap_or(0) == 0 {
             self.preallocate_new_partial(&output, len)?;
         }
-        let mut hashes = Vec::with_capacity(len.div_ceil(block) as usize);
-        let mut buffer = vec![0; block as usize];
+        // A cached donor can disappear or become unsuitable before opening.
+        // Freshly allocated zeros are not old copy data worth scanning.
+        let reusable_len = if input.is_some() || basis_size.unwrap_or(0) > 0 {
+            len
+        } else {
+            0
+        };
+        let mut hashes = Vec::with_capacity(reusable_len.div_ceil(block) as usize);
+        let mut buffer = vec![0; block.min(reusable_len) as usize];
         let reader = input.as_ref().unwrap_or(&output);
-        for index in 0..len.div_ceil(block) {
+        for index in 0..reusable_len.div_ceil(block) {
             let off = index * block;
             let bytes = &mut buffer[..(len - off).min(block) as usize];
             if reader.read_exact_at(bytes, off).is_err() {
@@ -9207,6 +9214,69 @@ mod tests {
             fs::read(partial_path(&later, &id).unwrap()).unwrap(),
             b"later bytes"
         );
+    }
+
+    #[test]
+    fn seed_basis_without_a_usable_donor_returns_no_reusable_blocks() {
+        for rooted in [false, true] {
+            for unsuitable in [false, true] {
+                let temporary = crate::test_support::tempdir().unwrap();
+                let target = temporary.path().join("file");
+                let donor = temporary.path().join(".file.syq-tmp.abcdefghijklmnop");
+                fs::write(&donor, b"old bytes").unwrap();
+                let mut ops = FsOps::new();
+                if rooted {
+                    ops.destination_root = Some(Arc::new(
+                        Root::from_directory(File::open(temporary.path()).unwrap()).unwrap(),
+                    ));
+                    ops.destination_prefix = Some(path_bytes(temporary.path()));
+                }
+                let path = if rooted {
+                    b"file".to_vec()
+                } else {
+                    path_bytes(&target)
+                };
+                let id = [10; 16];
+                let len = 2 * MIN_HASH_BLOCK_BYTES;
+                let preparation = ops
+                    .prepare(
+                        PartialTarget {
+                            path: &path,
+                            id: &id,
+                            guard: None,
+                        },
+                        PrepareOptions {
+                            size: len,
+                            inplace: false,
+                            mode: 0o600,
+                            attempt: 0,
+                            create_if_missing: true,
+                        },
+                    )
+                    .unwrap();
+                assert!(preparation.has_candidates);
+                fs::remove_file(&donor).unwrap();
+                if unsuitable {
+                    fs::create_dir(&donor).unwrap();
+                }
+                let hashes = ops
+                    .seed_basis(&path, &id, len, MIN_HASH_BLOCK_BYTES, 0, None)
+                    .unwrap();
+                assert!(hashes.is_empty(), "fresh zero-filled output is not a donor");
+                let partial = partial_path(&target, &id).unwrap();
+                assert_eq!(fs::metadata(&partial).unwrap().len(), len);
+                assert!(!target.exists());
+                // On a retry the existing private output is a real basis,
+                // including blocks whose contents happen to be all zeros.
+                let hashes = ops
+                    .seed_basis(&path, &id, len, MIN_HASH_BLOCK_BYTES, 1, None)
+                    .unwrap();
+                assert_eq!(
+                    hashes,
+                    vec![content_digest(&vec![0; MIN_HASH_BLOCK_BYTES as usize]); 2]
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -5271,35 +5271,35 @@ impl FsOps {
         }
         // A cached donor can disappear or become unsuitable before opening.
         // Freshly allocated zeros are not old copy data worth scanning.
-        let reusable_len = if input.is_some() || basis_size.unwrap_or(0) > 0 {
-            len
-        } else {
-            0
-        };
-        let mut hashes = Vec::with_capacity(reusable_len.div_ceil(block) as usize);
-        let mut buffer = vec![0; block.min(reusable_len) as usize];
-        let reader = input.as_ref().unwrap_or(&output);
-        for index in 0..reusable_len.div_ceil(block) {
-            let off = index * block;
-            let bytes = &mut buffer[..(len - off).min(block) as usize];
-            if reader.read_exact_at(bytes, off).is_err() {
-                // The controller treats an absent hash as a block to transfer.
-                break;
+        let reader = input
+            .as_ref()
+            .or_else(|| (basis_size.unwrap_or(0) > 0).then_some(&output));
+        let mut hashes = Vec::new();
+        if let Some(reader) = reader {
+            hashes.reserve(len.div_ceil(block) as usize);
+            let mut buffer = vec![0; block.min(len) as usize];
+            for index in 0..len.div_ceil(block) {
+                let off = index * block;
+                let bytes = &mut buffer[..(len - off).min(block) as usize];
+                if reader.read_exact_at(bytes, off).is_err() {
+                    // The controller treats an absent hash as a block to transfer.
+                    break;
+                }
+                let hash = content_digest(bytes);
+                if input.is_some() {
+                    #[cfg(debug_assertions)]
+                    test_race_barrier(
+                        "SYQ_TEST_REUSE_READY_FILE",
+                        "SYQ_TEST_REUSE_CONTINUE_FILE",
+                        "SYQ_TEST_HOLD_REUSE_MS",
+                        "reuse buffered bytes",
+                    )?;
+                    output
+                        .write_all_at(bytes, off)
+                        .context("write reused block")?;
+                }
+                hashes.push(hash);
             }
-            let hash = content_digest(bytes);
-            if input.is_some() {
-                #[cfg(debug_assertions)]
-                test_race_barrier(
-                    "SYQ_TEST_REUSE_READY_FILE",
-                    "SYQ_TEST_REUSE_CONTINUE_FILE",
-                    "SYQ_TEST_HOLD_REUSE_MS",
-                    "reuse buffered bytes",
-                )?;
-                output
-                    .write_all_at(bytes, off)
-                    .context("write reused block")?;
-            }
-            hashes.push(hash);
         }
         if output.metadata()?.len() != len {
             output.set_len(len)?;

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -2053,40 +2053,30 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     // Only exact placement onto bare `~` needs the receiver's canonical
     // spelling: it names HOME rather than a literal leaf. Other placements
     // keep the operator's spelling; registration handles their path policy.
-    let exact_native_destination =
-        args.interface != Interface::Rsync && args.placement == Placement::As;
-    let expand_exact_home =
-        exact_native_destination && args.restricted_grant.is_none() && operator_dst_root == b"~";
-    let (dst_root, dst_root_entry) = if expand_exact_home {
-        let (entry, canonical) = stat_and_canonicalize(
-            &mut *dst_ctl,
-            &operator_dst_root,
-            &operator_dst_root,
-            dst.is_remote(),
-        )?;
+    let expand_exact_home = args.interface != Interface::Rsync
+        && args.placement == Placement::As
+        && args.restricted_grant.is_none()
+        && operator_dst_root == b"~";
+    let (dst_root, mut dst_root_entry) = if expand_exact_home {
+        let (entry, canonical) = stat_and_canonicalize(&mut *dst_ctl, &operator_dst_root)?;
         (canonical.as_os_str().as_bytes().to_vec(), entry)
     } else {
-        (
-            operator_dst_root.clone(),
-            stat_one(&mut *dst_ctl, &operator_dst_root, false)?,
-        )
-    };
-    // Rsync retains its destination-directory compatibility rule. Native
-    // container placement keeps the named symlink by default or resolves its
-    // complete chain under the destination follow policy. Exact native
-    // placement always selects the final directory entry; destination
-    // following applies only to its parent path.
-    let (dst_root, mut dst_root_entry) = match args.interface {
-        Interface::Rsync => follow_dir_symlink(&mut *dst_ctl, &dst_root, dst_root_entry)?,
-        _ if args.follows_native_destination_paths() && args.placement == Placement::Into => {
+        let entry = stat_one(&mut *dst_ctl, &operator_dst_root, false)?;
+        // Rsync retains its destination-directory compatibility rule. Native
+        // container placement follows links only under the destination policy;
+        // exact placement preserves the final directory entry.
+        if args.interface == Interface::Rsync {
+            follow_dir_symlink(&mut *dst_ctl, &operator_dst_root, entry)?
+        } else if args.follows_native_destination_paths() && args.placement == Placement::Into {
             follow_container_symlink(
                 &mut *dst_ctl,
                 &operator_dst_root,
-                dst_root_entry,
+                entry,
                 args.target_existence != Existence::Existing,
             )?
+        } else {
+            (operator_dst_root.clone(), entry)
         }
-        _ => (dst_root, dst_root_entry),
     };
     if debug() {
         crate::output::diagnostic!(
@@ -3852,24 +3842,16 @@ fn parent_path(path: &[u8]) -> PathBytes {
 /// avoids an extra RTT when expanding a remote bare-home destination.
 fn stat_and_canonicalize(
     conn: &mut dyn Conn,
-    stat_path: &[u8],
-    canonical_path: &[u8],
-    remote: bool,
+    path: &[u8],
 ) -> Result<(Option<Entry>, std::path::PathBuf)> {
-    if !remote {
-        return Ok((
-            stat_one(conn, stat_path, false)?,
-            crate::fsops::normalize(&crate::fsops::resolve(canonical_path)),
-        ));
-    }
     conn.send(Request::StatMany {
-        paths: vec![stat_path.to_vec()],
+        paths: vec![path.to_vec()],
         sources: None,
         follow: false,
         guard: None,
     })?;
     conn.send(Request::Canonicalize {
-        path: canonical_path.to_vec(),
+        path: path.to_vec(),
         guard: None,
     })?;
     // Consume both replies before interpreting either endpoint error so the

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -655,48 +655,6 @@ fn format_tcp_stats(pairs: &[TcpPairStats], has_ssh_data: bool) -> String {
     output
 }
 
-#[derive(Debug, Eq, PartialEq)]
-enum DestinationIdentityPlan {
-    /// The command-restricted enrollment already supplied the canonical
-    /// parent plus literal placement leaf. No receiver observation is needed.
-    Enrolled(std::path::PathBuf),
-    /// Canonicalize the complete destination spelling.
-    Canonicalize(PathBytes),
-    /// Canonicalize only the parent, then restore the literal placement leaf.
-    CanonicalizeParent {
-        parent: PathBytes,
-        exact_path: PathBytes,
-    },
-}
-
-fn destination_identity_plan(
-    exact_native_destination: bool,
-    restricted_receiver: bool,
-    operator_dst_root: &[u8],
-    destination_path: &[u8],
-) -> DestinationIdentityPlan {
-    if exact_native_destination && restricted_receiver {
-        // Direct setup replaces the public operand with the enrolled
-        // destination: a canonical parent plus its literal leaf. The signed
-        // grant binds these same absolute bytes. Asking the receiver to
-        // canonicalize the parent would both be unnecessary and exceed the
-        // exact destination's observation scope.
-        DestinationIdentityPlan::Enrolled(crate::fsops::resolve(destination_path))
-    } else if exact_native_destination && operator_dst_root == b"~" {
-        // Bare `~` names HOME rather than a literal leaf named `~`. Resolve the
-        // complete spelling so that expansion happens, while ordinary exact
-        // destinations continue to preserve their final symlink as a leaf.
-        DestinationIdentityPlan::Canonicalize(operator_dst_root.to_vec())
-    } else if exact_native_destination {
-        DestinationIdentityPlan::CanonicalizeParent {
-            parent: parent_path(operator_dst_root),
-            exact_path: operator_dst_root.to_vec(),
-        }
-    } else {
-        DestinationIdentityPlan::Canonicalize(destination_path.to_vec())
-    }
-}
-
 struct DestinationRoot<'a> {
     path: &'a [u8],
     existed: bool,
@@ -2092,36 +2050,26 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     // (lexically only; symlinks stay the self-copy guard's business) keeps
     // `dst`, `dst/`, `dst/.` and `dst//` from producing keys that disagree.
     let operator_dst_root = clean_root(&dst.path);
-    // Exact native placement names a directory entry, so its identity is the
-    // canonical parent plus the operator-supplied leaf. Ordinary endpoints
-    // compute that form here; restricted setup already supplied and signed
-    // it. Canonicalizing the whole path would dereference an existing leaf
-    // symlink and give the self-copy guard and resumable-copy identity the
-    // wrong destination.
+    // Only exact placement onto bare `~` needs the receiver's canonical
+    // spelling: it names HOME rather than a literal leaf. Other placements
+    // keep the operator's spelling; registration handles their path policy.
     let exact_native_destination =
         args.interface != Interface::Rsync && args.placement == Placement::As;
     let expand_exact_home =
         exact_native_destination && args.restricted_grant.is_none() && operator_dst_root == b"~";
-    let identity_plan = destination_identity_plan(
-        exact_native_destination,
-        args.restricted_grant.is_some(),
-        &operator_dst_root,
-        &dst.path,
-    );
-    let (dst_root_entry, dst_canonical) = match identity_plan {
-        DestinationIdentityPlan::Enrolled(canonical) => (
+    let (dst_root, dst_root_entry) = if expand_exact_home {
+        let (entry, canonical) = stat_and_canonicalize(
+            &mut *dst_ctl,
+            &operator_dst_root,
+            &operator_dst_root,
+            dst.is_remote(),
+        )?;
+        (canonical.as_os_str().as_bytes().to_vec(), entry)
+    } else {
+        (
+            operator_dst_root.clone(),
             stat_one(&mut *dst_ctl, &operator_dst_root, false)?,
-            canonical,
-        ),
-        DestinationIdentityPlan::Canonicalize(path) => {
-            stat_and_canonicalize(&mut *dst_ctl, &operator_dst_root, &path, dst.is_remote())?
-        }
-        DestinationIdentityPlan::CanonicalizeParent { parent, exact_path } => {
-            let (entry, mut canonical) =
-                stat_and_canonicalize(&mut *dst_ctl, &operator_dst_root, &parent, dst.is_remote())?;
-            append_final_component(&mut canonical, &exact_path);
-            (entry, canonical)
-        }
+        )
     };
     // Rsync retains its destination-directory compatibility rule. Native
     // container placement keeps the named symlink by default or resolves its
@@ -2129,11 +2077,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     // placement always selects the final directory entry; destination
     // following applies only to its parent path.
     let (dst_root, mut dst_root_entry) = match args.interface {
-        Interface::Rsync => follow_dir_symlink(&mut *dst_ctl, &operator_dst_root, dst_root_entry)?,
-        _ if expand_exact_home => (
-            dst_canonical.as_os_str().as_bytes().to_vec(),
-            dst_root_entry,
-        ),
+        Interface::Rsync => follow_dir_symlink(&mut *dst_ctl, &dst_root, dst_root_entry)?,
         _ if args.follows_native_destination_paths() && args.placement == Placement::Into => {
             follow_container_symlink(
                 &mut *dst_ctl,
@@ -2142,7 +2086,7 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                 args.target_existence != Existence::Existing,
             )?
         }
-        _ => (operator_dst_root.clone(), dst_root_entry),
+        _ => (dst_root, dst_root_entry),
     };
     if debug() {
         crate::output::diagnostic!(
@@ -3903,22 +3847,9 @@ fn parent_path(path: &[u8]) -> PathBytes {
     }
 }
 
-/// Append the final raw component of `path` to an already-canonicalized
-/// parent. Native exact placement deliberately treats this component as a
-/// directory entry rather than resolving through it.
-fn append_final_component(parent: &mut std::path::PathBuf, path: &[u8]) {
-    let component = path
-        .rsplit(|byte| *byte == b'/')
-        .next()
-        .filter(|component| !component.is_empty());
-    if let Some(component) = component {
-        parent.push(OsStr::from_bytes(component));
-    }
-}
-
 /// Fetch the destination root's entry and canonical spelling in one network
 /// turn. They are independent read-only queries; sending both before waiting
-/// avoids an otherwise unnecessary RTT on every remote copy.
+/// avoids an extra RTT when expanding a remote bare-home destination.
 fn stat_and_canonicalize(
     conn: &mut dyn Conn,
     stat_path: &[u8],
@@ -9383,29 +9314,6 @@ mod tests {
                 "clean_root({given:?})"
             );
         }
-    }
-
-    #[test]
-    fn restricted_exact_identity_uses_the_enrolled_leaf_without_observing_its_parent() {
-        assert_eq!(
-            destination_identity_plan(true, true, b"/enrolled/root/link", b"/enrolled/root/link",),
-            DestinationIdentityPlan::Enrolled(std::path::PathBuf::from("/enrolled/root/link"))
-        );
-        assert_eq!(
-            destination_identity_plan(false, true, b"/enrolled/root", b"/enrolled/root"),
-            DestinationIdentityPlan::Canonicalize(b"/enrolled/root".to_vec())
-        );
-        assert_eq!(
-            destination_identity_plan(true, false, b"links/exact", b"links/exact"),
-            DestinationIdentityPlan::CanonicalizeParent {
-                parent: b"links".to_vec(),
-                exact_path: b"links/exact".to_vec(),
-            }
-        );
-        assert_eq!(
-            destination_identity_plan(true, false, b"~", b"~"),
-            DestinationIdentityPlan::Canonicalize(b"~".to_vec())
-        );
     }
 
     #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -13654,6 +13654,20 @@ fn native_endpoint_port_reaches_ssh() {
 }
 
 #[test]
+fn native_local_exact_bare_home_expands_before_identity_check() {
+    let t = Tmp::new();
+    fs::create_dir_all(t.path("home")).unwrap();
+    write(&t.path("src/file"), b"home destination");
+    let out = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["cp", "--src", &t.s("src"), "--as", "~", "-q"])
+        .env("HOME", t.path("home"))
+        .run()
+        .expect("copy to a local bare-home destination");
+    assert_output_ok(&out);
+    assert_eq!(read(&t.path("home/file")), b"home destination");
+}
+
+#[test]
 fn native_remote_exact_bare_home_expands_before_identity_check() {
     let t = Tmp::new();
     let rsh = fake_rsh(&t);


### PR DESCRIPTION
A cached resume donor can disappear or become unusable between discovery and opening. When no other basis exists, the receiver now returns no reusable hashes instead of scanning its newly allocated zero-filled output. The controller transfers the whole file; source hashing is still started concurrently and is not eliminated by this change. An optional reader distinguishes reusable bytes from a fresh output. Existing private retry bytes, including real zero-filled blocks, remain eligible for reuse, and output sizing/preallocation is preserved.

Copy setup now requests destination canonicalization only for exact placement onto bare `~`, where its result expands the remote home directory. A single selection branch keeps other destinations on their existing stat and registration path. Bare-home canonicalization uses one path parameter and the same connection operation locally and remotely. Remove the unused identity-planning enum, parent canonicalization, and obsolete resume-identity comments.

Private partial naming, donor priority, collision checks, cleanup results, and extra disk-space requirements are unchanged. No helper message format, persistent state, CLI, or SDK schema changes.

Validation on the tree committed as `ddd76c6`:

- The missing/unsuitable donor regression failed before the fix and passes after it, for rooted and ordinary paths; it also checks that retry zeros remain reusable.
- Formatting, all-target/all-feature Clippy with warnings denied, and documentation links passed.
- `cargo test --all-targets`: 1,105 passed (612 unit, 467 local integration, 26 other integration); one existing ignored test. This includes local and remote bare-home expansion, symlink placement, restricted receivers, and concurrent copies.
- Default isolated three-container OpenSSH suite passed again for the tree committed as `ddd76c6`, including restricted SSH/TCP resume, destination mappings, remote coordinator placements, streaming, benchmark push/pull and interruption cleanup.
- No task macOS execution. Latest master `75a4371` Linux and rsync compatibility passed; macOS is running. The earlier master `aaeb23d` macOS suite failed because the concurrent-copy test's first process exceeded its ten-second test barrier while awaiting the second copy. That timeout is not changed here.
