### PR TITLE
Fix a reader race in the macOS socket deadline test

### DIFF
--- a/src/destination.rs
+++ b/src/destination.rs
@@ -1633,6 +1633,9 @@ mod tests {
 
     #[test]
     fn partial_writes_do_not_renew_the_exchange_deadline() {
+        // Encode before starting the short socket deadline.
+        let mut message = Vec::new();
+        write_message(&mut message, &"x".repeat(MAX_MESSAGE / 2)).unwrap();
         let (mut writer, mut reader) = UnixStream::pair().unwrap();
         socket2::SockRef::from(&writer)
             .set_send_buffer_size(1024)
@@ -1640,14 +1643,13 @@ mod tests {
         reader
             .set_read_timeout(Some(Duration::from_millis(50)))
             .unwrap();
-        let (stop, stopped) = mpsc::channel();
         let peer = std::thread::spawn(move || {
             let end = Instant::now() + Duration::from_secs(2);
             let mut received = 0;
             let mut bytes = [0; 1024];
             while Instant::now() < end {
                 match reader.read(&mut bytes) {
-                    Ok(0) => break,
+                    Ok(0) => return received,
                     Ok(count) => received += count,
                     Err(error)
                         if matches!(
@@ -1656,24 +1658,22 @@ mod tests {
                         ) => {}
                     Err(error) => panic!("{error}"),
                 }
-                if stopped.recv_timeout(Duration::from_millis(30)).is_ok() {
-                    break;
-                }
+                std::thread::sleep(Duration::from_millis(30));
             }
-            received
+            panic!("peer did not reach EOF after receiving {received} bytes");
         });
         let start = Instant::now();
-        let result = write_message(
-            &mut DeadlineSocket {
-                socket: &mut writer,
-                deadline: start + Duration::from_millis(150),
-            },
-            &"x".repeat(MAX_MESSAGE / 2),
-        );
+        let result = DeadlineSocket {
+            socket: &mut writer,
+            deadline: start + Duration::from_millis(150),
+        }
+        .write_all(&message);
         let elapsed = start.elapsed();
-        let _ = stop.send(());
+        // Let the peer drain bytes already accepted by the socket. Stopping
+        // it immediately can report zero payload progress when it is delayed.
+        drop(writer);
         let received = peer.join().unwrap();
-        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::TimedOut);
         assert!(received > 4, "peer made no payload progress");
         assert!(
             elapsed < Duration::from_millis(500),


### PR DESCRIPTION
The macOS run on master `5539112` failed because the deadline test could stop its reader before it consumed payload already queued in the Unix socket. A delayed reader reproduces the same “peer made no payload progress” assertion even though the writer times out correctly.

Close the writer and let the peer drain to EOF before counting progress. Encode the test message before starting the 150 ms socket deadline, and require `TimedOut` specifically. The existing 500 ms upper bound remains. This changes only the regression test; runtime behavior and protocols are unchanged.

Validation:
- Reproduced the old failure with a delayed reader; the revised test also passes with a delayed reader.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` passed.
- `cargo test --bin syq`: 634 passed, 3 ignored.
- Full macOS workflow at `81cb1d7`: **passed** (native tests, clippy, Python/JavaScript/Go SDKs, benchmark and release shell suites), https://github.com/greaber/syq/actions/runs/34739551002.
- No separate local integration or real-SSH run for this test-only change.

Branch status: `fix-current-ci` is clean and pushed at `81cb1d7`. Master `5539112`: ci and rsync-compat passed; macos failed in the test addressed here. Pull requests do not automatically start test workflows.

<details>
<summary>Final scripts/branch-status.sh output (exit 1 for the existing master failure)</summary>

```text
Worktree: /home/grant/repos/syq/.worktrees/fix-current-ci
Branch:   fix-current-ci at 81cb1d7 (clean)
Upstream: origin/fix-current-ci (ahead 0, behind 0)
Master:   5539112 from refs/heads/master (branch is ahead 1, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      5539112  https://github.com/greaber/syq/actions/runs/34718752877
  rsync-compat.yml success      5539112  https://github.com/greaber/syq/actions/runs/34718752742
  macos.yml        failure      5539112  https://github.com/greaber/syq/actions/runs/34718752764

Pull request: #337 https://github.com/greaber/syq/pull/337
  base master, open, review none, merge state clean
  GitHub head 81cb1d7: matches local 81cb1d7
  checks: none registered yet

WARNING: master is red: macos.yml failure at 5539112 https://github.com/greaber/syq/actions/runs/34718752764
```
</details>
