### PR TITLE
Fix nondeterministic local-copy resume tests

### DIFF
--- a/tests/local_copy_selection/mod.rs
+++ b/tests/local_copy_selection/mod.rs
@@ -182,8 +182,20 @@ fn medium_failure_keeps_old_destination_and_resumes_changed_source() {
     let mut changed = original;
     changed[..1 << 20].fill(b'c');
     write(&t.path("src/file"), &changed);
+    // ENOSPC can stop the companion before it completes. Reproduce that state
+    // deterministically and select ranges so the retry exercises partial reuse
+    // instead of the direct-copy fast path for multiple pending files.
+    if t.path("dst/small").exists() {
+        fs::remove_file(t.path("dst/small")).unwrap();
+    }
     let out = compat_command()
-        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
+        .args([
+            "-a",
+            "--tuning-options=copy-path=ranges",
+            "--no-progress",
+            &t.s("src/"),
+            &t.s("dst/"),
+        ])
         .env("SYQ_DEBUG", "1")
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
         .env("SYQ_TEST_COPY_LOCAL_FS", "local")
@@ -259,7 +271,15 @@ fn fresh_medium_failure_does_not_publish_and_changed_source_resumes() {
 
     contents[..1 << 20].fill(b'x');
     write(&t.path("src/file"), &contents);
-    let resumed = run().run().unwrap();
+    // Keep the companion pending as it may be after ENOSPC, and explicitly
+    // select ranges to test reuse rather than the multi-file direct-copy path.
+    if t.path("dst/tiny").exists() {
+        fs::remove_file(t.path("dst/tiny")).unwrap();
+    }
+    let resumed = run()
+        .arg("--tuning-options=copy-path=ranges")
+        .run()
+        .unwrap();
     assert_output_ok(&resumed);
     assert_eq!(partial_files(&t.path("dst")), partials);
     // Cleanup changes the containing directory's mtime. Check copied directory


### PR DESCRIPTION
The interrupted local-copy tests assumed every retry would use ranges. An injected ENOSPC can leave the tiny companion unfinished, allowing the retry to select the documented multi-file direct-copy path instead. This caused CI at 8618cf3 to fail a strategy counter assertion even though the copied contents were correct.

Make the companion explicitly pending and select `--tuning-options=copy-path=ranges` on retry in both affected tests. This reliably exercises partial reuse while preserving the publication, changed-source, and partial-file checks. Runtime behavior is unchanged.

Validation at 95923f2:
- Formatting and all-target/all-feature Clippy passed.
- Unit tests: 612 passed, one existing ignored.
- All six local-copy selection tests passed.
- Controlled reproductions covered existing/new destinations and pending/completed companions; all four verified correct contents, unchanged old partials, and range selection.
- Full integration and real-SSH suites were not run for this test-only change.

`branch-status.sh` reports the task worktree clean at 95923f2. Latest master CI remains failed at 8618cf3 (the failure addressed here); rsync compatibility and macOS passed at that SHA. PRs do not automatically run test workflows.
