### PR TITLE
Prepare syq 0.6.0 release

### DIFF
--- a/.github/release-notes/v0.6.0.md
+++ b/.github/release-notes/v0.6.0.md
@@ -1,12 +1,4 @@
-# Changelog
-
-User-facing changes are recorded here starting with the release after
-[0.5.2](https://github.com/greaber/syq/releases/tag/v0.5.2).
-Earlier releases have notes on [GitHub Releases](https://github.com/greaber/syq/releases).
-
-## 0.6.0 — 2026-09-13
-
-Changes since 0.5.2.
+syq 0.6.0 improves copy safety and performance and changes how receiving machines are selected.
 
 Highlights include safer concurrent copies, lower CPU use for large Linux
 transfers, and receiving names that remain assigned while a machine is offline.
@@ -23,7 +15,7 @@ transfers, and receiving names that remain assigned while a machine is offline.
   with `syq persist connect SERVER`. Older commands do not enforce the new
   assignments. To replace a receiving machine, stop its connection and run
   `syq persist destinations forget NAME` on the server. See
-  [updating connections](docs/persistence-reference.md#updating-connections).
+  [updating connections](https://greaber.github.io/syq/persistence-reference.html#updating-connections).
 - Interrupted copies now leave private `.FILENAME.syq-tmp.RANDOM` files.
   Partials from 0.5.2 (`.syq-part.`) are not reused or selected by the new
   cleanup command. Finish interrupted transfers before upgrading if you need
@@ -36,7 +28,7 @@ transfers, and receiving names that remain assigned while a machine is offline.
   an independent command at `~/.local/bin/syq`. This can happen during dry runs,
   completion, and background connection setup. Existing commands are kept;
   installation failure does not fail the copy. See
-  [automatic installation](docs/install.md#automatic-installation-on-ssh-servers).
+  [automatic installation](https://greaber.github.io/syq/install.html#automatic-installation-on-ssh-servers).
 - New standalone installations keep their self-update receipt beside the
   executable, normally `.syq-install.json`. Existing receipts in the syq
   configuration directory remain supported.
@@ -53,7 +45,7 @@ transfers, and receiving names that remain assigned while a machine is offline.
 - Scan or copy errors now prevent pruning. Pruning also protects recognized
   partials, replacement recovery entries, and their parent directories, and
   refuses source overlap it can identify. See
-  [pruning rules and coverage](docs/reference.md#mirror-a-directory).
+  [pruning rules and coverage](https://greaber.github.io/syq/reference.html#mirror-a-directory).
 - Failed non-directory replacements preserve the previous destination when
   staging fails. Truncated local copies and failed or cancelled range writes
   cannot be published as complete files.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "syq"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syq"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.94"
 description = "Parallel file copy with an explicit native CLI and rsync compatibility"


### PR DESCRIPTION
Prepares syq 0.6.0 with matching Cargo metadata, a dated changelog, and curated release notes. The minor version reflects the receiving-name syntax change and persistent-connection upgrade requirements; the notes also cover partial-file compatibility and directory replacement behavior relative to published 0.5.2.

Validation: cargo check, fmt, clippy with all targets/features and warnings denied, unit tests (651 passed, 3 ignored), Python native API inventory, documentation links, and mdBook 0.5.4 passed. The docs audit reuses the unchanged guide content validated in #340 and checks changelog coverage through the current master. Default real-SSH release certification is running; exact merge-commit CI and preflight follow before tagging.
