### PR TITLE
Fix current Linux and macOS CI failures

### DIFF
--- a/src/destination.rs
+++ b/src/destination.rs
@@ -273,9 +273,15 @@ impl Write for DeadlineSocket<'_> {
     fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
         loop {
             deadline_remaining(self.deadline)?;
-            match socket2::SockRef::from(&*self.socket)
-                .send_with_flags(bytes, libc::MSG_DONTWAIT | libc::MSG_NOSIGNAL)
-            {
+            // Darwin's Unix-stream send path checks the kernel-private
+            // MSG_NBIO flag, not MSG_DONTWAIT, while waiting for buffer space.
+            // This per-call flag avoids toggling O_NONBLOCK on a descriptor
+            // shared with socket clones. MSG_NBIO has been 0x20000 in XNU.
+            #[cfg(target_vendor = "apple")]
+            let flags = libc::MSG_DONTWAIT | libc::MSG_NOSIGNAL | 0x20000;
+            #[cfg(not(target_vendor = "apple"))]
+            let flags = libc::MSG_DONTWAIT | libc::MSG_NOSIGNAL;
+            match socket2::SockRef::from(&*self.socket).send_with_flags(bytes, flags) {
                 Ok(count) => return Ok(count),
                 Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
                 Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
@@ -471,6 +477,10 @@ fn exchange(
         };
         anyhow::Error::new(error).context(message)
     })?;
+    // Configure the next protocol phase before the peer can close after its
+    // reply. macOS may reject socket timeout changes after peer shutdown.
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
     let mut io = DeadlineSocket {
         socket: &mut stream,
         deadline,
@@ -491,10 +501,6 @@ fn exchange(
         },
     )?;
     let reply = read_message(&mut io)?;
-    // Callers that retain the stream keep the existing per-operation budget
-    // for the next protocol phase, rather than the spent handshake budget.
-    stream.set_read_timeout(Some(timeout))?;
-    stream.set_write_timeout(Some(timeout))?;
     if let Reply::Error(error) = &reply {
         bail!("receiving machine: {error}");
     }

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -11738,8 +11738,20 @@ fn copy_local_disk_write_failure_keeps_old_destination_and_resumes_changed_sourc
     let mut changed = original;
     changed[..1 << 20].fill(b'c');
     write(&t.path("src/file"), &changed);
+    // ENOSPC can stop the companion before it completes. Reproduce that state
+    // deterministically and select ranges so the retry exercises partial reuse
+    // instead of the direct-copy fast path for multiple pending files.
+    if t.path("dst/small").exists() {
+        fs::remove_file(t.path("dst/small")).unwrap();
+    }
     let out = compat_command()
-        .args(["-a", "--no-progress", &t.s("src/"), &t.s("dst/")])
+        .args([
+            "-a",
+            "--tuning-options=copy-path=ranges",
+            "--no-progress",
+            &t.s("src/"),
+            &t.s("dst/"),
+        ])
         .env("SYQ_DEBUG", "1")
         .env("SYQ_TEST_COPY_LOCAL_EXDEV", "1")
         .env("SYQ_TEST_COPY_LOCAL_FS", "local")


### PR DESCRIPTION
Fix the two current post-merge CI regressions.

- Make receiver exchange writes honor their absolute deadline on Darwin, whose Unix-stream send path requires the per-call MSG_NBIO flag while waiting for buffer space.
- Configure retained socket timeouts before the peer can close and make macOS reject the late setsockopt call.
- Make the disk-write recovery regression deterministic by selecting its intended ranged-copy path.

Checks:
- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-targets
- scripts/test-real-ssh.sh
- Full macOS workflow: https://github.com/greaber/syq/actions/runs/34527990356