### PR TITLE
Accommodate destination timestamp precision in native copies

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -310,7 +310,8 @@ compares whole seconds exactly and ignores as many trailing fractional digits
 as are zero in the destination timestamp. For example, destination `.120000000`
 seconds matches source `.123456789`; a whole-second destination timestamp
 ignores the source fraction entirely. This accommodates destinations that
-truncate fractional seconds. `syq rsync` compares whole seconds only.
+truncate fractional seconds. Directory metadata previews use the same fractional
+precision rule. `syq rsync` compares whole seconds only when checking file contents.
 
 Syq preserves the source timestamp at the destination, so the machines' clocks
 do not need to agree. A timestamp difference outside that precision triggers

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -305,16 +305,20 @@ formats are neither reused nor selected by this command; remove those manually.
 
 ## Check file contents
 
-Syq normally skips files whose size and modification time match, including
-fractional seconds. It preserves the source timestamp at the destination, so
-the machines' clocks do not need to agree. A changed timestamp triggers checking
-even when it is older than the destination's, unless you request `--skip-newer`.
-A destination that rounds timestamps to coarser precision can cause unchanged
-files to be checked or copied again on later runs.
+Syq normally skips files whose size and modification time match. `syq cp`
+compares whole seconds exactly and ignores as many trailing fractional digits
+as are zero in the destination timestamp. For example, destination `.120000000`
+seconds matches source `.123456789`; a whole-second destination timestamp
+ignores the source fraction entirely. This accommodates destinations that
+truncate fractional seconds. `syq rsync` compares whole seconds only.
+
+Syq preserves the source timestamp at the destination, so the machines' clocks
+do not need to agree. A timestamp difference outside that precision triggers
+checking even when the source is older, unless you request `--skip-newer`.
 
 Matching metadata is a shortcut, not proof that contents match. An edit can
-preserve both size and timestamp, and some filesystems record timestamps with
-less precision. `--hash` checks contents even when those two attributes match:
+preserve both size and timestamp, and changes within the ignored fraction can
+be missed. `--hash` checks contents even when those two attributes match:
 
 ```sh
 syq cp --hash --srcs-in project --into backup

--- a/docs/rsync-compat.md
+++ b/docs/rsync-compat.md
@@ -29,9 +29,11 @@ on the same host cannot be pruned. Preview deletion scope with `--dry-run -v`;
 see [deletion rules](reference.md#mirror-a-directory).
 
 The compatibility command uses rsync's default size-and-whole-second timestamp
-quick check. Native `syq cp` also compares fractional seconds. Use `-c` to compare
-contents when size and timestamp match; source timestamps are preserved, so
-ordinary clock skew does not require the source timestamp to be newer.
+quick check. Native `syq cp` also compares fractional seconds at the precision
+suggested by the destination timestamp; see [timestamp matching](reference.md#check-file-contents).
+Use `-c` to compare contents when size and timestamp match; source timestamps
+are preserved, so ordinary clock skew does not require the source timestamp
+to be newer.
 
 Syq uses numeric IDs and always keeps partial files, so `--numeric-ids` and
 `--partial` are accepted no-ops. `-P` enables progress. Compression is on by

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -26,6 +26,22 @@ use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 
+/// Compare at the decimal precision suggested by the destination timestamp.
+/// Trailing zeros may reflect either filesystem truncation or a round timestamp;
+/// this is the size/mtime shortcut, not a content verification.
+pub(crate) fn destination_fraction_matches(source: u32, destination: u32) -> bool {
+    if destination == 0 {
+        return true;
+    }
+    let mut precision = 1;
+    let mut fraction = destination;
+    while fraction.is_multiple_of(10) {
+        precision *= 10;
+        fraction /= 10;
+    }
+    source / precision == destination / precision
+}
+
 pub const PARTIAL_MARKER: &str = ".syq-tmp.";
 const FD_CACHE_MAX: usize = 16;
 const PARTIAL_DIRECTORY_CACHE_MAX: usize = 64;
@@ -1815,8 +1831,8 @@ impl FsOps {
                 }
             }
         }
-        // This fused path serves native copies: use all available timestamp
-        // precision, matching the native planner's quick check.
+        // This fused path serves native copies: share the planner's inferred
+        // destination precision so dispatch does not change the skip decision.
         let mut unchanged: Vec<bool> = request
             .files
             .iter()
@@ -1826,7 +1842,10 @@ impl FsOps {
                     request.flags & flags::TIMES != 0
                         && stat.st_size as u64 == file.data.len() as u64
                         && stat.st_mtime == file.meta.mtime
-                        && stat.st_mtime_nsec as u32 == file.meta.mtime_nsec
+                        && destination_fraction_matches(
+                            file.meta.mtime_nsec,
+                            stat.st_mtime_nsec as u32,
+                        )
                 })
             })
             .collect();

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -9,7 +9,9 @@ use crate::conn::{
     endpoint_error, ok, Conn, DataAddressSource, DataTransport, Endpoint, RemoteSpec,
     SshMultiplexer, TcpCandidate, TcpPairStats,
 };
-use crate::fsops::{content_digest, is_partial_name, is_recovery_name, join};
+use crate::fsops::{
+    content_digest, destination_fraction_matches, is_partial_name, is_recovery_name, join,
+};
 pub(crate) use crate::mapping::validate_manifest_path;
 use crate::mapping::{read_mapping_manifest, DeclaredKind, ManifestEntry};
 use crate::progress::{commas, human, Progress};
@@ -4071,22 +4073,6 @@ fn kind_label(kind: Kind) -> &'static str {
 
 fn special_creation_supported(destination_supports_sockets: bool, kind: Kind) -> bool {
     kind != Kind::Socket || destination_supports_sockets
-}
-
-/// Compare at the decimal precision suggested by the destination timestamp.
-/// Trailing zeros may reflect either filesystem truncation or a round timestamp;
-/// this is the size/mtime shortcut, not a content verification.
-fn destination_fraction_matches(source: u32, destination: u32) -> bool {
-    if destination == 0 {
-        return true;
-    }
-    let mut precision = 1;
-    let mut fraction = destination;
-    while fraction.is_multiple_of(10) {
-        precision *= 10;
-        fraction /= 10;
-    }
-    source / precision == destination / precision
 }
 
 fn metadata_differs(source: &Entry, destination: &Entry, flags: u8) -> bool {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -4073,6 +4073,22 @@ fn special_creation_supported(destination_supports_sockets: bool, kind: Kind) ->
     kind != Kind::Socket || destination_supports_sockets
 }
 
+/// Compare at the decimal precision suggested by the destination timestamp.
+/// Trailing zeros may reflect either filesystem truncation or a round timestamp;
+/// this is the size/mtime shortcut, not a content verification.
+fn destination_fraction_matches(source: u32, destination: u32) -> bool {
+    if destination == 0 {
+        return true;
+    }
+    let mut precision = 1;
+    let mut fraction = destination;
+    while fraction.is_multiple_of(10) {
+        precision *= 10;
+        fraction /= 10;
+    }
+    source / precision == destination / precision
+}
+
 fn metadata_differs(source: &Entry, destination: &Entry, flags: u8) -> bool {
     (flags & flags::MODE != 0 && source.mode & 0o7777 != destination.mode & 0o7777)
         || (flags & flags::OWNER != 0 && source.uid != destination.uid)
@@ -6040,7 +6056,8 @@ impl Planner<'_> {
                         d.kind == Kind::File
                             && d.size == e.size
                             && (opts.flags & flags::TIMES != 0 && d.mtime == e.mtime)
-                            && (!opts.precise_mtime || d.mtime_nsec == e.mtime_nsec)
+                            && (!opts.precise_mtime
+                                || destination_fraction_matches(e.mtime_nsec, d.mtime_nsec))
                     });
                     let dst_newer = opts.update
                         && dst_entry.as_ref().is_some_and(|d| {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -4080,7 +4080,8 @@ fn metadata_differs(source: &Entry, destination: &Entry, flags: u8) -> bool {
         || (flags & flags::OWNER != 0 && source.uid != destination.uid)
         || (flags & flags::GROUP != 0 && source.gid != destination.gid)
         || (flags & flags::TIMES != 0
-            && (source.mtime, source.mtime_nsec) != (destination.mtime, destination.mtime_nsec))
+            && (source.mtime != destination.mtime
+                || !destination_fraction_matches(source.mtime_nsec, destination.mtime_nsec)))
 }
 
 fn publication_metadata_flags(requested: u8) -> u8 {

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -20979,3 +20979,51 @@ fn resume_prefers_a_partial_to_the_old_destination_contents() {
     );
     assert_eq!(partial_files(&t.0).len(), 1);
 }
+
+#[test]
+fn native_mtime_uses_destination_decimal_precision() {
+    // Different same-size bytes make an accidental copy/skip observable. Set
+    // exact timestamps to emulate destination truncation without mounting a FS.
+    for (source_nsec, destination_nsec, source_seconds, same_size, skipped) in [
+        (123_456_789, 123_456_789, 10, true, true),
+        (123_456_789, 123_456_788, 10, true, false),
+        (123_456_789, 123_456_700, 10, true, true),
+        (123_456_789, 123_456_800, 10, true, false),
+        (123_456_789, 120_000_000, 10, true, true),
+        (129_999_999, 120_000_000, 10, true, true),
+        (130_000_000, 120_000_000, 10, true, false),
+        (120_000_000, 123_456_789, 10, true, false),
+        (999_999_999, 0, 10, true, true),
+        (0, 0, 10, true, true),
+        (123_456_789, 0, 11, true, false),
+        (123_456_789, 0, 9, true, false),
+        (123_456_789, 120_000_000, 10, false, false),
+    ] {
+        let t = Tmp::new();
+        write(&t.path("src"), b"new");
+        write(&t.path("dst"), if same_size { b"old" } else { b"older" });
+        for (name, seconds, nanos) in [
+            ("src", source_seconds, source_nsec),
+            ("dst", 10, destination_nsec),
+        ] {
+            let time = std::time::UNIX_EPOCH + std::time::Duration::new(seconds, nanos);
+            File::options()
+                .write(true)
+                .open(t.path(name))
+                .unwrap()
+                .set_times(fs::FileTimes::new().set_modified(time))
+                .unwrap();
+        }
+        run_native_ok(&["cp", &t.s("src"), "--as", &t.s("dst")]);
+        assert_eq!(
+            read(&t.path("dst")),
+            if skipped { b"old" } else { b"new" },
+            "source={source_seconds}.{source_nsec:09}, destination=10.{destination_nsec:09}"
+        );
+        if skipped {
+            // Content verification must bypass the inferred-precision shortcut.
+            run_native_ok(&["cp", "--hash", &t.s("src"), "--as", &t.s("dst")]);
+            assert_eq!(read(&t.path("dst")), b"new");
+        }
+    }
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -21116,3 +21116,36 @@ fn native_mtime_uses_destination_decimal_precision() {
         }
     }
 }
+
+#[test]
+fn directory_dry_run_uses_destination_timestamp_precision() {
+    for (source_ns, destination_ns, differs) in [
+        (123_456_789, 120_000_000, false),
+        (123_456_789, 0, false),
+        (123_456_789, 130_000_000, true),
+        (120_000_000, 123_456_789, true),
+    ] {
+        let t = Tmp::new();
+        fs::create_dir_all(t.path("src/sub")).unwrap();
+        fs::create_dir_all(t.path("dst/sub")).unwrap();
+        set_mtime(&t.path("src"), 10);
+        set_mtime(&t.path("dst"), 10);
+        for (name, nanos) in [("src/sub", source_ns), ("dst/sub", destination_ns)] {
+            File::open(t.path(name))
+                .unwrap()
+                .set_times(
+                    fs::FileTimes::new()
+                        .set_modified(std::time::UNIX_EPOCH + std::time::Duration::new(10, nanos)),
+                )
+                .unwrap();
+        }
+        let out = syq_cp_in(
+            &t.path(""),
+            &["src", "--as", "dst", "--dry-run", "-v"],
+            None,
+        );
+        assert_output_ok(&out);
+        let stderr = String::from_utf8_lossy(&out.stdout);
+        assert_eq!(stderr.contains("metadata"), differs, "{stderr}");
+    }
+}

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -8243,6 +8243,95 @@ fn native_remote_rm_uses_explicit_or_path_selected_helpers() {
 /// results records must match the ordinary engine's for the same copy, and
 /// anything the one-turn path declines must reach the engine unchanged.
 #[test]
+fn small_push_mtime_precision_matches_stats_dry_run_and_hash() {
+    for (source_seconds, source_nsec, destination_nsec, same_size, matches) in [
+        (10, 123_456_789, 120_000_000, true, true),
+        (10, 123_456_789, 123_456_700, true, true),
+        (10, 123_456_789, 0, true, true),
+        (10, 130_000_000, 120_000_000, true, false),
+        (10, 120_000_000, 123_456_789, true, false),
+        (11, 123_456_789, 120_000_000, true, false),
+        (10, 123_456_789, 120_000_000, false, false),
+    ] {
+        for option in [None, Some("--stats"), Some("--dry-run"), Some("--hash")] {
+            let t = Tmp::new();
+            let ssh = fake_ssh(&t);
+            write(&t.path("source"), b"new");
+            let old: &[u8] = if same_size { b"old" } else { b"older" };
+            write(&t.path("remote-home/dest/source"), old);
+            for (path, seconds, nanos) in [
+                ("source", source_seconds, source_nsec),
+                ("remote-home/dest/source", 10, destination_nsec),
+            ] {
+                File::open(t.path(path))
+                    .unwrap()
+                    .set_times(fs::FileTimes::new().set_modified(
+                        std::time::UNIX_EPOCH + std::time::Duration::new(seconds, nanos),
+                    ))
+                    .unwrap();
+            }
+            let before = fs::metadata(t.path("remote-home/dest/source")).unwrap();
+            let mut command = Command::new(env!("CARGO_BIN_EXE_syq"));
+            command
+                .args([
+                    "cp",
+                    "--syq-path",
+                    env!("CARGO_BIN_EXE_syq"),
+                    "--no-progress",
+                    "--results",
+                    &t.s("results.ndjson"),
+                    &t.s("source"),
+                    "--to",
+                    "fake.example",
+                    "--into",
+                    &t.s("remote-home/dest"),
+                ])
+                .env("FAKE_REMOTE_HOME", t.path("remote-home"))
+                .env("FAKE_REMOTE_BIN", t.path("remote-bin"))
+                .env("FAKE_RSH_LOG", t.path("rsh.log"))
+                .env(
+                    "PATH",
+                    format!("{}:/usr/bin:/bin", ssh.parent().unwrap().display()),
+                )
+                .env("SYQ_DEBUG", "1");
+            if let Some(option) = option {
+                command.arg(option);
+            }
+            let output = command.run().unwrap();
+            assert_output_ok(&output);
+            assert_eq!(
+                stderr_of(&output).contains("small copy: published"),
+                option.is_none(),
+                "wrong dispatch for {option:?}: {}",
+                stderr_of(&output)
+            );
+            let skipped = matches && option != Some("--hash");
+            let unchanged = skipped || option == Some("--dry-run");
+            assert_eq!(read(&t.path("remote-home/dest/source")), if unchanged { old } else { b"new" },
+                "option={option:?}, source={source_seconds}.{source_nsec:09}, destination=10.{destination_nsec:09}");
+            if unchanged {
+                let after = fs::metadata(t.path("remote-home/dest/source")).unwrap();
+                assert_eq!(after.ino(), before.ino());
+                assert_eq!(
+                    (after.mtime(), after.mtime_nsec()),
+                    (before.mtime(), before.mtime_nsec())
+                );
+            }
+            let records = fs::read_to_string(t.path("results.ndjson")).unwrap();
+            let result: serde_json::Value =
+                serde_json::from_str(records.lines().last().unwrap()).unwrap();
+            assert_eq!(result["status"], "success");
+            assert_eq!(result["files_unchanged"], u64::from(skipped), "{records}");
+            assert_eq!(
+                result["bytes_transferred"],
+                if skipped { 0 } else { 3 },
+                "{records}"
+            );
+        }
+    }
+}
+
+#[test]
 fn small_pushes_take_one_turn_and_match_the_engine() {
     let t = Tmp::new();
     let ssh = fake_ssh(&t);


### PR DESCRIPTION
`syq cp` now compares fractional mtimes at the decimal precision suggested by the destination timestamp: `.120000000` matches source `.123456789`, while whole seconds and sizes must still match. The planner and the small-file remote receiver use the same comparison, so enabling `--stats` or previewing with `--dry-run` does not change the skip decision. Directory metadata previews use the same fractional rule; live copies still restore directory timestamps after child mutations. This avoids repeated file work and noisy directory previews after decimal timestamp truncation.

Trailing zeros are a heuristic: same-size changes within the ignored fraction can be skipped. `--hash` still checks contents, and `syq rsync` keeps its seconds-only comparison.

Validation at `407c6e4`: formatting, Clippy with all targets/features and warnings denied, `cargo test --all-targets`, and documentation links passed. The native suite includes the 13-case local timestamp/size matrix, existing subsecond/older-edit tests, and a new remote-helper regression with 28 cases spanning the normal small-copy path, `--stats`, `--dry-run`, and `--hash`. It checks contents, skipped destination identity/timestamps, results accounting and actual dispatch. The remote regression reproduced the reported replacement on `0192e97` before the fix. The rsync compatibility guide also links to the destination-precision explanation. The documentation correction passed link checks at `daaf3d9`. Directory-preview follow-up `22ad295` passed formatting, Clippy, 629 unit tests (one existing ignored), 25 directory-focused integration tests, and documentation links. Its regression covers matching truncated timestamps and differences outside the destination precision. Full default real-SSH validation of the receiver fix at `407c6e4` passed; lab containers, networks, volumes, and image were removed. No actual coarse-filesystem mount or macOS execution was performed locally.

Compatibility: inspected released `v0.5.2`, whose general planner used seconds-only matching. No timestamp storage, helper message, resume identity or automation schema changes. Existing filesystem timestamps remain readable by both versions; the new native comparison uses the destination's apparent decimal precision.


Full SSH validation was not repeated for the directory-preview-only follow-up.


Synchronized with master `32492e5` at `9715735`. The append-location conflict preserves both timestamp regressions and the many-root prune regression. Formatting, Clippy, `cargo test --all-targets`, and documentation links passed on the merge commit. Full real-SSH validation was not repeated for this synchronization; the conflict only joined independent test additions. A merge simulation with PR332 at `52103fb` also succeeds.

Current branch status:

```text
Worktree: /home/grant/repos/syq/.worktrees/timestamp-precision
Branch:   timestamp-precision at 9715735 (clean)
Upstream: origin/timestamp-precision (ahead 0, behind 0)
Master:   3662857 from refs/heads/master (branch is ahead 12, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           in_progress  32492e5  https://github.com/greaber/syq/actions/runs/34717975333
  rsync-compat.yml success      32492e5  https://github.com/greaber/syq/actions/runs/34717975352
  macos.yml        in_progress  32492e5  https://github.com/greaber/syq/actions/runs/34717975358

Pull request: #330 https://github.com/greaber/syq/pull/330
  base master, open, review none, merge state clean
  GitHub head 9715735: matches local 9715735
  checks: none registered yet
```
