### PR TITLE
Keep copy and performance docs focused on user tasks

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -95,7 +95,7 @@ cargo test --bin syq
 
 Also run integration tests that exercise your change. SSH, remote-helper,
 enrollment, receiver, transport, and remote-coordinator changes need
-`scripts/test-real-ssh.sh`; see the [real-SSH test setup](../tests/real-ssh/README.md).
+`scripts/test-real-ssh.sh`; see the [real-SSH test setup](https://github.com/greaber/syq/blob/master/tests/real-ssh/README.md).
 For documentation changes, run `python3 scripts/check-doc-links.py`.
 See the repository's `AGENTS.md` for the full contribution workflow.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,12 +43,10 @@ Compare syq with rsync on your own machines, or with rsync and cp locally:
 curl --proto '=https' --tlsv1.2 -fLsS https://raw.githubusercontent.com/greaber/syq/master/scripts/try-benchmark.sh | bash
 ```
 
-The default sends 1,024 small throwaway files to an SSH host you choose and
-compares syq with rsync over three rounds, following an untimed tuning warm-up
-(`--warmup off` skips it). Local copies, large files, and
-automatic sizing are optional. The script checks the copied contents and cleans up afterward.
+Choose an SSH host to compare syq with rsync, or a local copy to include cp.
+The script creates test data, checks the copied contents, and cleans up afterward.
 If syq is missing, it offers to install it. See [quick comparison](speed.md#quick-comparison)
-to download the script and run it again.
+for workload sizes, warm-up time, and command-line options.
 
 <figure class="benchmark-example">
 <table>

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -107,19 +107,15 @@ syq cp --from hostA -C /data --mapping pairs.ndjson --to hostB --into /archive
 ```
 
 `--mapping -` reads the manifest from stdin. File contents follow the selected
-copy route. The restricted receiver verifies the authorized manifest and permits
-writes only at its listed destinations, plus creation of necessary parent
-directories. New implicit parents use normal directory permissions subject to
-the receiver’s umask. Existing implicit parents keep their permissions, including
-restoration if copying temporarily requires write access. A listed directory
-still selects only that directory, not its unlisted children. If a file or symlink
-blocks an implicit parent, the affected entries fail and unrelated mappings
-continue. Move or remove the obstruction before retrying, even when the manifest
-explicitly lists the parent directory.
-Restricted receivers count mapped destinations and their parent directories
-against the copy’s entry limit. Each manifest line can be up to 1 MiB, and each
-destination path up to 4096 bytes. There is no separate limit on the total
-manifest size.
+copy route. The restricted receiver permits writes only at the listed
+destinations and creates missing parent directories as needed. New parents use
+permissions limited by the receiver's umask; existing parents keep theirs.
+If a file or symlink blocks a parent directory, move or remove it before
+retrying. The affected entries fail while unrelated mappings continue.
+
+Mapped destinations and their parent directories count against the receiver's
+entry limit. Each manifest line can be up to 1 MiB, and each destination path
+up to 4096 bytes. There is no separate limit on the total manifest size.
 
 ## Emitting a mapping
 

--- a/docs/persistence-reference.md
+++ b/docs/persistence-reference.md
@@ -62,9 +62,8 @@ across upgrades; include it in private backups if you want to restore the same
 identity. Losing it requires releasing the old names on each server. Copying it
 to another machine gives that machine the same receiver identity. If the old
 connection is still responsive, the replacement is rejected; use different
-profile names to receive on both machines at once. If the old connection is
-unresponsive, reconnecting waits for its heartbeat cleanup to release the name
-lock. It does not displace the existing connection.
+profile names to receive on both machines at once. An unresponsive connection
+must time out before its name can reconnect.
 
 ## Directories
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -7,19 +7,9 @@ syq cp project --into backup
 This copies `project` to `backup/project`. Existing files are updated when
 needed; unrelated files stay.
 
-The default final summary reports transferred files and bytes, unchanged
-files and bytes, directories created, elapsed time, rate, and any errors.
-
-Add `-v` to list copied paths. `-vv` also explains helper selection and
-transport; `--stats` adds scan totals, excluded-file counts, connection count,
-and available TCP statistics. For example:
-
-```sh
-syq cp -vv --stats project --into backup
-```
-
-See [diagnosing a slow copy](speed.md#diagnose-a-slow-copy) for interpreting
-transport and performance details.
+The final summary shows what was copied or skipped, how long it took, and any
+errors. Add `-v` to list copied paths. For connection and performance details,
+see [diagnosing a slow copy](speed.md#diagnose-a-slow-copy).
 
 ## See where files go
 
@@ -89,10 +79,9 @@ Enclose IPv6 addresses in brackets: `alice@[2001:db8::1]:2222`.
 A colon in a native path is simply part of the path.
 
 Use `--to @NAME` to send local source files to a registered receiving machine.
-The `@` is required: `--to laptop` always selects an SSH destination, while
-`--to @laptop` selects the receiver and fails if it is offline or its identity
-check fails. Receiver destinations do not switch to SSH when unavailable. See [Send files home from a server](receive.md)
-for setup and receiver-side path settings.
+The `@` is required: `--to laptop` selects an SSH destination, while
+`--to @laptop` requires that receiver to be connected and pass its identity check.
+See [Send files home from a server](receive.md) for setup and destination paths.
 
 For two remote endpoints, see [Copy between servers](remote-to-remote.md).
 
@@ -128,10 +117,9 @@ syq cp report.txt --as-new reports/final.txt
 `--into` uses or creates a directory. `--as` can rename a directory too.
 Sources that would collide at one destination are refused before copying.
 
-For a missing or empty destination, syq checks available space before copying
-and refuses a clear shortage. It also checks free inodes when the filesystem
-reports a meaningful count; exFAT on macOS does not. These checks are estimates:
-allocation failures during the copy still cause an error.
+For a missing or empty destination, syq checks available space and, where the
+filesystem reports it, capacity for new files. It refuses a clear shortage,
+but these estimates do not guarantee that the copy will fit.
 
 ## Choose which existing files to update
 
@@ -205,19 +193,19 @@ Pruning stays inside the copied directories. Copying named directories `a`
 and `b` into `backup` prunes `backup/a` and `backup/b`, leaving `backup/c` alone.
 Ignored paths and files skipped by size limits are protected.
 
-Scan or copy errors prevent deletion. Syq refuses to prune a destination
-that it can identify as containing its source. Checks cover local copies and
-copies between remote paths with the same host name, user, and port. They do not
-detect overlap through different SSH aliases, local-to-SSH connections, or shared
-storage across different hosts. An interruption after deletion starts can leave
-some extras removed. Do not prune
-while another copy is writing into the same tree: its completed files can be treated as extras. Recognized partial files
-and replacement recovery entries (`.syq-swap-<pid>-<number>`) are protected
-from pruning, along with their contents and parent directories. With `-v`, syq
-lists each extra file it keeps because its name matches the partial-file format.
-When a copied path resolves to a different filename spelling at the destination,
-pruning protects that entry. If hard links make the match ambiguous, it can keep
-additional links to the same file.
+Scan or copy errors prevent deletion. An interruption after deletion starts
+can leave some extras removed. Do not prune while another copy is writing into
+the same tree: its completed files can be treated as extras.
+
+Keep the source outside the destination you are pruning. Syq checks this for
+local copies and remote paths with the same host name, user, and port, but
+cannot detect overlap through different SSH aliases, local-to-SSH connections,
+or shared storage across hosts.
+
+Pruning keeps syq's partial files and `.syq-swap-...` recovery entries, including
+their contents and parent directories. Use `-v` to see files kept because their
+names match the partial-file format. If different filename spellings resolve
+to a copied file, syq protects it; this can also keep extra hard links to it.
 
 ## Ignoring paths
 
@@ -251,40 +239,20 @@ Ignored paths are also protected from pruning.
 
 ## Resume an interrupted copy
 
-Rerun the command. Completed files are skipped; partially copied files can
-reuse matching blocks. Each run writes its own fresh partial beside the
-destination and replaces the final file only when complete. When resuming,
-syq can copy bytes from a previous partial or the existing destination into its
-own output, hash the bytes it copied, and transfer blocks that differ from the
-source before publishing. The previous partial stays unchanged. Reuse is best
-effort; local direct copies can be faster than looking for reusable blocks and
-take priority.
+Rerun the command. Completed files are skipped, and syq can reuse matching
+parts of an interrupted file. It writes a new temporary file beside the
+destination and replaces the final file only when complete. Previous partials
+stay unchanged. Reuse is not guaranteed; local copies may use the filesystem's
+faster copy operations instead.
 
 Resuming requires space for the new output as well as the previous partial.
 This can require enough free space for another complete file, even when only
 a small amount remains to transfer.
 
-Syq preserves filename bytes and reports names the destination cannot create as
-copy errors. It checks exact destination and partial-file name conflicts, but
-does not preflight case or Unicode equivalence. Source names that the destination
-considers equivalent can overwrite one another; rename them before copying when
-you need to preserve both files.
-
-A directory cannot replace a file or symlink, and a file, symlink or special
-file cannot replace a directory, even an empty one. Syq reports an error and
-skips the conflicting directory's subtree. This follows cp's conservative
-behavior and applies to both `syq cp` and `syq rsync`.
-
-Replacements between non-directory entries stage the new entry before
-publication. Some replacements require an atomic exchange; if the
-filesystem does not support it, the old entry is preserved and the operation
-fails. An interrupted exchange can leave the previous entry beside its
-replacement under a `.syq-swap-...` name; inspect it before removing it.
-
-Concurrent copies use separate partials. With unchanged sources, each completed
-file comes from one copy; different copies may win for different files. This
-does not make a whole tree a snapshot. `--inplace` still exposes unfinished
-updates, and pruning can delete another copy's completed files.
+Concurrent copies use separate temporary files. With unchanged sources, each
+completed file comes from one copy, but the whole tree is not a snapshot.
+[In-place writes](#in-place-writes) expose unfinished updates, and pruning can
+delete another copy's completed files.
 
 Partials are named `.FILENAME.syq-tmp.RANDOM`, with 16 random characters at the
 end. The filename portion is shortened or omitted when space is tight. Syq
@@ -304,11 +272,27 @@ syq clean-partials --on server --cwd /data -j 8 backup archive
 
 This command removes regular files with the current partial-name format. It
 keeps directories, other filenames, and symlinks, and does not follow symlinks.
-Use `--root DIR` to confine traversal and `--results FILE` for removal results.
-The results use the same `mode: "rm"` records as `syq rm`; they do not distinguish
-a partial sweep from other removal commands.
+Use `--root DIR` to confine traversal and `--results FILE` for the same
+[removal records](automation.md#removal-records) as `syq rm` (`mode: "rm"`).
 A regular file deliberately named like a partial is also selected. Old partial
 formats are neither reused nor selected by this command; remove those manually.
+
+## Conflicting names and file types
+
+Some filesystems treat names that differ only in case or Unicode spelling as
+the same name. Syq does not detect these collisions before copying, so one
+source can overwrite another. Rename conflicting sources first to keep both.
+Names the destination cannot create are reported as copy errors.
+
+Both `syq cp` and `syq rsync` refuse to replace a directory with a file, symlink,
+or special file, or the reverse, even when the directory is empty. The copy
+reports an error and skips that directory's contents. Move or remove the
+conflicting destination before retrying.
+
+Other replacements can fail if the filesystem lacks the operation needed to
+replace the old entry safely; the old entry is kept. An interruption can leave
+it beside its replacement under a `.syq-swap-...` name. Inspect that entry before
+removing it; `clean-partials` does not remove recovery entries.
 
 ## Check file contents
 

--- a/docs/remote-to-remote.md
+++ b/docs/remote-to-remote.md
@@ -104,19 +104,15 @@ syq receiver list
 syq receiver revoke ID
 ```
 
-Use the ID from `list`. Revocation stops all active restricted receivers for
-that enrollment and blocks new sessions. It waits for their shutdown before
-reporting success, then removes the enrollment from both machines. Other
-enrollments keep running. Revocation does not undo completed writes; interrupted
-copies fail and can leave partial files. Enroll again to authorize a new copy
-that can resume them.
+Use the ID from `list`. Revocation stops active copies for that enrollment,
+blocks new ones, and removes its setup from both machines. Other enrollments
+keep working. Completed writes remain; interrupted copies can leave partial
+files. Enroll again before retrying those copies.
 
-If receivers have not stopped within ten seconds, revocation reports failure
-and keeps the enrollment marked revoked. Retry `receiver revoke` to finish
-cleanup; an enrollment with unfinished revocation cannot be refreshed.
-
-For upgrading or sharing a receiver between installations, see
-[enrollment details](remote-reference.md#enrollment).
+If revocation reports that receivers have not stopped, the enrollment stays
+revoked. Retry `receiver revoke` to finish cleanup. See
+[enrollment details](remote-reference.md#enrollment) for upgrades and sharing
+between installations.
 
 If your machine reaches hostB through hostA, add `--via hostA` to `enroll` or
 `revoke`.
@@ -144,7 +140,6 @@ syq cp --coordinate-at local --from hostA --srcs-in data --to hostB --into /arch
 ```
 
 This uses your machine's bandwidth and ordinary SSH access to each endpoint.
-Syq never switches to it silently.
 
 Other authentication modes can use server-held credentials, a destination-
 restricted SSH agent, or full agent forwarding. They grant different authority;

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -19,82 +19,60 @@ with rsync over three rounds. Use `--mode pull` for downloads or `--mode local`
 to include cp. `--workload large` selects one 64 MiB file; `--workload both`
 runs both workloads. The script checks every copy and cleans up afterward.
 
-Before scoring each network workload, an untimed syq warm-up gives automatic
-tuning time to refine the remembered connection count. It uses the same
-direction, transport options and file type as the scored copies. It starts
-with 64 MiB or 1,024 small files and grows toward 60 seconds of copying,
-stopping after at most four copies or at 1 GiB per dataset, subject to free
-space. A slow copy can take longer than 60 seconds; preparation and checks
-also add time. The script reports the measured duration and warns if it hits
-a limit before the target. Reaching the target does not prove tuning settled.
-
-Use `--warmup off` for a short comparison using the existing cached or default
-count. A cached count alone does not currently skip the warm-up automatically.
-Warm-up is skipped for local copies, comparisons without scored syq
-trials, and manual `--connections` or `--tuning-options` overrides. The scored
-dataset size stays the same. For pull warm-ups, identical data is generated
-locally and remotely and checked, avoiding a large preliminary upload; the
-remote host needs Bash, OpenSSL, dd and split for that step.
-
-For one scored syq copy with your own options:
-
-```sh
-bash try-benchmark.sh --yes --mode pull --host j5 --tool syq --rounds 1 \
-  -- --no-tcp --connections 1 -v
-```
-
-An untimed tiny copy still prepares the helper. Options after `--` apply to
-syq's setup, warm-up, calibration and scored copies; path, removal and output-file
-options are excluded to keep copies inside the disposable dataset. Use
-`--tool rsync` for a separate rsync comparison, omitting syq options after `--`.
-Full commands and scratch paths appear only with `-v`, `-vv`, or `--verbose`
-after `--`. Syq's extra summary appears with those flags or `--stats`; the
-benchmark always reports verified trial results and failures.
-See [tuning options](tuning.md#streaming-and-request-windows) for request-window
-and small-file batch experiments, and `bash try-benchmark.sh --help` for all options.
+Network comparisons first run an untimed syq warm-up so it can learn a useful
+connection count. This aims for 60 seconds of copying, using up to four copies
+of datasets no larger than 1 GiB each, subject to free space. Slow copies and
+preparation can take longer. Use `--warmup off` for a shorter comparison using
+the existing learned or default count. Local copies and manual tuning skip
+this warm-up.
 
 `--size quick` is the fixed-size default. For longer tests, `--size medium`
 uses 1 GiB or 4,096 small files; `--size large` uses 8 GiB or 16,384 files.
-`--size auto` makes verified, unscored syq copies and grows the dataset until
-copying takes about five seconds or scratch space limits growth. There is no
-fixed total-data or runtime limit. All scored tools use the same dataset.
+`--size auto` grows the test data until a syq copy takes about five seconds or
+scratch space limits growth, with no fixed total-data or runtime limit. All
+scored tools use the same dataset. Longer tests help reveal sustained
+throughput, but neither sizing nor warm-up guarantees tuning has settled.
 
-The script needs Bash, rsync, OpenSSL and standard Unix utilities locally;
-syq timing uses Perl's core JSON::PP module. Remote tests need SSH access and
-rsync on the other machine. Scratch parents must exist: `--source-dir` is
-always local and `--dest-dir` is the remote scratch parent for push and pull.
-Generation and checks keep the launch directory visible to tmux.
+To try your own syq options, put them after `--`:
 
-Generation, helper preparation, warm-up and content checks are untimed. Each scored
-copy uses an empty destination, with permissions and modification times
-preserved. Syq persistence is disabled in private settings and rsync uses fresh
-SSH connections, so the total timer includes connection startup. This leaves
-the normal [learned connection counts](tuning.md#remembered-connection-counts)
-active unless you override tuning; trials can reuse and update them. Caches are
-not flushed and copies do not wait for durable storage. Failed commands or
-content checks stop the comparison.
+```sh
+bash try-benchmark.sh --yes --mode pull --host server --tool syq --rounds 1 \
+  -- --no-tcp --connections 1 -v
+```
 
-Network results use decimal MB/s, averaging trial speeds. Local comparisons
-use seconds: filesystem cloning can avoid moving bytes, so fast copy times
-are not disk bandwidth measurements. Each tool may use its normal optimizations.
+These options also apply to setup and warm-up copies. Path, removal, and
+output-file options are excluded to keep the test inside its disposable
+directories. `-v` shows full commands and scratch paths. Use `--tool rsync`
+for a separate rsync comparison, omitting syq options after `--`. See
+[tuning options](tuning.md) for experiments, or run
+`bash try-benchmark.sh --help` for all script options.
 
-The main table always uses total command time, including connection startup.
-A separate syq table shows mean total time, its copying interval, other time
-(total minus copying), and copying speed in decimal MB/s. Copying speed is
-copied bytes divided by copying seconds and 1,000,000, averaged across trial
-speeds. It also appears after each syq trial. A copying interval below timer
-resolution makes copying speed unavailable. Other time covers work outside that interval, such as
-setup and finishing. Copying spans the first file work through the last completed
-work: it includes waiting and per-file overhead, and can overlap planning and
-connection setup. It is neither pure network time nor an exact separation of
-setup from transfer. The script does not estimate this breakdown for rsync or cp.
+The script needs Bash, rsync, OpenSSL, standard Unix utilities, and Perl's
+core JSON::PP module locally. Remote tests need SSH access and rsync on the
+other machine; pull warm-ups also need Bash, OpenSSL, dd, and split there.
+Scratch parent directories must exist. `--source-dir` selects the local
+parent; `--dest-dir` selects the remote parent for both push and pull.
 
-The script adds a note when at least 20% of syq's total time falls outside
-copying, or its mean copying interval is under one second. These are diagnostic
-thresholds, not guarantees that longer tests saturate the link. Short jobs still
-measure useful completion time; use `--workload large --size auto` or a larger
-fixed size to investigate sustained throughput. Compare both tools using their
-total times, rather than comparing syq's copying interval with rsync's total.
+Each scored copy uses an empty destination and preserves permissions and
+modification times. Generation, helper preparation, warm-up, and content
+checks are untimed. Failed commands or content checks stop the comparison.
+SSH connection reuse is disabled for both tools during network tests; syq's
+[learned connection counts](tuning.md#remembered-connection-counts) remain
+active unless you override tuning. Caches are not flushed, and copies do not
+wait for durable storage.
+
+Compare tools using the main table, which includes connection startup in total
+command time. Network results show decimal MB/s averaged across trials. Local
+results show seconds, because filesystem cloning can avoid moving bytes;
+those times do not measure disk bandwidth.
+
+The separate syq timing table helps explain slow results. It divides total time
+into the copying interval and time outside it, such as setup and finishing.
+The copying interval includes waiting and per-file work, and can overlap
+planning and connection setup. Use it to diagnose syq, not to compare against
+another tool's total time. If the script flags a short copying interval or
+substantial time outside it, try a larger workload to investigate sustained
+throughput.
 
 ## Benchmarks
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -1,8 +1,8 @@
 # Tuning options
 
-Syq adjusts performance automatically. These controls are for developers and
-for investigating copies where the defaults perform poorly. These experimental controls appear in `--help-all`; their keys and
-bounds may change between releases.
+Syq adjusts performance automatically. Use these controls to investigate copies
+where the defaults perform poorly. They appear in `--help-all` and are
+experimental; their keys and bounds may change between releases.
 
 `--connections N` (or `-j N`) fixes the connection count and disables automatic
 adjustment. In `syq rsync`, use `--syq-connections N`. Use the same count when
@@ -16,14 +16,11 @@ normally lives at `~/.cache/syq/tuning.json` (`XDG_CACHE_HOME` can change its
 parent). The quick benchmark uses this cache, even though it disables SSH
 connection persistence. Its temporary file paths do not change the cache key.
 
-Learning takes time: syq samples every 2.5 seconds and needs a warm-up interval
-plus two stable samples for one measurement. Saving a count requires a
-successful copy with at least two measured worker counts and an unchanged
-transport. Failed or aborted copies leave the previous cached count intact.
-If a copy finishes during another probe, syq saves the last accepted count. Short copies may only use their starting count. The benchmark's
-[untimed warm-up](speed.md#quick-comparison) allows more time before scoring;
-neither its 60-second target nor the separate five-second automatic sizing
-target guarantees tuning has settled.
+Short copies may finish before syq can learn a better count. Only successful
+copies that compare enough connection counts without changing transport update
+the cache; failed or interrupted copies leave it unchanged. The benchmark's
+[untimed warm-up](speed.md#quick-comparison) gives learning more time before
+scoring, but does not guarantee that tuning has settled.
 
 `--connections N` disables automatic adjustment and cache use. Supplying
 `--tuning-options` bypasses reading and updating learned counts, but live
@@ -53,10 +50,7 @@ syq cp large-file --to server --as /scratch/benchmark-copy \
 
 Sizes accept `K`, `M`, and `G`, using powers of 1024. Unknown keys, repeated
 keys, and out-of-range values fail the command. Overrides apply to the remote
-coordinator too. They are not saved, and these runs neither read nor update
-the remembered connection count. Connection auto-tuning still runs unless you
-fix `--connections` (`--syq-connections` with `syq rsync`). These are experimental
-controls whose keys and bounds may change between releases.
+coordinator too and are not saved.
 
 Larger requests reduce overhead per byte; deeper pipelines allow more requests
 to await replies at once. Both can increase memory use. Neither changes the
@@ -84,7 +78,7 @@ To test the amount of outstanding large-file work over SSH, keep the worker
 count and copy method fixed, then vary only the request window:
 
 ```sh
-bash try-benchmark.sh --yes --mode pull --host j5 --workload large \
+bash try-benchmark.sh --yes --mode pull --host server --workload large \
   --tool syq --rounds 1 --size quick -- --no-tcp --connections 1 -v \
   --tuning-options copy-path=ranges,request-size=1M,pipeline-depth=4
 ```
@@ -102,7 +96,6 @@ such as `--tuning-options batch-files=512,batch-bytes=4M`. Those are batch
 ceilings, and the scheduler may choose smaller batches. `pipeline-depth` does
 not multiply small-file batches. After testing these controls, vary
 `--connections` separately to assess parallelism and its startup cost.
-
 
 For a direct comparison without the benchmark script, use fresh scratch destinations:
 

--- a/sdk/python/NATIVE_API.md
+++ b/sdk/python/NATIVE_API.md
@@ -111,15 +111,12 @@ Typed remote-to-remote copies require an enrolled receiver or
 `bytes`, or `os.PathLike`). To interleave rule files and inline patterns:
 `ignore=[syq.IgnoreFrom("rules"), "!keep.tmp"]`. The last matching rule wins.
 
-With `only_new=True`, directories already present when syq first checks them
-keep their metadata. Missing children are still added.
-Adding children may naturally change directory timestamps. Directories copied
-as new receive normal copy metadata. When several sources supply the same new
-directory, the last source supplies its metadata, just as without
-`only_new=True`. Adding children to those existing
-directories requires write access; permissions are not temporarily widened.
-Permission failures are reported in the result and raise `SyqOperationError`
-unless `check=False`. A dry run does not test write permission.
+With `only_new=True`, existing directories keep their metadata while receiving
+missing children. They must be writable; syq does not change their permissions
+to add files. Adding children can change directory timestamps, and a dry run
+does not test write access. See the
+[overwrite policies](https://greaber.github.io/syq/reference.html#choose-which-existing-files-to-update)
+for interactions with other copy options.
 
 <a id="removal"></a>
 


### PR DESCRIPTION
Recent copy and benchmark additions made task guides repeat reference material and explain implementation details before readers could act. Shorten the copy introduction, resume and pruning explanations, benchmark methodology, receiver revocation, and Python overwrite guidance. Give filename and type conflicts their own section, replace an internal example hostname, and fix the development guide's broken published SSH-test link.

Keep copy safety limits, recovery actions, benchmark workload/resource qualifications, measured figures and their sources, and all existing page URLs and anchors. Runtime behavior and public interfaces are unchanged.

Validation on 5a5902f:
- mdBook 0.5.4 build (release archive checked against the repository's pinned SHA-256), source links (22 files), and git diff whitespace check passed.
- 1,380 rendered links/assets passed; all 996 baseline page anchors preserved, including included Python documentation.
- Eight edited content pages checked in Chromium at 390px and 1440px, light and dark: no document overflow, missing images, or unresolved includes. Copy and Speed screenshots inspected.
- Rust, integration, and real-SSH suites not run: documentation-only changes.

Local browser preview on the workspace host: http://127.0.0.1:8876/speed.html and http://127.0.0.1:8876/reference.html.
