### PR TITLE
Reduce prune planner memory and skip unnecessary alias lookups

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -803,7 +803,12 @@ fn spawn_reader(
     std::sync::mpsc::Receiver<std::io::Result<crate::wire_budget::Budgeted<Response>>>,
     std::thread::JoinHandle<()>,
 ) {
-    let (tx, rx) = std::sync::mpsc::sync_channel(read_ahead);
+    // Control requests also pipeline up to the default depth. Keeping that
+    // capacity prevents a sequential helper blocking on replies while its
+    // coordinator is still sending requests (including large path batches).
+    let (tx, rx) = std::sync::mpsc::sync_channel(
+        read_ahead.max(crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH),
+    );
     let reader = std::thread::spawn(move || {
         let mut r = FrameReader::new(input);
         r.set_limit(MAX_HANDSHAKE_FRAME);
@@ -1538,7 +1543,8 @@ pub struct RemoteSpec {
     pub(crate) primed_control: std::sync::Arc<std::sync::Mutex<PrimedControl>>,
     /// Must cover the worker request pipeline: otherwise a helper blocked
     /// writing responses can stop reading requests while the coordinator is
-    /// still filling its pipeline. Control sessions do not need this depth.
+    /// still filling its pipeline. Readers also reserve the default depth
+    /// for pipelined control lookups.
     pub(crate) read_ahead: usize,
     pub(crate) forwarded: Option<std::sync::Arc<crate::destination::NamedReceipt>>,
 }
@@ -4263,63 +4269,66 @@ mod tests {
     #[test]
     fn tuning_pipeline_drains_responses_while_sending_large_requests() {
         use std::os::unix::net::UnixStream;
-        let (coordinator, helper) = UnixStream::pair().unwrap();
-        let timeout = std::time::Duration::from_secs(5);
-        for socket in [&coordinator, &helper] {
-            socket.set_read_timeout(Some(timeout)).unwrap();
-            socket.set_write_timeout(Some(timeout)).unwrap();
-        }
-        let depth = 64;
-        let server = std::thread::spawn(move || {
-            let mut requests = FrameReader::new(helper.try_clone().unwrap());
-            let mut responses = FrameWriter::new(helper, false);
-            responses.write_msg(&hello_ok()).unwrap();
-            for _ in 0..depth {
-                let Request::ReadRange { off, len, .. } = requests.read_msg().unwrap() else {
-                    panic!("expected a range request");
-                };
-                responses
-                    .write_msg(&Response::Block {
-                        off,
-                        hash: [0; 32],
-                        data: vec![7; len as usize],
+        // Even a one-deep file pipeline must accommodate control batches.
+        for (read_ahead, depth) in [(1, 4), (64, 64)] {
+            let (coordinator, helper) = UnixStream::pair().unwrap();
+            let timeout = std::time::Duration::from_secs(5);
+            for socket in [&coordinator, &helper] {
+                socket.set_read_timeout(Some(timeout)).unwrap();
+                socket.set_write_timeout(Some(timeout)).unwrap();
+            }
+            let server = std::thread::spawn(move || {
+                let mut requests = FrameReader::new(helper.try_clone().unwrap());
+                let mut responses = FrameWriter::new(helper, false);
+                responses.write_msg(&hello_ok()).unwrap();
+                for _ in 0..depth {
+                    let Request::ReadRange { off, len, .. } = requests.read_msg().unwrap() else {
+                        panic!("expected a range request");
+                    };
+                    responses
+                        .write_msg(&Response::Block {
+                            off,
+                            hash: [0; 32],
+                            data: vec![7; len as usize],
+                        })
+                        .unwrap();
+                }
+            });
+            let (responses, reader) =
+                spawn_reader(Box::new(coordinator.try_clone().unwrap()), read_ahead);
+            assert!(matches!(
+                responses.recv_timeout(timeout).unwrap().unwrap().value,
+                Response::HelloOk { .. }
+            ));
+            let mut requests = FrameWriter::new(coordinator, false);
+            // Both directions exceed socket buffering. A reader queue stuck at
+            // four responses deadlocks against a sequential helper while the
+            // coordinator is still sending its 64 requests.
+            for i in 0..depth {
+                requests
+                    .write_msg(&Request::ReadRange {
+                        path: vec![b'x'; 16 << 10],
+                        source: None,
+                        attempt: 0,
+                        off: i as u64 * (64 << 10),
+                        len: 64 << 10,
                     })
                     .unwrap();
             }
-        });
-        let (responses, reader) = spawn_reader(Box::new(coordinator.try_clone().unwrap()), depth);
-        assert!(matches!(
-            responses.recv_timeout(timeout).unwrap().unwrap().value,
-            Response::HelloOk { .. }
-        ));
-        let mut requests = FrameWriter::new(coordinator, false);
-        // Both directions exceed socket buffering. A reader queue stuck at
-        // four responses deadlocks against a sequential helper while the
-        // coordinator is still sending its 64 requests.
-        for i in 0..depth {
-            requests
-                .write_msg(&Request::ReadRange {
-                    path: vec![b'x'; 16 << 10],
-                    source: None,
-                    attempt: 0,
-                    off: i as u64 * (64 << 10),
-                    len: 64 << 10,
-                })
-                .unwrap();
-        }
-        for i in 0..depth {
-            let response = responses
-                .recv_timeout(timeout)
-                .unwrap()
-                .unwrap()
-                .into_inner();
-            assert!(matches!(response, Response::Block { off, data, .. }
+            for i in 0..depth {
+                let response = responses
+                    .recv_timeout(timeout)
+                    .unwrap()
+                    .unwrap()
+                    .into_inner();
+                assert!(matches!(response, Response::Block { off, data, .. }
                 if off == i as u64 * (64 << 10) && data == vec![7; 64 << 10]));
+            }
+            drop(responses);
+            drop(requests);
+            server.join().unwrap();
+            reader.join().unwrap();
         }
-        drop(responses);
-        drop(requests);
-        server.join().unwrap();
-        reader.join().unwrap();
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -4571,20 +4571,38 @@ struct PruneWalk<'a> {
 }
 
 impl<'a> PruneWalk<'a> {
-    fn new(seen: &'a std::collections::HashMap<PathBytes, Claim>, root: &[u8]) -> Self {
+    fn new(
+        seen: &'a std::collections::HashMap<PathBytes, Claim>,
+        root: &[u8],
+        sorted: Option<&[&'a PathBytes]>,
+    ) -> Self {
         Self {
             seen,
-            unmatched: seen
-                .keys()
-                .filter(|path| path_is_inside(path, root))
-                .collect(),
+            unmatched: match sorted {
+                Some(paths) => {
+                    let mut prefix = root.to_vec();
+                    if !prefix.ends_with(b"/") {
+                        prefix.push(b'/');
+                    }
+                    let start = paths.partition_point(|path| path.as_slice() < prefix.as_slice());
+                    paths[start..]
+                        .iter()
+                        .copied()
+                        .take_while(|path| path.starts_with(&prefix))
+                        .collect()
+                }
+                None => seen
+                    .keys()
+                    .filter(|path| path_is_inside(path, root))
+                    .collect(),
+            },
             entries: Vec::new(),
             shielded: Default::default(),
             recovery_parents: Default::default(),
         }
     }
 
-    fn push(&mut self, entry: Entry, root: &[u8], nested: &[PathBytes]) {
+    fn push(&mut self, mut entry: Entry, root: &[u8], nested: &[PathBytes]) {
         if entry.path.is_empty() {
             return;
         }
@@ -4614,6 +4632,7 @@ impl<'a> PruneWalk<'a> {
             }
             return;
         }
+        entry.path = full;
         self.entries.push(entry);
     }
 
@@ -4621,7 +4640,7 @@ impl<'a> PruneWalk<'a> {
         // Apply exact directory shields after all batches, independently of
         // scan order. Alias directory shields are applied after lookup.
         self.entries
-            .retain(|entry| !Planner::under_any(&self.shielded, &join(root, &entry.path), root));
+            .retain(|entry| !Planner::under_any(&self.shielded, &entry.path, root));
     }
 }
 
@@ -4640,30 +4659,63 @@ fn lookup_prune_aliases(
         .map(|entry| (entry.dev, entry.ino))
         .collect();
     let mut unmatched = walk.unmatched.iter();
+    // Remote response queues hold at least this many replies, even when the
+    // file-data pipeline is configured smaller. Local calls execute in send.
+    let depth = if conn.supports_request_pipelining() {
+        crate::transfer_tuning::DEFAULT_PIPELINE_DEPTH
+    } else {
+        1
+    };
+    let mut pending = std::collections::VecDeque::new();
+    let mut exhausted = false;
     loop {
-        let paths: Vec<_> = unmatched
-            .by_ref()
-            .take(512)
-            .map(|path| (**path).clone())
-            .collect();
-        if paths.is_empty() {
-            break;
-        }
-        let stats = match ok(
-            conn.call(Request::PruneLookup {
+        while !exhausted && pending.len() < depth {
+            let paths: Vec<_> = unmatched
+                .by_ref()
+                .take(512)
+                .map(|path| (**path).clone())
+                .collect();
+            if paths.is_empty() {
+                exhausted = true;
+                break;
+            }
+            if let Err(error) = conn.send(Request::PruneLookup {
                 paths: paths.clone(),
                 guard: guard.cloned(),
-            })?,
-            "inspect prune aliases",
-        )? {
-            Response::Stats(stats) => stats,
-            other => bail!("unexpected prune lookup response {other:?}"),
+            }) {
+                if !conn.is_dead() {
+                    crate::conn::drain_range_replies(conn, pending.len(), "inspect prune aliases")?;
+                }
+                return Err(error);
+            }
+            pending.push_back(paths);
+        }
+        let Some(paths) = pending.pop_front() else {
+            break;
+        };
+        let response = conn.recv()?;
+        let stats = (|| -> Result<_> {
+            match ok(response, "inspect prune aliases")? {
+                Response::Stats(stats) if stats.len() == paths.len() => Ok(stats),
+                Response::Stats(stats) => bail!(
+                    "stat reply count {} does not match request count {}",
+                    stats.len(),
+                    paths.len()
+                ),
+                other => bail!("unexpected prune lookup response {other:?}"),
+            }
+        })();
+        let stats = match stats {
+            Ok(stats) => stats,
+            Err(error) => {
+                // Keep the shared control connection at a request boundary.
+                crate::conn::drain_range_replies(conn, pending.len(), "inspect prune aliases")?;
+                return Err(error);
+            }
         };
         for (path, entry) in paths.iter().zip(stats) {
             if let Some(entry) = entry {
                 let identity = (entry.dev, entry.ino);
-                // Retain all ambiguous hard links, but do not accumulate
-                // identities that cannot protect any deletion candidate.
                 if candidates.contains(&identity) {
                     aliases.insert(identity, walk.seen[path]);
                 }
@@ -6981,16 +7033,20 @@ impl Planner<'_> {
         let mut roots = std::mem::take(&mut self.delete_roots);
         roots.sort();
         roots.dedup();
-        let inside = |p: &[u8], r: &[u8]| {
-            p.starts_with(r) && (r.ends_with(b"/") || p.get(r.len()) == Some(&b'/'))
-        };
+        // Sorting costs more than a few linear scans. Larger root sets share
+        // one index; focused timings cover this crossover.
+        let sorted_claims = (roots.len() >= 32).then(|| {
+            let mut paths: Vec<_> = self.dst_seen.keys().collect();
+            paths.sort_unstable();
+            paths
+        });
         for (root, sub) in roots.clone() {
             // Every root is walked with its own --ignore anchoring. A root nested in
             // this one (`syq rsync --delete a b/ dst`: dst/a inside dst) is left to
             // its own walk, so its patterns apply and nothing is deleted twice.
             let nested: Vec<PathBytes> = roots
                 .iter()
-                .filter(|(r, _)| *r != root && inside(r, &root))
+                .filter(|(r, _)| *r != root && path_is_inside(r, &root))
                 .map(|(r, _)| r.clone())
                 .collect();
             // Not there yet (a dry run into a new destination): nothing to delete.
@@ -7010,7 +7066,7 @@ impl Planner<'_> {
                 std::collections::HashSet::new();
             let mut partial_parents = std::collections::HashMap::new();
             let mut alias_parents = std::collections::HashSet::new();
-            let mut walk = PruneWalk::new(&self.dst_seen, &root);
+            let mut walk = PruneWalk::new(&self.dst_seen, &root, sorted_claims.as_deref());
             let res = self.dst.scan(
                 &root,
                 None,
@@ -7052,17 +7108,12 @@ impl Planner<'_> {
             let aliases = lookup_prune_aliases(self.dst, &walk, self.container_guard.as_ref())?;
             let mut shielded = walk.shielded;
             let recovery_parents = walk.recovery_parents;
-            for entry in &walk.entries {
-                let entry_path = &entry.path;
+            for entry in walk.entries {
+                let full = entry.path;
+                let entry_path =
+                    &full[root.len() + usize::from(!root.is_empty() && !root.ends_with(b"/"))..];
                 let entry_kind = entry.kind;
-
-                if entry_path.is_empty() {
-                    continue;
-                }
-                let full = join(&root, entry_path);
-                if nested.iter().any(|n| *n == full || inside(&full, n))
-                    || Planner::under_any(&shielded, &full, &root)
-                {
+                if Planner::under_any(&shielded, &full, &root) {
                     continue;
                 }
                 let claimed = aliases.get(&(entry.dev, entry.ino));
@@ -8936,12 +8987,19 @@ mod tests {
         requests: Vec<Request>,
         replies: std::collections::VecDeque<Response>,
         received: usize,
+        max_pending: usize,
+        local: bool,
+        latency: Option<std::time::Duration>,
+        ready: std::collections::VecDeque<std::time::Instant>,
         abort_on_receive: Option<Arc<Sched>>,
     }
 
     struct PipelineConn(Arc<Mutex<PipelineState>>);
 
     impl Conn for PipelineConn {
+        fn supports_request_pipelining(&self) -> bool {
+            !self.0.lock().unwrap().local
+        }
         fn begin_streaming_writes(&mut self) -> Result<()> {
             Ok(())
         }
@@ -8949,12 +9007,20 @@ mod tests {
             Ok(())
         }
         fn send(&mut self, request: Request) -> Result<()> {
-            self.0.lock().unwrap().requests.push(request);
+            let mut state = self.0.lock().unwrap();
+            state.requests.push(request);
+            if let Some(latency) = state.latency {
+                state.ready.push_back(std::time::Instant::now() + latency);
+            }
+            state.max_pending = state.max_pending.max(state.requests.len() - state.received);
             Ok(())
         }
         fn recv(&mut self) -> Result<Response> {
             let mut state = self.0.lock().unwrap();
             state.received += 1;
+            if let Some(ready) = state.ready.pop_front() {
+                std::thread::sleep(ready.saturating_duration_since(std::time::Instant::now()));
+            }
             if let Some(sched) = state.abort_on_receive.take() {
                 sched.abort();
             }
@@ -9049,6 +9115,103 @@ mod tests {
     }
 
     #[test]
+    fn prune_index_preserves_root_boundaries() {
+        let seen: std::collections::HashMap<_, _> = [
+            "dst",
+            "dst/file",
+            "dst/sub",
+            "dst/sub/file",
+            "dst/submarine/file",
+            "dst2/file",
+            "/file",
+        ]
+        .into_iter()
+        .map(|p| (p.as_bytes().to_vec(), Claim::Leaf))
+        .collect();
+        let mut sorted: Vec<_> = seen.keys().collect();
+        sorted.sort_unstable();
+        for root in [
+            b"dst".as_slice(),
+            b"dst/",
+            b"dst/sub",
+            b"dst/sub/",
+            b"missing",
+            b"/",
+            b"",
+        ] {
+            assert_eq!(
+                PruneWalk::new(&seen, root, None).unmatched,
+                PruneWalk::new(&seen, root, Some(&sorted)).unmatched
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "manual planner timing; run with --release --ignored --nocapture"]
+    fn prune_index_timing() {
+        use std::time::Instant;
+        let count = 200_000;
+        for roots in [1, 2, 10, 16, 32, 100] {
+            let seen: std::collections::HashMap<_, _> = (0..count)
+                .map(|i| {
+                    (
+                        format!("destination/root-{:03}/directory/file-{i:08}", i % roots)
+                            .into_bytes(),
+                        Claim::Leaf,
+                    )
+                })
+                .collect();
+            let root_paths: Vec<_> = (0..roots)
+                .map(|i| format!("destination/root-{i:03}").into_bytes())
+                .collect();
+            let start = Instant::now();
+            for root in &root_paths {
+                std::hint::black_box(PruneWalk::new(&seen, root, None));
+            }
+            let original = start.elapsed();
+            let start = Instant::now();
+            let mut sorted: Vec<_> = seen.keys().collect();
+            sorted.sort_unstable();
+            let sorting = start.elapsed();
+            for root in &root_paths {
+                std::hint::black_box(PruneWalk::new(&seen, root, Some(&sorted)));
+            }
+            eprintln!("claims={count} roots={roots} scan={original:?} index_total={:?} sorting={sorting:?}", start.elapsed());
+        }
+    }
+
+    #[test]
+    #[ignore = "manual simulated-latency timing; run with --ignored --nocapture"]
+    fn prune_pipeline_timing() {
+        let directory = tempfile::tempdir().unwrap();
+        let candidate = crate::fsops::lstat_entry(b"extra".to_vec(), directory.path()).unwrap();
+        let seen = (0..4096)
+            .map(|i| (format!("dst/file-{i}").into_bytes(), Claim::Leaf))
+            .collect();
+        let mut walk = PruneWalk::new(&seen, b"dst", None);
+        walk.push(candidate, b"dst", &[]);
+        for local in [true, false] {
+            let state = Arc::new(Mutex::new(PipelineState {
+                local,
+                latency: Some(std::time::Duration::from_millis(20)),
+                ..Default::default()
+            }));
+            state
+                .lock()
+                .unwrap()
+                .replies
+                .extend((0..8).map(|_| Response::Stats(vec![None; 512])));
+            let start = std::time::Instant::now();
+            lookup_prune_aliases(&mut PipelineConn(state.clone()), &walk, None).unwrap();
+            eprintln!(
+                "simulated RTT=20ms paths=4096 sequential={local} elapsed={:?}",
+                start.elapsed()
+            );
+            assert_eq!(state.lock().unwrap().max_pending, if local { 1 } else { 4 });
+        }
+    }
+
+    #[test]
     fn prune_walk_drops_synced_entries_and_skips_empty_candidate_lookups() {
         let directory = tempfile::tempdir().unwrap();
         let file = directory.path().join("file");
@@ -9057,7 +9220,7 @@ mod tests {
         let seen: std::collections::HashMap<_, _> = (0..10_000)
             .map(|index| (format!("dst/file-{index}").into_bytes(), Claim::Leaf))
             .collect();
-        let mut walk = PruneWalk::new(&seen, b"dst");
+        let mut walk = PruneWalk::new(&seen, b"dst", None);
         for index in 0..9_000 {
             let mut entry = template.clone();
             entry.path = format!("file-{index}").into_bytes();
@@ -9079,7 +9242,7 @@ mod tests {
         let seen = [(b"dst/blocked".to_vec(), Claim::Weak)]
             .into_iter()
             .collect();
-        let mut walk = PruneWalk::new(&seen, b"dst");
+        let mut walk = PruneWalk::new(&seen, b"dst", None);
         // The child deliberately arrives before its claimed directory.
         for path in [
             "blocked/child",
@@ -9094,7 +9257,7 @@ mod tests {
         walk.finish_scan(b"dst");
         assert!(walk.unmatched.is_empty());
         assert_eq!(walk.entries.len(), 1);
-        assert_eq!(walk.entries[0].path, b"extra");
+        assert_eq!(walk.entries[0].path, b"dst/extra");
         assert!(walk.recovery_parents.contains(b"dst/old".as_slice()));
     }
 
@@ -9105,10 +9268,10 @@ mod tests {
         std::fs::write(&file, b"contents").unwrap();
         let mut candidate = crate::fsops::lstat_entry(b"stored-name".to_vec(), &file).unwrap();
         candidate.ino = 42;
-        let seen: std::collections::HashMap<_, _> = (0..1_025)
+        let seen: std::collections::HashMap<_, _> = (0..3_073)
             .map(|index| (format!("dst/claim-{index}").into_bytes(), Claim::Leaf))
             .collect();
-        let mut walk = PruneWalk::new(&seen, b"dst");
+        let mut walk = PruneWalk::new(&seen, b"dst", None);
         walk.push(candidate.clone(), b"dst", &[]);
         let mut unrelated = candidate.clone();
         unrelated.ino = 43;
@@ -9116,21 +9279,28 @@ mod tests {
         state.lock().unwrap().replies.extend([
             Response::Stats(vec![Some(unrelated); 512]),
             Response::Stats(vec![None; 512]),
+            Response::Stats(vec![None; 512]),
+            Response::Stats(vec![None; 512]),
+            Response::Stats(vec![None; 512]),
+            Response::Stats(vec![None; 512]),
             Response::Stats(vec![Some(candidate.clone())]),
         ]);
         let aliases = lookup_prune_aliases(&mut PipelineConn(state.clone()), &walk, None).unwrap();
         assert_eq!(aliases.len(), 1);
         assert_eq!(aliases[&(candidate.dev, candidate.ino)], Claim::Leaf);
-        assert_eq!(state.lock().unwrap().requests.len(), 3);
+        assert_eq!(state.lock().unwrap().requests.len(), 7);
+        assert_eq!(state.lock().unwrap().max_pending, 4);
         assert!(state.lock().unwrap().replies.is_empty());
 
         let malformed = Arc::new(Mutex::new(PipelineState::default()));
-        malformed
-            .lock()
-            .unwrap()
-            .replies
-            .push_back(Response::Stats(vec![]));
-        assert!(lookup_prune_aliases(&mut PipelineConn(malformed), &walk, None).is_err());
+        malformed.lock().unwrap().replies.extend([
+            Response::Stats(vec![]),
+            Response::Stats(vec![None; 512]),
+            Response::Stats(vec![None; 512]),
+            Response::Stats(vec![None; 512]),
+        ]);
+        assert!(lookup_prune_aliases(&mut PipelineConn(malformed.clone()), &walk, None).is_err());
+        assert!(malformed.lock().unwrap().replies.is_empty());
     }
 
     #[test]

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -4560,6 +4560,123 @@ enum Claim {
     Weak,
 }
 
+/// Keep destination-only candidates, borrowing source claim paths instead of
+/// copying every destination spelling. Exact matches are discarded as scanned.
+struct PruneWalk<'a> {
+    seen: &'a std::collections::HashMap<PathBytes, Claim>,
+    unmatched: std::collections::HashSet<&'a PathBytes>,
+    entries: Vec<Entry>,
+    shielded: std::collections::HashSet<PathBytes>,
+    recovery_parents: std::collections::HashSet<PathBytes>,
+}
+
+impl<'a> PruneWalk<'a> {
+    fn new(seen: &'a std::collections::HashMap<PathBytes, Claim>, root: &[u8]) -> Self {
+        Self {
+            seen,
+            unmatched: seen
+                .keys()
+                .filter(|path| path_is_inside(path, root))
+                .collect(),
+            entries: Vec::new(),
+            shielded: Default::default(),
+            recovery_parents: Default::default(),
+        }
+    }
+
+    fn push(&mut self, entry: Entry, root: &[u8], nested: &[PathBytes]) {
+        if entry.path.is_empty() {
+            return;
+        }
+        let full = join(root, &entry.path);
+        if entry
+            .path
+            .split(|byte| *byte == b'/')
+            .any(|name| is_recovery_name(OsStr::from_bytes(name)))
+        {
+            for (index, byte) in full.iter().enumerate() {
+                if *byte == b'/' {
+                    self.recovery_parents.insert(full[..index].to_vec());
+                }
+            }
+            return;
+        }
+        self.unmatched.remove(&full);
+        if nested
+            .iter()
+            .any(|n| *n == full || path_is_inside(&full, n))
+        {
+            return;
+        }
+        if let Some(claim) = self.seen.get(&full) {
+            if *claim != Claim::Dir && entry.kind == Kind::Dir {
+                self.shielded.insert(full);
+            }
+            return;
+        }
+        self.entries.push(entry);
+    }
+
+    fn finish_scan(&mut self, root: &[u8]) {
+        // Apply exact directory shields after all batches, independently of
+        // scan order. Alias directory shields are applied after lookup.
+        self.entries
+            .retain(|entry| !Planner::under_any(&self.shielded, &join(root, &entry.path), root));
+    }
+}
+
+fn lookup_prune_aliases(
+    conn: &mut dyn Conn,
+    walk: &PruneWalk<'_>,
+    guard: Option<&ContainerGuard>,
+) -> Result<std::collections::HashMap<(u64, u64), Claim>> {
+    let mut aliases = std::collections::HashMap::new();
+    if walk.entries.is_empty() {
+        return Ok(aliases);
+    }
+    let candidates: std::collections::HashSet<_> = walk
+        .entries
+        .iter()
+        .map(|entry| (entry.dev, entry.ino))
+        .collect();
+    let mut unmatched = walk.unmatched.iter();
+    loop {
+        let paths: Vec<_> = unmatched
+            .by_ref()
+            .take(512)
+            .map(|path| (**path).clone())
+            .collect();
+        if paths.is_empty() {
+            break;
+        }
+        let stats = match ok(
+            conn.call(Request::PruneLookup {
+                paths: paths.clone(),
+                guard: guard.cloned(),
+            })?,
+            "inspect prune aliases",
+        )? {
+            Response::Stats(stats) => stats,
+            other => bail!("unexpected prune lookup response {other:?}"),
+        };
+        for (path, entry) in paths.iter().zip(stats) {
+            if let Some(entry) = entry {
+                let identity = (entry.dev, entry.ino);
+                // Retain all ambiguous hard links, but do not accumulate
+                // identities that cannot protect any deletion candidate.
+                if candidates.contains(&identity) {
+                    aliases.insert(identity, walk.seen[path]);
+                }
+            }
+        }
+    }
+    Ok(aliases)
+}
+
+fn path_is_inside(path: &[u8], root: &[u8]) -> bool {
+    path.starts_with(root) && (root.ends_with(b"/") || path.get(root.len()) == Some(&b'/'))
+}
+
 /// Everything the planner decided about one source entry, made once in the
 /// mapping loop so the directory pass and the per-kind arms can't disagree.
 struct Planned {
@@ -6892,15 +7009,8 @@ impl Planner<'_> {
             let mut protected: std::collections::HashSet<PathBytes> =
                 std::collections::HashSet::new();
             let mut partial_parents = std::collections::HashMap::new();
-            let mut recovery_parents = std::collections::HashSet::new();
             let mut alias_parents = std::collections::HashSet::new();
-            // Destination directories whose path the source claims as a
-            // non-directory (a file we chose not to send, a symlink skipped
-            // without -l, ...). The source has that path, so syq doesn't touch
-            // it — and gutting the directory underneath would be touching it.
-            let mut shielded: std::collections::HashSet<PathBytes> =
-                std::collections::HashSet::new();
-            let mut entries = Vec::new();
+            let mut walk = PruneWalk::new(&self.dst_seen, &root);
             let res = self.dst.scan(
                 &root,
                 None,
@@ -6909,26 +7019,7 @@ impl Planner<'_> {
                 true,
                 &mut |batch: Vec<Entry>| {
                     for entry in batch {
-                        if entry.path.is_empty() {
-                            continue;
-                        }
-                        if entry
-                            .path
-                            .split(|byte| *byte == b'/')
-                            .any(|name| is_recovery_name(OsStr::from_bytes(name)))
-                        {
-                            // A recovery entry can be a directory with old
-                            // contents. Protect the entire subtree and every
-                            // ancestor, independently of scan ordering.
-                            let full = join(&root, &entry.path);
-                            for (index, byte) in full.iter().enumerate() {
-                                if *byte == b'/' {
-                                    recovery_parents.insert(full[..index].to_vec());
-                                }
-                            }
-                            continue;
-                        }
-                        entries.push(entry);
+                        walk.push(entry, &root, &nested);
                     }
                     Ok(())
                 },
@@ -6952,43 +7043,16 @@ impl Planner<'_> {
             if self.delete_walk_failed {
                 return Ok(());
             }
-            // Prefer exact directory-entry spellings. Only claims absent from
-            // the walk need an actual receiver lookup: case/normalization
-            // aliases can resolve to an entry whose stored spelling differs.
-            // Do this after permission repair, without guessing filesystem
-            // naming rules or adding writes to dry runs.
-            let spellings: std::collections::HashSet<_> = entries
-                .iter()
-                .map(|entry| join(&root, &entry.path))
-                .collect();
-            let unmatched: Vec<_> = self
-                .dst_seen
-                .keys()
-                .filter(|path| inside(path, &root) && !spellings.contains(*path))
-                .cloned()
-                .collect();
-            let mut aliases = std::collections::HashMap::new();
-            for paths in unmatched.chunks(512) {
-                let stats = match ok(
-                    self.dst.call(Request::PruneLookup {
-                        paths: paths.to_vec(),
-                        guard: self.container_guard.clone(),
-                    })?,
-                    "inspect prune aliases",
-                )? {
-                    Response::Stats(stats) => stats,
-                    other => bail!("unexpected prune lookup response {other:?}"),
-                };
-                for (path, entry) in paths.iter().zip(stats) {
-                    if let Some(entry) = entry {
-                        // When several hard links could be the alias, retain
-                        // all of them. Exact-spelling claims above do not
-                        // protect unrelated hard links from pruning.
-                        aliases.insert((entry.dev, entry.ino), path.clone());
-                    }
-                }
+            walk.finish_scan(&root);
+            // There is nothing for an alias to protect when no candidates
+            // remain, including dry runs whose claimed files do not exist yet.
+            if walk.entries.is_empty() {
+                continue;
             }
-            for entry in &entries {
+            let aliases = lookup_prune_aliases(self.dst, &walk, self.container_guard.as_ref())?;
+            let mut shielded = walk.shielded;
+            let recovery_parents = walk.recovery_parents;
+            for entry in &walk.entries {
                 let entry_path = &entry.path;
                 let entry_kind = entry.kind;
 
@@ -7001,13 +7065,8 @@ impl Planner<'_> {
                 {
                     continue;
                 }
-                let exact = self.dst_seen.get(&full);
-                let claimed = exact.or_else(|| {
-                    aliases
-                        .get(&(entry.dev, entry.ino))
-                        .and_then(|spelling| self.dst_seen.get(spelling))
-                });
-                if exact.is_none() && claimed.is_some() {
+                let claimed = aliases.get(&(entry.dev, entry.ino));
+                if claimed.is_some() {
                     // An ambiguous hard link may live in an otherwise extra
                     // directory. Keep its ancestors as well as the link.
                     for (index, byte) in full.iter().enumerate() {
@@ -8987,6 +9046,91 @@ mod tests {
             benchmark: Default::default(),
             fast_batch_files: 1,
         }
+    }
+
+    #[test]
+    fn prune_walk_drops_synced_entries_and_skips_empty_candidate_lookups() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = directory.path().join("file");
+        std::fs::write(&file, b"contents").unwrap();
+        let template = crate::fsops::lstat_entry(Vec::new(), &file).unwrap();
+        let seen: std::collections::HashMap<_, _> = (0..10_000)
+            .map(|index| (format!("dst/file-{index}").into_bytes(), Claim::Leaf))
+            .collect();
+        let mut walk = PruneWalk::new(&seen, b"dst");
+        for index in 0..9_000 {
+            let mut entry = template.clone();
+            entry.path = format!("file-{index}").into_bytes();
+            walk.push(entry, b"dst", &[]);
+            assert!(walk.entries.is_empty(), "exact matches must not accumulate");
+        }
+        walk.finish_scan(b"dst");
+        assert_eq!(walk.unmatched.len(), 1_000);
+        let state = Arc::new(Mutex::new(PipelineState::default()));
+        let aliases = lookup_prune_aliases(&mut PipelineConn(state.clone()), &walk, None).unwrap();
+        assert!(aliases.is_empty());
+        assert!(state.lock().unwrap().requests.is_empty());
+    }
+
+    #[test]
+    fn prune_walk_keeps_shields_recovery_and_nested_scopes() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut entry = crate::fsops::lstat_entry(Vec::new(), directory.path()).unwrap();
+        let seen = [(b"dst/blocked".to_vec(), Claim::Weak)]
+            .into_iter()
+            .collect();
+        let mut walk = PruneWalk::new(&seen, b"dst");
+        // The child deliberately arrives before its claimed directory.
+        for path in [
+            "blocked/child",
+            "blocked",
+            "nested/extra",
+            "old/.syq-swap-123-4/data",
+            "extra",
+        ] {
+            entry.path = path.as_bytes().to_vec();
+            walk.push(entry.clone(), b"dst", &[b"dst/nested".to_vec()]);
+        }
+        walk.finish_scan(b"dst");
+        assert!(walk.unmatched.is_empty());
+        assert_eq!(walk.entries.len(), 1);
+        assert_eq!(walk.entries[0].path, b"extra");
+        assert!(walk.recovery_parents.contains(b"dst/old".as_slice()));
+    }
+
+    #[test]
+    fn prune_alias_lookups_are_bounded_and_keep_only_candidate_identities() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = directory.path().join("file");
+        std::fs::write(&file, b"contents").unwrap();
+        let mut candidate = crate::fsops::lstat_entry(b"stored-name".to_vec(), &file).unwrap();
+        candidate.ino = 42;
+        let seen: std::collections::HashMap<_, _> = (0..1_025)
+            .map(|index| (format!("dst/claim-{index}").into_bytes(), Claim::Leaf))
+            .collect();
+        let mut walk = PruneWalk::new(&seen, b"dst");
+        walk.push(candidate.clone(), b"dst", &[]);
+        let mut unrelated = candidate.clone();
+        unrelated.ino = 43;
+        let state = Arc::new(Mutex::new(PipelineState::default()));
+        state.lock().unwrap().replies.extend([
+            Response::Stats(vec![Some(unrelated); 512]),
+            Response::Stats(vec![None; 512]),
+            Response::Stats(vec![Some(candidate.clone())]),
+        ]);
+        let aliases = lookup_prune_aliases(&mut PipelineConn(state.clone()), &walk, None).unwrap();
+        assert_eq!(aliases.len(), 1);
+        assert_eq!(aliases[&(candidate.dev, candidate.ino)], Claim::Leaf);
+        assert_eq!(state.lock().unwrap().requests.len(), 3);
+        assert!(state.lock().unwrap().replies.is_empty());
+
+        let malformed = Arc::new(Mutex::new(PipelineState::default()));
+        malformed
+            .lock()
+            .unwrap()
+            .replies
+            .push_back(Response::Stats(vec![]));
+        assert!(lookup_prune_aliases(&mut PipelineConn(malformed), &walk, None).is_err());
     }
 
     #[test]

--- a/tests/local.rs
+++ b/tests/local.rs
@@ -20979,3 +20979,27 @@ fn resume_prefers_a_partial_to_the_old_destination_contents() {
     );
     assert_eq!(partial_files(&t.0).len(), 1);
 }
+
+#[test]
+fn delete_many_roots_keeps_claims_in_their_own_scope() {
+    let t = Tmp::new();
+    let mut sources = Vec::new();
+    for i in 0..40 {
+        let name = format!("group-{i:02}");
+        write(&t.path(&format!("src/{name}/keep")), b"keep");
+        write(&t.path(&format!("dst/{name}/keep")), b"keep");
+        write(&t.path(&format!("dst/{name}/extra")), b"extra");
+        sources.push(t.s(&format!("src/{name}")));
+    }
+    let destination = t.s("dst");
+    for dry in [true, false] {
+        let mut args = vec![if dry { "-an" } else { "-a" }, "--delete"];
+        args.extend(sources.iter().map(String::as_str));
+        args.push(&destination);
+        run_ok(&args);
+        for i in 0..40 {
+            assert_eq!(read(&t.path(&format!("dst/group-{i:02}/keep"))), b"keep");
+            assert_eq!(t.path(&format!("dst/group-{i:02}/extra")).exists(), dry);
+        }
+    }
+}

--- a/tests/real-ssh/scenarios.sh
+++ b/tests/real-ssh/scenarios.sh
@@ -123,6 +123,26 @@ done
 # The completion scenario expects to discover only its own endpoint.
 syq completion cache clear >/dev/null
 
+printf 'case: pipelined prune lookup with a one-deep data pipeline\n'
+python3 - <<'PY_PRUNE'
+import pathlib
+import subprocess
+import tempfile
+
+with tempfile.TemporaryDirectory(prefix="syq-prune-") as directory:
+    source = pathlib.Path(directory)
+    for index in range(4096):
+        (source / f"file-{index:04}").write_bytes(b"new content")
+    destination = "/tmp/syq-real-ssh/prune-pipeline"
+    subprocess.run(["ssh", "destination", f"mkdir -p {destination}; printf extra > {destination}/extra"], check=True, timeout=30)
+    command = ["syq", "cp", "--srcs-in", str(source), "--to", "destination", "--into", destination,
+               "--prune", "--no-tcp", "--no-progress", "--tuning-options", "pipeline-depth=1"]
+    subprocess.run(command + ["--dry-run"], check=True, timeout=90)
+    subprocess.run(["ssh", "destination", f"test -f {destination}/extra && test ! -e {destination}/file-0000"], check=True, timeout=30)
+    subprocess.run(command, check=True, timeout=120)
+    subprocess.run(["ssh", "destination", f"test ! -e {destination}/extra && test $(find {destination} -type f | wc -l) -eq 4096 && test \"$(cat {destination}/file-4095)\" = 'new content'"], check=True, timeout=30)
+PY_PRUNE
+
 printf 'case: ordinary SSH directory push and pull across separate hosts\n'
 mkdir -p /tmp/syq-ordinary-source/sub
 printf 'ordinary cross-host directory copy\n' > /tmp/syq-ordinary-source/sub/file


### PR DESCRIPTION
Pruning a mostly synchronized destination discards exact source matches during the walk and retains only deletion candidates. With no candidates, including a dry run introducing new files, it sends no alias lookups. Candidate paths are joined once, retained as full paths, and moved into the deletion plan. Redundant empty-path and nested-root checks are removed, and containment uses one shared helper.

For 32 or more delete roots, a sorted index selects each root's claims without repeatedly scanning unrelated claims. Smaller root sets keep the cheaper linear scan. Remote alias lookups pipeline four existing 512-path requests; local lookups stay sequential. Response queues accommodate those control requests even with `pipeline-depth=1`, reply counts remain validated, and operation failures drain queued replies before reusing the control connection. Directory shields, nested scopes, ignored paths, partials, recovery data and ambiguous hard-link protection retain their existing behavior.

Memory includes the source claim map, borrowed unmatched paths, candidates and protected ancestors. The optional index adds one pointer per claim rather than copies of path bytes. Destination entries with exact claims do not accumulate.

Validation at `afd9deb`: formatting, Clippy (all targets/features, warnings denied), `cargo test --all-targets` and documentation links passed: 633 unit tests and 514 integration tests. One pre-existing unit test and two explicitly manual timing tests are excluded from the ordinary run; both timing tests are run separately in release mode. Regressions cover root/prefix boundaries, a 40-root dry/live deletion, a seven-batch bounded pipeline, malformed-reply draining, out-of-order shielding, nested/recovery protection, and large bidirectional frames with a one-deep requested reader queue.

Full default real-SSH suite passed at `afd9deb`, including copy routes, restricted receivers, resume, benchmark sizing/warm-up and interruption cleanup. Lab containers, networks, volumes, image and state directory were verified removed. Its new 4,096-file regression passed dry/live pruning over OpenSSH with `pipeline-depth=1`: dry run left the destination untouched; live copy published all files and removed the one obsolete entry.

Optimized focused measurements at `afd9deb` (200,000 claims, sorting included): 32 roots took 88.3 ms with repeated scans versus 55.1 ms indexed; 100 roots took 233.8 ms versus 56.6 ms. Sorting was slower at 2 and 10 roots and roughly tied at 16, supporting the 32-root cutoff. With 4,096 unmatched paths and a simulated 20 ms round trip, sequential alias requests took 161.1 ms versus 40.3 ms pipelined. Reproduce with `cargo test --release --bin syq prune_ -- --ignored --nocapture --test-threads=1`. These are focused planner measurements and simulated latency, not end-to-end WAN or large-tree RSS benchmarks. No macOS execution or actual coarse-filesystem mount was performed locally.

Compatibility: no helper message, protocol version, persistent state, filename format, CLI option or results-schema changes. This schedules existing ordered requests differently; helper identity pinning is unchanged. Released `v0.5.2` already exposed ordered send/receive pipelining; this change uses the existing prune request from the PR base and introduces no new helper capability or cache.

Current branch status:

```text
Worktree: /home/grant/repos/syq/.worktrees/prune-planner-performance
Branch:   prune-planner-performance at afd9deb (clean)
Upstream: origin/prune-planner-performance (ahead 0, behind 0)
Master:   3662857 from refs/heads/master (branch is ahead 2, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      4942c6a  https://github.com/greaber/syq/actions/runs/34716433101
  rsync-compat.yml success      4942c6a  https://github.com/greaber/syq/actions/runs/34716433160
  macos.yml        success      4942c6a  https://github.com/greaber/syq/actions/runs/34716433107

Pull request: #331 https://github.com/greaber/syq/pull/331
  base master, open, review none, merge state clean
  GitHub head afd9deb: matches local afd9deb
  checks: none registered yet
```
