### PR TITLE
Reserve receiving names with persistent receiver keys

### DIFF
--- a/docs/exec.md
+++ b/docs/exec.md
@@ -19,8 +19,7 @@ existing tmux session.
 
 Replace `@laptop` with your desktop's receiving name. You can find it by running
 `syq persist destinations list` on the server or `syq persist receive status`
-on your desktop. The desktop must be connected: both `--on laptop` and
-`--on @laptop` fail while it is offline.
+on your desktop. Use `--on @laptop`; the desktop must be connected.
 
 ## Approve each command locally
 

--- a/docs/persistence-reference.md
+++ b/docs/persistence-reference.md
@@ -60,7 +60,11 @@ and syq versions. It lives in `~/.syq-receiver-identity/identity_ed25519` and is
 independent of your SSH login keys and profile settings. Keep that directory
 across upgrades; include it in private backups if you want to restore the same
 identity. Losing it requires releasing the old names on each server. Copying it
-to another machine gives that machine the same receiver identity.
+to another machine gives that machine the same receiver identity. If the old
+connection is still responsive, the replacement is rejected; use different
+profile names to receive on both machines at once. If the old connection is
+unresponsive, reconnecting waits for its heartbeat cleanup to release the name
+lock. It does not displace the existing connection.
 
 ## Directories
 

--- a/docs/persistence-reference.md
+++ b/docs/persistence-reference.md
@@ -168,8 +168,8 @@ preferences; use the newer binary to manage receiving.
 
 Connections created before persistent receiver identities remain discoverable.
 Their names become assigned when an updated receiving machine reconnects.
-Updated commands verify assigned names even when an older helper advertises
-them; a receiver without a matching identity is rejected. Older binaries do
+Updated commands verify assigned names even when their connection uses an older
+helper; a receiver without a matching identity is rejected. Older binaries do
 not enforce these assignments, so use updated syq commands on the server and
 stop older receiving services before switching versions. The receiver key and
 assignments are independent of the helper build and survive later upgrades.

--- a/docs/persistence-reference.md
+++ b/docs/persistence-reference.md
@@ -44,11 +44,23 @@ removed. `pending`, `approve`, and `deny` work across all profiles; prompts name
 the receiving profile. Without `--name`, `receive wait` waits for every enabled
 profile on that server.
 
-Names belong to a server account. Different laptops can receive through the same
-account under different names. If a name already has a live connection, another
-client's attempt is rejected without disturbing the existing connection. Other
-profiles remain usable. Choose a different name, or stop the original connection
-and run `syq persist connect server` on the waiting client to retry.
+Names belong to a server account and stay assigned to their original receiving
+machine when it disconnects. Another laptop cannot claim the same name, even
+while the original is offline. Stopping receiving or removing a local profile
+does not release its server-side name. Other profiles remain usable.
+
+To replace a laptop, stop its receiving connection, then run
+`syq persist destinations forget laptop` on the server. Run
+`syq persist connect server` on the replacement laptop to claim the released
+name. A rejected connection needs this explicit retry. Forgetting a live
+connection is refused.
+
+Syq generates one receiver key per local account, shared by receiving profiles
+and syq versions. It lives in `~/.syq-receiver-identity/identity_ed25519` and is
+independent of your SSH login keys and profile settings. Keep that directory
+across upgrades; include it in private backups if you want to restore the same
+identity. Losing it requires releasing the old names on each server. Copying it
+to another machine gives that machine the same receiver identity.
 
 ## Directories
 
@@ -100,7 +112,7 @@ syq persist destinations wait laptop --timeout 30
 syq persist destinations forget laptop
 ```
 
-`forget` removes a stale entry while its connection is stopped. For structured
+`forget` releases the name assignment while its connection is stopped. For structured
 status and approval requests, see [connection status](automation.md#connection-status).
 
 ## Isolated script scopes
@@ -149,3 +161,11 @@ After upgrading both machines, run `syq persist connect server` for each server.
 Saved names, directories, and limits carry over. Settings predating approval
 prompts require approval after upgrading. Older binaries may not read updated
 preferences; use the newer binary to manage receiving.
+
+Connections created before persistent receiver identities remain discoverable.
+Their names become assigned when an updated receiving machine reconnects.
+Updated commands verify assigned names even when an older helper advertises
+them; a receiver without a matching identity is rejected. Older binaries do
+not enforce these assignments, so use updated syq commands on the server and
+stop older receiving services before switching versions. The receiver key and
+assignments are independent of the helper build and survive later upgrades.

--- a/docs/receive.md
+++ b/docs/receive.md
@@ -51,7 +51,9 @@ syq persist connect server
 
 Then run `syq cp results --to @project` on the server. The directory must already
 exist. Each name has its own settings and approval policy, so you can keep a
-project separate from your general `laptop` destination.
+project separate from your general `laptop` destination. Names stay assigned to
+their receiving machine while it is offline; see [replacing a receiver](persistence-reference.md#names-and-profiles)
+when moving a name to another laptop.
 
 Use `syq persist receive status` to list profiles and
 `syq persist receive off --name project` to stop one. See

--- a/docs/receive.md
+++ b/docs/receive.md
@@ -92,6 +92,7 @@ for the trust boundary.
 When you use `--to laptop`, syq looks for a connected receiving machine with
 that name. If it is offline, syq tries an SSH host called `laptop` instead.
 Use `--to @laptop` when you want the command to fail if your laptop is offline.
+If an advertised receiver fails its identity check, the copy fails.
 Once a copy starts, it keeps the same destination even if the connection fails.
 
 The directory you set with `--cwd` is where incoming copies start. You can

--- a/docs/receive.md
+++ b/docs/receive.md
@@ -27,8 +27,8 @@ On the server, use the name from any shell, including an existing tmux session:
 
 ```sh
 ls -lh results
-syq cp results --to laptop
-syq cp report.pdf --to laptop --as reports/latest.pdf
+syq cp results --to @laptop
+syq cp report.pdf --to @laptop --as reports/latest.pdf
 ```
 
 Each incoming copy waits for approval **on your laptop** before it can inspect
@@ -89,10 +89,9 @@ for the trust boundary.
 
 ## Names and paths
 
-When you use `--to laptop`, syq looks for a connected receiving machine with
-that name. If it is offline, syq tries an SSH host called `laptop` instead.
-Use `--to @laptop` when you want the command to fail if your laptop is offline.
-If a connected receiver fails its identity check, the copy fails.
+Use `--to @laptop` to select a receiving machine. The command fails if that
+receiver is offline or fails its identity check. Without `@`, `--to laptop`
+always names an SSH destination, resolved through SSH configuration or DNS.
 Once a copy starts, it keeps the same destination even if the connection fails.
 
 The directory you set with `--cwd` is where incoming copies start. You can

--- a/docs/receive.md
+++ b/docs/receive.md
@@ -92,7 +92,7 @@ for the trust boundary.
 When you use `--to laptop`, syq looks for a connected receiving machine with
 that name. If it is offline, syq tries an SSH host called `laptop` instead.
 Use `--to @laptop` when you want the command to fail if your laptop is offline.
-If an advertised receiver fails its identity check, the copy fails.
+If a connected receiver fails its identity check, the copy fails.
 Once a copy starts, it keeps the same destination even if the connection fails.
 
 The directory you set with `--cwd` is where incoming copies start. You can

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -83,14 +83,18 @@ syq cp project --to server       # put project in your home directory on server
 syq cp --from server project     # fetch project into your current directory
 ```
 
-Endpoints use `[USER@]HOST[:PORT]`, for example `alice@server:2222`.
+SSH endpoints use `[USER@]HOST[:PORT]`, for example `alice@server:2222`.
 Host names cannot start with a dash, including when using an `--rsh` wrapper.
 Enclose IPv6 addresses in brackets: `alice@[2001:db8::1]:2222`.
 A colon in a native path is simply part of the path.
 
+Use `--to @NAME` to send local source files to a registered receiving machine.
+The `@` is required: `--to laptop` always selects an SSH destination, while
+`--to @laptop` selects the receiver and fails if it is offline or its identity
+check fails. Receiver destinations do not switch to SSH when unavailable. See [Send files home from a server](receive.md)
+for setup and receiver-side path settings.
+
 For two remote endpoints, see [Copy between servers](remote-to-remote.md).
-To send files to your laptop from a server shell, see
-[Send files home from a server](receive.md).
 
 ## Progress
 

--- a/docs/remote-reference.md
+++ b/docs/remote-reference.md
@@ -124,10 +124,11 @@ for each reply. Offline or unsupported connections are skipped. With none
 available, or with unsupported options, it uses the source machine's SSH access.
 Once approval is requested, refusal or failure ends the attempt.
 
-`--auth-from NAME` and `--auth-from @NAME` require that receiving machine.
-Names `ssh` and `auto` need the `@` prefix to distinguish them from the option
-values. `--via NAME` always means a receiving name. `--auth-from ssh` always
-treats `--to` as an SSH endpoint, even if it matches a receiving name.
+`--auth-from @NAME` and its alias `--via @NAME` require that receiving machine
+to authorize the copy. `--auth-from ssh` uses the source machine's SSH access.
+These options choose authorization, not the destination: `--to host` names an
+SSH destination, while `--to @NAME` sends files to a receiving machine.
+
 
 Authorization through a receiving machine does not support `--detach`, custom
 `--rsh` or `--syq-path`, `--no-bootstrap`, `--pscope`, alternative `--peer-auth`

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -37,7 +37,7 @@ it uses hostA's SSH access. A copy addressed to a live receiving name goes to
 that machine itself.
 
 Use `--auth-from @laptop` to choose your laptop explicitly, or `--auth-from ssh`
-to use hostA's SSH access. The default is `--auth-from auto`. `--via NAME` is
+to use hostA's SSH access. The default is `--auth-from auto`. `--via @NAME` is
 an alias for choosing a receiving machine. See
 [authorization selection](remote-reference.md#authorization-selection) for
 name rules and route restrictions.

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -33,8 +33,8 @@ syq cp results --to hostB --into /archive
 
 Syq uses the first available receiving machine in alphabetical name order.
 If none is available, or the requested options are unsupported on this route,
-it uses hostA's SSH access. A copy addressed to a live receiving name goes to
-that machine itself.
+it uses hostA's SSH access. `--to @laptop` instead sends the files to the
+receiving machine itself.
 
 Use `--auth-from @laptop` to choose your laptop explicitly, or `--auth-from ssh`
 to use hostA's SSH access. The default is `--auth-from auto`. `--via @NAME` is
@@ -47,8 +47,8 @@ prompt or `syq persist receive pending` and `syq persist receive approve REQUEST
 These requests require a decision even when `persist receive on --approve always` permits
 automatic copies onto the laptop itself. Once an approval request is sent,
 a refusal, interrupted connection, setup failure, or copy failure ends that
-attempt; syq does not try another authorizer or SSH. Explicit receiving names
-require a live return connection and never fall back to DNS lookup.
+attempt; syq does not try another authorizer or SSH. `--auth-from @NAME` and
+`--via @NAME` fail if that receiving machine is unavailable.
 
 The laptop uses its own SSH configuration, credentials, and trusted host keys
 to connect to hostB and install the matching syq helper. Connect to hostB with

--- a/docs/security.md
+++ b/docs/security.md
@@ -132,9 +132,9 @@ request more copies and invent their content. Once approved, it can inspect
 destination entries during copy planning and consume disk space within the
 approved limits. The laptop's receiving account is trusted.
 
-Bare destination names fall back to ordinary SSH while the laptop is offline.
-Use `@name` when you require a return connection and want failure instead of
-host resolution. A copy never switches routes after selecting its destination.
+Receiver destinations require `@name` and fail if that receiver is offline.
+Bare names always identify SSH destinations, resolved through SSH configuration
+or DNS. A copy never switches routes after selecting its destination.
 
 ## Limits to keep in mind
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -109,6 +109,14 @@ are validated before prompting; the restricted filesystem executor checks
 every operation after approval. The server receives no SSH agent.
 [Commands](exec.md) need separate approval.
 
+Receiving names stay assigned to a persistent receiver public key. Reconnecting
+requires proof of the corresponding private key; knowing the public key does
+not let another receiver claim the name. This prevents accidental reassignment
+and impersonation through registration, but the server account controls the
+assignment files and can replace them. It is not a security boundary against
+someone who controls that account. The receiver private key stays on the
+receiving machine and does not grant SSH login access.
+
 Approval permits that pending copy's destination, overwrite policy, and limits.
 It does not authenticate what you typed on a remote server or attest to source
 contents. The receiving user and desktop session remain trusted. Request IDs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -924,7 +924,9 @@ pub(crate) enum AuthFrom {
 
 impl AuthFrom {
     fn receiving(value: &str) -> Result<Self> {
-        let name = value.strip_prefix('@').unwrap_or(value);
+        let name = value
+            .strip_prefix('@')
+            .ok_or_else(|| anyhow::anyhow!("receiver references require @NAME"))?;
         crate::destination::validate_name(name)?;
         Ok(Self::Return(name.to_owned()))
     }
@@ -943,7 +945,7 @@ struct NativeRemoteArgs {
     /// Authorize with a live receiving machine, or use SSH from this machine (default: auto)
     #[arg(long, value_name = "auto|ssh|@NAME", value_parser = parse_auth_from, conflicts_with = "via")]
     auth_from: Option<AuthFrom>,
-    /// Alias for --auth-from @NAME; every bare value remains a receiving name
+    /// Alias for --auth-from @NAME
     #[arg(long, value_name = "@NAME")]
     via: Option<String>,
     /// Choose the endpoint that runs the coordinator
@@ -1008,7 +1010,7 @@ struct NativeCopyFields {
     suppress_summary: bool,
     #[command(flatten)]
     selection: NativeSelectionArgs,
-    /// Destination SSH endpoint or live receiving name; @NAME requires a return connection; placement defaults to --into .
+    /// Destination SSH endpoint or @NAME for a receiving machine; placement defaults to --into .
     #[arg(long, value_name = "ENDPOINT")]
     to: Option<String>,
     /// Follow symlinks in directly supplied destination paths

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1320,7 +1320,7 @@ fn option_takes_value(command: &clap::Command, option: &[u8]) -> bool {
 fn return_name_candidates(current: &[u8]) -> impl Iterator<Item = Candidate> + '_ {
     crate::destination::registered_names()
         .into_iter()
-        .flat_map(|name| [name.as_bytes().to_vec(), format!("@{name}").into_bytes()])
+        .map(|name| format!("@{name}").into_bytes())
         .filter(move |name| name.starts_with(current))
         .map(Candidate::text)
 }
@@ -1473,10 +1473,7 @@ fn complete_path_for(
         // an automatically selected authorizer. Explicit SSH keeps normal completion.
         return Ok(Vec::new());
     }
-    if endpoint.host.starts_with('@')
-        || (authorizer != Some("ssh")
-            && crate::destination::connection_names().contains(&endpoint.host))
-    {
+    if endpoint.host.starts_with('@') {
         return Ok(Vec::new());
     }
     remote_path_candidates(

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1467,7 +1467,7 @@ fn complete_path_for(
     if find_option_value(args, b"--via").is_some()
         || (authorizer != Some("ssh")
             && (authorizer.is_some_and(|value| value != "auto")
-                || (command == "cp" && !crate::destination::registered_names().is_empty())))
+                || (command == "cp" && !crate::destination::connection_names().is_empty())))
     {
         // Completion must never request copy approval or inspect hostB through
         // an automatically selected authorizer. Explicit SSH keeps normal completion.
@@ -1475,7 +1475,7 @@ fn complete_path_for(
     }
     if endpoint.host.starts_with('@')
         || (authorizer != Some("ssh")
-            && crate::destination::registered_names().contains(&endpoint.host))
+            && crate::destination::connection_names().contains(&endpoint.host))
     {
         return Ok(Vec::new());
     }

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -366,6 +366,7 @@ fn exchange(
             "named destination requires its matching helper; reconnect from the receiving machine"
         );
     }
+    let deadline = Instant::now() + timeout;
     let mut stream = UnixStream::connect(&registration.socket).context(
         "receiving machine is offline; run `syq persist connect SERVER` on that machine to reconnect to this server account",
     )?;
@@ -386,7 +387,11 @@ fn exchange(
             message,
         },
     )?;
-    let reply = read_message(&mut stream)?;
+    let remaining = deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .context("return channel exchange timed out")?;
+    let reply = read_socket_message(&mut stream, remaining)?;
     if let Reply::Error(error) = &reply {
         bail!("receiving machine: {error}");
     }
@@ -556,8 +561,6 @@ fn select_copy(args: &crate::cli::Args) -> Result<Option<handoff::Selection>> {
                     "--auth-from ssh requires local sources and an ordinary SSH --to destination"
                 );
             }
-            // This explicit choice also disambiguates an SSH host whose name
-            // happens to match a receiving machine's advertisement.
             return Ok(None);
         }
         crate::cli::AuthFrom::Auto => {}
@@ -568,36 +571,14 @@ fn select_copy(args: &crate::cli::Args) -> Result<Option<handoff::Selection>> {
     let Some(host) = destination.host.as_deref() else {
         return Ok(None);
     };
-    let explicit = host.starts_with('@');
-    let name = host.strip_prefix('@').unwrap_or(host).to_owned();
-    // A normal SSH endpoint with a user/port remains explicit SSH. Bare names
-    // opt into lookup only when this process can actually send a return copy.
-    let registration = if explicit {
-        load_registration(&name)?
-    } else {
-        if destination.user.is_some()
-            || destination.port.is_some()
-            || args.interface != crate::cli::Interface::NativeCp
-            || args.locations[..args.locations.len() - 1]
-                .iter()
-                .any(|l| l.is_remote())
-            || !registered_names().contains(&name)
-        {
-            return forward::select(args);
+    let Some(name) = host.strip_prefix('@') else {
+        if handoff::selected_name(handoff::Kind::Copy).is_some() {
+            bail!("receiver destinations require @NAME; retry the command with --to @NAME");
         }
-        if !registry()?.join(format!("{name}.json")).try_exists()?
-            && handoff::selected_name(handoff::Kind::Copy).is_none_or(|selected| selected != name)
-        {
-            return forward::select(args);
-        }
-        let registration = load_registration(&name)?;
-        if handoff::selected_name(handoff::Kind::Copy).is_none_or(|selected| selected != name)
-            && exchange(&registration, Message::Ping, Duration::from_secs(2)).is_err()
-        {
-            return forward::select(args);
-        }
-        registration
+        return forward::select(args);
     };
+    let name = name.to_owned();
+    let registration = load_registration(&name)?;
     if args.interface != crate::cli::Interface::NativeCp
         || args.locations[..args.locations.len() - 1]
             .iter()
@@ -1283,17 +1264,23 @@ fn register_inner(name: &str, socket: &Path, secret: &str) -> Result<i32> {
         .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
         .open(directory.join(format!("{name}.lock")))?;
     if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
-        // A laptop may reconnect before the server has noticed the old TCP
-        // session died. A retry still cannot displace an active registration
-        // or obtain its lock.
-        // Read only the saved credential: the old transport may be unresponsive.
+        // A responsive holder is a duplicate, even when a copied home directory
+        // gives both machines the same identity. Never replace a held lock.
+        if read_registration(name).is_ok_and(|previous| {
+            exchange(&previous, Message::Ping, Duration::from_secs(1))
+                .is_ok_and(|(_, reply)| matches!(reply, Reply::Ready))
+        }) {
+            bail!("destination @{name} is already connected; choose another receiver name to use both connections at the same time");
+        }
+        // The old transport may be dying. Its heartbeat releases the lock;
+        // only the same connection or verified owner may wait to reconnect.
         if read_registration(name).is_ok_and(|previous| previous.secret == secret) {
             crate::output::diagnostic!("syq: previous return connection is still closing");
             return Ok(RECONNECT_PENDING);
         }
         if let Some(owner) = identity::owner(&directory, name)? {
             // A restarted service has a new connection credential but keeps
-            // its receiver key. Verify the new connection, never the dying one.
+            // its receiver key. Verify it before allowing reconnect retries.
             identity::verify_receiver(name, &registration, Some(&owner))?;
             crate::output::diagnostic!("syq: previous return connection is still closing");
             return Ok(RECONNECT_PENDING);
@@ -1340,13 +1327,17 @@ fn register_inner(name: &str, socket: &Path, secret: &str) -> Result<i32> {
     }
     Ok(0)
 }
-fn available(name: &str) -> Result<()> {
-    let registration = load_registration(name)?;
-    let (_, reply) = exchange(&registration, Message::Ping, Duration::from_secs(1))?;
-    if !matches!(reply, Reply::Ready) {
-        bail!("destination not ready");
+fn available(name: &str, timeout: Duration) -> Result<Registration> {
+    let registration = read_registration(name)?;
+    if let Some(owner) = identity::owner(&registry()?, name)? {
+        identity::verify_receiver_with_timeout(name, &registration, Some(&owner), timeout)?;
+    } else {
+        let (_, reply) = exchange(&registration, Message::Ping, timeout)?;
+        if !matches!(reply, Reply::Ready) {
+            bail!("destination not ready");
+        }
     }
-    Ok(())
+    Ok(registration)
 }
 fn destinations(action: DestinationAction) -> Result<i32> {
     match action {
@@ -1369,7 +1360,7 @@ fn destinations(action: DestinationAction) -> Result<i32> {
             for name in names {
                 println!(
                     "@{name}\t{}",
-                    if available(&name).is_ok() {
+                    if available(&name, Duration::from_secs(1)).is_ok() {
                         "online"
                     } else {
                         "offline"
@@ -1404,18 +1395,25 @@ fn destinations(action: DestinationAction) -> Result<i32> {
             let deadline = Instant::now() + Duration::from_secs(timeout);
             let mut last_progress = Instant::now();
             loop {
-                match available(&name) {
-                    Ok(()) => return Ok(0),
-                    Err(error) if Instant::now() >= deadline => {
-                        return Err(error).context("timed out waiting for named destination")
-                    }
-                    Err(error) if last_progress.elapsed() >= Duration::from_secs(5) => {
-                        crate::output::diagnostic!("syq: waiting for @{name}: {error:#}");
-                        last_progress = Instant::now();
-                    }
-                    Err(_) => {}
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    bail!("timed out waiting for named destination");
                 }
-                std::thread::sleep(Duration::from_millis(200));
+                let error = match available(&name, remaining.min(Duration::from_secs(1))) {
+                    Ok(_) => return Ok(0),
+                    Err(error) => error,
+                };
+                if last_progress.elapsed() >= Duration::from_secs(5) {
+                    crate::output::diagnostic!("syq: waiting for @{name}: {error:#}");
+                    last_progress = Instant::now();
+                }
+                std::thread::sleep(
+                    Duration::from_millis(200)
+                        .min(deadline.saturating_duration_since(Instant::now())),
+                );
+                if Instant::now() >= deadline {
+                    return Err(error).context("timed out waiting for named destination");
+                }
             }
         }
     }

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -201,7 +201,7 @@ fn wait_fd(
     fd: std::os::fd::RawFd,
     events: i16,
     deadline: Instant,
-    cancelled: &impl Fn() -> bool,
+    cancelled: Option<&dyn Fn() -> bool>,
 ) -> std::io::Result<()> {
     let mut descriptor = libc::pollfd {
         fd,
@@ -209,13 +209,18 @@ fn wait_fd(
         revents: 0,
     };
     loop {
-        if cancelled() {
+        if cancelled.is_some_and(|check| check()) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::ConnectionAborted,
                 "return request cancelled",
             ));
         }
-        let milliseconds = deadline_remaining(deadline)?.as_millis().clamp(1, 100) as i32;
+        // Only cancellation needs periodic wakeups. Socket and handshake waits
+        // can sleep until readiness or their deadline, including human approval.
+        let cap = if cancelled.is_some() { 100 } else { i32::MAX };
+        let milliseconds = deadline_remaining(deadline)?
+            .as_millis()
+            .clamp(1, cap as u128) as i32;
         // The caller keeps the descriptor alive and descriptor is writable during
         // poll. Signals and spurious wakeups never renew the deadline.
         let ready = unsafe { libc::poll(&mut descriptor, 1, milliseconds) };
@@ -256,12 +261,9 @@ impl Read for DeadlineSocket<'_> {
             let error = std::io::Error::last_os_error();
             match error.kind() {
                 std::io::ErrorKind::Interrupted => continue,
-                std::io::ErrorKind::WouldBlock => wait_fd(
-                    self.socket.as_raw_fd(),
-                    libc::POLLIN,
-                    self.deadline,
-                    &|| false,
-                )?,
+                std::io::ErrorKind::WouldBlock => {
+                    wait_fd(self.socket.as_raw_fd(), libc::POLLIN, self.deadline, None)?
+                }
                 _ => return Err(error),
             }
         }
@@ -276,12 +278,9 @@ impl Write for DeadlineSocket<'_> {
             {
                 Ok(count) => return Ok(count),
                 Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => wait_fd(
-                    self.socket.as_raw_fd(),
-                    libc::POLLOUT,
-                    self.deadline,
-                    &|| false,
-                )?,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    wait_fd(self.socket.as_raw_fd(), libc::POLLOUT, self.deadline, None)?
+                }
                 Err(error) => return Err(error),
             }
         }
@@ -468,7 +467,7 @@ fn exchange(
         let message = if error.kind() == std::io::ErrorKind::WouldBlock {
             "receiving machine is busy; try again shortly"
         } else {
-            "could not connect to receiving machine; if it is offline, run `syq persist connect SERVER` on that machine to reconnect to this server account"
+            "could not connect to receiving machine; try again or check its connection to this server"
         };
         anyhow::Error::new(error).context(message)
     })?;
@@ -1554,7 +1553,19 @@ mod tests {
         let listener = Socket::new(Domain::UNIX, Type::STREAM, None).unwrap();
         listener.bind(&SockAddr::unix(&path).unwrap()).unwrap();
         listener.listen(0).unwrap();
-        let _queued = connect_socket(&path, Instant::now() + Duration::from_secs(1)).unwrap();
+        let mut queued = Vec::new();
+        let mut full = false;
+        for _ in 0..16 {
+            match connect_socket(&path, Instant::now() + Duration::from_secs(1)) {
+                Ok(socket) => queued.push(socket),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    full = true;
+                    break;
+                }
+                Err(error) => panic!("fill listen queue: {error}"),
+            }
+        }
+        assert!(full, "test did not fill the listen queue");
         let registration = Registration {
             version: REGISTRATION_VERSION,
             identity: crate::identity::build().into(),

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -467,7 +467,7 @@ fn exchange(
         let message = if error.kind() == std::io::ErrorKind::WouldBlock {
             "receiving machine is busy; try again shortly"
         } else {
-            "could not connect to receiving machine; try again or check its connection to this server"
+            "could not connect to receiving machine; it may be busy or its connection may have ended; try again, or run `syq persist connect SERVER` on the receiving machine to connect to this server account"
         };
         anyhow::Error::new(error).context(message)
     })?;

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -1,8 +1,8 @@
 //! Named, permission-checked return channels over laptop-initiated SSH.
 //!
-//! This protocol uses transient advertisements maintained by persistence,
-//! independent of durable receiver enrollments. The remote account is the requester identity: shells
-//! and jobs under that account intentionally share access to its registrations.
+//! Persistence maintains transient advertisements and durable name ownership,
+//! independent of restricted receiver enrollments. The remote account is the
+//! requester identity: shells and jobs under it share access to registrations.
 use anyhow::{bail, Context, Result};
 use base64::Engine as _;
 use clap::{CommandFactory, Parser, Subcommand};
@@ -30,9 +30,10 @@ use crate::private_broker::{PrivateBroker, PrivateBrokerConfig, TrackedStream};
 pub(crate) mod exec;
 mod forward;
 pub(crate) mod handoff;
+mod identity;
 
 // Discovery is independent of the build-pinned request protocol. Keep the
-// Ping/Ready JSON envelope and this version stable across helper wire changes.
+// Ping/Ready and Identify/Identity JSON envelopes stable across helper wire changes.
 const DISCOVERY_VERSION: u16 = 2;
 const VERSION: u16 = 2;
 const REGISTRATION_VERSION: u16 = 3;
@@ -125,6 +126,10 @@ struct Envelope {
 #[derive(Serialize, Deserialize)]
 enum Message {
     Ping,
+    Identify {
+        name: String,
+        challenge: String,
+    },
     Exec(exec::ExecRequest),
     Request(Box<CopyRequest>),
     Forward {
@@ -139,6 +144,7 @@ enum Message {
 #[derive(Serialize, Deserialize)]
 enum Reply {
     Ready,
+    Identity(identity::Proof),
     Approved(Approved),
     Error(String),
 }
@@ -231,6 +237,13 @@ pub(crate) fn validate_name(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Protect the actual identity location, including an explicitly supplied HOME.
+/// Merely computing the path must not create receiver state.
+pub(crate) fn receiver_identity_directory() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME").context("HOME is unset")?;
+    Ok(fs::canonicalize(home)?.join(".syq-receiver-identity"))
+}
+
 fn registry() -> Result<PathBuf> {
     private_directory(".syq-destinations-v3")
 }
@@ -272,17 +285,18 @@ pub(crate) fn registered_names() -> Vec<String> {
     };
     let mut names: Vec<_> = entries
         .filter_map(|entry| {
-            let name = entry
-                .ok()?
-                .file_name()
-                .to_str()?
-                .strip_suffix(".json")?
+            let file = entry.ok()?.file_name();
+            let file = file.to_str()?;
+            let name = file
+                .strip_suffix(".json")
+                .or_else(|| file.strip_suffix(".owner"))?
                 .to_owned();
             validate_name(&name).ok()?;
             Some(name)
         })
         .collect();
     names.sort();
+    names.dedup();
     names
 }
 
@@ -293,6 +307,9 @@ fn load_registration(name: &str) -> Result<Registration> {
         Ok(encoded) => encoded,
         Err(error) if error.chain().any(|cause| cause.downcast_ref::<std::io::Error>()
             .is_some_and(|error| error.kind() == std::io::ErrorKind::NotFound)) => {
+            if identity::owner(&registry()?, name)?.is_some() {
+                bail!("receiving machine @{name} is offline; reconnect its original receiver with `syq persist connect SERVER`, or release the name on this server with `syq persist destinations forget {name}`");
+            }
             let names = registered_names();
             let advice = if names.is_empty() {
                 "On the receiving machine, run `syq persist connect SERVER`, using the SSH endpoint for this server account.".to_owned()
@@ -314,6 +331,9 @@ fn load_registration(name: &str) -> Result<Registration> {
     {
         bail!("invalid destination helper registration; reconnect from the receiving machine");
     }
+    if let Some(owner) = identity::owner(&registry()?, name)? {
+        identity::verify_receiver(name, &registration, Some(&owner))?;
+    }
     Ok(registration)
 }
 fn exchange(
@@ -321,7 +341,9 @@ fn exchange(
     message: Message,
     timeout: Duration,
 ) -> Result<(UnixStream, Reply)> {
-    if !matches!(message, Message::Ping) && registration.identity != crate::identity::build() {
+    if !matches!(message, Message::Ping | Message::Identify { .. })
+        && registration.identity != crate::identity::build()
+    {
         bail!(
             "named destination requires its matching helper; reconnect from the receiving machine"
         );
@@ -334,13 +356,13 @@ fn exchange(
     write_message(
         &mut stream,
         &Envelope {
-            version: if matches!(message, Message::Ping) {
+            version: if matches!(message, Message::Ping | Message::Identify { .. }) {
                 DISCOVERY_VERSION
             } else {
                 VERSION
             },
-            // Ping is the fixed discovery contract. All authoritative requests
-            // above still require this executable to match the receiving build.
+            // Discovery and identity proofs are stable across builds. Copy,
+            // command, and forwarding requests still require a matching helper.
             identity: registration.identity.clone(),
             secret: registration.secret.clone(),
             message,
@@ -545,6 +567,11 @@ fn select_copy(args: &crate::cli::Args) -> Result<Option<handoff::Selection>> {
         {
             return forward::select(args);
         }
+        if !registry()?.join(format!("{name}.json")).try_exists()?
+            && handoff::selected_name(handoff::Kind::Copy).is_none_or(|selected| selected != name)
+        {
+            return forward::select(args);
+        }
         let registration = load_registration(&name)?;
         if handoff::selected_name(handoff::Kind::Copy).is_none_or(|selected| selected != name)
             && exchange(&registration, Message::Ping, Duration::from_secs(2)).is_err()
@@ -718,6 +745,8 @@ struct Prompt {
     decision: mpsc::SyncSender<bool>,
 }
 struct Receiver {
+    name: String,
+    identity_key: ssh_key::PrivateKey,
     requester: String,
     approval_mode: crate::receive_approval::Mode,
     notifications: crate::receive_approval::Notifications,
@@ -787,12 +816,15 @@ impl Receiver {
     fn handle(&self, mut stream: TrackedStream) -> Result<()> {
         let envelope: Envelope =
             read_socket_message(&mut stream.try_clone()?, Duration::from_secs(10))?;
-        let version = if matches!(envelope.message, Message::Ping) {
+        let version = if matches!(envelope.message, Message::Ping | Message::Identify { .. }) {
             DISCOVERY_VERSION
         } else {
             VERSION
         };
-        if envelope.version != version || envelope.identity != crate::identity::build() {
+        if envelope.version != version
+            || (!matches!(envelope.message, Message::Identify { .. })
+                && envelope.identity != crate::identity::build())
+        {
             bail!("named destination build mismatch; restart with matching syq builds");
         }
         if envelope.secret != self.secret {
@@ -801,6 +833,13 @@ impl Receiver {
         match envelope.message {
             Message::Exec(request) => self.execute(request, stream),
             Message::Ping => write_message(&mut stream, &Reply::Ready),
+            Message::Identify { name, challenge } => {
+                if name != self.name {
+                    bail!("receiver identity requested for a different profile");
+                }
+                let proof = identity::prove(&self.identity_key, &name, &challenge, &self.secret)?;
+                write_message(&mut stream, &Reply::Identity(proof))
+            }
             Message::Forward { target, request } => self.forward(target, *request, stream),
             Message::Request(request) => {
                 let _request = self.request_lock.try_lock().map_err(|_| {
@@ -988,6 +1027,8 @@ pub(crate) fn serve_background(
     #[cfg(test)]
     let (prompts, _requests) = mpsc::sync_channel(1);
     let receiver = Arc::new(Receiver {
+        name: config.name.clone(),
+        identity_key: identity::load_key()?,
         requester: format!(
             "{} (receiving profile @{})",
             spec.endpoint.label(),
@@ -1233,6 +1274,9 @@ fn register_inner(name: &str, socket: &Path, secret: &str) -> Result<i32> {
         }
         bail!("destination @{name} is already registered by another connection");
     }
+    let owner = identity::owner(&directory, name)?;
+    let public_key = identity::verify_receiver(name, &registration, owner.as_deref())?;
+    identity::claim(&directory, name, &public_key)?;
     let path = directory.join(format!("{name}.json"));
     let mut temporary = tempfile::NamedTempFile::new_in(&directory)?;
     temporary.write_all(&serde_json::to_vec(&registration)?)?;
@@ -1283,14 +1327,19 @@ fn destinations(action: DestinationAction) -> Result<i32> {
         DestinationAction::List => {
             let mut names = Vec::new();
             for entry in fs::read_dir(registry()?)? {
-                let name = entry?.file_name().to_string_lossy().into_owned();
-                if let Some(name) = name.strip_suffix(".json") {
+                let file = entry?.file_name();
+                let file = file.to_string_lossy();
+                if let Some(name) = file
+                    .strip_suffix(".json")
+                    .or_else(|| file.strip_suffix(".owner"))
+                {
                     if validate_name(name).is_ok() {
                         names.push(name.to_owned());
                     }
                 }
             }
             names.sort();
+            names.dedup();
             for name in names {
                 println!(
                     "@{name}\t{}",
@@ -1314,7 +1363,7 @@ fn destinations(action: DestinationAction) -> Result<i32> {
             if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
                 bail!("destination @{name} is still registered; stop its receiver first");
             }
-            fs::remove_file(directory.join(format!("{name}.json")))?;
+            identity::forget(&directory, &name)?;
             println!("syq: forgot offline destination @{name}");
             Ok(0)
         }
@@ -1448,6 +1497,8 @@ mod tests {
     ) {
         let (prompts, requests) = mpsc::sync_channel(1);
         let receiver = Arc::new(Receiver {
+            name: "laptop".into(),
+            identity_key: identity::generate_key().unwrap(),
             requester: "test-server".into(),
             approval_mode: crate::receive_approval::Mode::Always,
             notifications: crate::receive_approval::Notifications::Off,

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -300,7 +300,7 @@ pub(crate) fn registered_names() -> Vec<String> {
     names
 }
 
-fn load_registration(name: &str) -> Result<Registration> {
+fn read_registration(name: &str) -> Result<Registration> {
     validate_name(name)?;
     let path = registry()?.join(format!("{name}.json"));
     let encoded = match crate::delegation::read_private_regular(&path, "named destination", MAX_MESSAGE) {
@@ -331,6 +331,11 @@ fn load_registration(name: &str) -> Result<Registration> {
     {
         bail!("invalid destination helper registration; reconnect from the receiving machine");
     }
+    Ok(registration)
+}
+
+fn load_registration(name: &str) -> Result<Registration> {
+    let registration = read_registration(name)?;
     if let Some(owner) = identity::owner(&registry()?, name)? {
         identity::verify_receiver(name, &registration, Some(&owner))?;
     }
@@ -1266,9 +1271,17 @@ fn register_inner(name: &str, socket: &Path, secret: &str) -> Result<i32> {
         .open(directory.join(format!("{name}.lock")))?;
     if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
         // A laptop may reconnect before the server has noticed the old TCP
-        // session died. Only the same ephemeral credential gets a retry; it
-        // still cannot displace an active registration or obtain its lock.
-        if load_registration(name).is_ok_and(|previous| previous.secret == secret) {
+        // session died. A retry still cannot displace an active registration
+        // or obtain its lock.
+        // Read only the saved credential: the old transport may be unresponsive.
+        if read_registration(name).is_ok_and(|previous| previous.secret == secret) {
+            crate::output::diagnostic!("syq: previous return connection is still closing");
+            return Ok(RECONNECT_PENDING);
+        }
+        if let Some(owner) = identity::owner(&directory, name)? {
+            // A restarted service has a new connection credential but keeps
+            // its receiver key. Verify the new connection, never the dying one.
+            identity::verify_receiver(name, &registration, Some(&owner))?;
             crate::output::diagnostic!("syq: previous return connection is still closing");
             return Ok(RECONNECT_PENDING);
         }
@@ -1284,7 +1297,7 @@ fn register_inner(name: &str, socket: &Path, secret: &str) -> Result<i32> {
     let meta = fs::symlink_metadata(&path)?;
     guard.record = Some((path, (meta.dev(), meta.ino())));
     // Drop the advertisement before releasing its name lock, including on a
-    // normal disconnect. A crash can leave a stale record, never a reservation.
+    // normal disconnect. Ownership survives; a crash cannot keep the live lock.
     let _guard = guard;
     write_message(&mut std::io::stdout(), &Reply::Ready)?;
     let mut input = std::io::stdin();
@@ -1294,7 +1307,7 @@ fn register_inner(name: &str, socket: &Path, secret: &str) -> Result<i32> {
             events: libc::POLLIN,
             revents: 0,
         };
-        // A quiet, half-open SSH transport must not reserve a name forever.
+        // A quiet, half-open SSH transport must not block reconnection forever.
         let ready = unsafe { libc::poll(&mut descriptor, 1, 15_000) };
         if ready < 0 {
             let error = std::io::Error::last_os_error();

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -267,6 +267,15 @@ fn private_directory(name: &str) -> Result<PathBuf> {
 /// Completion only lists local names; it never creates state or asks a laptop
 /// for file listings without a transfer approval.
 pub(crate) fn registered_names() -> Vec<String> {
+    local_names(true)
+}
+
+/// Connection records only, for completion routing without network probes.
+pub(crate) fn connection_names() -> Vec<String> {
+    local_names(false)
+}
+
+fn local_names(include_offline: bool) -> Vec<String> {
     let Some(home) = std::env::var_os("HOME") else {
         return Vec::new();
     };
@@ -289,7 +298,11 @@ pub(crate) fn registered_names() -> Vec<String> {
             let file = file.to_str()?;
             let name = file
                 .strip_suffix(".json")
-                .or_else(|| file.strip_suffix(".owner"))?
+                .or_else(|| {
+                    include_offline
+                        .then(|| file.strip_suffix(".owner"))
+                        .flatten()
+                })?
                 .to_owned();
             validate_name(&name).ok()?;
             Some(name)
@@ -1371,6 +1384,9 @@ fn destinations(action: DestinationAction) -> Result<i32> {
             let lock = OpenOptions::new()
                 .read(true)
                 .write(true)
+                .create(true)
+                .truncate(false)
+                .mode(0o600)
                 .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
                 .open(directory.join(format!("{name}.lock")))?;
             if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -197,17 +197,26 @@ fn deadline_remaining(deadline: Instant) -> std::io::Result<Duration> {
         })
 }
 
-fn wait_socket(socket: &impl AsRawFd, events: i16, deadline: Instant) -> std::io::Result<()> {
+fn wait_fd(
+    fd: std::os::fd::RawFd,
+    events: i16,
+    deadline: Instant,
+    cancelled: &impl Fn() -> bool,
+) -> std::io::Result<()> {
     let mut descriptor = libc::pollfd {
-        fd: socket.as_raw_fd(),
+        fd,
         events,
         revents: 0,
     };
     loop {
-        let milliseconds = deadline_remaining(deadline)?
-            .as_millis()
-            .clamp(1, i32::MAX as u128) as i32;
-        // The borrowed socket remains alive and descriptor is writable during
+        if cancelled() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionAborted,
+                "return request cancelled",
+            ));
+        }
+        let milliseconds = deadline_remaining(deadline)?.as_millis().clamp(1, 100) as i32;
+        // The caller keeps the descriptor alive and descriptor is writable during
         // poll. Signals and spurious wakeups never renew the deadline.
         let ready = unsafe { libc::poll(&mut descriptor, 1, milliseconds) };
         if ready < 0 {
@@ -247,9 +256,12 @@ impl Read for DeadlineSocket<'_> {
             let error = std::io::Error::last_os_error();
             match error.kind() {
                 std::io::ErrorKind::Interrupted => continue,
-                std::io::ErrorKind::WouldBlock => {
-                    wait_socket(self.socket, libc::POLLIN, self.deadline)?
-                }
+                std::io::ErrorKind::WouldBlock => wait_fd(
+                    self.socket.as_raw_fd(),
+                    libc::POLLIN,
+                    self.deadline,
+                    &|| false,
+                )?,
                 _ => return Err(error),
             }
         }
@@ -264,9 +276,12 @@ impl Write for DeadlineSocket<'_> {
             {
                 Ok(count) => return Ok(count),
                 Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                    wait_socket(self.socket, libc::POLLOUT, self.deadline)?
-                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => wait_fd(
+                    self.socket.as_raw_fd(),
+                    libc::POLLOUT,
+                    self.deadline,
+                    &|| false,
+                )?,
                 Err(error) => return Err(error),
             }
         }
@@ -294,19 +309,9 @@ fn connect_socket(path: &Path, deadline: Instant) -> std::io::Result<UnixStream>
     deadline_remaining(deadline)?;
     let socket = Socket::new(Domain::UNIX, Type::STREAM, None)?;
     socket.set_nonblocking(true)?;
-    match socket.connect(&SockAddr::unix(path)?) {
-        Ok(()) => {}
-        Err(error) if error.raw_os_error() == Some(libc::EINPROGRESS) => {
-            wait_socket(&socket, libc::POLLOUT, deadline)?;
-            if let Some(error) = socket.take_error()? {
-                return Err(error);
-            }
-            socket.peer_addr()?;
-        }
-        // In particular, Linux reports EAGAIN for a full Unix listen queue:
-        // no connection is pending. Return it without a blocking connect retry.
-        Err(error) => return Err(error),
-    }
+    // Unix stream connect completes immediately or fails. In particular,
+    // Linux reports EAGAIN for a full listen queue, with no connection pending.
+    socket.connect(&SockAddr::unix(path)?)?;
     socket.set_nonblocking(false)?;
     let descriptor: std::os::fd::OwnedFd = socket.into();
     Ok(descriptor.into())
@@ -459,9 +464,14 @@ fn exchange(
         );
     }
     let deadline = Instant::now() + timeout;
-    let mut stream = connect_socket(&registration.socket, deadline).context(
-        "receiving machine is offline; run `syq persist connect SERVER` on that machine to reconnect to this server account",
-    )?;
+    let mut stream = connect_socket(&registration.socket, deadline).map_err(|error| {
+        let message = if error.kind() == std::io::ErrorKind::WouldBlock {
+            "receiving machine is busy; try again shortly"
+        } else {
+            "could not connect to receiving machine; if it is offline, run `syq persist connect SERVER` on that machine to reconnect to this server account"
+        };
+        anyhow::Error::new(error).context(message)
+    })?;
     let mut io = DeadlineSocket {
         socket: &mut stream,
         deadline,
@@ -1534,6 +1544,34 @@ mod tests {
     use crate::cli::{Args, Interface, Location, Placement};
     use crate::conn::Conn;
     use crate::proto::{Request, Response};
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn full_listen_queue_reports_busy_without_reconnect_advice() {
+        use socket2::{Domain, SockAddr, Socket, Type};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("busy.sock");
+        let listener = Socket::new(Domain::UNIX, Type::STREAM, None).unwrap();
+        listener.bind(&SockAddr::unix(&path).unwrap()).unwrap();
+        listener.listen(0).unwrap();
+        let _queued = connect_socket(&path, Instant::now() + Duration::from_secs(1)).unwrap();
+        let registration = Registration {
+            version: REGISTRATION_VERSION,
+            identity: crate::identity::build().into(),
+            socket: path,
+            secret: "test".into(),
+            program: b"/test/syq".to_vec(),
+        };
+        let error = exchange(&registration, Message::Ping, Duration::from_millis(100))
+            .err()
+            .unwrap();
+        assert!(error.to_string().contains("busy"), "{error:#}");
+        assert!(!error.to_string().contains("reconnect"), "{error:#}");
+        assert_eq!(
+            error.downcast_ref::<std::io::Error>().unwrap().kind(),
+            std::io::ErrorKind::WouldBlock
+        );
+    }
 
     #[test]
     fn registration_retries_socket_timeout_but_not_peer_rejection() {

--- a/src/destination.rs
+++ b/src/destination.rs
@@ -185,39 +185,131 @@ pub(crate) fn read_message<T: DeserializeOwned>(reader: &mut impl Read) -> Resul
     reader.read_exact(&mut bytes)?;
     Ok(serde_json::from_slice(&bytes)?)
 }
+fn deadline_remaining(deadline: Instant) -> std::io::Result<Duration> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|time| !time.is_zero())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "return channel exchange timed out",
+            )
+        })
+}
+
+fn wait_socket(socket: &impl AsRawFd, events: i16, deadline: Instant) -> std::io::Result<()> {
+    let mut descriptor = libc::pollfd {
+        fd: socket.as_raw_fd(),
+        events,
+        revents: 0,
+    };
+    loop {
+        let milliseconds = deadline_remaining(deadline)?
+            .as_millis()
+            .clamp(1, i32::MAX as u128) as i32;
+        // The borrowed socket remains alive and descriptor is writable during
+        // poll. Signals and spurious wakeups never renew the deadline.
+        let ready = unsafe { libc::poll(&mut descriptor, 1, milliseconds) };
+        if ready < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        if ready > 0 {
+            return Ok(());
+        }
+    }
+}
+
+struct DeadlineSocket<'a> {
+    socket: &'a mut UnixStream,
+    deadline: Instant,
+}
+impl Read for DeadlineSocket<'_> {
+    fn read(&mut self, bytes: &mut [u8]) -> std::io::Result<usize> {
+        loop {
+            deadline_remaining(self.deadline)?;
+            // recv writes at most bytes.len() bytes into this live mutable
+            // slice. Per-call nonblocking mode does not affect socket clones.
+            let count = unsafe {
+                libc::recv(
+                    self.socket.as_raw_fd(),
+                    bytes.as_mut_ptr().cast(),
+                    bytes.len(),
+                    libc::MSG_DONTWAIT,
+                )
+            };
+            if count >= 0 {
+                return Ok(count as usize);
+            }
+            let error = std::io::Error::last_os_error();
+            match error.kind() {
+                std::io::ErrorKind::Interrupted => continue,
+                std::io::ErrorKind::WouldBlock => {
+                    wait_socket(self.socket, libc::POLLIN, self.deadline)?
+                }
+                _ => return Err(error),
+            }
+        }
+    }
+}
+impl Write for DeadlineSocket<'_> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        loop {
+            deadline_remaining(self.deadline)?;
+            match socket2::SockRef::from(&*self.socket)
+                .send_with_flags(bytes, libc::MSG_DONTWAIT | libc::MSG_NOSIGNAL)
+            {
+                Ok(count) => return Ok(count),
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    wait_socket(self.socket, libc::POLLOUT, self.deadline)?
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        deadline_remaining(self.deadline)?;
+        Ok(())
+    }
+}
+
 /// A complete incoming envelope has an absolute deadline, including clients
 /// trickling bytes. Timeout budgets cannot be renewed by partial progress.
 pub(crate) fn read_socket_message<T: DeserializeOwned>(
     socket: &mut UnixStream,
     timeout: Duration,
 ) -> Result<T> {
-    struct DeadlineReader<'a> {
-        socket: &'a mut UnixStream,
-        deadline: Instant,
-    }
-    impl Read for DeadlineReader<'_> {
-        fn read(&mut self, bytes: &mut [u8]) -> std::io::Result<usize> {
-            let remaining = self
-                .deadline
-                .checked_duration_since(Instant::now())
-                .filter(|time| !time.is_zero())
-                .ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::TimedOut,
-                        "return channel handshake timed out",
-                    )
-                })?;
-            self.socket.set_read_timeout(Some(remaining))?;
-            self.socket.read(bytes)
-        }
-    }
-    let previous = socket.read_timeout()?;
-    let result = read_message(&mut DeadlineReader {
+    read_message(&mut DeadlineSocket {
         socket,
         deadline: Instant::now() + timeout,
-    });
-    socket.set_read_timeout(previous)?;
-    result
+    })
+}
+
+fn connect_socket(path: &Path, deadline: Instant) -> std::io::Result<UnixStream> {
+    use socket2::{Domain, SockAddr, Socket, Type};
+    deadline_remaining(deadline)?;
+    let socket = Socket::new(Domain::UNIX, Type::STREAM, None)?;
+    socket.set_nonblocking(true)?;
+    match socket.connect(&SockAddr::unix(path)?) {
+        Ok(()) => {}
+        Err(error) if error.raw_os_error() == Some(libc::EINPROGRESS) => {
+            wait_socket(&socket, libc::POLLOUT, deadline)?;
+            if let Some(error) = socket.take_error()? {
+                return Err(error);
+            }
+            socket.peer_addr()?;
+        }
+        // In particular, Linux reports EAGAIN for a full Unix listen queue:
+        // no connection is pending. Return it without a blocking connect retry.
+        Err(error) => return Err(error),
+    }
+    socket.set_nonblocking(false)?;
+    let descriptor: std::os::fd::OwnedFd = socket.into();
+    Ok(descriptor.into())
 }
 
 fn random_token() -> Result<String> {
@@ -367,13 +459,15 @@ fn exchange(
         );
     }
     let deadline = Instant::now() + timeout;
-    let mut stream = UnixStream::connect(&registration.socket).context(
+    let mut stream = connect_socket(&registration.socket, deadline).context(
         "receiving machine is offline; run `syq persist connect SERVER` on that machine to reconnect to this server account",
     )?;
-    stream.set_read_timeout(Some(timeout))?;
-    stream.set_write_timeout(Some(timeout))?;
+    let mut io = DeadlineSocket {
+        socket: &mut stream,
+        deadline,
+    };
     write_message(
-        &mut stream,
+        &mut io,
         &Envelope {
             version: if matches!(message, Message::Ping | Message::Identify { .. }) {
                 DISCOVERY_VERSION
@@ -387,11 +481,11 @@ fn exchange(
             message,
         },
     )?;
-    let remaining = deadline
-        .checked_duration_since(Instant::now())
-        .filter(|remaining| !remaining.is_zero())
-        .context("return channel exchange timed out")?;
-    let reply = read_socket_message(&mut stream, remaining)?;
+    let reply = read_message(&mut io)?;
+    // Callers that retain the stream keep the existing per-operation budget
+    // for the next protocol phase, rather than the spent handshake budget.
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
     if let Reply::Error(error) = &reply {
         bail!("receiving machine: {error}");
     }
@@ -1480,6 +1574,56 @@ mod tests {
             }
             assert!(!path.exists(), "failed registration must remove its socket");
         }
+    }
+
+    #[test]
+    fn partial_writes_do_not_renew_the_exchange_deadline() {
+        let (mut writer, mut reader) = UnixStream::pair().unwrap();
+        socket2::SockRef::from(&writer)
+            .set_send_buffer_size(1024)
+            .unwrap();
+        reader
+            .set_read_timeout(Some(Duration::from_millis(50)))
+            .unwrap();
+        let (stop, stopped) = mpsc::channel();
+        let peer = std::thread::spawn(move || {
+            let end = Instant::now() + Duration::from_secs(2);
+            let mut received = 0;
+            let mut bytes = [0; 1024];
+            while Instant::now() < end {
+                match reader.read(&mut bytes) {
+                    Ok(0) => break,
+                    Ok(count) => received += count,
+                    Err(error)
+                        if matches!(
+                            error.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) => {}
+                    Err(error) => panic!("{error}"),
+                }
+                if stopped.recv_timeout(Duration::from_millis(30)).is_ok() {
+                    break;
+                }
+            }
+            received
+        });
+        let start = Instant::now();
+        let result = write_message(
+            &mut DeadlineSocket {
+                socket: &mut writer,
+                deadline: start + Duration::from_millis(150),
+            },
+            &"x".repeat(MAX_MESSAGE / 2),
+        );
+        let elapsed = start.elapsed();
+        let _ = stop.send(());
+        let received = peer.join().unwrap();
+        assert!(result.is_err());
+        assert!(received > 4, "peer made no payload progress");
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "write took {elapsed:?}"
+        );
     }
 
     pub(super) fn args(source: &Path, destination: &str) -> Args {

--- a/src/destination/exec.rs
+++ b/src/destination/exec.rs
@@ -67,7 +67,10 @@ enum Event {
 pub(crate) fn run(argv: &[OsString]) -> Result<i32> {
     let matches = command_for_help().try_get_matches_from(argv)?;
     let command = ExecCommand::from_arg_matches(&matches)?;
-    let name = command.on.strip_prefix('@').unwrap_or(&command.on);
+    let name = command
+        .on
+        .strip_prefix('@')
+        .context("receiver references require @NAME")?;
     validate_name(name)?;
     let request = ExecRequest {
         argv: command.argv.iter().map(|a| a.as_bytes().to_vec()).collect(),

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -305,7 +305,9 @@ impl ForwardChild {
             match reply {
                 Ok(Reply::Approved(approved)) => return Ok((child, approved)),
                 Ok(Reply::Error(error)) => bail!("destination refused the copy: {error}"),
-                Ok(Reply::Ready) => bail!("invalid destination setup response"),
+                Ok(Reply::Ready | Reply::Identity(_)) => {
+                    bail!("invalid destination setup response")
+                }
                 Err(error) => {
                     // Match ordinary bootstrap: a missing helper or an exec
                     // failure may retry setup once, before a copy is approved.

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -98,9 +98,8 @@ pub(super) fn select(args: &crate::cli::Args) -> Result<Option<handoff::Selectio
         (name, registration)
     } else {
         let Some(found) = registered_names().into_iter().find_map(|name| {
-            let registration = load_registration(&name).ok()?;
-            let (_, reply) = exchange(&registration, Message::Ping, Duration::from_secs(2)).ok()?;
-            matches!(reply, Reply::Ready).then_some((name, registration))
+            let registration = available(&name, Duration::from_secs(2)).ok()?;
+            Some((name, registration))
         }) else {
             return Ok(None);
         };

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -291,14 +291,14 @@ impl ForwardChild {
                     &mut DeadlineIo {
                         inner: child.child.stdin.as_mut().unwrap(),
                         deadline,
-                        cancelled,
+                        cancelled: Some(cancelled),
                     },
                     request,
                 )?;
                 read_message::<Reply>(&mut DeadlineIo {
                     inner: child.child.stdout.as_mut().unwrap(),
                     deadline,
-                    cancelled,
+                    cancelled: Some(cancelled),
                 })
             })();
             match reply {
@@ -490,12 +490,12 @@ fn relay(
     result
 }
 
-struct DeadlineIo<'a, T, F> {
+struct DeadlineIo<'a, T> {
     inner: &'a mut T,
     deadline: Instant,
-    cancelled: &'a F,
+    cancelled: Option<&'a dyn Fn() -> bool>,
 }
-impl<T: Read + AsRawFd, F: Fn() -> bool> Read for DeadlineIo<'_, T, F> {
+impl<T: Read + AsRawFd> Read for DeadlineIo<'_, T> {
     fn read(&mut self, bytes: &mut [u8]) -> std::io::Result<usize> {
         wait_fd(
             self.inner.as_raw_fd(),
@@ -506,7 +506,7 @@ impl<T: Read + AsRawFd, F: Fn() -> bool> Read for DeadlineIo<'_, T, F> {
         self.inner.read(bytes)
     }
 }
-impl<T: Write + AsRawFd, F: Fn() -> bool> Write for DeadlineIo<'_, T, F> {
+impl<T: Write + AsRawFd> Write for DeadlineIo<'_, T> {
     fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
         wait_fd(
             self.inner.as_raw_fd(),
@@ -550,9 +550,7 @@ impl<R: Read + AsRawFd> Read for HandshakeInput<R> {
             return Ok(0);
         }
         if self.pending.load(Ordering::Acquire) {
-            wait_fd(self.inner.as_raw_fd(), libc::POLLIN, self.deadline, &|| {
-                false
-            })?;
+            wait_fd(self.inner.as_raw_fd(), libc::POLLIN, self.deadline, None)?;
         }
         let count = self.inner.read(bytes)?;
         if count > 0 && !self.started {
@@ -591,7 +589,7 @@ fn receive() -> Result<i32> {
         let request: HelperRequest = read_message(&mut DeadlineIo {
             inner: &mut input,
             deadline: Instant::now() + Duration::from_secs(10),
-            cancelled: &|| false,
+            cancelled: None,
         })?;
         if request.version != HELPER_VERSION || request.identity != crate::identity::build() {
             bail!("return helper build mismatch");
@@ -926,7 +924,7 @@ mod tests {
         let error = read_message::<Reply>(&mut DeadlineIo {
             inner: &mut reader,
             deadline: Instant::now() + Duration::from_millis(20),
-            cancelled: &|| false,
+            cancelled: None,
         })
         .err()
         .unwrap();
@@ -937,7 +935,7 @@ mod tests {
         let error = read_message::<Reply>(&mut DeadlineIo {
             inner: &mut reader,
             deadline: Instant::now() + Duration::from_secs(60),
-            cancelled: &|| true,
+            cancelled: Some(&|| true),
         })
         .err()
         .unwrap();

--- a/src/destination/forward.rs
+++ b/src/destination/forward.rs
@@ -490,43 +490,6 @@ fn relay(
     result
 }
 
-fn wait_fd(
-    fd: std::os::fd::RawFd,
-    events: i16,
-    deadline: Instant,
-    cancelled: &impl Fn() -> bool,
-) -> std::io::Result<()> {
-    loop {
-        if cancelled() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::ConnectionAborted,
-                "return request cancelled",
-            ));
-        }
-        let left = deadline
-            .checked_duration_since(Instant::now())
-            .filter(|d| !d.is_zero())
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "return helper deadline expired",
-                )
-            })?;
-        let mut descriptor = libc::pollfd {
-            fd,
-            events,
-            revents: 0,
-        };
-        let result =
-            unsafe { libc::poll(&mut descriptor, 1, left.as_millis().clamp(1, 100) as i32) };
-        if result > 0 {
-            return Ok(());
-        }
-        if result < 0 && std::io::Error::last_os_error().kind() != std::io::ErrorKind::Interrupted {
-            return Err(std::io::Error::last_os_error());
-        }
-    }
-}
 struct DeadlineIo<'a, T, F> {
     inner: &'a mut T,
     deadline: Instant,

--- a/src/destination/identity.rs
+++ b/src/destination/identity.rs
@@ -1,0 +1,338 @@
+//! Stable receiver ownership, independent of executable and SSH login keys.
+use super::*;
+use ssh_key::{private::Ed25519Keypair, HashAlg, LineEnding, PrivateKey, PublicKey, SshSig};
+
+const NAMESPACE: &str = "syq-receiver-identity-v1";
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Proof {
+    public_key: String,
+    signature: String,
+}
+
+pub(super) fn generate_key() -> Result<PrivateKey> {
+    let mut seed = [0; 32];
+    getrandom::fill(&mut seed)?;
+    let pair = Ed25519Keypair::from_seed(&seed);
+    seed.fill(0);
+    Ok(PrivateKey::new(pair.into(), "syq-receiver")?)
+}
+
+pub(super) fn load_key() -> Result<PrivateKey> {
+    load_key_from(&private_directory(".syq-receiver-identity")?)
+}
+
+fn load_key_from(directory: &Path) -> Result<PrivateKey> {
+    let path = directory.join("identity_ed25519");
+    // Publish a complete key without overwriting a concurrent creator's key.
+    // Invalid or unreadable existing state is never silently regenerated.
+    if !path.try_exists()? {
+        let key = generate_key()?;
+        let mut temporary = tempfile::NamedTempFile::new_in(directory)?;
+        temporary.write_all(key.to_openssh(LineEnding::LF)?.as_bytes())?;
+        temporary.as_file().sync_all()?;
+        match temporary.persist_noclobber(&path) {
+            Ok(_) => fs::File::open(directory)?.sync_all()?,
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    let encoded = crate::delegation::read_private_regular(&path, "receiver identity key", 8192)?;
+    let key = PrivateKey::from_openssh(encoded).context("read receiver identity key; restore its backup or explicitly replace the server's name assignments")?;
+    if key.is_encrypted() || !key.algorithm().is_ed25519() {
+        bail!("receiver identity must be an unencrypted Ed25519 key");
+    }
+    Ok(key)
+}
+
+fn payload(name: &str, challenge: &str, secret: &str) -> Result<Vec<u8>> {
+    validate_name(name)?;
+    if challenge.len() != 43 {
+        bail!("invalid receiver identity challenge");
+    }
+    // Structured fields bind the proof to a fresh challenge, the profile name,
+    // and the credential of this particular return connection.
+    Ok(serde_json::to_vec(&(name, challenge, secret))?)
+}
+
+pub(super) fn prove(key: &PrivateKey, name: &str, challenge: &str, secret: &str) -> Result<Proof> {
+    let signature = key.sign(
+        NAMESPACE,
+        HashAlg::Sha256,
+        &payload(name, challenge, secret)?,
+    )?;
+    Ok(Proof {
+        public_key: key.public_key().to_openssh()?,
+        signature: signature.to_pem(LineEnding::LF)?,
+    })
+}
+
+fn verify(
+    proof: Proof,
+    name: &str,
+    challenge: &str,
+    secret: &str,
+    owner: Option<&str>,
+) -> Result<String> {
+    let key = PublicKey::from_openssh(&proof.public_key)?;
+    if !key.algorithm().is_ed25519() {
+        bail!("receiver identity must use Ed25519");
+    }
+    if let Some(owner) = owner {
+        if key.key_data() != PublicKey::from_openssh(owner)?.key_data() {
+            bail!("destination @{name} belongs to a different receiver; stop the original receiver and run `syq persist destinations forget {name}` on this server before connecting its replacement");
+        }
+    }
+    key.verify(
+        NAMESPACE,
+        &payload(name, challenge, secret)?,
+        &SshSig::from_pem(&proof.signature)?,
+    )
+    .context("receiver identity proof does not verify")?;
+    Ok(key.to_openssh()?)
+}
+
+pub(super) fn verify_receiver(
+    name: &str,
+    registration: &Registration,
+    owner: Option<&str>,
+) -> Result<String> {
+    let challenge = random_token()?;
+    let (_, reply) = exchange(
+        registration,
+        Message::Identify {
+            name: name.into(),
+            challenge: challenge.clone(),
+        },
+        Duration::from_secs(10),
+    )
+    .context(
+        "cannot verify receiver identity; reconnect with an updated syq on the receiving machine",
+    )?;
+    let Reply::Identity(proof) = reply else {
+        bail!("receiver did not provide an identity proof; update syq on the receiving machine and reconnect");
+    };
+    verify(proof, name, &challenge, &registration.secret, owner)
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Owner {
+    version: u16,
+    public_key: String,
+}
+
+pub(super) fn owner(directory: &Path, name: &str) -> Result<Option<String>> {
+    validate_name(name)?;
+    let path = directory.join(format!("{name}.owner"));
+    let bytes =
+        match crate::delegation::read_private_regular(&path, "receiver name ownership", 8192) {
+            Ok(bytes) => bytes,
+            Err(error)
+                if error.chain().any(|cause| {
+                    cause
+                        .downcast_ref::<std::io::Error>()
+                        .is_some_and(|e| e.kind() == std::io::ErrorKind::NotFound)
+                }) =>
+            {
+                return Ok(None)
+            }
+            Err(error) => return Err(error),
+        };
+    let owner: Owner = serde_json::from_slice(&bytes)?;
+    if owner.version != 1 {
+        bail!("unsupported receiver ownership record; use the syq version that created it");
+    }
+    PublicKey::from_openssh(&owner.public_key)?;
+    Ok(Some(owner.public_key))
+}
+
+/// Caller holds the same name lock used by live advertisements and forget.
+pub(super) fn claim(directory: &Path, name: &str, key: &str) -> Result<()> {
+    if let Some(previous) = owner(directory, name)? {
+        if PublicKey::from_openssh(&previous)?.key_data()
+            != PublicKey::from_openssh(key)?.key_data()
+        {
+            bail!("destination @{name} belongs to a different receiver");
+        }
+        return Ok(());
+    }
+    let mut temporary = tempfile::NamedTempFile::new_in(directory)?;
+    temporary.write_all(&serde_json::to_vec(&Owner {
+        version: 1,
+        public_key: key.into(),
+    })?)?;
+    temporary.as_file().sync_all()?;
+    temporary.persist_noclobber(directory.join(format!("{name}.owner")))?;
+    fs::File::open(directory)?.sync_all()?;
+    Ok(())
+}
+
+pub(super) fn forget(directory: &Path, name: &str) -> Result<()> {
+    let mut removed = false;
+    // Remove the advertisement first so a crash never leaves it unowned.
+    for extension in ["json", "owner"] {
+        match fs::remove_file(directory.join(format!("{name}.{extension}"))) {
+            Ok(()) => removed = true,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+        fs::File::open(directory)?.sync_all()?;
+    }
+    if !removed {
+        bail!("no destination @{name} is registered");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_is_stable_across_reloads_and_concurrent_creators() {
+        let dir = tempfile::tempdir().unwrap();
+        let keys = std::thread::scope(|scope| {
+            let tasks: Vec<_> = (0..8)
+                .map(|_| {
+                    scope.spawn(|| {
+                        load_key_from(dir.path())
+                            .unwrap()
+                            .public_key()
+                            .to_openssh()
+                            .unwrap()
+                    })
+                })
+                .collect();
+            tasks
+                .into_iter()
+                .map(|task| task.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+        assert!(keys.iter().all(|key| key == &keys[0]));
+        assert_eq!(
+            keys[0],
+            load_key_from(dir.path())
+                .unwrap()
+                .public_key()
+                .to_openssh()
+                .unwrap()
+        );
+        fs::write(dir.path().join("identity_ed25519"), b"corrupt").unwrap();
+        assert!(load_key_from(dir.path()).is_err());
+    }
+
+    #[test]
+    fn proof_binds_key_name_challenge_and_connection() {
+        let key = generate_key().unwrap();
+        let other = generate_key().unwrap().public_key().to_openssh().unwrap();
+        let public = key.public_key().to_openssh().unwrap();
+        let challenge = random_token().unwrap();
+        let proof = || prove(&key, "laptop", &challenge, "connection-one").unwrap();
+        assert!(verify(
+            proof(),
+            "laptop",
+            &challenge,
+            "connection-one",
+            Some(&public)
+        )
+        .is_ok());
+        assert!(verify(
+            proof(),
+            "laptop",
+            &challenge,
+            "connection-one",
+            Some(&other)
+        )
+        .is_err());
+        assert!(verify(
+            proof(),
+            "other",
+            &challenge,
+            "connection-one",
+            Some(&public)
+        )
+        .is_err());
+        assert!(verify(
+            proof(),
+            "laptop",
+            &random_token().unwrap(),
+            "connection-one",
+            Some(&public)
+        )
+        .is_err());
+        assert!(verify(
+            proof(),
+            "laptop",
+            &challenge,
+            "connection-two",
+            Some(&public)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn proof_works_across_builds_but_not_different_receivers() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_broker, receiver, mut registration, _) =
+            super::super::tests::broker(dir.path(), super::super::Approval::Always);
+        let owner = receiver.identity_key.public_key().to_openssh().unwrap();
+        registration.identity = "another-syq-version".into();
+        assert!(verify_receiver("laptop", &registration, Some(&owner)).is_ok());
+        let other = generate_key().unwrap().public_key().to_openssh().unwrap();
+        assert!(verify_receiver("laptop", &registration, Some(&other)).is_err());
+        assert!(verify_receiver("project", &registration, Some(&owner)).is_err());
+    }
+
+    #[test]
+    fn released_v052_advertisement_and_ping_still_decode() {
+        // Unchanged v0.5.2 wire shapes: ownership is a separate record.
+        let registration: Registration = serde_json::from_str(r#"{"version":3,"identity":"old-build","socket":"/tmp/receiver.sock","secret":"old-secret","program":[47,115,121,113]}"#).unwrap();
+        assert_eq!(registration.version, REGISTRATION_VERSION);
+        let ping: Envelope = serde_json::from_str(
+            r#"{"version":2,"identity":"old-build","secret":"old-secret","message":"Ping"}"#,
+        )
+        .unwrap();
+        assert_eq!(ping.version, DISCOVERY_VERSION);
+        assert!(matches!(ping.message, Message::Ping));
+        let reply: Reply = serde_json::from_str(r#""Ready""#).unwrap();
+        assert!(matches!(reply, Reply::Ready));
+    }
+
+    #[test]
+    fn private_key_and_ownership_reject_unsafe_or_unknown_state() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+        let dir = tempfile::tempdir().unwrap();
+        load_key_from(dir.path()).unwrap();
+        let path = dir.path().join("identity_ed25519");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(load_key_from(dir.path()).is_err());
+        fs::rename(&path, dir.path().join("backup")).unwrap();
+        symlink(dir.path().join("backup"), &path).unwrap();
+        assert!(load_key_from(dir.path()).is_err());
+        let public = generate_key().unwrap().public_key().to_openssh().unwrap();
+        claim(dir.path(), "laptop", &public).unwrap();
+        fs::write(
+            dir.path().join("laptop.owner"),
+            br#"{"version":99,"public_key":"invalid"}"#,
+        )
+        .unwrap();
+        assert!(owner(dir.path(), "laptop").is_err());
+        assert!(claim(dir.path(), "laptop", &public).is_err());
+    }
+
+    #[test]
+    fn ownership_survives_disconnect_until_explicit_forget() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = generate_key().unwrap().public_key().to_openssh().unwrap();
+        let second = generate_key().unwrap().public_key().to_openssh().unwrap();
+        claim(dir.path(), "laptop", &first).unwrap();
+        claim(dir.path(), "laptop", &first).unwrap();
+        assert!(claim(dir.path(), "laptop", &second).is_err());
+        assert_eq!(owner(dir.path(), "laptop").unwrap(), Some(first));
+        forget(dir.path(), "laptop").unwrap();
+        claim(dir.path(), "laptop", &second).unwrap();
+        assert_eq!(owner(dir.path(), "laptop").unwrap(), Some(second));
+    }
+}

--- a/src/destination/identity.rs
+++ b/src/destination/identity.rs
@@ -301,6 +301,8 @@ mod tests {
     #[test]
     fn released_v052_advertisement_and_ping_still_decode() {
         // Unchanged v0.5.2 wire shapes: ownership is a separate record.
+        // tests/receiver_identity_compat.py also checks actual released binaries,
+        // including probes sent to a dying connection during reconnect retries.
         let registration: Registration = serde_json::from_str(r#"{"version":3,"identity":"old-build","socket":"/tmp/receiver.sock","secret":"old-secret","program":[47,115,121,113]}"#).unwrap();
         assert_eq!(registration.version, REGISTRATION_VERSION);
         let ping: Envelope = serde_json::from_str(

--- a/src/destination/identity.rs
+++ b/src/destination/identity.rs
@@ -158,10 +158,14 @@ pub(super) fn claim(directory: &Path, name: &str, key: &str) -> Result<()> {
         }
         return Ok(());
     }
+    // Comments are untrusted metadata, not identity. Keep records bounded by
+    // the Ed25519 key size even when the wire key carries a long comment.
+    let mut key = PublicKey::from_openssh(key)?;
+    key.set_comment("");
     let mut temporary = tempfile::NamedTempFile::new_in(directory)?;
     temporary.write_all(&serde_json::to_vec(&Owner {
         version: 1,
-        public_key: key.into(),
+        public_key: key.to_openssh()?,
     })?)?;
     temporary.as_file().sync_all()?;
     temporary.persist_noclobber(directory.join(format!("{name}.owner")))?;
@@ -323,6 +327,28 @@ mod tests {
     }
 
     #[test]
+    fn long_key_comment_does_not_poison_ownership() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = generate_key().unwrap();
+        let challenge = random_token().unwrap();
+        let mut proof = prove(&key, "laptop", &challenge, "secret").unwrap();
+        proof.public_key.push_str(&"x".repeat(16_384));
+        let public = verify(proof, "laptop", &challenge, "secret", None).unwrap();
+        claim(dir.path(), "laptop", &public).unwrap();
+        let saved = owner(dir.path(), "laptop").unwrap().unwrap();
+        assert!(saved.len() < 128);
+        verify(
+            prove(&key, "laptop", &challenge, "secret").unwrap(),
+            "laptop",
+            &challenge,
+            "secret",
+            Some(&saved),
+        )
+        .unwrap();
+        claim(dir.path(), "laptop", &public).unwrap();
+    }
+
+    #[test]
     fn ownership_survives_disconnect_until_explicit_forget() {
         let dir = tempfile::tempdir().unwrap();
         let first = generate_key().unwrap().public_key().to_openssh().unwrap();
@@ -330,9 +356,19 @@ mod tests {
         claim(dir.path(), "laptop", &first).unwrap();
         claim(dir.path(), "laptop", &first).unwrap();
         assert!(claim(dir.path(), "laptop", &second).is_err());
-        assert_eq!(owner(dir.path(), "laptop").unwrap(), Some(first));
+        assert_eq!(
+            PublicKey::from_openssh(&owner(dir.path(), "laptop").unwrap().unwrap())
+                .unwrap()
+                .key_data(),
+            PublicKey::from_openssh(&first).unwrap().key_data()
+        );
         forget(dir.path(), "laptop").unwrap();
         claim(dir.path(), "laptop", &second).unwrap();
-        assert_eq!(owner(dir.path(), "laptop").unwrap(), Some(second));
+        assert_eq!(
+            PublicKey::from_openssh(&owner(dir.path(), "laptop").unwrap().unwrap())
+                .unwrap()
+                .key_data(),
+            PublicKey::from_openssh(&second).unwrap().key_data()
+        );
     }
 }

--- a/src/destination/identity.rs
+++ b/src/destination/identity.rs
@@ -98,6 +98,15 @@ pub(super) fn verify_receiver(
     registration: &Registration,
     owner: Option<&str>,
 ) -> Result<String> {
+    verify_receiver_with_timeout(name, registration, owner, Duration::from_secs(10))
+}
+
+pub(super) fn verify_receiver_with_timeout(
+    name: &str,
+    registration: &Registration,
+    owner: Option<&str>,
+    timeout: Duration,
+) -> Result<String> {
     let challenge = random_token()?;
     let (_, reply) = exchange(
         registration,
@@ -105,7 +114,7 @@ pub(super) fn verify_receiver(
             name: name.into(),
             challenge: challenge.clone(),
         },
-        Duration::from_secs(10),
+        timeout,
     )
     .context(
         "cannot verify receiver identity; reconnect with an updated syq on the receiving machine",

--- a/src/restricted.rs
+++ b/src/restricted.rs
@@ -4457,6 +4457,7 @@ pub(crate) fn named_authority(
         });
     }
     for path in [
+        crate::destination::receiver_identity_directory()?,
         crate::receive_service::config_path()?
             .parent()
             .unwrap()

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -19383,7 +19383,13 @@ fn receiver_destinations_require_sigil_and_never_fall_back() {
     fs::remove_file(t.path("ssh-used")).unwrap();
     let explicit = run(&["cp", "source", "--to", "@laptop"]);
     assert!(!explicit.status.success());
-    assert!(stderr_of(&explicit).contains("offline"));
+    let error = stderr_of(&explicit);
+    assert!(
+        error.contains("could not connect to receiving machine"),
+        "{error}"
+    );
+    assert!(!error.contains("offline"), "{error}");
+    assert!(!error.contains("reconnect"), "{error}");
     assert!(!t.path("ssh-used").exists());
     // An older process can hand a selected bare receiver to this helper.
     // Reject that spelling rather than reinterpret its pinned destination as SSH.

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -19389,7 +19389,7 @@ fn receiver_destinations_require_sigil_and_never_fall_back() {
         "{error}"
     );
     assert!(!error.contains("offline"), "{error}");
-    assert!(!error.contains("reconnect"), "{error}");
+    assert!(error.contains("syq persist connect SERVER"), "{error}");
     assert!(!t.path("ssh-used").exists());
     // An older process can hand a selected bare receiver to this helper.
     // Reject that spelling rather than reinterpret its pinned destination as SSH.

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -18990,6 +18990,87 @@ fn named_destination_offline_failure_settles_results_and_completes_names_locally
 }
 
 #[test]
+fn owned_receiver_wait_respects_deadline_with_partial_identity_reply() {
+    use std::os::unix::net::UnixListener;
+    let t = Tmp::new();
+    let registry = t.path(".syq-destinations-v3");
+    fs::create_dir(&registry).unwrap();
+    fs::set_permissions(&registry, fs::Permissions::from_mode(0o700)).unwrap();
+    let socket_path = t.path("receiver.sock");
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let key = ssh_key::PrivateKey::new(
+        ssh_key::private::Ed25519Keypair::from_seed(&[1; 32]).into(),
+        "test",
+    )
+    .unwrap();
+    for (extension, value) in [
+        (
+            "json",
+            serde_json::json!({"version":3,"identity":"test-build",
+            "socket":socket_path,"secret":"test","program":env!("CARGO_BIN_EXE_syq").as_bytes()}),
+        ),
+        (
+            "owner",
+            serde_json::json!({"version":1,"public_key":key.public_key().to_openssh().unwrap()}),
+        ),
+    ] {
+        let path = registry.join(format!("laptop.{extension}"));
+        write(&path, &serde_json::to_vec(&value).unwrap());
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+    let responder = std::thread::spawn(move || {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut socket = loop {
+            match listener.accept() {
+                Ok((socket, _)) => break socket,
+                Err(e)
+                    if e.kind() == std::io::ErrorKind::WouldBlock
+                        && std::time::Instant::now() < deadline =>
+                {
+                    std::thread::sleep(std::time::Duration::from_millis(10))
+                }
+                Err(e) => panic!("receiver accept: {e}"),
+            }
+        };
+        // Keep making partial framing progress beyond the one-second deadline.
+        for byte in 100u32.to_be_bytes() {
+            if socket.write_all(&[byte]).is_err() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(400));
+        }
+        std::thread::sleep(std::time::Duration::from_secs(2));
+    });
+    let start = std::time::Instant::now();
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "persist",
+            "destinations",
+            "wait",
+            "laptop",
+            "--timeout",
+            "1",
+        ])
+        .env("HOME", t.path(""))
+        .env("SYQ_NO_UPDATE_CHECK", "1")
+        .output()
+        .unwrap();
+    let elapsed = start.elapsed();
+    responder.join().unwrap();
+    assert!(!output.status.success());
+    assert!(
+        stderr_of(&output).contains("timed out waiting"),
+        "{}",
+        stderr_of(&output)
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "wait took {elapsed:?}"
+    );
+}
+
+#[test]
 fn forgetting_offline_owner_recreates_missing_lock() {
     let t = Tmp::new();
     write(&t.path(".syq-destinations-v3/laptop.owner"), b"{}");
@@ -19171,7 +19252,7 @@ fn receiving_preferences_are_durable_default_on_and_distinguish_cwd_from_root() 
 }
 
 #[test]
-fn receiving_names_fall_back_only_before_a_live_route_is_selected() {
+fn receiver_destinations_require_sigil_and_never_fall_back() {
     use std::os::unix::net::UnixListener;
     let t = Tmp::new();
     write(&t.path("source"), b"source");
@@ -19229,14 +19310,41 @@ fn receiving_names_fall_back_only_before_a_live_route_is_selected() {
     assert!(!explicit.status.success());
     assert!(stderr_of(&explicit).contains("offline"));
     assert!(!t.path("ssh-used").exists());
+    // An older process can hand a selected bare receiver to this helper.
+    // Reject that spelling rather than reinterpret its pinned destination as SSH.
+    let guard_registration = format!(
+        r#"{{"version":3,"identity":{},"socket":{},"secret":"test","program":{}}}"#,
+        serde_json::to_string(identity.trim()).unwrap(),
+        serde_json::to_string(&socket_path).unwrap(),
+        serde_json::to_string(env!("CARGO_BIN_EXE_syq").as_bytes()).unwrap(),
+    );
+    let guard = serde_json::json!({"name":"laptop","identity":identity.trim(),
+        "kind":"Copy","registration":blake3::hash(guard_registration.as_bytes()).to_hex().to_string()})
+    .to_string();
+    let handed_off = run(&[
+        "--return-handoff-v1",
+        &guard,
+        "cp",
+        "source",
+        "--to",
+        "laptop",
+    ]);
+    assert!(!handed_off.status.success());
+    assert!(
+        stderr_of(&handed_off).contains("receiver destinations require @NAME"),
+        "{}",
+        stderr_of(&handed_off)
+    );
+    assert!(!t.path("ssh-used").exists());
     let listener = UnixListener::bind(&socket_path).unwrap();
     listener.set_nonblocking(true).unwrap();
+    let bare = run(&["cp", "source", "--to", "laptop", "--no-tcp"]);
+    assert!(!bare.status.success());
+    assert!(t.path("ssh-used").exists());
+    fs::remove_file(t.path("ssh-used")).unwrap();
     let responder = std::thread::spawn(move || {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        for response in [
-            serde_json::json!("Ready"),
-            serde_json::json!({"Error":"copy denied by test policy"}),
-        ] {
+        for response in [serde_json::json!({"Error":"copy denied by test policy"})] {
             let mut socket = loop {
                 match listener.accept() {
                     Ok((socket, _)) => break socket,
@@ -19265,7 +19373,7 @@ fn receiving_names_fall_back_only_before_a_live_route_is_selected() {
             socket.write_all(&response).unwrap();
         }
     });
-    let denied = run(&["cp", "source", "--to", "laptop"]);
+    let denied = run(&["cp", "source", "--to", "@laptop"]);
     responder.join().unwrap();
     assert!(!denied.status.success());
     assert!(
@@ -19385,7 +19493,7 @@ fn receiving_v2_preferences_migrate_without_retaining_implicit_approval() {
 }
 
 #[test]
-fn return_via_completes_bare_and_explicit_names_without_contacting_hosts() {
+fn return_via_completes_only_explicit_names_without_contacting_hosts() {
     let t = Tmp::new();
     write(&t.path(".syq-destinations-v3/laptop.json"), b"{}");
     fs::set_permissions(
@@ -19400,7 +19508,7 @@ fn return_via_completes_bare_and_explicit_names_without_contacting_hosts() {
     fs::set_permissions(t.path("bin/ssh"), fs::Permissions::from_mode(0o755)).unwrap();
     for option in ["--via", "--auth-from"] {
         for (prefix, expected) in [
-            ("lap", b"laptop\0".as_slice()),
+            ("lap", b"".as_slice()),
             ("@lap", b"@laptop\0"),
             ("absent", b""),
         ] {
@@ -19647,11 +19755,17 @@ fn automatic_authorization_selects_live_names_and_stops_after_a_refusal() {
         .collect();
     let legacy = run(&argv);
     assert!(
-        stderr_of(&legacy).contains("copy denied by fixture"),
+        stderr_of(&legacy).contains("receiver references require @NAME"),
         "{}",
         stderr_of(&legacy)
     );
     assert!(!t.path("ssh-used").exists());
+    // The released fixture stays unchanged: its bare receiver reference is
+    // explicitly rejected, and adding @ is the recovery path.
+    let explicit = run(&[
+        "cp", "source", "--to", "backup", "--via", "@ssh", "--into", "out",
+    ]);
+    assert!(stderr_of(&explicit).contains("copy denied by fixture"));
     let messages = responder.join().unwrap();
     assert_eq!(messages[0]["secret"], "laptop");
     assert_eq!(messages[0]["message"], "Ping");
@@ -19706,7 +19820,7 @@ fn automatic_authorization_completion_keeps_local_paths_and_never_prompts() {
         vec![],
         vec!["--auth-from", "@laptop"],
         vec!["--auth-from", "auto"],
-        vec!["--via", "laptop"],
+        vec!["--via", "@laptop"],
     ] {
         let mut words = vec!["syq", "cp", "source", "--to", "backup"];
         words.extend(selector);
@@ -19735,7 +19849,7 @@ fn return_exec_completion_and_offline_selection_never_contact_ssh() {
     )
     .unwrap();
     assert_completion_candidates(&t, &["syq", "ex"], &["exec"]);
-    assert_completion_candidates(&t, &["syq", "exec", "--on", "lap"], &["laptop"]);
+    assert_completion_candidates(&t, &["syq", "exec", "--on", "lap"], &[]);
     assert_completion_candidates(&t, &["syq", "exec", "--on", "@lap"], &["@laptop"]);
     assert_completion_candidates(&t, &["syq", "exec", "--cw"], &["--cwd"]);
     assert_completion_candidates(&t, &["syq", "exec", "--on", "laptop", "--", "--he"], &[]);
@@ -19753,7 +19867,7 @@ fn return_exec_completion_and_offline_selection_never_contact_ssh() {
             .output()
             .unwrap();
         assert!(!output.status.success());
-        if matches!(name, "absent" | "@absent") {
+        if name == "@absent" {
             let error = String::from_utf8_lossy(&output.stderr);
             assert!(
                 error.contains("no receiving machine named @absent is registered"),

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -18989,6 +18989,81 @@ fn named_destination_offline_failure_settles_results_and_completes_names_locally
     assert_eq!(completion.stdout, b"@laptop\0");
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn receiver_wait_and_list_do_not_block_on_a_full_listen_queue() {
+    use socket2::{Domain, SockAddr, Socket, Type};
+    use std::time::{Duration, Instant};
+    let t = Tmp::new();
+    let registry = t.path(".syq-destinations-v3");
+    fs::create_dir(&registry).unwrap();
+    fs::set_permissions(&registry, fs::Permissions::from_mode(0o700)).unwrap();
+    let socket_path = t.path("receiver.sock");
+    let address = SockAddr::unix(&socket_path).unwrap();
+    let listener = Socket::new(Domain::UNIX, Type::STREAM, None).unwrap();
+    listener.bind(&address).unwrap();
+    listener.listen(0).unwrap();
+    let mut queued = Vec::new();
+    let mut full = false;
+    for _ in 0..16 {
+        let client = Socket::new(Domain::UNIX, Type::STREAM, None).unwrap();
+        client.set_nonblocking(true).unwrap();
+        match client.connect(&address) {
+            Ok(()) => queued.push(client),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                full = true;
+                break;
+            }
+            Err(error) => panic!("fill listen queue: {error}"),
+        }
+    }
+    assert!(full, "test did not fill the listen queue");
+    let path = registry.join("stuck.json");
+    write(
+        &path,
+        &serde_json::to_vec(&serde_json::json!({
+            "version":3,"identity":"test-build","socket":socket_path,
+            "secret":"test","program":env!("CARGO_BIN_EXE_syq").as_bytes(),
+        }))
+        .unwrap(),
+    );
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+    // A hard watchdog unblocks even the old blocking implementation, so a
+    // regression fails the latency assertion instead of hanging the test suite.
+    let (stop, stopped) = std::sync::mpsc::channel();
+    let watchdog = std::thread::spawn(move || {
+        let _ = stopped.recv_timeout(Duration::from_secs(4));
+        drop(listener);
+        drop(queued);
+    });
+    let start = Instant::now();
+    let run = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_syq"))
+            .args(args)
+            .env("HOME", t.path(""))
+            .env("SYQ_NO_UPDATE_CHECK", "1")
+            .output()
+            .unwrap()
+    };
+    let wait = run(&["persist", "destinations", "wait", "stuck", "--timeout", "1"]);
+    let list = run(&["persist", "destinations", "list"]);
+    let elapsed = start.elapsed();
+    let _ = stop.send(());
+    watchdog.join().unwrap();
+    assert!(!wait.status.success());
+    assert!(
+        stderr_of(&wait).contains("timed out waiting"),
+        "{}",
+        stderr_of(&wait)
+    );
+    assert_output_ok(&list);
+    assert_eq!(list.stdout, b"@stuck\toffline\n");
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "wait/list took {elapsed:?}"
+    );
+}
+
 #[test]
 fn owned_receiver_wait_respects_deadline_with_partial_identity_reply() {
     use std::os::unix::net::UnixListener;

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -18990,6 +18990,102 @@ fn named_destination_offline_failure_settles_results_and_completes_names_locally
 }
 
 #[test]
+fn forgetting_offline_owner_recreates_missing_lock() {
+    let t = Tmp::new();
+    write(&t.path(".syq-destinations-v3/laptop.owner"), b"{}");
+    fs::set_permissions(
+        t.path(".syq-destinations-v3"),
+        fs::Permissions::from_mode(0o700),
+    )
+    .unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args(["persist", "destinations", "forget", "laptop"])
+        .env("HOME", t.path(""))
+        .env("SYQ_NO_UPDATE_CHECK", "1")
+        .output()
+        .unwrap();
+    assert_output_ok(&output);
+    assert!(!t.path(".syq-destinations-v3/laptop.owner").exists());
+    assert_eq!(
+        fs::metadata(t.path(".syq-destinations-v3/laptop.lock"))
+            .unwrap()
+            .mode()
+            & 0o777,
+        0o600
+    );
+}
+
+#[test]
+fn offline_receiver_ownership_keeps_names_but_allows_remote_completion() {
+    let t = Tmp::new();
+    fs::create_dir_all(t.path("remote-home/data/nested")).unwrap();
+    write(&t.path("home/.syq-destinations-v3/fake.owner"), b"{}");
+    fs::set_permissions(
+        t.path("home/.syq-destinations-v3"),
+        fs::Permissions::from_mode(0o700),
+    )
+    .unwrap();
+    let names = completion_command(
+        &t,
+        &[
+            "__complete",
+            "fish",
+            "4",
+            "--",
+            "syq",
+            "cp",
+            "source",
+            "--to",
+            "@fake",
+        ],
+    )
+    .output()
+    .unwrap();
+    assert_output_ok(&names);
+    assert_eq!(names.stdout, b"@fake\0");
+    let ssh = fake_ssh(&t);
+    let path = format!("{}/n", t.s("remote-home/data"));
+    let output = completion_command(
+        &t,
+        &[
+            "__complete",
+            "bash",
+            "9",
+            "--",
+            "syq",
+            "cp",
+            "--syq-path",
+            env!("CARGO_BIN_EXE_syq"),
+            "--src",
+            "source",
+            "--to",
+            "fake",
+            "--into",
+            &path,
+        ],
+    )
+    .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+    .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+    .env(
+        "PATH",
+        format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+    )
+    .output()
+    .unwrap();
+    assert_output_ok(&output);
+    assert_eq!(
+        completion_values(&output.stdout),
+        vec![(
+            b'p',
+            t.path("remote-home/data/nested/")
+                .as_os_str()
+                .as_encoded_bytes()
+                .to_vec()
+        )]
+    );
+}
+
+#[test]
 fn receiving_preferences_are_durable_default_on_and_distinguish_cwd_from_root() {
     let t = Tmp::new();
     fs::create_dir(t.path("downloads")).unwrap();

--- a/tests/real-ssh/Dockerfile
+++ b/tests/real-ssh/Dockerfile
@@ -77,4 +77,6 @@ COPY tests/real-ssh/test-receiver-revoke.py /usr/local/libexec/syq-test-receiver
 
 COPY tests/real-ssh/test-restricted-mapping.py /usr/local/libexec/syq-test-restricted-mapping.py
 
+COPY tests/real-ssh/test-receiver-identity.py /usr/local/libexec/syq-test-receiver-identity.py
+
 ENTRYPOINT ["/usr/local/libexec/syq-real-ssh-entrypoint"]

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -60,7 +60,7 @@ The source sshd permits remote Unix socket forwarding for named return transfers
 keeps forwarding disabled. The runner has no SSH server. Return scenarios cover
 copies from independent source shells without a forwarded agent, destination
 background startup through persistence, `--root` traversal refusal, unconfined
-`--cwd` paths, conflicting names, reconnection after killing the owned SSH
+`--cwd` paths, conflicting names, offline ownership and explicit receiver replacement, reconnection after killing the owned SSH
 transport, recovery after a server heartbeat times out while the client is
 paused, and stopping receiving with persistence. Approval cases cover local
 allow/deny, one-use IDs, disconnect and settings cancellation, and explicit

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -102,6 +102,13 @@ The experimental streaming path also runs over TCP and SSH, with push, pull,
 source/destination coordination and a local relay. Each streaming copy has a
 25-second deadline and is compared byte for byte, including a signed receiver.
 
+For receiver-state compatibility against an unchanged v0.5.2 binary, run
+`python3 tests/receiver_identity_compat.py target/debug/syq /path/to/v0.5.2/syq`
+from the repository root. It accepts the official release or a build of tag
+commit `fd2b17c642e6`, checks its version and build identity, and uses disposable
+local sockets and state. It also checks that reconnect probes send only Ping
+to the old connection and verify identity through the new one.
+
 This suite is intentionally outside `cargo test` and CI. Run it after changing
 SSH, remote-helper, enrollment, restricted-receiver, transport, or remote
 topology behavior, and before cutting a release. For release preparation, use

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -102,13 +102,6 @@ The experimental streaming path also runs over TCP and SSH, with push, pull,
 source/destination coordination and a local relay. Each streaming copy has a
 25-second deadline and is compared byte for byte, including a signed receiver.
 
-For receiver-state compatibility against an unchanged v0.5.2 binary, run
-`python3 tests/receiver_identity_compat.py target/debug/syq /path/to/v0.5.2/syq`
-from the repository root. It accepts the official release or a build of tag
-commit `fd2b17c642e6`, checks its version and build identity, and uses disposable
-local sockets and state. It also checks that reconnect probes send only Ping
-to the old connection and verify identity through the new one.
-
 This suite is intentionally outside `cargo test` and CI. Run it after changing
 SSH, remote-helper, enrollment, restricted-receiver, transport, or remote
 topology behavior, and before cutting a release. For release preparation, use
@@ -194,3 +187,12 @@ expiry cases verify automatic recovery and successful subsequent copies.
 The suite also revokes an enrollment while two restricted copies are writing,
 checks that both fail without publishing their files, and verifies that a fresh
 enrollment can resume their partials.
+
+For receiver-state compatibility against an unchanged v0.5.2 binary, run
+`python3 tests/receiver_identity_compat.py target/debug/syq /path/to/v0.5.2/syq`
+from the repository root. It accepts the official release or a clean build of tag
+commit `fd2b17c642e6`, checks its version and build identity, and uses disposable
+local sockets and state. It also checks that reconnect probes send only Ping
+to an unresponsive old connection without displacing it, and that readiness
+checks verify the identity of the registered receiver. Dirty baseline builds
+are rejected.

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -428,6 +428,8 @@ if ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop -
 fi
 test ! -e "$receive_root/after-stop"
 ssh source 'test ! -e ~/.syq-destinations-v3/laptop.json'
+printf 'case: offline names require the original receiver identity or explicit replacement\n'
+python3 /usr/local/libexec/syq-test-receiver-identity.py
 # Unrelated pooling scenarios count SSH commands; explicitly disable receiving.
 syq persist receive off
 syq completion cache clear >/dev/null

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -306,8 +306,8 @@ fi
 
 printf 'case: duplicate named return cannot displace the existing laptop\n'
 (
-    export XDG_RUNTIME_DIR=/tmp/syq-duplicate-runtime XDG_CONFIG_HOME=/tmp/syq-duplicate-config
-    mkdir -p "$XDG_RUNTIME_DIR" "$XDG_CONFIG_HOME"
+    export HOME=/tmp/syq-duplicate-home XDG_RUNTIME_DIR=/tmp/syq-duplicate-runtime XDG_CONFIG_HOME=/tmp/syq-duplicate-config
+    mkdir -p "$HOME" "$XDG_RUNTIME_DIR" "$XDG_CONFIG_HOME"
     trap 'syq persist off' EXIT
     syq persist on
     syq persist receive on --name laptop --root /tmp/syq-real-ssh-receive-other
@@ -316,7 +316,7 @@ printf 'case: duplicate named return cannot displace the existing laptop\n'
         echo 'duplicate named destination unexpectedly succeeded' >&2
         exit 1
     fi
-    syq persist receive status --json | python3 -c 'import json,sys; states=json.load(sys.stdin)["connections"]; assert any(s["connection"]["phase"] == "failed" and "already registered" in s["connection"]["error"] for s in states), states'
+    syq persist receive status --json | python3 -c 'import json,sys; states=json.load(sys.stdin)["connections"]; assert any(s["connection"]["phase"] == "failed" and "different receiver" in s["connection"]["error"] for s in states), states'
 )
 ssh source 'syq persist destinations wait laptop --timeout 5'
 

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -201,7 +201,7 @@ syq persist receive remove "$(hostname)"
 syq persist receive wait source --timeout 30
 ssh source 'syq persist destinations wait laptop --timeout 30'
 printf 'case: return copies await local approval and denial leaves no destination\n'
-timeout 20 ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to laptop --as denied' &
+timeout 20 ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as denied' &
 return_copy_pid=$!
 syq persist receive pending --wait --timeout 10 --json > /tmp/syq-pending.json
 request_id=$(python3 -c 'import json; r=json.load(open("/tmp/syq-pending.json")); assert len(r)==1 and "source" in r[0]["from"] and "denied" in r[0]["destination"],r; print(r[0]["id"])')
@@ -225,7 +225,7 @@ test ! -e "$receive_root/denied"
 if syq persist receive approve "$request_id"; then echo 'denied approval ID was reused' >&2; exit 1; fi
 
 printf 'case: approval allows only the pending copy once\n'
-timeout 20 ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to laptop --as approved' &
+timeout 20 ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as approved' &
 return_copy_pid=$!
 syq persist receive pending --wait --timeout 10 --json > /tmp/syq-pending.json
 request_id=$(python3 -c 'import json; print(json.load(open("/tmp/syq-pending.json"))[0]["id"])')
@@ -237,7 +237,7 @@ printf 'return\n' | cmp - "$receive_root/approved"
 if syq persist receive approve "$request_id"; then echo 'used approval ID was reused' >&2; exit 1; fi
 
 printf 'case: disconnected requests cannot be approved later\n'
-ssh source 'timeout 2 syq cp /tmp/syq-real-ssh/return-source/message.txt --to laptop --as disconnected' &
+ssh source 'timeout 2 syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as disconnected' &
 return_copy_pid=$!
 syq persist receive pending --wait --timeout 10 --json > /tmp/syq-pending.json
 request_id=$(python3 -c 'import json; print(json.load(open("/tmp/syq-pending.json"))[0]["id"])')
@@ -256,7 +256,7 @@ if syq persist receive approve "$request_id"; then echo 'disconnected request wa
 test ! -e "$receive_root/disconnected"
 
 printf 'case: changing policy cancels a pending request\n'
-timeout 20 ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to laptop --as cancelled-policy' &
+timeout 20 ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as cancelled-policy' &
 return_copy_pid=$!
 syq persist receive pending --wait --timeout 10 --json > /tmp/syq-pending.json
 request_id=$(python3 -c 'import json; print(json.load(open("/tmp/syq-pending.json"))[0]["id"])')
@@ -277,7 +277,7 @@ python3 /usr/local/libexec/syq-test-return-exec.py
 printf 'case: explicit automatic approval supports unattended copies\n'
 syq persist receive on --approve always
 syq persist receive wait source --timeout 30
-ssh source 'test -z "${SSH_AUTH_SOCK:-}"; syq cp --preserve permissions --srcs-in /tmp/syq-real-ssh/return-source --to laptop --into first'
+ssh source 'test -z "${SSH_AUTH_SOCK:-}"; syq cp --preserve permissions --srcs-in /tmp/syq-real-ssh/return-source --to @laptop --into first'
 remote_manifest source /tmp/syq-real-ssh/return-source /tmp/syq-return-source.manifest
 (
     cd "$receive_root/first"
@@ -304,10 +304,12 @@ if ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop -
     exit 1
 fi
 
-printf 'case: duplicate named return cannot displace the existing laptop\n'
+printf 'case: a copied receiver identity cannot displace a responsive laptop\n'
 (
+    original_receiver_identity=$HOME/.syq-receiver-identity
     export HOME=/tmp/syq-duplicate-home XDG_RUNTIME_DIR=/tmp/syq-duplicate-runtime XDG_CONFIG_HOME=/tmp/syq-duplicate-config
     mkdir -p "$HOME" "$XDG_RUNTIME_DIR" "$XDG_CONFIG_HOME"
+    cp -a "$original_receiver_identity" "$HOME/"
     trap 'syq persist off' EXIT
     syq persist on
     syq persist receive on --name laptop --root /tmp/syq-real-ssh-receive-other
@@ -316,7 +318,7 @@ printf 'case: duplicate named return cannot displace the existing laptop\n'
         echo 'duplicate named destination unexpectedly succeeded' >&2
         exit 1
     fi
-    syq persist receive status --json | python3 -c 'import json,sys; states=json.load(sys.stdin)["connections"]; assert any(s["connection"]["phase"] == "failed" and "different receiver" in s["connection"]["error"] for s in states), states'
+    syq persist receive status --json | python3 -c 'import json,sys; states=json.load(sys.stdin)["connections"]; assert any(s["connection"]["phase"] == "failed" and "already connected" in s["connection"]["error"] for s in states), states'
 )
 ssh source 'syq persist destinations wait laptop --timeout 5'
 
@@ -403,9 +405,9 @@ printf 'return\n' | cmp - "$receive_root/after-heartbeat-timeout"
 printf 'case: cwd permits destinations outside its starting directory\n'
 syq persist receive on --cwd "$receive_root"
 syq persist receive wait source --timeout 30
-ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to laptop --as ../syq-return-outside'
+ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as ../syq-return-outside'
 printf 'return\n' | cmp - /tmp/syq-return-outside
-ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to laptop --as /tmp/syq-return-absolute'
+ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as /tmp/syq-return-absolute'
 printf 'return\n' | cmp - /tmp/syq-return-absolute
 python3 /usr/local/libexec/syq-test-receive-profiles.py
 printf 'case: persist receive off/on keeps ordinary persistence and restarts receiving\n'
@@ -418,7 +420,7 @@ if ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop -
 fi
 syq persist receive on
 syq persist receive wait source --timeout 30
-ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to laptop --as reenabled'
+ssh source 'syq cp /tmp/syq-real-ssh/return-source/message.txt --to @laptop --as reenabled'
 printf 'return\n' | cmp - "$receive_root/reenabled"
 printf 'case: persistence off stops background receiving\n'
 syq persist off

--- a/tests/real-ssh/test-receive-profiles.py
+++ b/tests/real-ssh/test-receive-profiles.py
@@ -112,14 +112,16 @@ with tempfile.TemporaryDirectory(prefix="syq-profiles-") as directory:
 
     print("case: two clients can receive; duplicate name fails only that profile", flush=True)
     (root / "runtime").mkdir(mode=0o700)
-    other_env = dict(os.environ, XDG_CONFIG_HOME=str(root / "config"), XDG_RUNTIME_DIR=str(root / "runtime"))
+    other_home = root / "other-home"
+    other_home.mkdir(mode=0o700)
+    other_env = dict(os.environ, HOME=str(other_home), XDG_CONFIG_HOME=str(root / "config"), XDG_RUNTIME_DIR=str(root / "runtime"))
     other_root = root / "other"
     other_root.mkdir()
     try:
         receive("on", "--name", "laptop", "--root", str(other_root), "--notify", "off", env=other_env)
         receive("on", "--name", "other-client", "--root", str(other_root), "--notify", "off", "--approve", "always", env=other_env)
         conflict = run("syq", "persist", "connect", "source", "--timeout", "30", env=other_env, ok=False)
-        assert conflict.returncode != 0 and "already registered" in conflict.stderr, conflict
+        assert conflict.returncode != 0 and "different receiver" in conflict.stderr, conflict
         receive("wait", "source", "--name", "other-client", "--timeout", "30", env=other_env)
         assert profile("laptop", other_env)["connection"]["phase"] == "failed"
         assert profile("laptop")["connection"]["ssh_pid"] == original

--- a/tests/real-ssh/test-receive-profiles.py
+++ b/tests/real-ssh/test-receive-profiles.py
@@ -121,7 +121,7 @@ with tempfile.TemporaryDirectory(prefix="syq-profiles-") as directory:
         receive("on", "--name", "laptop", "--root", str(other_root), "--notify", "off", env=other_env)
         receive("on", "--name", "other-client", "--root", str(other_root), "--notify", "off", "--approve", "always", env=other_env)
         conflict = run("syq", "persist", "connect", "source", "--timeout", "30", env=other_env, ok=False)
-        assert conflict.returncode != 0 and "different receiver" in conflict.stderr, conflict
+        assert conflict.returncode != 0 and "already connected" in conflict.stderr, conflict
         receive("wait", "source", "--name", "other-client", "--timeout", "30", env=other_env)
         assert profile("laptop", other_env)["connection"]["phase"] == "failed"
         assert profile("laptop")["connection"]["ssh_pid"] == original

--- a/tests/real-ssh/test-receiver-identity.py
+++ b/tests/real-ssh/test-receiver-identity.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Exercise offline ownership and explicit replacement in disposable accounts."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def run(*args, env=None, success=True):
+    result = subprocess.run(args, env=env, text=True, capture_output=True, timeout=60)
+    print(result.stdout, end="", flush=True)
+    print(result.stderr, end="", flush=True)
+    assert (result.returncode == 0) == success, (args, result.returncode)
+    return result.stdout
+
+
+# The scenario runner has just stopped its original laptop connection.
+original_key = Path.home() / ".syq-receiver-identity/identity_ed25519"
+key_before = original_key.read_bytes()
+owner_before = run("ssh", "source", "cat ~/.syq-destinations-v3/laptop.owner")
+listing = run("ssh", "source", "syq persist destinations list")
+assert "@laptop\toffline" in listing, listing
+with tempfile.TemporaryDirectory(prefix="syq-other-receiver-") as directory:
+    env = dict(os.environ, HOME=directory,
+               XDG_CONFIG_HOME=directory + "/config", XDG_RUNTIME_DIR=directory + "/runtime")
+    Path(env["XDG_RUNTIME_DIR"]).mkdir(mode=0o700)
+    try:
+        run("syq", "persist", "receive", "on", "--name", "laptop", "--root", directory, env=env)
+        run("syq", "persist", "connect", "source", "--timeout", "15", env=env, success=False)
+        state = json.loads(run("syq", "persist", "receive", "status", "--json", env=env))
+        assert any("different receiver" in (c["connection"].get("error") or "")
+                   for c in state["connections"]), state
+        assert run("ssh", "source", "cat ~/.syq-destinations-v3/laptop.owner") == owner_before
+        run("ssh", "source", "syq persist destinations forget laptop")
+        run("syq", "persist", "connect", "source", "--timeout", "15", env=env)
+        run("ssh", "source", "syq persist destinations wait laptop --timeout 5")
+        # Incoming copies cannot overwrite the identity, including under a
+        # test-specific HOME rather than the account's passwd home directory.
+        receiver_key = Path(directory) / ".syq-receiver-identity/identity_ed25519"
+        receiver_key_before = receiver_key.read_bytes()
+        run("syq", "persist", "receive", "on", "--name", "laptop", "--approve", "always", env=env)
+        run("syq", "persist", "receive", "wait", "source", "--timeout", "15", env=env)
+        run("ssh", "source", "syq cp /tmp/syq-real-ssh/return-source/message.txt "
+            "--to @laptop --as .syq-receiver-identity/identity_ed25519", success=False)
+        assert receiver_key.read_bytes() == receiver_key_before
+        owner_after = run("ssh", "source", "cat ~/.syq-destinations-v3/laptop.owner")
+        assert owner_before != owner_after
+        run("ssh", "source", "syq persist destinations forget laptop", success=False)
+    finally:
+        run("syq", "persist", "off", env=env)
+    run("ssh", "source", "syq persist destinations forget laptop")
+assert original_key.read_bytes() == key_before
+# Reusing the original installation after a service restart keeps its identity.
+run("syq", "persist", "connect", "source")
+assert run("ssh", "source", "cat ~/.syq-destinations-v3/laptop.owner") == owner_before
+run("syq", "persist", "off")

--- a/tests/real-ssh/test-return-handoff.py
+++ b/tests/real-ssh/test-return-handoff.py
@@ -20,8 +20,8 @@ run("syq", "persist", "receive", "wait", "source", "--timeout", "30")
 run("ssh", "source", "syq-other-build persist destinations wait laptop --timeout 5")
 root = Path("/tmp/syq-real-ssh-receive")
 expected = run("ssh", "source", "cat /tmp/syq-real-ssh/return-source/message.txt")
-for name in ("laptop", "@laptop"):
-    target = "skew-explicit" if name.startswith("@") else "skew-bare"
+for name in ("@laptop",):
+    target = "skew-explicit"
     run("ssh", "source", shlex.join([
         "syq-other-build", "cp", "/tmp/syq-real-ssh/return-source/message.txt",
         "--to", name, "--as", target,
@@ -115,7 +115,7 @@ try:
     args = [binary, 'cp', '--srcs-in', base + '/ignore-source', '--ignore', '*.log',
             '--ignore', '!drop.tmp', '--ignore-from', path, '--ignore', '!allow.tmp',
             '--ignore-from', base + '/extra-rules', '--ignore', '!keep.cache',
-            '--to', 'laptop' if kind == 'stdin' else '@laptop', '--into', target,
+            '--to', '@laptop', '--into', target,
             '--prune', '--max-delete', '1']
     if kind == 'stdin':
         args.append('--follow')  # /dev/stdin is a symlink on Linux.

--- a/tests/receiver_identity_compat.py
+++ b/tests/receiver_identity_compat.py
@@ -26,6 +26,12 @@ def run(*args, env=None, success=True, input=None):
     return result
 
 
+old_version = run(previous, "--version").stdout.decode().strip()
+assert old_version == "syq 0.5.2", f"expected v0.5.2 baseline, got {old_version!r}"
+old_identity = run(previous, "--build-identity").stdout.decode().strip()
+assert old_identity in ("v0.5.2", "v0.5.2+dev.fd2b17c642e6"), old_identity
+
+
 def read_frame(stream):
     deadline = time.monotonic() + 10
 
@@ -151,6 +157,7 @@ with tempfile.TemporaryDirectory(prefix="syq-id-compat-") as directory:
                               error=b"already connected"):
                 assert owner.read_bytes() == owned_bytes
         paused.set()
+        before_retry = len(messages)
         for secret in ("test-connection-secret", "restarted-service"):
             with registration(candidate, home, key_one, retry=True, secret=secret):
                 assert owner.read_bytes() == owned_bytes
@@ -159,7 +166,13 @@ with tempfile.TemporaryDirectory(prefix="syq-id-compat-") as directory:
         paused.clear()
         print("PASS: responsive duplicates fail; unresponsive same-identity reconnects wait without displacing the lock", flush=True)
         run(previous, "persist", "destinations", "wait", "laptop", "--timeout", "1", env=env)
+        # The successful old-client Ping also drains earlier queued probes.
+        retry_messages = messages[before_retry:]
+        assert retry_messages and all(message == "Ping" for message in retry_messages), retry_messages
+        before_ready = len(messages)
         run(candidate, "persist", "destinations", "wait", "laptop", "--timeout", "1", env=env)
+        ready_messages = messages[before_ready:]
+        assert len(ready_messages) == 1 and "Identify" in ready_messages[0], ready_messages
     assert owner.read_bytes() == owned_bytes and not advertisement.exists()
     print("PASS: v0.5.2 discovers new advertisements; disconnect preserves ownership", flush=True)
 

--- a/tests/receiver_identity_compat.py
+++ b/tests/receiver_identity_compat.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Run against candidate and released v0.5.2 binaries; uses only temporary state.
+
+Usage: python3 tests/receiver_identity_compat.py CANDIDATE V0_5_2_BINARY
+"""
+import contextlib
+import json
+import os
+from pathlib import Path
+import select
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+candidate, previous = map(lambda arg: str(Path(arg).resolve()), sys.argv[1:])
+
+
+def run(*args, env=None, success=True, input=None):
+    result = subprocess.run(args, env=env, input=input, capture_output=True, timeout=15)
+    assert (result.returncode == 0) == success, (args, result.returncode, result.stderr)
+    return result
+
+
+def read_frame(stream):
+    deadline = time.monotonic() + 10
+
+    def exact(count):
+        data = b""
+        while len(data) < count:
+            remaining = deadline - time.monotonic()
+            assert remaining > 0 and select.select([stream], [], [], remaining)[0], "frame timeout"
+            block = os.read(stream.fileno(), count - len(data))
+            assert block, "truncated frame"
+            data += block
+        return data
+
+    return json.loads(exact(struct.unpack("!I", exact(4))[0]))
+
+
+@contextlib.contextmanager
+def registration(binary, home, key, *, success=True, legacy=False):
+    """A local test peer exercises the binary's actual registration entry point."""
+    env = dict(os.environ, HOME=str(home), SYQ_NO_UPDATE_CHECK="1")
+    path = home / "return.sock"
+    listener = socket.socket(socket.AF_UNIX)
+    listener.bind(str(path))
+    path.chmod(0o600)
+    listener.listen()
+    listener.settimeout(.1)
+    stopped = threading.Event()
+    errors = []
+
+    def serve():
+        try:
+            while not stopped.is_set():
+                try:
+                    stream, _ = listener.accept()
+                except TimeoutError:
+                    continue
+                with stream:
+                    stream.settimeout(10)
+                    envelope = read_frame(stream)
+                    assert envelope["secret"] == "test-connection-secret"
+                    message = envelope["message"]
+                    if message == "Ping":
+                        reply = "Ready"
+                    elif legacy:
+                        reply = {"Error": "unknown variant Identify (v0.5.2 peer)"}
+                    else:
+                        fields = message["Identify"]
+                        payload = json.dumps([fields["name"], fields["challenge"], envelope["secret"]],
+                                             separators=(",", ":")).encode()
+                        signing_env = dict(os.environ)
+                        signing_env.pop("SSH_AUTH_SOCK", None)
+                        signature = run("ssh-keygen", "-Y", "sign", "-f", str(key),
+                                        "-n", "syq-receiver-identity-v1", env=signing_env,
+                                        input=payload).stdout.decode()
+                        reply = {"Identity": {"public_key": key.with_suffix(".pub").read_text().strip(),
+                                              "signature": signature}}
+                    data = json.dumps(reply).encode()
+                    stream.sendall(struct.pack("!I", len(data)) + data)
+        except Exception as error:
+            errors.append(error)
+
+    thread = threading.Thread(target=serve)
+    thread.start()
+    process = subprocess.Popen([binary, "--destination-register", "laptop", str(path),
+                                "test-connection-secret"], env=env, stdin=subprocess.PIPE,
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        if success:
+            assert read_frame(process.stdout) == "Ready"
+        else:
+            _, stderr = process.communicate(timeout=15)
+            assert process.returncode != 0 and b"different receiver" in stderr, stderr
+        yield env
+    finally:
+        if process.poll() is None:
+            process.stdin.close()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+                raise
+        stopped.set()
+        thread.join(timeout=12)
+        listener.close()
+        assert not thread.is_alive() and not errors, errors
+
+
+with tempfile.TemporaryDirectory(prefix="syq-id-compat-") as directory:
+    home = Path(directory)
+    key_one, key_two = home / "one", home / "two"
+    for key in (key_one, key_two):
+        run("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key))
+    owner = home / ".syq-destinations-v3/laptop.owner"
+    advertisement = home / ".syq-destinations-v3/laptop.json"
+    with registration(previous, home, key_one, legacy=True) as env:
+        old_bytes = advertisement.read_bytes()
+        run(candidate, "persist", "destinations", "wait", "laptop", "--timeout", "1", env=env)
+        assert advertisement.read_bytes() == old_bytes and not owner.exists()
+    print("PASS: new binary reads unchanged v0.5.2 advertisement and discovery", flush=True)
+
+    with registration(candidate, home, key_one) as env:
+        owned_bytes = owner.read_bytes()
+        run(previous, "persist", "destinations", "wait", "laptop", "--timeout", "1", env=env)
+        run(candidate, "persist", "destinations", "wait", "laptop", "--timeout", "1", env=env)
+    assert owner.read_bytes() == owned_bytes and not advertisement.exists()
+    print("PASS: v0.5.2 discovers new advertisements; disconnect preserves ownership", flush=True)
+
+    with registration(previous, home, key_one, legacy=True) as env:
+        result = run(candidate, "persist", "destinations", "wait", "laptop", "--timeout", "1",
+                     env=env, success=False)
+        assert b"cannot verify receiver identity" in result.stderr, result.stderr
+        assert owner.read_bytes() == owned_bytes
+    print("PASS: downgraded receiver without identity support is rejected for an assigned name", flush=True)
+
+    with registration(previous, home, key_two) as env:
+        result = run(candidate, "persist", "destinations", "wait", "laptop", "--timeout", "1",
+                     env=env, success=False)
+        assert b"different receiver" in result.stderr, result.stderr
+        assert owner.read_bytes() == owned_bytes
+    print("PASS: new lookup rejects a conflicting advertisement written by v0.5.2", flush=True)
+
+    with registration(candidate, home, key_two, success=False):
+        assert owner.read_bytes() == owned_bytes
+    run(candidate, "persist", "destinations", "forget", "laptop", env=env)
+    with registration(candidate, home, key_two):
+        assert owner.read_bytes() != owned_bytes
+    print("PASS: offline collision is rejected until explicit forget", flush=True)

--- a/tests/receiver_identity_compat.py
+++ b/tests/receiver_identity_compat.py
@@ -44,7 +44,7 @@ def read_frame(stream):
 
 @contextlib.contextmanager
 def registration(binary, home, key, *, success=True, legacy=False, retry=False, messages=None,
-                 secret="test-connection-secret"):
+                 secret="test-connection-secret", paused=None, error=b"different receiver"):
     """A local test peer exercises the binary's actual registration entry point."""
     env = dict(os.environ, HOME=str(home), SYQ_NO_UPDATE_CHECK="1")
     path = home / ("return-" + uuid.uuid4().hex + ".sock")
@@ -70,6 +70,11 @@ def registration(binary, home, key, *, success=True, legacy=False, retry=False, 
                     message = envelope["message"]
                     if messages is not None:
                         messages.append(message)
+                    if paused is not None and paused.is_set():
+                        for _ in range(200):
+                            if not paused.is_set() or stopped.wait(.01):
+                                break
+                        continue
                     if message == "Ping":
                         reply = "Ready"
                     elif legacy:
@@ -86,7 +91,10 @@ def registration(binary, home, key, *, success=True, legacy=False, retry=False, 
                         reply = {"Identity": {"public_key": key.with_suffix(".pub").read_text().strip(),
                                               "signature": signature}}
                     data = json.dumps(reply).encode()
-                    stream.sendall(struct.pack("!I", len(data)) + data)
+                    try:
+                        stream.sendall(struct.pack("!I", len(data)) + data)
+                    except BrokenPipeError:
+                        pass  # A timed-out liveness probe already closed its end.
         except Exception as error:
             errors.append(error)
 
@@ -103,7 +111,7 @@ def registration(binary, home, key, *, success=True, legacy=False, retry=False, 
             assert read_frame(process.stdout) == "Ready"
         else:
             _, stderr = process.communicate(timeout=15)
-            assert process.returncode != 0 and b"different receiver" in stderr, stderr
+            assert process.returncode != 0 and error in stderr, stderr
         yield env
     finally:
         if process.poll() is None:
@@ -134,18 +142,22 @@ with tempfile.TemporaryDirectory(prefix="syq-id-compat-") as directory:
     print("PASS: new binary reads unchanged v0.5.2 advertisement and discovery", flush=True)
 
     messages = []
-    with registration(candidate, home, key_one, messages=messages) as env:
+    paused = threading.Event()
+    with registration(candidate, home, key_one, messages=messages, paused=paused) as env:
         owned_bytes = owner.read_bytes()
-        before_retry = list(messages)
-        with registration(candidate, home, key_one, retry=True):
-            assert messages == before_retry, messages
-            assert owner.read_bytes() == owned_bytes
-        with registration(candidate, home, key_one, retry=True, secret="restarted-service"):
-            assert messages == before_retry, messages
-            assert owner.read_bytes() == owned_bytes
+        for key, secret in [(key_one, "test-connection-secret"),
+                            (key_one, "restarted-service"), (key_two, "other-receiver")]:
+            with registration(candidate, home, key, success=False, secret=secret,
+                              error=b"already connected"):
+                assert owner.read_bytes() == owned_bytes
+        paused.set()
+        for secret in ("test-connection-secret", "restarted-service"):
+            with registration(candidate, home, key_one, retry=True, secret=secret):
+                assert owner.read_bytes() == owned_bytes
         with registration(candidate, home, key_two, success=False, secret="other-receiver"):
             assert owner.read_bytes() == owned_bytes
-        print("PASS: reconnects and service restarts wait without contacting or displacing the old transport", flush=True)
+        paused.clear()
+        print("PASS: responsive duplicates fail; unresponsive same-identity reconnects wait without displacing the lock", flush=True)
         run(previous, "persist", "destinations", "wait", "laptop", "--timeout", "1", env=env)
         run(candidate, "persist", "destinations", "wait", "laptop", "--timeout", "1", env=env)
     assert owner.read_bytes() == owned_bytes and not advertisement.exists()

--- a/tests/receiver_identity_compat.py
+++ b/tests/receiver_identity_compat.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import threading
 import time
+import uuid
 
 candidate, previous = map(lambda arg: str(Path(arg).resolve()), sys.argv[1:])
 
@@ -42,10 +43,11 @@ def read_frame(stream):
 
 
 @contextlib.contextmanager
-def registration(binary, home, key, *, success=True, legacy=False):
+def registration(binary, home, key, *, success=True, legacy=False, retry=False, messages=None,
+                 secret="test-connection-secret"):
     """A local test peer exercises the binary's actual registration entry point."""
     env = dict(os.environ, HOME=str(home), SYQ_NO_UPDATE_CHECK="1")
-    path = home / "return.sock"
+    path = home / ("return-" + uuid.uuid4().hex + ".sock")
     listener = socket.socket(socket.AF_UNIX)
     listener.bind(str(path))
     path.chmod(0o600)
@@ -64,8 +66,10 @@ def registration(binary, home, key, *, success=True, legacy=False):
                 with stream:
                     stream.settimeout(10)
                     envelope = read_frame(stream)
-                    assert envelope["secret"] == "test-connection-secret"
+                    assert envelope["secret"] == secret
                     message = envelope["message"]
+                    if messages is not None:
+                        messages.append(message)
                     if message == "Ping":
                         reply = "Ready"
                     elif legacy:
@@ -89,10 +93,13 @@ def registration(binary, home, key, *, success=True, legacy=False):
     thread = threading.Thread(target=serve)
     thread.start()
     process = subprocess.Popen([binary, "--destination-register", "laptop", str(path),
-                                "test-connection-secret"], env=env, stdin=subprocess.PIPE,
+                                secret], env=env, stdin=subprocess.PIPE,
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
-        if success:
+        if retry:
+            _, stderr = process.communicate(timeout=15)
+            assert process.returncode == 75 and b"still closing" in stderr, stderr
+        elif success:
             assert read_frame(process.stdout) == "Ready"
         else:
             _, stderr = process.communicate(timeout=15)
@@ -126,8 +133,19 @@ with tempfile.TemporaryDirectory(prefix="syq-id-compat-") as directory:
         assert advertisement.read_bytes() == old_bytes and not owner.exists()
     print("PASS: new binary reads unchanged v0.5.2 advertisement and discovery", flush=True)
 
-    with registration(candidate, home, key_one) as env:
+    messages = []
+    with registration(candidate, home, key_one, messages=messages) as env:
         owned_bytes = owner.read_bytes()
+        before_retry = list(messages)
+        with registration(candidate, home, key_one, retry=True):
+            assert messages == before_retry, messages
+            assert owner.read_bytes() == owned_bytes
+        with registration(candidate, home, key_one, retry=True, secret="restarted-service"):
+            assert messages == before_retry, messages
+            assert owner.read_bytes() == owned_bytes
+        with registration(candidate, home, key_two, success=False, secret="other-receiver"):
+            assert owner.read_bytes() == owned_bytes
+        print("PASS: reconnects and service restarts wait without contacting or displacing the old transport", flush=True)
         run(previous, "persist", "destinations", "wait", "laptop", "--timeout", "1", env=env)
         run(candidate, "persist", "destinations", "wait", "laptop", "--timeout", "1", env=env)
     assert owner.read_bytes() == owned_bytes and not advertisement.exists()

--- a/tests/return_handoff.rs
+++ b/tests/return_handoff.rs
@@ -98,7 +98,7 @@ fn replaced_helper_fails_the_build_guard_instead_of_reexecuting_forever() {
         serde_json::from_str(results.lines().last().unwrap()).unwrap();
     assert_eq!(terminal["status"], "failed");
     assert_failure(
-        &fixture.run(&["exec", "--on", "laptop", "--", "true"]),
+        &fixture.run(&["exec", "--on", "@laptop", "--", "true"]),
         "registered return helper has a different build",
     );
 }


### PR DESCRIPTION
Receiving names keep their identity across disconnects and syq upgrades. A second laptop cannot claim an offline name owned by another receiver; replacement requires `syq persist destinations forget NAME` on the server. Each receiving account keeps a separate Ed25519 identity key, shared across profiles and versions, and proves ownership with a fresh signed challenge bound to the name and connection credential. The server account still controls the ownership ledger.

Receiver references now require `@NAME`: `--to laptop` denotes an SSH destination and `--to @laptop` denotes the receiver, which fails when offline. The same explicit spelling applies to `exec --on`, `--via`, and named `--auth-from`; profile-management commands still use plain names. `--auth-from ssh` chooses the source machine's SSH credentials rather than changing the destination namespace. Completion and documentation follow these rules.

A responsive existing receiver rejects a duplicate with an instruction to choose another name, including when both machines share a copied identity key. An unresponsive same-identity connection can retry until the existing holder's heartbeat cleanup releases the lock; it cannot steal or displace it. Readiness probes respect their caller's deadline, including partial replies, and a verified identity reply counts as liveness without an extra Ping. List/wait probes use up to one second; automatic authorizer discovery uses up to two seconds per receiver. Proofs are not cached across process boundaries, and the defensive claim check remains.

Ownership records omit untrusted key comments, forget can recreate a missing lock file, and offline owner-only entries no longer suppress SSH path completion. Incoming copies cannot overwrite receiver identity state, including under an overridden HOME.

Compatibility:

- Tested against an unmodified binary built from v0.5.2 (`fd2b17c`). Version-3 registrations and discovery Ping/Ready remain unchanged; version-1 ownership records are separate. Existing unowned connections remain discoverable and become assigned on an upgraded reconnect. Older binaries can discover new registrations but cannot enforce ownership. New commands reject incompatible or conflicting peers for assigned names. Profile preferences, grants, receipts, and resume state are unchanged.
- Removing bare receiver references is an explicitly authorized break scoped to the currently unused receiver interface. Existing commands must add `@`; the unchanged v0.4.0 SDK `--via ssh` fixture now tests explicit rejection and recovery with `--via @ssh`. Old bare copy handoffs are rejected rather than reinterpreting their selected destination as SSH. Both binary versions can still read the unchanged persistent formats as described above; older commands retain their old name-selection behavior.

Socket connect, request writes, and reply reads share an absolute deadline. Reads and writes use per-call nonblocking operations with bounded polling, so partial progress cannot renew that deadline. Periodic 100 ms wakeups apply only to waits with cancellation callbacks; socket and noncancellable handshake waits sleep until readiness or their remaining deadline.

A full Unix listen queue is verified to produce WouldBlock on Linux and receives “receiving machine is busy; try again shortly.” This classification has not been verified on macOS. A busy macOS receiver returning another error receives the generic connection error with the underlying OS error. This message says the receiver may be busy or its connection may have ended, and offers a retry or `syq persist connect SERVER` on the receiving machine. It stays neutral about the cause while providing recovery advice for stale registrations after an unclean disconnect. The queue regression fills the queue in a bounded loop instead of assuming its capacity.

The v0.5.2 compatibility script validates the old binary's version and build identity, asserts that only Ping is sent to an unresponsive incumbent during retries without displacing it, and checks that readiness uses one Identify request. The SSH test guide documents its invocation and clean baseline requirement. Receiver destination documentation consistently requires @NAME.

Validation for `746f9e2`:

- Formatting, all-target/all-feature clippy with warnings denied, and cargo test --bin syq passed: 621 tests, one pre-existing ignored test requiring the official v0.3.2 executable. The relative-program command-execution test failed once with a missing exit-status frame; its focused retry and the full binary-suite retry passed without changes to that path.
- The focused stale-registration integration test passed. It requires failure without SSH fallback, the recovery command in the error, and no assertion that the machine is offline. It no longer forbids the word “reconnect.”
- Full default OpenSSH suite passed against clean 746f9e2, including the stale-connection recovery message, receiver smoke tests, benchmark verification, and interruption cleanup. The runner exited 0 and removed its containers.
- The complete all-target suite (470 local tests plus help/output/handoff/update), v0.5.2 binary compatibility, and full OpenSSH suite previously passed for 5737d72's runtime code. This follow-up changes only an error string and its test assertion; full all-target and compatibility runs were not repeated.
- Prior Linux strace of the idle ten-second exchange showed one 9,999 ms poll until timeout. Polling behavior, wire formats, and persistent state are unchanged by this wording correction.
- macOS validation was not run for this follow-up; the busy-queue tests are Linux-only.

Remaining review decision: duplicate detection still uses a one-second reply budget while the holder heartbeat allows ten seconds. Aligning those budgets remains pending discussion. Repeated identity verification is unchanged under the prior decision to defer caching. Forwarding pipe adapters continue blocking I/O after polling: no hang has been reproduced in that path, and the user accepted the assessed likelihood and impact instead of adding descriptor-handling changes. The PR has not been merged.

Branch status:

```text
Worktree: /home/grant/repos/syq/.worktrees/persistent-receiver-identity
Branch:   persistent-receiver-identity at 746f9e2 (clean)
Upstream: origin/persistent-receiver-identity (ahead 0, behind 0)
Master:   8618cf3 from refs/heads/master (branch is ahead 11, behind 6)

Master CI (latest post-merge run per workflow):
  ci.yml           success      97eceef  https://github.com/greaber/syq/actions/runs/34490834287
  rsync-compat.yml success      97eceef  https://github.com/greaber/syq/actions/runs/34490834273
  macos.yml        success      97eceef  https://github.com/greaber/syq/actions/runs/34490834291

Pull request: #325 https://github.com/greaber/syq/pull/325
  base master, open, review none, merge state clean
  GitHub head 746f9e2: matches local 746f9e2
  checks: none registered yet
```
