### PR TITLE
Fix fresh copies to macOS exFAT destinations

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -128,6 +128,11 @@ syq cp report.txt --as-new reports/final.txt
 `--into` uses or creates a directory. `--as` can rename a directory too.
 Sources that would collide at one destination are refused before copying.
 
+For a missing or empty destination, syq checks available space before copying
+and refuses a clear shortage. It also checks free inodes when the filesystem
+reports a meaningful count; exFAT on macOS does not. These checks are estimates:
+allocation failures during the copy still cause an error.
+
 ## Choose which existing files to update
 
 By default, selected destination entries are updated when needed.

--- a/src/fsops.rs
+++ b/src/fsops.rs
@@ -2546,6 +2546,19 @@ impl FsOps {
         let files_available = statvfs_counter(stats.f_favail);
         let available_bytes = blocks_available.saturating_mul(fragment_size);
         let available_inodes = (files != 0 && files_available <= files).then_some(files_available);
+        #[cfg(target_os = "macos")]
+        let available_inodes = available_inodes.and_then(|available| {
+            let mut filesystem = std::mem::MaybeUninit::<libc::statfs>::uninit();
+            if unsafe { libc::fstatfs(directory.as_raw_fd(), filesystem.as_mut_ptr()) } != 0 {
+                return None;
+            }
+            let filesystem = unsafe { filesystem.assume_init() };
+            let name = unsafe { CStr::from_ptr(filesystem.f_fstypename.as_ptr()) };
+            // macOS exFAT reports f_files=1 and f_favail=0 even while new
+            // files can be created. That is unavailable inode accounting,
+            // not exhaustion. Keep zero authoritative on other filesystems.
+            (name.to_bytes() != b"exfat").then_some(available)
+        });
         #[cfg(debug_assertions)]
         let available_bytes = match std::env::var_os("SYQ_TEST_AVAILABLE_BYTES") {
             Some(value) => value

--- a/tests/macos_exfat.rs
+++ b/tests/macos_exfat.rs
@@ -1,0 +1,125 @@
+//! Copy to a real macOS exFAT volume, including its native capacity counters.
+#![cfg(target_os = "macos")]
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+struct ExfatImage {
+    scratch: Option<tempfile::TempDir>,
+    mount: PathBuf,
+}
+
+impl ExfatImage {
+    fn new() -> Self {
+        let scratch = tempfile::tempdir().unwrap();
+        let root = scratch.path().canonicalize().unwrap();
+        let image = root.join("exfat.dmg");
+        let mount = root.join("mount");
+        fs::create_dir(&mount).unwrap();
+        // exFAT volume labels have a short length limit.
+        assert!(Command::new("hdiutil")
+            .args(["create", "-size", "64m", "-fs", "ExFAT", "-volname", "SYQTEST"])
+            .arg(&image)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("hdiutil")
+            .args(["attach", "-nobrowse", "-mountpoint"])
+            .arg(&mount)
+            .arg(&image)
+            .status()
+            .unwrap()
+            .success());
+        Self {
+            scratch: Some(scratch),
+            mount,
+        }
+    }
+}
+
+impl Drop for ExfatImage {
+    fn drop(&mut self) {
+        let detached = Command::new("hdiutil")
+            .arg("detach")
+            .arg(&self.mount)
+            .status()
+            .is_ok_and(|status| status.success());
+        if !detached {
+            // Never recursively clean a temporary directory still containing
+            // a mounted filesystem, including when a copy assertion failed.
+            let retained = self.scratch.take().unwrap().keep();
+            eprintln!(
+                "exFAT detach failed; image retained at {}",
+                retained.display()
+            );
+            if !std::thread::panicking() {
+                panic!("could not detach the test exFAT image");
+            }
+        }
+    }
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn fresh_exfat_destinations_have_unknown_inode_capacity() {
+    let volume = ExfatImage::new();
+    let source_dir = tempfile::tempdir().unwrap();
+    let source = source_dir.path().canonicalize().unwrap().join("source");
+    fs::write(&source, b"payload").unwrap();
+    let copy = |destination: &str, placement: &str, extra: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_syq"))
+            .arg("cp")
+            .arg(&source)
+            .arg(placement)
+            .arg(volume.mount.join(destination))
+            .arg("--no-progress")
+            .args(extra)
+            .output()
+            .unwrap()
+    };
+
+    // Both a missing exact file and an existing empty directory must pass
+    // preflight using the filesystem's actual counters, without overrides.
+    let dry = copy("dry", "--as", &["--dry-run"]);
+    assert_success(&dry);
+    assert!(String::from_utf8_lossy(&dry.stdout).contains("free inode count unavailable"));
+    assert!(!volume.mount.join("dry").exists());
+    assert_success(&copy("file", "--as", &[]));
+    assert_eq!(fs::read(volume.mount.join("file")).unwrap(), b"payload");
+    fs::create_dir(volume.mount.join("empty")).unwrap();
+    assert_success(&copy("empty", "--into", &[]));
+    assert_eq!(
+        fs::read(volume.mount.join("empty/source")).unwrap(),
+        b"payload"
+    );
+    assert_success(&copy("missing", "--into", &[]));
+    assert_eq!(
+        fs::read(volume.mount.join("missing/source")).unwrap(),
+        b"payload"
+    );
+
+    // Unknown inode accounting must not disable the byte-capacity check.
+    // A sparse source exceeds the entire image without allocating that data.
+    fs::File::create(&source)
+        .unwrap()
+        .set_len(128 * 1024 * 1024)
+        .unwrap();
+    let shortage = copy("too-large", "--as", &[]);
+    assert_eq!(shortage.status.code(), Some(1));
+    let error = String::from_utf8_lossy(&shortage.stderr);
+    assert!(
+        error.contains("fresh destination capacity preflight failed"),
+        "{error}"
+    );
+    assert!(error.contains("logical file data"), "{error}");
+    assert!(!volume.mount.join("too-large").exists());
+}


### PR DESCRIPTION
Fresh copies to macOS exFAT destinations failed before writing anything: a mounted 64 MiB image reported `f_files=1`, `f_ffree=0`, and `f_favail=0` despite accepting new files. Syq interpreted that as inode exhaustion.

Identify exFAT with `fstatfs` on the same open destination directory and report its inode count as unavailable. Byte-capacity checks and zero-inode rejection on other filesystems remain intact. Document the capacity checks in the copy reference.

The mounted-image regression fails against the original `5120daf` code and passes with the repair. It covers dry runs, a missing exact file, existing empty and missing directories, and a source larger than the volume. The test runs automatically with the macOS all-targets suite and detaches its disposable image on success or assertion failure.

Compatibility: `v0.5.2` already uses `Option<u64>` for the per-request inode count and skips the inode check for `None`. This uses that existing meaning without changing the helper protocol, persistent state, CLI, or SDK interfaces. Old binaries retain the bug until upgraded; there is no state migration.

Validation of the tree committed as `86b196a`:

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --bin syq`: 607 passed; the existing opt-in v0.3.2 receiver test remained ignored.
- `cargo test --locked --test macos_exfat -- --nocapture`: passed after demonstrating the original failure.
- `cargo test --locked --test local fresh_`: 7 passed.
- `cargo test --locked --test local small_push_refusals_and_failures_match_the_engine -- --exact`: passed with a disposable `XDG_CONFIG_HOME`. The first run inherited enabled persistence and reused a helper with an earlier injected zero-byte setting; isolating configuration resolved it without test or product changes. Test-owned background services and records were cleaned up.
- `scripts/test-real-ssh.sh`: complete default three-container suite passed, including benchmark and interruption cleanup checks. It built this same source tree before the commit was created.
- `python3 scripts/check-doc-links.py`: 22 files checked, no problems.

The complete native all-targets test suite and the optional real-SSH max-sessions-1 profile were not run for this narrow macOS change.

<details>
<summary>Branch status at review handoff</summary>

```text
Worktree: /Users/grant/repos/syq/.worktrees/exfat-capacity-investigation
Branch:   exfat-capacity-investigation at 86b196a (clean)
Upstream: origin/exfat-capacity-investigation (ahead 0, behind 0)
Master:   5120daf from refs/heads/master (branch is ahead 1, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      3662857  https://github.com/greaber/syq/actions/runs/34562999472
  rsync-compat.yml success      3662857  https://github.com/greaber/syq/actions/runs/34562999519
  macos.yml        success      3662857  https://github.com/greaber/syq/actions/runs/34562999491

Pull request: #334 https://github.com/greaber/syq/pull/334
  base master, open, review none, merge state clean
  GitHub head 86b196a: matches local 86b196a
  checks: none registered yet
```

</details>
