### PR TITLE
Add the first changelog with upgrade notes since 0.5.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,13 @@ Authorization continues through retries and resumed turns for the same release
 and ends when it completes or is cancelled. Another release requires another
 invocation. Read-only or dry-run invocations stay within their stated scope.
 
+During release preparation, compare `CHANGELOG.md` with all changes since the
+previous published release. Include user-facing fixes, performance improvements,
+and consequential behavior or compatibility changes. Finalize the entry with
+the release version and date, and use it to prepare the GitHub release notes.
+Do not treat an existing changelog entry as evidence that later changes have
+already been covered. See `RELEASING.md` for the release checklist.
+
 The user chose this explicit invocation boundary to prevent accidental
 publication while allowing an invoked release to finish autonomously. Keep
 validation gates, branch protections, tag permanence, and secret boundaries;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Earlier releases have notes on [GitHub Releases](https://github.com/greaber/syq/
 
 Changes since 0.5.2.
 
+Highlights include safer concurrent copies, lower CPU use for large Linux
+transfers, and receiving names that remain assigned while a machine is offline.
+
 ### Upgrade notes
 
 - Receiving machines now require `@NAME`: use `--to @laptop`,
@@ -63,11 +66,14 @@ Changes since 0.5.2.
 
 ### Performance and tools
 
+- Large transfers on Linux can use substantially less CPU when several workers
+  write one file. This benefits TCP and local range copies while keeping
+  reception and hashing parallel. [PR #336](https://github.com/greaber/syq/pull/336)
+  records the measured CPU savings and copy times, which vary by workload.
+  Independent SSH helpers do not share this optimization.
 - Local destinations use directory descriptors directly without a loopback
   data connection. Metadata workers are reused between batches, large prune
   plans use less temporary storage, and remote alias checks are pipelined.
-- Linux range writes to the same file are serialized within each helper
-  process, while reception and hashing remain parallel.
 - The benchmark script defaults to small SSH uploads, adds an untimed tuning
   warm-up, supports individual tools and explicit syq tuning options, and
   separates total time from copying time. Use `--mode local` for local tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+User-facing changes are recorded here starting with the release after
+[0.5.2](https://github.com/greaber/syq/releases/tag/v0.5.2).
+Earlier releases have notes on [GitHub Releases](https://github.com/greaber/syq/releases).
+
+## Unreleased
+
+Changes since 0.5.2.
+
+### Upgrade notes
+
+- Receiving machines now require `@NAME`: use `--to @laptop`,
+  `--auth-from @laptop`, `--via @laptop`, and `syq exec --on @laptop`.
+  **`--to laptop` now always selects an SSH host**, even when a receiving
+  machine has that name.
+- Receiving names stay assigned to the same machine while it is offline.
+  Before upgrading, stop receiving services with `syq persist off`, including
+  any script scopes. Upgrade the commands on both machines, then reconnect
+  with `syq persist connect SERVER`. Older commands do not enforce the new
+  assignments. To replace a receiving machine, stop its connection and run
+  `syq persist destinations forget NAME` on the server. See
+  [updating connections](docs/persistence-reference.md#updating-connections).
+- Interrupted copies now leave private `.FILENAME.syq-tmp.RANDOM` files.
+  Partials from 0.5.2 (`.syq-part.`) are not reused or selected by the new
+  cleanup command. Finish interrupted transfers before upgrading if you need
+  to preserve their resume progress; otherwise, retry the copy and inspect
+  old partials before removing them manually.
+- Both `syq cp` and `syq rsync` refuse replacement between a directory and
+  any non-directory, even an empty directory. Move or remove the obstruction
+  before retrying. Replacements between non-directory types remain supported.
+- When an official release bootstraps an SSH helper, it also tries to install
+  an independent command at `~/.local/bin/syq`. This can happen during dry runs,
+  completion, and background connection setup. Existing commands are kept;
+  installation failure does not fail the copy. See
+  [automatic installation](docs/install.md#automatic-installation-on-ssh-servers).
+- New standalone installations keep their self-update receipt beside the
+  executable, normally `.syq-install.json`. Existing receipts in the syq
+  configuration directory remain supported.
+
+### Copying and cleanup
+
+- Concurrent copies use separate partial files and check reused blocks against
+  the source. A successful retry can leave earlier partials behind.
+  `syq clean-partials --dry-run TREE` previews their removal; stop copies before
+  running `syq clean-partials TREE`. Remote cleanup uses `--on SERVER`.
+- Resume discovery is bounded: directories with more than 256 partials may
+  not reuse all of them. Shortened or omitted filename prefixes may also
+  prevent reuse. These cases resend data rather than compromising the result.
+- Scan or copy errors now prevent pruning. Pruning also protects recognized
+  partials, replacement recovery entries, and their parent directories, and
+  refuses source overlap it can identify. See
+  [pruning rules and coverage](docs/reference.md#mirror-a-directory).
+- Failed non-directory replacements preserve the previous destination when
+  staging fails. Truncated local copies and failed or cancelled range writes
+  cannot be published as complete files.
+- Native copies now compare fractional modification times at the precision
+  suggested by the destination timestamp. This catches more same-size edits
+  within a second. `syq rsync` keeps its whole-second file comparison;
+  `--hash` (`-c` in rsync mode) checks content regardless of timestamps.
+- macOS copies handle directory permission repair more consistently and no
+  longer mistake exFAT's unavailable inode count for a full filesystem.
+
+### Performance and tools
+
+- Local destinations use directory descriptors directly without a loopback
+  data connection. Metadata workers are reused between batches, large prune
+  plans use less temporary storage, and remote alias checks are pipelined.
+- Linux range writes to the same file are serialized within each helper
+  process, while reception and hashing remain parallel.
+- The benchmark script defaults to small SSH uploads, adds an untimed tuning
+  warm-up, supports individual tools and explicit syq tuning options, and
+  separates total time from copying time. Use `--mode local` for local tests
+  and `--warmup off` to skip warm-up.
+- Documentation separates task guides from persistence and tuning references.
+  Existing documentation heading links are preserved.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ across machines.
 It aims to perform well across file sizes, directory sizes, and network speeds.
 
 [Documentation](https://greaber.github.io/syq/) ·
-[Benchmarks](https://greaber.github.io/syq-bench/)
+[Benchmarks](https://greaber.github.io/syq-bench/) ·
+[Changelog](https://github.com/greaber/syq/blob/master/CHANGELOG.md)
 
 Quick links to docs for common tasks:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -161,8 +161,10 @@ For an already-prepared version with matching evidence, start at step 2. A new
 release request does not require another preparation PR or another test run.
 
 1. Update the package version in `Cargo.toml`, run `cargo check` to refresh
-   `Cargo.lock`, then run the normal locked checks to validate it. Write the
-   curated introduction and breaking-change notes in
+   `Cargo.lock`, then run the normal locked checks to validate it. Finalize the
+   `Unreleased` entry in `CHANGELOG.md` with the version and release date,
+   checking it against the changes since the previous release. Use that entry
+   to write the curated introduction and breaking-change notes in
    `.github/release-notes/v<version>.md`; the release workflow prepends that
    file to GitHub's generated contributor and change list. Merge the version
    and release notes through the protected branch. Peer compatibility is


### PR DESCRIPTION
Add the first repository changelog, covering published v0.5.2 (`fd2b17c`) through `bdfaad2`. It highlights upgrade implications, fixes, and performance improvements, including PR #336's reduction in Linux receiver CPU use. README links to it.

AGENTS.md now requires comparing the changelog with all changes since the previous published release. RELEASING.md requires finalizing the version/date and using the entry for curated GitHub release notes. The heading stays Unreleased until the release skill chooses a version.

Validation:
- At runtime baseline `bdfaad2`, fmt, all-feature/all-target Clippy, and all-target tests passed (1,180 tests; 3 ignored).
- Receiver compatibility passed against the checksum-verified official v0.5.2 Linux binary. Installer tests and all 38 benchmark script tests passed.
- Documentation links, Python API inventory, pinned mdBook 0.5.4 build, and preservation of previous documentation heading anchors checked successfully. Documentation links and diff checks passed after the final guidance edit at `0d64459`.
- No new full real-SSH or local macOS run; runtime tests were not repeated for documentation edits. Exact-candidate release validation remains outstanding.

Latest branch-status output:

```text
Worktree: /home/grant/repos/syq/.worktrees/release-change-review
Branch:   release-change-review at 0d64459 (clean)
Upstream: origin/release-change-review (ahead 0, behind 0)
Master:   bdfaad2 from refs/heads/master (branch is ahead 3, behind 0)

Master CI (latest post-merge run per workflow):
  ci.yml           success      257b339  https://github.com/greaber/syq/actions/runs/34744072164
  rsync-compat.yml success      257b339  https://github.com/greaber/syq/actions/runs/34744072167
  macos.yml        success      257b339  https://github.com/greaber/syq/actions/runs/34744072119

Pull request: #341 https://github.com/greaber/syq/pull/341
  base master, open, review none, merge state clean
  GitHub head 0d64459: matches local 0d64459
  checks: none registered yet
```
