### PR TITLE
Scale full SSH testing to behavioral impact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,9 +350,9 @@ handoff when a change is broad, crosses subsystem boundaries, changes shared
 test infrastructure, or leaves meaningful uncertainty about the affected
 surface. Do not run unrelated suites merely because they exist.
 
-Changes to SSH, remote helpers, enrollment, restricted receivers, transports,
-or remote coordinator placement should also run the local-only three-container
-OpenSSH suite:
+Run the local-only three-container OpenSSH suite when changes materially affect
+connection setup, helper bootstrap, authentication or authorization, remote
+process lifecycle, transport behavior, or remote coordinator placement:
 
 ```bash
 scripts/test-real-ssh.sh
@@ -360,6 +360,17 @@ scripts/test-real-ssh.sh
 
 It is intentionally not part of ordinary CI or `cargo test`; see
 `tests/real-ssh/README.md` for its isolation and coverage.
+
+Choose this check by behavioral impact, not merely by which file changed.
+Small review fixes to diagnostics, documentation, or isolated validation checks
+can use focused tests when those tests adequately exercise the change. Batch
+related fixes before running the full suite. After a successful run, inspect
+the intervening changes before repeating it; rerun when they affect the SSH
+scenarios or leave meaningful uncertainty that focused tests cannot resolve.
+Report the SHA of the last successful full run, the checks on the current SHA,
+and why a repeat was unnecessary. Do not describe an earlier run as testing the
+current tree. Release validation still follows the exact-commit requirements
+under release tag lifecycle.
 
 Pull requests do not start automated test workflows. The agent remains
 responsible for running the baseline above, choosing focused integration tests,

--- a/tests/real-ssh/README.md
+++ b/tests/real-ssh/README.md
@@ -102,9 +102,10 @@ The experimental streaming path also runs over TCP and SSH, with push, pull,
 source/destination coordination and a local relay. Each streaming copy has a
 25-second deadline and is compared byte for byte, including a signed receiver.
 
-This suite is intentionally outside `cargo test` and CI. Run it after changing
-SSH, remote-helper, enrollment, restricted-receiver, transport, or remote
-topology behavior, and before cutting a release. For release preparation, use
+This suite is intentionally outside `cargo test` and CI. Use the
+[verification guidance](../../AGENTS.md#verification) to decide when a change
+needs the full suite or focused tests, and run it before cutting a release.
+For release preparation, use
 `scripts/release-readiness.py v<version> --check-ssh` after committing: it records
 successful default-profile validation for the complete clean tree, reusable
 across an identical-tree merge. See `RELEASING.md` for the evidence rules.


### PR DESCRIPTION
The verification guidance triggered a full three-container SSH run even for small review fixes. Choose that suite by behavioral impact, batch related changes, and use focused tests when they adequately cover a small fix. Require an assessment of intervening changes before repeating a successful full run, with the tested SHAs reported accurately. Release validation requirements remain unchanged.

Point the SSH test README to this guidance so it does not maintain a conflicting rule.

Validation at `7742361`: documentation links (22 files) and `git diff --check` passed. Rust and SSH suites were not run for this guidance-only change.

Branch status:

```text
Worktree: /home/grant/repos/syq/.worktrees/ssh-check-guidance
Branch:   ssh-check-guidance at 7742361 (clean)
Upstream: origin/ssh-check-guidance (ahead 0, behind 0)
Master:   5539112 from refs/heads/master (branch is ahead 30, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           in_progress  9f110f4  https://github.com/greaber/syq/actions/runs/34743397280
  rsync-compat.yml in_progress  9f110f4  https://github.com/greaber/syq/actions/runs/34743397278
  macos.yml        in_progress  9f110f4  https://github.com/greaber/syq/actions/runs/34743397267

Pull request: #339 https://github.com/greaber/syq/pull/339
  base master, open, review none, merge state clean
  GitHub head 7742361: matches local 7742361
  checks: none registered yet
```
