### PR TITLE
Clarify prune diagnostics and consolidate safety helpers

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -159,8 +159,9 @@ The placement options `--into-existing` and `--as-existing` check only the
 placement path, rather than every copied entry.
 
 `--skip-newer` compares timestamps, not the age of the contents. It affects only
-regular-file pairs; replacing a different entry type still occurs. Combine it
-with `--only-existing` to avoid creating missing entries too.
+regular-file pairs; replacements between non-directory entry types still
+occur, but replacing a directory with a non-directory or the reverse is
+refused. Combine it with `--only-existing` to avoid creating missing entries too.
 
 `--only-new` cannot combine with either policy. Neither `--only-new` nor
 `--skip-newer` can combine with `--inplace`: an interrupted write could leave
@@ -269,7 +270,7 @@ skips the conflicting directory's subtree. This follows cp's conservative
 behavior and applies to both `syq cp` and `syq rsync`.
 
 Replacements between non-directory entries stage the new entry before
-publication. Some guarded replacements require an atomic exchange; if the
+publication. Some replacements require an atomic exchange; if the
 filesystem does not support it, the old entry is preserved and the operation
 fails. An interrupted exchange can leave the previous entry beside its
 replacement under a `.syq-swap-...` name; inspect it before removing it.

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -1010,10 +1010,16 @@ pub(crate) fn partial_path_with_name_max(
     Ok(parent.join(OsString::from_vec(component)))
 }
 
+const RECOVERY_PREFIX: &str = ".syq-swap-";
+
+pub(crate) fn recovery_name(process: u32, counter: u64) -> String {
+    format!("{RECOVERY_PREFIX}{process}-{counter}")
+}
+
 /// Names used for displaced entries during interrupted replacement. Keep
 /// this separate from resumable partials: clean-partials must not remove them.
 pub fn is_recovery_name(name: &OsStr) -> bool {
-    let Some(suffix) = name.as_bytes().strip_prefix(b".syq-swap-") else {
+    let Some(suffix) = name.as_bytes().strip_prefix(RECOVERY_PREFIX.as_bytes()) else {
         return false;
     };
     let mut fields = suffix.split(|byte| *byte == b'-');
@@ -7241,6 +7247,28 @@ fn apply_owner_if_changed(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn replacement_names_preserve_existing_recovery_format() {
+        assert_eq!(recovery_name(123, 456), ".syq-swap-123-456");
+        // Literal old names stay protected; never regenerate this inventory.
+        for name in [
+            ".syq-swap-123-456",
+            ".syq-swap-0-0",
+            ".syq-swap-4294967295-18446744073709551615",
+        ] {
+            assert!(is_recovery_name(OsStr::new(name)));
+        }
+        for name in [
+            ".syq-swap-",
+            ".syq-swap-123-",
+            ".syq-swap--456",
+            ".syq-swap-123-456-extra",
+            ".syq-swap-123-x",
+        ] {
+            assert!(!is_recovery_name(OsStr::new(name)));
+        }
+    }
+
     #[test]
     fn prune_lookup_distinguishes_missing_paths_from_inspection_errors() {
         use std::os::unix::fs::PermissionsExt;

--- a/src/rooted.rs
+++ b/src/rooted.rs
@@ -2071,22 +2071,16 @@ fn open_directory_at(parent: &File, component: &[u8]) -> io::Result<File> {
 /// Use O_SEARCH for searchable directories, then O_EVTONLY when only read
 /// permission is available. Neither changes permissions during inspection.
 /// Descendant lookups still enforce search permission and never follow links.
+#[cfg(target_os = "macos")]
 fn open_directory_metadata_at(parent: &File, component: &[u8]) -> io::Result<File> {
-    #[cfg(target_os = "macos")]
-    {
-        match open_directory_at(parent, component) {
-            Err(error) if error.kind() == io::ErrorKind::PermissionDenied => open_at(
-                parent.as_raw_fd(),
-                &component_cstring(component),
-                libc::O_EVTONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-                0,
-            ),
-            result => result,
-        }
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        open_directory_at(parent, component)
+    match open_directory_at(parent, component) {
+        Err(error) if error.kind() == io::ErrorKind::PermissionDenied => open_at(
+            parent.as_raw_fd(),
+            &component_cstring(component),
+            libc::O_EVTONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0,
+        ),
+        result => result,
     }
 }
 
@@ -2368,7 +2362,7 @@ fn create_temporary(
 ) -> Result<CString> {
     for _ in 0..32 {
         let counter = NEXT_SWAP_NAME.fetch_add(1, Ordering::Relaxed);
-        let name = CString::new(format!(".syq-swap-{}-{counter}", std::process::id()))
+        let name = CString::new(crate::fsops::recovery_name(std::process::id(), counter))
             .expect("generated swap name contains no NUL");
         match create(parent.directory.as_raw_fd(), &name) {
             Ok(()) => return Ok(name),

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -2356,11 +2356,39 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
     // so attempt it only for local paths or matching SSH endpoints.
     let same_machine = (!srcs[0].is_remote() && !dst.is_remote())
         || (srcs[0].is_remote() && dst.is_remote() && srcs[0].same_host(dst));
+    let mut prune_overlap_unsearchable = false;
     if same_machine {
         let roots = source_roots.get().expect("source roots registered");
         let mut source_checks = Vec::new();
         let mut ancestry_checks = Vec::new();
         let may_prune = opts.delete && roots.iter().any(|root| root.selection.relative.is_empty());
+        let primary_suffix = if expand_exact_home || dst_is_dir {
+            Vec::new()
+        } else {
+            operator_dst_root
+                .rsplit(|byte| *byte == b'/')
+                .next()
+                .unwrap_or_default()
+                .to_vec()
+        };
+        let prune_suffixes: Vec<_> = if may_prune {
+            srcs.iter()
+                .zip(roots)
+                .filter(|(_, root)| root.selection.relative.is_empty())
+                .map(|(candidate, _)| {
+                    if candidate.copies_contents()
+                        || args.files_from.is_some()
+                        || args.placement == Placement::As
+                    {
+                        primary_suffix.clone()
+                    } else {
+                        join(&primary_suffix, &candidate.basename())
+                    }
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
         for (source_index, (source, root)) in srcs.iter().zip(roots).enumerate() {
             // Registration represents every selected directory as an empty
             // path beneath that directory descriptor. Exact files and
@@ -2370,15 +2398,6 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             if !source_is_directory && !may_prune {
                 continue;
             }
-            let primary_suffix = if expand_exact_home || dst_is_dir {
-                Vec::new()
-            } else {
-                operator_dst_root
-                    .rsplit(|byte| *byte == b'/')
-                    .next()
-                    .unwrap_or_default()
-                    .to_vec()
-            };
             let mut suffixes = vec![primary_suffix.clone()];
             if dst_is_dir && !source.copies_contents() && args.files_from.is_none() {
                 let basename = source.basename();
@@ -2390,24 +2409,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
             // overlap checks apply only to copied directory roots. Compare
             // every selected source with every such root: one source's prune
             // must not remove another selected source.
-            let mut prune_suffixes = Vec::new();
-            if may_prune {
-                for (candidate, candidate_root) in srcs.iter().zip(roots) {
-                    if !candidate_root.selection.relative.is_empty() {
-                        continue;
-                    }
-                    let suffix = if candidate.copies_contents()
-                        || args.files_from.is_some()
-                        || args.placement == Placement::As
-                    {
-                        primary_suffix.clone()
-                    } else {
-                        join(&primary_suffix, &candidate.basename())
-                    };
-                    if !suffixes.contains(&suffix) {
-                        suffixes.push(suffix.clone());
-                    }
-                    prune_suffixes.push(suffix);
+            for suffix in &prune_suffixes {
+                if !suffixes.contains(suffix) {
+                    suffixes.push(suffix.clone());
                 }
             }
             let checked_for_prune = suffixes
@@ -2450,7 +2454,11 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
                     DirectoryRelation::Separate => {}
                     DirectoryRelation::SourceUnsearchable => {
                         if checks_prune {
-                            progress.error("syq: source directory cannot be searched to check pruning overlap");
+                            prune_overlap_unsearchable = true;
+                            progress.error(&format!(
+                                "syq: cannot check pruning overlap for source {}: a source ancestor cannot be searched",
+                                display(&source.path)
+                            ));
                         }
                     }
                     DirectoryRelation::Ancestor if !checks_prune => {}
@@ -3139,6 +3147,9 @@ fn run_transfer(args: Args, progress: Arc<Progress>) -> Result<i32> {
         if st.scan_warned {
             delete_plan = DeletePlan::Skipped("source scan errors");
             progress.eprintln("syq: source scan reported errors; skipping deletions");
+        } else if prune_overlap_unsearchable {
+            delete_plan = DeletePlan::Skipped("source ancestry could not be checked");
+            progress.eprintln("syq: source ancestry could not be checked; skipping deletions");
         } else if progress.errors.load(Relaxed) != 0 {
             delete_plan = DeletePlan::Skipped("copy errors");
             progress.eprintln("syq: copy reported errors; skipping deletions");
@@ -3877,6 +3888,12 @@ fn prepare_existing_destination(
     Ok((selection, filesystem, anchor))
 }
 
+fn ancestor_prefixes(path: &[u8]) -> impl Iterator<Item = &[u8]> {
+    path.iter()
+        .enumerate()
+        .filter_map(|(index, byte)| (*byte == b'/').then_some(&path[..index]))
+}
+
 fn parent_path(path: &[u8]) -> PathBytes {
     match path.iter().rposition(|byte| *byte == b'/') {
         Some(0) => b"/".to_vec(),
@@ -4558,6 +4575,13 @@ enum Claim {
     /// A symlink or special file syq intends to create.
     Leaf,
     Weak,
+}
+
+/// A failed entry's result identity, with a source path only in mapping mode.
+struct FailedEntry<'a> {
+    dst: &'a [u8],
+    src: Option<&'a [u8]>,
+    kind: Option<DeclaredKind>,
 }
 
 /// Everything the planner decided about one source entry, made once in the
@@ -6031,9 +6055,8 @@ impl Planner<'_> {
                         self.progress.files_excluded.fetch_add(1, Relaxed);
                         continue;
                     }
-                    if !opts.verify_only && dst_entry.as_ref().is_some_and(|d| d.kind == Kind::Dir)
+                    if self.refuse_directory_target(&dst_path, &dst_rel, e.kind, dst_entry.as_ref())
                     {
-                        self.fail_directory_type_change(&dst_path, &dst_rel, e.kind);
                         continue;
                     }
                     let same = dst_entry.as_ref().is_some_and(|d| {
@@ -6178,9 +6201,8 @@ impl Planner<'_> {
                         self.progress.files_excluded.fetch_add(1, Relaxed);
                         continue;
                     }
-                    if !opts.verify_only && dst_entry.as_ref().is_some_and(|d| d.kind == Kind::Dir)
+                    if self.refuse_directory_target(&dst_path, &dst_rel, e.kind, dst_entry.as_ref())
                     {
-                        self.fail_directory_type_change(&dst_path, &dst_rel, e.kind);
                         continue;
                     }
                     let target = e.link.clone().unwrap_or_default();
@@ -6259,9 +6281,8 @@ impl Planner<'_> {
                         self.progress.files_excluded.fetch_add(1, Relaxed);
                         continue;
                     }
-                    if !opts.verify_only && dst_entry.as_ref().is_some_and(|d| d.kind == Kind::Dir)
+                    if self.refuse_directory_target(&dst_path, &dst_rel, e.kind, dst_entry.as_ref())
                     {
-                        self.fail_directory_type_change(&dst_path, &dst_rel, e.kind);
                         continue;
                     }
                     let same = dst_entry
@@ -6593,6 +6614,20 @@ impl Planner<'_> {
         )
     }
 
+    fn refuse_directory_target(
+        &self,
+        dst: &[u8],
+        dst_rel: &[u8],
+        kind: Kind,
+        entry: Option<&Entry>,
+    ) -> bool {
+        if self.opts.verify_only || !entry.is_some_and(|entry| entry.kind == Kind::Dir) {
+            return false;
+        }
+        self.fail_directory_type_change(dst, dst_rel, kind);
+        true
+    }
+
     fn fail_directory_type_change(&self, dst: &[u8], dst_rel: &[u8], kind: Kind) {
         let message = if kind == Kind::Dir {
             format!(
@@ -6607,30 +6642,22 @@ impl Planner<'_> {
         };
         self.progress
             .error_classified(&message, Some("conflict"), None);
-        if self.opts.dry_run {
-            return;
-        }
-        if let Some(results) = self.progress.results_writer() {
-            let (action, kind) = match kind {
-                Kind::Dir => ("create_directory", "dir"),
-                Kind::File => ("transfer_file", "file"),
-                Kind::Symlink => ("create_symlink", "symlink"),
-                _ => ("create_special", "special"),
-            };
-            results.emit_operation(&crate::results::OperationRecord {
-                action,
+        self.emit_entry_failed(
+            FailedEntry {
                 dst: dst_rel,
                 src: self.mapping_source_rel(dst_rel).as_deref(),
-                kind,
-                disposition: "failed",
-                bytes: None,
-                attempts: None,
-                retryable: Some("no"),
-                class: Some("conflict"),
-                os_kind: None,
-                message: Some(&message),
-            });
-        }
+                kind: Some(match kind {
+                    Kind::Dir => DeclaredKind::Dir,
+                    Kind::File => DeclaredKind::File,
+                    Kind::Symlink => DeclaredKind::Symlink,
+                    _ => DeclaredKind::Special,
+                }),
+            },
+            "no",
+            "conflict",
+            None,
+            &message,
+        );
     }
 
     /// Report only real manifest entries beneath a protected obstruction;
@@ -6684,6 +6711,27 @@ impl Planner<'_> {
         os_kind: Option<&'static str>,
         message: &str,
     ) {
+        self.emit_entry_failed(
+            FailedEntry {
+                dst: &entry.dst,
+                src: Some(&entry.src),
+                kind: entry.kind,
+            },
+            retryable,
+            class,
+            os_kind,
+            message,
+        );
+    }
+
+    fn emit_entry_failed(
+        &self,
+        entry: FailedEntry<'_>,
+        retryable: &'static str,
+        class: &'static str,
+        os_kind: Option<&'static str>,
+        message: &str,
+    ) {
         // Dry runs are trace-only: the error record and terminal accounting
         // still reflect the failure.
         if self.opts.dry_run {
@@ -6698,8 +6746,8 @@ impl Planner<'_> {
             };
             results.emit_operation(&crate::results::OperationRecord {
                 action,
-                dst: &entry.dst,
-                src: Some(&entry.src),
+                dst: entry.dst,
+                src: entry.src,
                 kind,
                 disposition: "failed",
                 bytes: None,
@@ -6921,11 +6969,7 @@ impl Planner<'_> {
                             // contents. Protect the entire subtree and every
                             // ancestor, independently of scan ordering.
                             let full = join(&root, &entry.path);
-                            for (index, byte) in full.iter().enumerate() {
-                                if *byte == b'/' {
-                                    recovery_parents.insert(full[..index].to_vec());
-                                }
-                            }
+                            recovery_parents.extend(ancestor_prefixes(&full).map(<[u8]>::to_vec));
                             continue;
                         }
                         entries.push(entry);
@@ -6935,11 +6979,7 @@ impl Planner<'_> {
                 &mut |paths: Vec<PathBytes>| {
                     for p in paths {
                         // Every ancestor of an ignored path is protected.
-                        for (i, &c) in p.iter().enumerate() {
-                            if c == b'/' {
-                                protected.insert(join(&root, &p[..i]));
-                            }
-                        }
+                        protected.extend(ancestor_prefixes(&p).map(|prefix| join(&root, prefix)));
                     }
                     Ok(())
                 },
@@ -7010,11 +7050,7 @@ impl Planner<'_> {
                 if exact.is_none() && claimed.is_some() {
                     // An ambiguous hard link may live in an otherwise extra
                     // directory. Keep its ancestors as well as the link.
-                    for (index, byte) in full.iter().enumerate() {
-                        if *byte == b'/' {
-                            alias_parents.insert(full[..index].to_vec());
-                        }
-                    }
+                    alias_parents.extend(ancestor_prefixes(&full).map(<[u8]>::to_vec));
                 }
                 match claimed {
                     Some(Claim::Dir) => continue,
@@ -7038,12 +7074,10 @@ impl Planner<'_> {
                                     "syq: not deleting {rel}: its name matches syq's partial-file format; use syq clean-partials after copies stop"
                                 ));
                     }
-                    for (index, byte) in full.iter().enumerate() {
-                        if *byte == b'/' {
-                            partial_parents
-                                .entry(full[..index].to_vec())
-                                .or_insert_with(|| rel.clone());
-                        }
+                    for prefix in ancestor_prefixes(&full) {
+                        partial_parents
+                            .entry(prefix.to_vec())
+                            .or_insert_with(|| rel.clone());
                     }
                 } else {
                     if entry_kind == Kind::Dir {

--- a/tests/data_safety/mod.rs
+++ b/tests/data_safety/mod.rs
@@ -489,3 +489,51 @@ fn resume_accepts_pre_path_hash_partial_filename() {
     assert_eq!(result["bytes_transferred"], 0);
     assert_eq!(result["bytes_unchanged"], data.len() as u64);
 }
+
+#[cfg(debug_assertions)]
+#[test]
+fn prune_ancestry_permission_error_names_source_and_explains_skipping() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping permission denial: running as root");
+        return;
+    }
+    let t = Tmp::new();
+    write(&t.path("ancestor/src/file"), b"source contents");
+    write(&t.path("dst/extra"), b"keep");
+    let ready = t.path("ready");
+    let continuation = t.path("continue");
+    let child = Command::new(env!("CARGO_BIN_EXE_syq"))
+        .args([
+            "cp",
+            "--prune",
+            "--srcs-in",
+            &t.s("ancestor/src"),
+            "--into",
+            &t.s("dst"),
+        ])
+        .env("SYQ_TEST_SOURCE_ROOTS_REGISTERED_FILE", &ready)
+        .env("SYQ_TEST_SOURCE_ROOTS_CONTINUE_FILE", &continuation)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .start()
+        .unwrap();
+    wait_for(
+        "source registration",
+        std::time::Duration::from_secs(10),
+        || ready.exists(),
+    );
+    fs::set_permissions(t.path("ancestor"), fs::Permissions::from_mode(0o000)).unwrap();
+    fs::write(&continuation, b"continue").unwrap();
+    let out = child.wait_with_output().unwrap();
+    fs::set_permissions(t.path("ancestor"), fs::Permissions::from_mode(0o700)).unwrap();
+    assert!(!out.status.success());
+    let stderr = stderr_of(&out);
+    assert!(stderr.contains(&t.s("ancestor/src")), "{stderr}");
+    assert!(
+        stderr.contains("source ancestry could not be checked; skipping deletions"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("copy reported errors"), "{stderr}");
+    assert_eq!(read(&t.path("dst/file")), b"source contents");
+    assert_eq!(read(&t.path("dst/extra")), b"keep");
+}


### PR DESCRIPTION
When a source ancestor cannot be searched for pruning-overlap checks, syq now names the selected source and says deletions were skipped because ancestry could not be checked. Successful copies can still complete; the safety-check failure still produces a nonzero outcome and prevents deletion. The reference also correctly describes directory/non-directory refusals under `--skip-newer` and removes “guarded” from the replacement explanation.

The remaining changes consolidate existing behavior: build the prune suffix inventory once, share ancestor-prefix traversal and directory-target refusal checks, reuse the failed-entry result emitter, centralize replacement recovery naming, and compile the directory-metadata helper only on macOS. Source/root ancestry walks themselves are unchanged.

Validation at `55d41c4`: formatting, Clippy (all targets/features, warnings denied), `cargo test --all-targets`, and documentation links passed. A new permission-denial integration test verifies that copying completes, extras stay, and the error names the source and explains skipped pruning. Literal recovery-name tests and the existing mapping, directory-conflict, prune and replacement tests passed. The full default `scripts/test-real-ssh.sh` suite passed using a source snapshot identical to committed tree `55d41c4`, including remote copy routes, restricted receivers, resume, benchmark sizing/warm-up and interruption cleanup. Its containers, network, volumes, image and state directory were verified absent afterward. No macOS execution was performed locally.

Compatibility: verified released `v0.5.2` uses the unchanged `.syq-swap-PID-counter` format. Existing names remain protected; no cleanup eligibility or recovery lifecycle changes. Helper messages, persisted state and automation fields/classes/dispositions are unchanged; only explanatory messages change.

Outside this PR: timestamp comparison, prune buffering/lookups, full ancestry optimization, orphaned staged-leaf handling, inode-collision handling and cancellation records.


Synchronized with master `32492e5` at `52103fb`. The resolution preserves the optimized prune walker and failed-entry helper, and applies the shared ancestor iterator to recovery protection in its new walker location. Formatting, Clippy, `cargo test --all-targets`, and documentation links passed on the merge commit. Full real-SSH validation was not repeated for this conflict resolution; the integration change is the equivalent ancestor iterator, with transport/protocol behavior unchanged. A merge simulation with PR330 at `9715735` also succeeds.

Current branch status:

```text
Worktree: /home/grant/repos/syq/.worktrees/pr326-cleanups
Branch:   pr326-cleanups at 52103fb (clean)
Upstream: origin/pr326-cleanups (ahead 0, behind 0)
Master:   3662857 from refs/heads/master (branch is ahead 9, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           in_progress  32492e5  https://github.com/greaber/syq/actions/runs/34717975333
  rsync-compat.yml success      32492e5  https://github.com/greaber/syq/actions/runs/34717975352
  macos.yml        in_progress  32492e5  https://github.com/greaber/syq/actions/runs/34717975358

Pull request: #332 https://github.com/greaber/syq/pull/332
  base master, open, review none, merge state clean
  GitHub head 52103fb: matches local 52103fb
  checks: none registered yet
```
