### PR TITLE
docs: add social card metadata to the book theme

### DIFF
--- a/theme/README.md
+++ b/theme/README.md
@@ -76,6 +76,11 @@ Shared landing-actions buttons offer installation, benchmarks, sending files
 home, server-to-server copies and programmable file placement. Quickstart
 examples follow under Try a copy.
 
+head.hbs adds Open Graph and Twitter card metadata so shared documentation
+links render a titled card rather than a bare URL. Title varies per page;
+og:image and og:url are deliberately absent, for the reasons noted in the file.
+It is not part of the shared toolkit, so site-ui.json does not map it.
+
 ## SDK documentation
 
 The SDK guide, API reference and compatibility pages in docs/ use mdBook

--- a/theme/head.hbs
+++ b/theme/head.hbs
@@ -1,0 +1,10 @@
+{{!-- Social card metadata. og:image is intentionally absent: the repository
+      carries no stable social image, and mdBook's generated favicon is
+      content-hashed, so its filename changes between builds.
+      og:url is absent too: the page path is only available here as a `.md`
+      source path, and a URL that redirects is worse than none. --}}
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="{{ book_title }}">
+<meta property="og:title" content="{{ title }}">
+<meta property="og:description" content="{{ description }}">
+<meta name="twitter:card" content="summary">


### PR DESCRIPTION
Sharing a syq docs link on X renders a bare URL, because no page declares a `twitter:card` — X needs one to render any card at all. No page declares Open Graph tags either.

This adds `theme/head.hbs`, following the same theme-override pattern as the existing `header.hbs`.

```
before:  24 built pages, 0 with og:title
after:   24 built pages, 23 with og:title, 23 distinct
```

The 24th is `sdk-compatibility.html`, the redirect stub from `[output.html.redirect]` — a redirect shouldn't carry social metadata.

### What I deliberately left out

I want to be straight that this is a partial fix, and why:

**No `og:image`.** The repository contains no image at all — I checked. mdBook's generated favicon is content-hashed (`favicon-8114d1fc.png`), so its filename changes between builds and can't be referenced stably. Adding a social image is a branding decision and a binary asset, which felt like yours to make rather than something to slip into a drive-by PR. If you add one, the tag is three lines in the same file and I'm happy to follow up.

**No `og:url`.** The template only receives the path as a `.md` source path (`security.md`), and mdBook has no string helper to turn that into `security.html`. A URL that 308s is worse than an absent one — crawlers fall back to the shared URL itself, which is already correct.

So this takes shared links from *bare URL* to *titled card with description*. It does not give them a picture.

### Respecting the theme contract

`theme/README.md` documents the shared toolkit as byte-for-byte identical to the syq-bench copy. `site-ui.json` maps `brand.css`, `sidebar.*`, `controls.*`, `fonts`, and `header.hbs` → `site-nav.html`. **`head.hbs` is not in that map and `header.hbs` is untouched**, so the equality check is unaffected. I couldn't run `check-site-ui.py` myself since it needs the syq-bench checkout.

I added a short paragraph to `theme/README.md` since that file documents every other theme decision.

### Verified

Built with the pinned mdBook v0.5.4 from `pages.yml` (same version, macOS build) and ran `scripts/check-doc-links.py`: `checked 22 files; 0 problems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)